### PR TITLE
Fix Windows build: Cast glong/gulong types in element property introspection

### DIFF
--- a/backend/src/gst/discovery.rs
+++ b/backend/src/gst/discovery.rs
@@ -1122,8 +1122,12 @@ impl ElementDiscovery {
                             (PropertyType::Int { min, max }, default)
                         } else if let Some(param_spec) = pspec.downcast_ref::<glib::ParamSpecLong>()
                         {
-                            let min = param_spec.minimum();
-                            let max = param_spec.maximum();
+                            // Cast glong to i64 for cross-platform compatibility
+                            // glong is i32 on Windows but i64 on Linux
+                            #[allow(clippy::unnecessary_cast)]
+                            let min = param_spec.minimum() as i64;
+                            #[allow(clippy::unnecessary_cast)]
+                            let max = param_spec.maximum() as i64;
                             let default =
                                 std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                                     element.property::<i64>(&name)
@@ -1150,8 +1154,12 @@ impl ElementDiscovery {
                         } else if let Some(param_spec) =
                             pspec.downcast_ref::<glib::ParamSpecULong>()
                         {
-                            let min = param_spec.minimum();
-                            let max = param_spec.maximum();
+                            // Cast gulong to u64 for cross-platform compatibility
+                            // gulong is u32 on Windows but u64 on Linux
+                            #[allow(clippy::unnecessary_cast)]
+                            let min = param_spec.minimum() as u64;
+                            #[allow(clippy::unnecessary_cast)]
+                            let max = param_spec.maximum() as u64;
                             let default =
                                 std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                                     element.property::<u64>(&name)


### PR DESCRIPTION
## Summary
- Fix Windows build type mismatches in element property introspection
- Add explicit casts for glong/gulong to i64/u64
- Resolves 4 compilation errors on Windows platform

## Problem
The Windows build was failing with 4 type mismatch errors in `backend/src/gst/discovery.rs`:
- Lines 1133:50 and 1133:55 - `glong` (i32 on Windows, i64 on Linux)
- Lines 1161:51 and 1161:56 - `gulong` (u32 on Windows, u64 on Linux)

These errors occurred in the `introspect_element_properties_lazy()` function when handling `ParamSpecLong` and `ParamSpecULong` property types.

## Solution
Added explicit type casts with `as i64` and `as u64` for cross-platform compatibility:
- Cast `param_spec.minimum()` and `param_spec.maximum()` for `ParamSpecLong`
- Cast `param_spec.minimum()` and `param_spec.maximum()` for `ParamSpecULong`  
- Added `#[allow(clippy::unnecessary_cast)]` annotations to suppress warnings on Linux

This matches the fix that was already applied to the pad property introspection code in the same file.

## Testing
- Pre-commit checks pass (formatting + clippy)
- CI will verify Windows, Linux, and macOS builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)