### PR TITLE
Fix Docker build hanging in GitHub Actions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -18,6 +18,7 @@ jobs:
   docker-publish:
     name: Build and Push to Docker Hub
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
       packages: write
@@ -57,6 +58,6 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64
-          # Use build-time annotations for better metadata
-          provenance: true
-          sbom: true
+          # Disable provenance and SBOM to prevent build hangs
+          provenance: false
+          sbom: false


### PR DESCRIPTION
- Disabled provenance and SBOM attestations which are known to cause build hangs in GitHub Actions with Docker Buildx
- Added 60-minute timeout to docker-publish job to prevent indefinite hangs
- These attestations were causing the Docker builds to hang indefinitely

Fixes the Docker build hang issue reported in the workflow runs.