### PR TITLE
chore: Bump version to 0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4724,7 +4724,7 @@ checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 
 [[package]]
 name = "strom-backend"
-version = "0.1.0"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4760,7 +4760,7 @@ dependencies = [
 
 [[package]]
 name = "strom-frontend"
-version = "0.1.0"
+version = "0.1.3"
 dependencies = [
  "console_error_panic_hook",
  "eframe",
@@ -4785,7 +4785,7 @@ dependencies = [
 
 [[package]]
 name = "strom-mcp-server"
-version = "0.1.0"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "reqwest",
@@ -4799,7 +4799,7 @@ dependencies = [
 
 [[package]]
 name = "strom-types"
-version = "0.1.0"
+version = "0.1.3"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["types", "backend", "frontend", "mcp-server"]
 default-members = ["backend"]
 
 [workspace.package]
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Per"]


### PR DESCRIPTION
## Summary
- Bump version from 0.1.2 to 0.1.3

## Changes
- Update workspace version in Cargo.toml
- Update Cargo.lock

## After merge
Tag `v0.1.3` to trigger Release and Docker Publish workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)