### PR TITLE
fix: Pass backend port to native GUI frontend

### DIFF
--- a/backend/src/gui.rs
+++ b/backend/src/gui.rs
@@ -6,23 +6,26 @@ use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 #[cfg(feature = "gui")]
-pub fn launch_gui() -> eframe::Result<()> {
-    tracing::info!("Launching native GUI...");
-    strom_frontend::run_native_gui()
+pub fn launch_gui(port: u16) -> eframe::Result<()> {
+    tracing::info!("Launching native GUI connecting to port {}...", port);
+    strom_frontend::run_native_gui(port)
 }
 
 #[cfg(feature = "gui")]
-pub fn launch_gui_with_shutdown(shutdown_flag: Arc<AtomicBool>) -> eframe::Result<()> {
-    tracing::info!("Launching native GUI with shutdown handler...");
-    strom_frontend::run_native_gui_with_shutdown(shutdown_flag)
+pub fn launch_gui_with_shutdown(port: u16, shutdown_flag: Arc<AtomicBool>) -> eframe::Result<()> {
+    tracing::info!(
+        "Launching native GUI with shutdown handler connecting to port {}...",
+        port
+    );
+    strom_frontend::run_native_gui_with_shutdown(port, shutdown_flag)
 }
 
 #[cfg(not(feature = "gui"))]
-pub fn launch_gui() -> Result<(), String> {
+pub fn launch_gui(_port: u16) -> Result<(), String> {
     Err("GUI feature not enabled. Rebuild with --features gui".to_string())
 }
 
 #[cfg(not(feature = "gui"))]
-pub fn launch_gui_with_shutdown(_shutdown_flag: Arc<AtomicBool>) -> Result<(), String> {
+pub fn launch_gui_with_shutdown(_port: u16, _shutdown_flag: Arc<AtomicBool>) -> Result<(), String> {
     Err("GUI feature not enabled. Rebuild with --features gui".to_string())
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -164,7 +164,7 @@ fn run_with_gui(
     let _guard = runtime.enter();
 
     // Run GUI on main thread (blocks until window closes)
-    if let Err(e) = strom_backend::gui::launch_gui_with_shutdown(shutdown_flag_gui) {
+    if let Err(e) = strom_backend::gui::launch_gui_with_shutdown(port, shutdown_flag_gui) {
         error!("GUI error: {:?}", e);
     }
 

--- a/frontend/src/app.rs
+++ b/frontend/src/app.rs
@@ -85,6 +85,9 @@ pub struct StromApp {
     /// Shutdown flag for Ctrl+C handling (native mode only)
     #[cfg(not(target_arch = "wasm32"))]
     shutdown_flag: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
+    /// Port number for backend connection (native mode only)
+    #[cfg(not(target_arch = "wasm32"))]
+    port: u16,
     /// Meter data storage for all audio level meters
     meter_data: MeterDataStore,
     /// Current theme preference
@@ -95,11 +98,12 @@ pub struct StromApp {
 
 impl StromApp {
     /// Create a new application instance.
+    /// For WASM, the port parameter is ignored (URL is detected from browser location).
+    #[cfg(target_arch = "wasm32")]
     pub fn new(cc: &eframe::CreationContext<'_>) -> Self {
         // Note: Dark theme is set in main.rs before creating the app
 
-        // Detect API base URL - different logic for WASM vs native
-        #[cfg(target_arch = "wasm32")]
+        // Detect API base URL from browser location
         let api_base_url = {
             // WASM: Detect if we're in development mode (trunk serve) by checking the window location
             if let Some(window) = web_sys::window() {
@@ -124,73 +128,28 @@ impl StromApp {
             }
         };
 
-        #[cfg(not(target_arch = "wasm32"))]
-        let api_base_url = "http://localhost:3000/api";
-
-        // Create channels for async communication
-        let channels = AppStateChannels::new();
-
-        let mut app = Self {
-            api: ApiClient::new(api_base_url),
-            flows: Vec::new(),
-            selected_flow_idx: None,
-            graph: GraphEditor::new(),
-            palette: ElementPalette::new(),
-            status: "Ready".to_string(),
-            error: None,
-            loading: false,
-            needs_refresh: true,
-            new_flow_name: String::new(),
-            show_new_flow_dialog: false,
-            elements_loaded: false,
-            blocks_loaded: false,
-            flow_pending_deletion: None,
-            ws_client: None,
-            connection_state: ConnectionState::Disconnected,
-            channels,
-            editing_properties_idx: None,
-            properties_name_buffer: String::new(),
-            properties_description_buffer: String::new(),
-            properties_clock_type_buffer: strom_types::flow::GStreamerClockType::Monotonic,
-            properties_ptp_domain_buffer: String::new(),
-            #[cfg(not(target_arch = "wasm32"))]
-            shutdown_flag: None,
-            meter_data: MeterDataStore::new(),
-            theme_preference: ThemePreference::System,
-            version_info: None,
-        };
-
-        // Apply initial theme based on system preference
-        app.apply_theme(cc.egui_ctx.clone());
-
-        // Load default elements temporarily (will be replaced by API data)
-        app.palette.load_default_elements();
-
-        // Set up WebSocket connection for real-time updates
-        app.setup_websocket_connection(cc.egui_ctx.clone());
-
-        //Load version info
-        app.load_version(cc.egui_ctx.clone());
-
-        app
+        Self::new_internal(cc, api_base_url, None)
     }
 
-    /// Create a new application instance with shutdown handler (native mode only).
+    /// Create a new application instance for native mode.
     #[cfg(not(target_arch = "wasm32"))]
-    pub fn new_with_shutdown(
+    pub fn new(cc: &eframe::CreationContext<'_>, port: u16) -> Self {
+        let api_base_url = format!("http://localhost:{}/api", port);
+        Self::new_internal(cc, api_base_url, None, port)
+    }
+
+    /// Internal constructor shared by all creation methods (WASM version).
+    #[cfg(target_arch = "wasm32")]
+    fn new_internal(
         cc: &eframe::CreationContext<'_>,
-        shutdown_flag: std::sync::Arc<std::sync::atomic::AtomicBool>,
+        api_base_url: String,
+        _shutdown_flag: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
     ) -> Self {
-        // Note: Dark theme is set in main.rs before creating the app
-
-        // Detect API base URL - different logic for WASM vs native
-        let api_base_url = "http://localhost:3000/api";
-
         // Create channels for async communication
         let channels = AppStateChannels::new();
 
         let mut app = Self {
-            api: ApiClient::new(api_base_url),
+            api: ApiClient::new(&api_base_url),
             flows: Vec::new(),
             selected_flow_idx: None,
             graph: GraphEditor::new(),
@@ -212,7 +171,6 @@ impl StromApp {
             properties_description_buffer: String::new(),
             properties_clock_type_buffer: strom_types::flow::GStreamerClockType::Monotonic,
             properties_ptp_domain_buffer: String::new(),
-            shutdown_flag: Some(shutdown_flag),
             meter_data: MeterDataStore::new(),
             theme_preference: ThemePreference::System,
             version_info: None,
@@ -231,6 +189,73 @@ impl StromApp {
         app.load_version(cc.egui_ctx.clone());
 
         app
+    }
+
+    /// Internal constructor shared by all creation methods (native version).
+    #[cfg(not(target_arch = "wasm32"))]
+    fn new_internal(
+        cc: &eframe::CreationContext<'_>,
+        api_base_url: String,
+        shutdown_flag: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
+        port: u16,
+    ) -> Self {
+        // Create channels for async communication
+        let channels = AppStateChannels::new();
+
+        let mut app = Self {
+            api: ApiClient::new(&api_base_url),
+            flows: Vec::new(),
+            selected_flow_idx: None,
+            graph: GraphEditor::new(),
+            palette: ElementPalette::new(),
+            status: "Ready".to_string(),
+            error: None,
+            loading: false,
+            needs_refresh: true,
+            new_flow_name: String::new(),
+            show_new_flow_dialog: false,
+            elements_loaded: false,
+            blocks_loaded: false,
+            flow_pending_deletion: None,
+            ws_client: None,
+            connection_state: ConnectionState::Disconnected,
+            channels,
+            editing_properties_idx: None,
+            properties_name_buffer: String::new(),
+            properties_description_buffer: String::new(),
+            properties_clock_type_buffer: strom_types::flow::GStreamerClockType::Monotonic,
+            properties_ptp_domain_buffer: String::new(),
+            shutdown_flag,
+            port,
+            meter_data: MeterDataStore::new(),
+            theme_preference: ThemePreference::System,
+            version_info: None,
+        };
+
+        // Apply initial theme based on system preference
+        app.apply_theme(cc.egui_ctx.clone());
+
+        // Load default elements temporarily (will be replaced by API data)
+        app.palette.load_default_elements();
+
+        // Set up WebSocket connection for real-time updates
+        app.setup_websocket_connection(cc.egui_ctx.clone());
+
+        // Load version info
+        app.load_version(cc.egui_ctx.clone());
+
+        app
+    }
+
+    /// Create a new application instance with shutdown handler (native mode only).
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn new_with_shutdown(
+        cc: &eframe::CreationContext<'_>,
+        port: u16,
+        shutdown_flag: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    ) -> Self {
+        let api_base_url = format!("http://localhost:{}/api", port);
+        Self::new_internal(cc, api_base_url, Some(shutdown_flag), port)
     }
 
     /// Apply the current theme preference to the UI context.
@@ -298,7 +323,7 @@ impl StromApp {
         };
 
         #[cfg(not(target_arch = "wasm32"))]
-        let ws_url = "ws://localhost:3000/api/ws".to_string();
+        let ws_url = format!("ws://localhost:{}/api/ws", self.port);
 
         tracing::info!("Connecting WebSocket to: {}", ws_url);
         let mut ws_client = WebSocketClient::new(ws_url);

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -19,32 +19,11 @@ pub use app::StromApp;
 
 // Re-export the native entry point (without tracing init - parent should handle that)
 #[cfg(not(target_arch = "wasm32"))]
-pub fn run_native_gui() -> eframe::Result<()> {
-    tracing::info!("Initializing Strom frontend (embedded mode)");
-
-    let native_options = eframe::NativeOptions {
-        viewport: egui::ViewportBuilder::default()
-            .with_inner_size([1280.0, 720.0])
-            .with_title("Strom - GStreamer Flow Engine"),
-        ..Default::default()
-    };
-
-    eframe::run_native(
-        "Strom",
-        native_options,
-        Box::new(|cc| {
-            // Theme is now set by the app based on user preference
-            Ok(Box::new(StromApp::new(cc)))
-        }),
-    )
-}
-
-// Native entry point with shutdown handler for Ctrl+C
-#[cfg(not(target_arch = "wasm32"))]
-pub fn run_native_gui_with_shutdown(
-    shutdown_flag: std::sync::Arc<std::sync::atomic::AtomicBool>,
-) -> eframe::Result<()> {
-    tracing::info!("Initializing Strom frontend (embedded mode with shutdown handler)");
+pub fn run_native_gui(port: u16) -> eframe::Result<()> {
+    tracing::info!(
+        "Initializing Strom frontend (embedded mode) connecting to port {}",
+        port
+    );
 
     let native_options = eframe::NativeOptions {
         viewport: egui::ViewportBuilder::default()
@@ -58,7 +37,39 @@ pub fn run_native_gui_with_shutdown(
         native_options,
         Box::new(move |cc| {
             // Theme is now set by the app based on user preference
-            Ok(Box::new(StromApp::new_with_shutdown(cc, shutdown_flag)))
+            Ok(Box::new(StromApp::new(cc, port)))
+        }),
+    )
+}
+
+// Native entry point with shutdown handler for Ctrl+C
+#[cfg(not(target_arch = "wasm32"))]
+pub fn run_native_gui_with_shutdown(
+    port: u16,
+    shutdown_flag: std::sync::Arc<std::sync::atomic::AtomicBool>,
+) -> eframe::Result<()> {
+    tracing::info!(
+        "Initializing Strom frontend (embedded mode with shutdown handler) connecting to port {}",
+        port
+    );
+
+    let native_options = eframe::NativeOptions {
+        viewport: egui::ViewportBuilder::default()
+            .with_inner_size([1280.0, 720.0])
+            .with_title("Strom - GStreamer Flow Engine"),
+        ..Default::default()
+    };
+
+    eframe::run_native(
+        "Strom",
+        native_options,
+        Box::new(move |cc| {
+            // Theme is now set by the app based on user preference
+            Ok(Box::new(StromApp::new_with_shutdown(
+                cc,
+                port,
+                shutdown_flag,
+            )))
         }),
     )
 }


### PR DESCRIPTION
## Summary

- Adds port parameter to `run_native_gui()` and `run_native_gui_with_shutdown()` in frontend
- Adds port field to `StromApp` struct (native mode only)
- Passes port from backend `main.rs` through `gui.rs` to frontend
- Uses configurable port for both API and WebSocket connections

## Problem

When starting the strom-backend on a non-default port (e.g., `--port 3001` or `STROM_PORT=3001`), the native egui frontend was still hardcoded to connect to port 3000, causing the GUI to fail to communicate with the backend.

## Solution

The port is now passed from the backend through the GUI launcher to the frontend app, which uses it to construct the correct API and WebSocket URLs.

## Test plan

- [x] Build with `cargo run --features gui -- --port 3001`
- [x] Verify logs show: `Launching native GUI with shutdown handler connecting to port 3001...`
- [x] Verify logs show: `Server listening on 0.0.0.0:3001`
- [ ] Manual test: Verify GUI connects and loads flows correctly on custom port

🤖 Generated with [Claude Code](https://claude.com/claude-code)