### PR TITLE
ci: Add verbose output for Docker build debugging

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -50,6 +50,9 @@ jobs:
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
+        env:
+          # Enable verbose output for debugging build progress
+          BUILDKIT_PROGRESS: plain
         with:
           context: .
           push: true


### PR DESCRIPTION
## Summary
- Enable `BUILDKIT_PROGRESS=plain` to show detailed build progress in CI logs
- This will help identify where the Docker build is getting stuck/timing out

## Background
Local Docker builds complete in ~11 minutes, but CI builds timeout at 60+ minutes. With verbose output enabled, we can see exactly which build step is taking too long.

## Test plan
- [ ] Merge this PR
- [ ] Trigger a Docker Publish workflow run (manual dispatch)
- [ ] Check the build logs to see detailed progress output
- [ ] Identify the bottleneck step

🤖 Generated with [Claude Code](https://claude.com/claude-code)