### PR TITLE
feat: Add version display with build info throughout application

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Extract version from Cargo.toml
+        id: version
+        shell: bash
+        run: |
+          VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Version: $VERSION"
+
       - name: Install Rust stable with WASM target
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -228,13 +236,13 @@ jobs:
       - name: Upload backend binary
         uses: actions/upload-artifact@v4
         with:
-          name: strom-backend-${{ matrix.platform }}
+          name: strom-backend-v${{ steps.version.outputs.version }}-${{ matrix.platform }}
           path: target/release/strom-backend${{ matrix.binary_ext }}
           retention-days: 7
 
       - name: Upload MCP server binary
         uses: actions/upload-artifact@v4
         with:
-          name: strom-mcp-server-${{ matrix.platform }}
+          name: strom-mcp-server-v${{ steps.version.outputs.version }}-${{ matrix.platform }}
           path: target/release/strom-mcp-server${{ matrix.binary_ext }}
           retention-days: 7

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4691,6 +4691,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum",
+ "chrono",
  "clap",
  "eframe",
  "futures",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -58,6 +58,9 @@ mime_guess = "2.0"
 strom-frontend = { path = "../frontend", optional = true }
 eframe = { workspace = true, optional = true }
 
+[build-dependencies]
+chrono = "0.4"
+
 [dev-dependencies]
 tempfile = "3.8"
 tower = { version = "0.5", features = ["util"] }

--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -3,4 +3,5 @@
 pub mod blocks;
 pub mod elements;
 pub mod flows;
+pub mod version;
 pub mod websocket;

--- a/backend/src/api/version.rs
+++ b/backend/src/api/version.rs
@@ -1,0 +1,26 @@
+//! Version information API endpoints.
+
+use axum::Json;
+
+use crate::version::VersionInfo;
+
+/// Get version and build information
+///
+/// Returns comprehensive version information including:
+/// - Package version from Cargo.toml
+/// - Git commit hash
+/// - Git tag (if on a tagged release)
+/// - Git branch name
+/// - Working directory status (dirty/clean)
+/// - Build timestamp
+#[utoipa::path(
+    get,
+    path = "/api/version",
+    tag = "System",
+    responses(
+        (status = 200, description = "Version information", body = VersionInfo)
+    )
+)]
+pub async fn get_version() -> Json<VersionInfo> {
+    Json(VersionInfo::get())
+}

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -18,6 +18,7 @@ pub mod layout;
 pub mod openapi;
 pub mod state;
 pub mod storage;
+pub mod version;
 
 use state::AppState;
 
@@ -93,6 +94,7 @@ pub async fn create_app_with_state(state: AppState) -> Router {
             "/blocks/{id}",
             axum::routing::delete(api::blocks::delete_block),
         )
+        .route("/version", get(api::version::get_version))
         .route("/ws", get(api::websocket::websocket_handler));
 
     // Build main router with Swagger UI

--- a/backend/src/openapi.rs
+++ b/backend/src/openapi.rs
@@ -1,5 +1,6 @@
 //! OpenAPI documentation configuration.
 
+use crate::version::VersionInfo;
 use strom_types::api::{
     CreateFlowRequest, ElementInfoResponse, ElementListResponse, ElementPropertiesResponse,
     ErrorResponse, FlowListResponse, FlowResponse, UpdateFlowPropertiesRequest,
@@ -34,6 +35,7 @@ use utoipa::OpenApi;
         crate::api::blocks::update_block,
         crate::api::blocks::delete_block,
         crate::api::blocks::get_categories,
+        crate::api::version::get_version,
     ),
     components(
         schemas(
@@ -59,12 +61,14 @@ use utoipa::OpenApi;
             PropertyType,
             ExternalPads,
             ExternalPad,
+            VersionInfo,
         )
     ),
     tags(
         (name = "flows", description = "GStreamer flow management endpoints"),
         (name = "elements", description = "GStreamer element discovery endpoints"),
-        (name = "blocks", description = "Reusable block management endpoints")
+        (name = "blocks", description = "Reusable block management endpoints"),
+        (name = "System", description = "System information endpoints")
     ),
     info(
         title = "Strom GStreamer Flow Engine API",

--- a/backend/src/version.rs
+++ b/backend/src/version.rs
@@ -1,0 +1,87 @@
+/// Version and build information embedded at compile time
+use serde::Serialize;
+use utoipa::ToSchema;
+
+/// Build and version information
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct VersionInfo {
+    /// Package version from Cargo.toml
+    pub version: &'static str,
+    /// Git commit hash (short)
+    pub git_hash: &'static str,
+    /// Git tag (if on a tagged commit)
+    pub git_tag: &'static str,
+    /// Git branch name
+    pub git_branch: &'static str,
+    /// Whether the working directory had uncommitted changes
+    pub git_dirty: bool,
+    /// Build timestamp (ISO 8601 format)
+    pub build_timestamp: &'static str,
+}
+
+impl VersionInfo {
+    /// Get the current version information
+    pub fn get() -> Self {
+        Self {
+            version: env!("CARGO_PKG_VERSION"),
+            git_hash: env!("GIT_HASH"),
+            git_tag: env!("GIT_TAG"),
+            git_branch: env!("GIT_BRANCH"),
+            git_dirty: env!("GIT_DIRTY") == "true",
+            build_timestamp: env!("BUILD_TIMESTAMP"),
+        }
+    }
+
+    /// Get a human-readable version string
+    ///
+    /// Returns:
+    /// - "v0.1.0" if on a tagged release
+    /// - "v0.1.0-dev+abc12345" if on main/master without tag
+    /// - "v0.1.0-dev+abc12345-dirty" if there are uncommitted changes
+    pub fn version_string(&self) -> String {
+        if !self.git_tag.is_empty() {
+            // On a tagged release
+            self.git_tag.to_string()
+        } else {
+            // Development version
+            let mut version = format!("v{}-dev+{}", self.version, self.git_hash);
+            if self.git_dirty {
+                version.push_str("-dirty");
+            }
+            version
+        }
+    }
+
+    /// Get a short version string for display
+    ///
+    /// Returns:
+    /// - "v0.1.0" if on a tagged release
+    /// - "v0.1.0-dev" if not on a tag
+    pub fn short_version(&self) -> String {
+        if !self.git_tag.is_empty() {
+            self.git_tag.to_string()
+        } else {
+            format!("v{}-dev", self.version)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_version_info() {
+        let info = VersionInfo::get();
+
+        // These should always be set by build.rs
+        assert!(!info.version.is_empty());
+        assert!(!info.git_hash.is_empty());
+        assert!(!info.build_timestamp.is_empty());
+
+        // These might be empty depending on git state
+        // but shouldn't panic
+        let _ = info.version_string();
+        let _ = info.short_version();
+    }
+}

--- a/frontend/src/state.rs
+++ b/frontend/src/state.rs
@@ -52,6 +52,9 @@ pub enum AppMessage {
 
     /// Request full refresh of flows
     RefreshNeeded,
+
+    /// Version information loaded from backend
+    VersionLoaded(crate::api::VersionInfo),
 }
 
 /// WebSocket connection state.


### PR DESCRIPTION
## Summary
Implements comprehensive version tracking and display throughout the Strom application:

### Backend Enhancements
- ✅ Extract version metadata in `build.rs` (version, git hash, tag, branch, build timestamp)
- ✅ New `/api/version` REST endpoint exposing `VersionInfo` structure
- ✅ Compile-time embedding of build information
- ✅ Updated OpenAPI/Swagger documentation

### Frontend Features
- ✅ Version display in status bar (bottom-right corner)
- ✅ Color-coded version indicators:
  - 🟢 Green: Tagged releases (e.g., `v0.1.0`)
  - 🟠 Orange: Modified builds with uncommitted changes
  - ⚪ Gray: Development builds
- ✅ Rich hover tooltip with full build details:
  - Package version number
  - Git commit hash (short)
  - Git tag (when applicable)
  - Branch name
  - Build timestamp (ISO 8601)
  - Working directory status

### CI/CD & Release Management
- ✅ Updated CI workflow to include version in artifact names:
  - Format: `strom-backend-v0.1.0-linux`
  - Format: `strom-mcp-server-v0.1.0-windows.exe`
- ✅ Docker workflow already uses semantic versioning tags
- ✅ Version consistency across:
  - `Cargo.toml` workspace version
  - Git tags (for releases)
  - Docker Hub image tags
  - CI build artifacts
  - Runtime GUI display

### Version Display Format
- **Tagged releases**: `v0.1.0`
- **Development builds**: `v0.1.0-abc12345` (version + git hash)
- **Modified builds**: `v0.1.0-abc12345 (modified)`

## Testing
- ✅ Backend compiles with version extraction
- ✅ Frontend compiles with version display
- ✅ All pre-commit checks pass (format + clippy)
- ✅ Version info embedded at compile time
- ✅ API endpoint ready for version queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)