### PR TITLE
chore: bump version to 0.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4800,7 +4800,7 @@ checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 
 [[package]]
 name = "strom-backend"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4838,7 +4838,7 @@ dependencies = [
 
 [[package]]
 name = "strom-frontend"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "console_error_panic_hook",
  "eframe",
@@ -4863,7 +4863,7 @@ dependencies = [
 
 [[package]]
 name = "strom-mcp-server"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "reqwest",
@@ -4877,7 +4877,7 @@ dependencies = [
 
 [[package]]
 name = "strom-types"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["types", "backend", "frontend", "mcp-server"]
 default-members = ["backend"]
 
 [workspace.package]
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Per"]


### PR DESCRIPTION
## Summary
Bump version to 0.1.4 for release with Docker CI fix.

## Changes since v0.1.3
- Fix Docker CI builds that were hanging (PR #25)
- Centralize default port constant (PR #24)

## Release Process
After merging this PR:
1. Create tag: `git tag v0.1.4`
2. Push tag: `git push origin v0.1.4`
3. This triggers:
   - `release.yml` → builds binaries → creates GitHub Release
   - `docker-publish.yml` → builds & pushes Docker image

🤖 Generated with [Claude Code](https://claude.com/claude-code)