### PR TITLE
chore: Use workspace version for mcp-server package

### DIFF
--- a/mcp-server/Cargo.toml
+++ b/mcp-server/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "strom-mcp-server"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
 
 [dependencies]
 # Async runtime


### PR DESCRIPTION
## Summary
- Standardize mcp-server Cargo.toml to use workspace version
- Ensures all packages use version 0.1.0 from workspace definition
- Prepares repository for v0.1.0 release

## Changes
Updated `mcp-server/Cargo.toml` to use:
- `version.workspace = true`
- `edition.workspace = true`
- `license.workspace = true`
- `authors.workspace = true`

This matches the pattern used by all other workspace members (backend, frontend, types).

🤖 Generated with [Claude Code](https://claude.com/claude-code)