### PR TITLE
perf: Disable arm64 Docker builds to improve publish time

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -56,7 +56,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           # Use build-time annotations for better metadata
           provenance: true
           sbom: true


### PR DESCRIPTION
## Summary
- Disable arm64 platform builds in Docker publish workflow
- Keep only linux/amd64 builds to significantly reduce build time
- Resolves excessive build times in CI

## Problem
The arm64 Docker builds are taking excessively long to complete in the publish workflow, as seen in [actions run 19538961531](https://github.com/Eyevinn/strom/actions/runs/19538961531/job/55939925493). This delays releases and increases CI resource usage.

## Solution
Remove `linux/arm64` from the platforms list in `.github/workflows/docker-publish.yml`, keeping only `linux/amd64`.

## Impact
- Faster Docker publish workflow completion
- Reduced CI resource usage
- Users needing arm64 images can build locally using the provided Dockerfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)