### PR TITLE
refactor: Centralize default port constant in strom-types

### DIFF
--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -48,7 +48,7 @@ impl Config {
         let port = env::var("STROM_PORT")
             .ok()
             .and_then(|p| p.parse().ok())
-            .unwrap_or(3000);
+            .unwrap_or(strom_types::DEFAULT_PORT);
 
         let data_dir = env::var("STROM_DATA_DIR").ok().map(PathBuf::from);
         let flows_path = env::var("STROM_FLOWS_PATH").ok().map(PathBuf::from);
@@ -64,7 +64,7 @@ impl Default for Config {
         Self::from_env().unwrap_or_else(|_| {
             // Ultimate fallback (should rarely happen)
             Self {
-                port: 3000,
+                port: strom_types::DEFAULT_PORT,
                 flows_path: PathBuf::from("flows.json"),
                 blocks_path: PathBuf::from("blocks.json"),
             }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -55,7 +55,7 @@ struct Args {
     command: Option<Commands>,
 
     /// Port to listen on
-    #[arg(short, long, env = "STROM_PORT", default_value = "3000")]
+    #[arg(short, long, env = "STROM_PORT", default_value_t = strom_types::DEFAULT_PORT)]
     port: u16,
 
     /// Data directory (contains flows.json and blocks.json)

--- a/frontend/src/main.rs
+++ b/frontend/src/main.rs
@@ -88,7 +88,7 @@ fn main() -> eframe::Result<()> {
         native_options,
         Box::new(|cc| {
             // Theme is now set by the app based on user preference
-            Ok(Box::new(StromApp::new(cc)))
+            Ok(Box::new(StromApp::new(cc, strom_types::DEFAULT_PORT)))
         }),
     )
 }

--- a/mcp-server/src/main.rs
+++ b/mcp-server/src/main.rs
@@ -523,8 +523,8 @@ async fn main() -> Result<()> {
         .init();
 
     // Get Strom API URL from environment or use default
-    let api_url =
-        std::env::var("STROM_API_URL").unwrap_or_else(|_| "http://localhost:3000".to_string());
+    let api_url = std::env::var("STROM_API_URL")
+        .unwrap_or_else(|_| format!("http://localhost:{}", strom_types::DEFAULT_PORT));
 
     info!("Starting Strom MCP Server");
     info!("Connecting to Strom API at: {}", api_url);

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -3,6 +3,9 @@
 //! This crate contains domain models and API types shared between
 //! the backend and frontend components.
 
+/// Default port for the Strom backend server.
+pub const DEFAULT_PORT: u16 = 3000;
+
 pub mod api;
 pub mod block;
 pub mod element;


### PR DESCRIPTION
## Summary
- Add `DEFAULT_PORT` constant (3000) to `strom-types` crate
- Update all code references to use the centralized constant instead of hardcoded values

## Changes
- `types/src/lib.rs`: Add `pub const DEFAULT_PORT: u16 = 3000;`
- `backend/src/main.rs`: Use `strom_types::DEFAULT_PORT` for CLI default
- `backend/src/config.rs`: Use constant in env var fallback and default impl
- `frontend/src/main.rs`: Use constant for native mode default
- `mcp-server/src/main.rs`: Use constant in API URL default

This ensures the default port 3000 is defined in one place, making it easier to change if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)