### PR TITLE
Fix Docker CI: Limit cargo parallelism to prevent OOM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,10 @@ RUN curl -L https://github.com/trunk-rs/trunk/releases/download/v0.21.5/trunk-x8
 # Add WASM target for frontend compilation
 RUN rustup target add wasm32-unknown-unknown
 
+# Limit parallelism to avoid OOM during gst-plugin-webrtc compilation in CI
+# Set before chef cook so build environment matches
+ENV CARGO_BUILD_JOBS=2
+
 # Copy recipe and build dependencies (this layer is cached)
 COPY --from=planner /app/recipe.json recipe.json
 RUN cargo chef cook --release --recipe-path recipe.json


### PR DESCRIPTION
## Summary
- Set `CARGO_BUILD_JOBS=2` in Dockerfile to limit build parallelism
- Prevents memory exhaustion during `gst-plugin-webrtc` compilation in CI

## Problem
The Docker Publish workflow was hanging for 26+ minutes compiling `gst-plugin-webrtc`. This is likely due to memory pressure in the GitHub Actions Docker buildx environment, where the default parallelism level causes too many concurrent compilation units.

## Solution
Added `ENV CARGO_BUILD_JOBS=2` before the cargo build commands to limit parallelism and reduce memory pressure. This should allow the build to complete successfully, albeit slower.

## Testing
- Previous Docker builds were hanging indefinitely
- This fix should allow builds to complete within the 60-minute timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)