### PR TITLE
fix: Switch Docker cache from registry to GitHub Actions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -58,9 +58,9 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          # Use registry cache stored in Docker Hub for better reliability
-          cache-from: type=registry,ref=${{ env.IMAGE_NAME }}:buildcache
-          cache-to: type=registry,ref=${{ env.IMAGE_NAME }}:buildcache,mode=max
+          # Use GitHub Actions cache (much faster than registry cache)
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           platforms: linux/amd64
           # Disable provenance and SBOM to prevent build hangs
           provenance: false


### PR DESCRIPTION
## Summary
Switch from registry cache (`type=registry`) to GitHub Actions cache (`type=gha`) for Docker builds.

## Problem
Docker builds were hanging/timing out at 60+ minutes while local builds complete in ~11 minutes.

The **registry cache** was the culprit:
- Requires pulling cache layers from Docker Hub (slow network I/O)
- Cache images may not exist or be stale
- Every layer check requires network round-trip
- Not optimized for GitHub Actions environment

## Solution
Switch to **GitHub Actions cache** (`type=gha`):
- Native to GitHub Actions infrastructure
- Much faster (local to runner)
- Automatically managed by GitHub
- No external network dependencies for cache

## Expected Result
Build times should drop from 60+ minutes to ~15-20 minutes (accounting for GitHub runner being slower than local machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)