### PR TITLE
feat: Add 6 GUI improvements for flow management and monitoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2924,6 +2924,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4846,6 +4855,7 @@ dependencies = [
  "futures-util",
  "gloo-net",
  "gloo-timers",
+ "instant",
  "reqwest",
  "serde",
  "serde_json",

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -83,6 +83,7 @@ pub async fn create_app_with_state_and_auth(
         )
         .route("/flows/{id}/start", post(api::flows::start_flow))
         .route("/flows/{id}/stop", post(api::flows::stop_flow))
+        .route("/flows/{id}/latency", get(api::flows::get_flow_latency))
         .route("/flows/{id}/debug-graph", get(api::flows::debug_graph))
         .route(
             "/flows/{id}/properties",

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -627,6 +627,13 @@ impl AppState {
 
         manager.get_pad_property(element_id, pad_name, property_name)
     }
+
+    /// Query the latency of a running pipeline.
+    /// Returns (min_latency_ns, max_latency_ns, live) if query succeeds.
+    pub async fn get_flow_latency(&self, flow_id: &FlowId) -> Option<(u64, u64, bool)> {
+        let pipelines = self.inner.pipelines.read().await;
+        pipelines.get(flow_id).and_then(|p| p.query_latency())
+    }
 }
 
 impl Default for AppState {

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -27,6 +27,9 @@ uuid.workspace = true
 # Async utilities
 futures-util = { version = "0.3", default-features = false, features = ["std"] }
 
+# Cross-platform time (works on both native and WASM)
+instant = "0.1"
+
 # Logging
 tracing.workspace = true
 

--- a/frontend/src/app.rs
+++ b/frontend/src/app.rs
@@ -67,6 +67,8 @@ pub struct StromApp {
     blocks_loaded: bool,
     /// Flow pending deletion (for confirmation dialog)
     flow_pending_deletion: Option<(strom_types::FlowId, String)>,
+    /// Flow pending copy (to be processed after render)
+    flow_pending_copy: Option<Flow>,
     /// WebSocket client for real-time updates
     ws_client: Option<WebSocketClient>,
     /// Connection state
@@ -104,6 +106,16 @@ pub struct StromApp {
     auth_status: Option<AuthStatusResponse>,
     /// Whether we're checking auth status
     checking_auth: bool,
+    /// Show import flow dialog
+    show_import_dialog: bool,
+    /// Buffer for import JSON text
+    import_json_buffer: String,
+    /// Error message for import dialog
+    import_error: Option<String>,
+    /// Cached latency info for flows (flow_id -> LatencyInfo)
+    latency_cache: std::collections::HashMap<String, crate::api::LatencyInfo>,
+    /// Last time latency was fetched (for periodic refresh)
+    last_latency_fetch: instant::Instant,
 }
 
 impl StromApp {
@@ -173,6 +185,7 @@ impl StromApp {
             elements_loaded: false,
             blocks_loaded: false,
             flow_pending_deletion: None,
+            flow_pending_copy: None,
             ws_client: None,
             connection_state: ConnectionState::Disconnected,
             channels,
@@ -187,6 +200,11 @@ impl StromApp {
             login_screen: LoginScreen::default(),
             auth_status: None,
             checking_auth: false,
+            show_import_dialog: false,
+            import_json_buffer: String::new(),
+            import_error: None,
+            latency_cache: std::collections::HashMap::new(),
+            last_latency_fetch: instant::Instant::now(),
         };
 
         // Apply initial theme based on system preference
@@ -228,6 +246,7 @@ impl StromApp {
             elements_loaded: false,
             blocks_loaded: false,
             flow_pending_deletion: None,
+            flow_pending_copy: None,
             ws_client: None,
             connection_state: ConnectionState::Disconnected,
             channels,
@@ -245,6 +264,11 @@ impl StromApp {
             login_screen: LoginScreen::default(),
             auth_status: None,
             checking_auth: false,
+            show_import_dialog: false,
+            import_json_buffer: String::new(),
+            import_error: None,
+            latency_cache: std::collections::HashMap::new(),
+            last_latency_fetch: instant::Instant::now(),
         };
 
         // Apply initial theme based on system preference
@@ -634,6 +658,47 @@ impl StromApp {
         });
     }
 
+    /// Fetch latency for all running flows.
+    fn fetch_latency_for_running_flows(&self, ctx: &Context) {
+        use strom_types::PipelineState;
+
+        // Find all flows that are currently playing
+        let running_flows: Vec<_> = self
+            .flows
+            .iter()
+            .filter(|f| f.state == Some(PipelineState::Playing))
+            .map(|f| f.id)
+            .collect();
+
+        if running_flows.is_empty() {
+            return;
+        }
+
+        // Fetch latency for each running flow
+        for flow_id in running_flows {
+            let api = self.api.clone();
+            let tx = self.channels.sender();
+            let ctx = ctx.clone();
+            let flow_id_str = flow_id.to_string();
+
+            spawn_task(async move {
+                match api.get_flow_latency(flow_id).await {
+                    Ok(latency) => {
+                        let _ = tx.send(AppMessage::LatencyLoaded {
+                            flow_id: flow_id_str,
+                            latency,
+                        });
+                    }
+                    Err(_) => {
+                        // Flow not running or latency not available - silently ignore
+                        let _ = tx.send(AppMessage::LatencyNotAvailable(flow_id_str));
+                    }
+                }
+                ctx.request_repaint();
+            });
+        }
+    }
+
     /// Save the current flow to the backend.
     fn save_current_flow(&mut self, ctx: &Context) {
         tracing::info!(
@@ -658,6 +723,7 @@ impl StromApp {
 
                 let flow_clone = flow.clone();
                 let api = self.api.clone();
+                let tx = self.channels.sender();
                 let ctx = ctx.clone();
 
                 self.status = "Saving flow...".to_string();
@@ -669,9 +735,15 @@ impl StromApp {
                             tracing::info!(
                                 "Flow saved successfully - WebSocket event will trigger refresh"
                             );
+                            let _ =
+                                tx.send(AppMessage::FlowOperationSuccess("Flow saved".to_string()));
                         }
                         Err(e) => {
                             tracing::error!("Failed to save flow: {}", e);
+                            let _ = tx.send(AppMessage::FlowOperationError(format!(
+                                "Failed to save flow: {}",
+                                e
+                            )));
                         }
                     }
                     ctx.request_repaint();
@@ -693,6 +765,7 @@ impl StromApp {
 
         let new_flow = Flow::new(self.new_flow_name.clone());
         let api = self.api.clone();
+        let tx = self.channels.sender();
         let ctx = ctx.clone();
 
         self.status = "Creating flow...".to_string();
@@ -706,9 +779,17 @@ impl StromApp {
                         "Flow created successfully: {} - WebSocket event will trigger refresh",
                         created_flow.name
                     );
+                    let _ = tx.send(AppMessage::FlowOperationSuccess(format!(
+                        "Flow '{}' created",
+                        created_flow.name
+                    )));
                 }
                 Err(e) => {
                     tracing::error!("Failed to create flow: {}", e);
+                    let _ = tx.send(AppMessage::FlowOperationError(format!(
+                        "Failed to create flow: {}",
+                        e
+                    )));
                 }
             }
             ctx.request_repaint();
@@ -720,6 +801,7 @@ impl StromApp {
         if let Some(flow) = self.current_flow() {
             let flow_id = flow.id;
             let api = self.api.clone();
+            let tx = self.channels.sender();
             let ctx = ctx.clone();
 
             self.status = "Starting flow...".to_string();
@@ -730,9 +812,15 @@ impl StromApp {
                         tracing::info!(
                             "Flow started successfully - WebSocket event will trigger refresh"
                         );
+                        let _ =
+                            tx.send(AppMessage::FlowOperationSuccess("Flow started".to_string()));
                     }
                     Err(e) => {
                         tracing::error!("Failed to start flow: {}", e);
+                        let _ = tx.send(AppMessage::FlowOperationError(format!(
+                            "Failed to start flow: {}",
+                            e
+                        )));
                     }
                 }
                 ctx.request_repaint();
@@ -745,6 +833,7 @@ impl StromApp {
         if let Some(flow) = self.current_flow() {
             let flow_id = flow.id;
             let api = self.api.clone();
+            let tx = self.channels.sender();
             let ctx = ctx.clone();
 
             self.status = "Stopping flow...".to_string();
@@ -755,9 +844,15 @@ impl StromApp {
                         tracing::info!(
                             "Flow stopped successfully - WebSocket event will trigger refresh"
                         );
+                        let _ =
+                            tx.send(AppMessage::FlowOperationSuccess("Flow stopped".to_string()));
                     }
                     Err(e) => {
                         tracing::error!("Failed to stop flow: {}", e);
+                        let _ = tx.send(AppMessage::FlowOperationError(format!(
+                            "Failed to stop flow: {}",
+                            e
+                        )));
                     }
                 }
                 ctx.request_repaint();
@@ -768,6 +863,7 @@ impl StromApp {
     /// Delete a flow.
     fn delete_flow(&mut self, flow_id: strom_types::FlowId, ctx: &Context) {
         let api = self.api.clone();
+        let tx = self.channels.sender();
         let ctx = ctx.clone();
 
         self.status = "Deleting flow...".to_string();
@@ -778,9 +874,14 @@ impl StromApp {
                     tracing::info!(
                         "Flow deleted successfully - WebSocket event will trigger refresh"
                     );
+                    let _ = tx.send(AppMessage::FlowOperationSuccess("Flow deleted".to_string()));
                 }
                 Err(e) => {
                     tracing::error!("Failed to delete flow: {}", e);
+                    let _ = tx.send(AppMessage::FlowOperationError(format!(
+                        "Failed to delete flow: {}",
+                        e
+                    )));
                 }
             }
             ctx.request_repaint();
@@ -796,6 +897,12 @@ impl StromApp {
 
                 if ui.button("New Flow").clicked() {
                     self.show_new_flow_dialog = true;
+                }
+
+                if ui.button("Import").clicked() {
+                    self.show_import_dialog = true;
+                    self.import_json_buffer.clear();
+                    self.import_error = None;
                 }
 
                 if ui.button("Refresh").clicked() {
@@ -822,10 +929,18 @@ impl StromApp {
                     };
 
                     ui.colored_label(state_color, format!("State: {}", state_text));
+
+                    // Show latency for running flows
+                    let is_running = matches!(state, PipelineState::Playing);
+                    if is_running {
+                        if let Some(latency) = self.latency_cache.get(&flow_id.to_string()) {
+                            ui.label(format!("Latency: {}", latency.min_latency_formatted));
+                        }
+                    }
+
                     ui.separator();
 
                     // Show Start or Restart button depending on state
-                    let is_running = matches!(state, PipelineState::Playing);
                     let button_text = if is_running {
                         "🔄 Restart"
                     } else {
@@ -836,6 +951,7 @@ impl StromApp {
                         if is_running {
                             // For restart: stop first, then start
                             let api = self.api.clone();
+                            let tx = self.channels.sender();
                             let ctx_clone = ctx.clone();
 
                             self.status = "Restarting flow...".to_string();
@@ -849,17 +965,20 @@ impl StromApp {
                                         match api.start_flow(flow_id).await {
                                             Ok(_) => {
                                                 tracing::info!("Flow restarted successfully - WebSocket events will trigger refresh");
+                                                let _ = tx.send(AppMessage::FlowOperationSuccess("Flow restarted".to_string()));
                                             }
                                             Err(e) => {
                                                 tracing::error!(
                                                     "Failed to start flow after stop: {}",
                                                     e
                                                 );
+                                                let _ = tx.send(AppMessage::FlowOperationError(format!("Failed to restart flow: {}", e)));
                                             }
                                         }
                                     }
                                     Err(e) => {
                                         tracing::error!("Failed to stop flow for restart: {}", e);
+                                        let _ = tx.send(AppMessage::FlowOperationError(format!("Failed to restart flow: {}", e)));
                                     }
                                 }
                                 ctx_clone.request_repaint();
@@ -1066,6 +1185,29 @@ impl StromApp {
                                 ui.add_space(4.0);
                                 if ui.small_button("🗑").on_hover_text("Delete flow").clicked() {
                                     self.flow_pending_deletion = Some((flow.id, flow.name.clone()));
+                                }
+                                if ui.small_button("📋").on_hover_text("Copy flow").clicked() {
+                                    self.flow_pending_copy = Some(flow.clone());
+                                }
+                                if ui
+                                    .small_button("📤")
+                                    .on_hover_text("Export flow to clipboard")
+                                    .clicked()
+                                {
+                                    // Serialize flow to JSON and copy to clipboard
+                                    match serde_json::to_string_pretty(flow) {
+                                        Ok(json) => {
+                                            ui.ctx().copy_text(json);
+                                            self.status = format!(
+                                                "Flow '{}' exported to clipboard",
+                                                flow.name
+                                            );
+                                        }
+                                        Err(e) => {
+                                            self.error =
+                                                Some(format!("Failed to export flow: {}", e));
+                                        }
+                                    }
                                 }
                                 if ui
                                     .small_button("⚙")
@@ -1644,6 +1786,261 @@ impl StromApp {
             });
     }
 
+    /// Render the import flow dialog.
+    fn render_import_dialog(&mut self, ctx: &Context) {
+        if !self.show_import_dialog {
+            return;
+        }
+
+        egui::Window::new("Import Flow")
+            .collapsible(false)
+            .resizable(true)
+            .default_width(500.0)
+            .default_height(400.0)
+            .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
+            .show(ctx, |ui| {
+                ui.label("Paste flow JSON below:");
+                ui.add_space(5.0);
+
+                // Large text area for JSON input
+                egui::ScrollArea::vertical()
+                    .max_height(300.0)
+                    .show(ui, |ui| {
+                        ui.add(
+                            egui::TextEdit::multiline(&mut self.import_json_buffer)
+                                .desired_width(f32::INFINITY)
+                                .desired_rows(15)
+                                .font(egui::TextStyle::Monospace)
+                                .hint_text("Paste flow JSON here..."),
+                        );
+                    });
+
+                // Show error if any
+                if let Some(ref error) = self.import_error {
+                    ui.add_space(5.0);
+                    ui.colored_label(Color32::RED, error);
+                }
+
+                ui.add_space(10.0);
+
+                ui.horizontal(|ui| {
+                    if ui.button("📥 Import").clicked() {
+                        self.import_flow_from_json(ctx);
+                    }
+
+                    if ui.button("Cancel").clicked() {
+                        self.show_import_dialog = false;
+                        self.import_json_buffer.clear();
+                        self.import_error = None;
+                    }
+                });
+            });
+    }
+
+    /// Import a flow from the JSON buffer.
+    /// Note: The backend's create_flow only takes a name, so we create first then update.
+    fn import_flow_from_json(&mut self, ctx: &Context) {
+        if self.import_json_buffer.trim().is_empty() {
+            self.import_error = Some("Please paste flow JSON first".to_string());
+            return;
+        }
+
+        // Try to parse the JSON as a Flow
+        match serde_json::from_str::<Flow>(&self.import_json_buffer) {
+            Ok(flow) => {
+                // Regenerate all IDs to avoid conflicts
+                let flow = Self::regenerate_flow_ids(flow);
+
+                let api = self.api.clone();
+                let tx = self.channels.sender();
+                let ctx = ctx.clone();
+                let flow_name = flow.name.clone();
+
+                self.status = format!("Importing flow '{}'...", flow_name);
+                self.show_import_dialog = false;
+                self.import_json_buffer.clear();
+                self.import_error = None;
+
+                spawn_task(async move {
+                    // Step 1: Create an empty flow with the name
+                    match api.create_flow(&flow).await {
+                        Ok(created_flow) => {
+                            tracing::info!(
+                                "Empty flow created: {} ({}), now updating with content...",
+                                created_flow.name,
+                                created_flow.id
+                            );
+
+                            // Step 2: Update the created flow with the full content
+                            let mut full_flow = flow.clone();
+                            full_flow.id = created_flow.id;
+
+                            match api.update_flow(&full_flow).await {
+                                Ok(_) => {
+                                    tracing::info!(
+                                        "Flow imported successfully: {} - WebSocket event will trigger refresh",
+                                        flow_name
+                                    );
+                                    let _ = tx.send(AppMessage::FlowOperationSuccess(format!(
+                                        "Flow '{}' imported",
+                                        flow_name
+                                    )));
+                                }
+                                Err(e) => {
+                                    tracing::error!(
+                                        "Failed to update imported flow with content: {}",
+                                        e
+                                    );
+                                    let _ = tx.send(AppMessage::FlowOperationError(format!(
+                                        "Failed to import flow: {}",
+                                        e
+                                    )));
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            tracing::error!("Failed to create flow for import: {}", e);
+                            let _ = tx.send(AppMessage::FlowOperationError(format!(
+                                "Failed to import flow: {}",
+                                e
+                            )));
+                        }
+                    }
+                    ctx.request_repaint();
+                });
+            }
+            Err(e) => {
+                self.import_error = Some(format!("Invalid JSON: {}", e));
+            }
+        }
+    }
+
+    /// Regenerate all IDs in a flow (flow ID, element IDs, block IDs) and update links.
+    /// This is used for both import and copy operations to avoid ID conflicts.
+    fn regenerate_flow_ids(mut flow: Flow) -> Flow {
+        use std::collections::HashMap;
+
+        // Generate new flow ID
+        flow.id = uuid::Uuid::new_v4();
+
+        // Reset state to Null
+        flow.state = Some(PipelineState::Null);
+
+        // Clear auto_restart flag
+        flow.properties.auto_restart = false;
+
+        // Clear runtime data (e.g., SDP for AES67 blocks)
+        for block in &mut flow.blocks {
+            block.runtime_data = None;
+        }
+
+        // Build mapping of old IDs to new IDs for elements
+        let mut element_id_map: HashMap<String, String> = HashMap::new();
+        for element in &mut flow.elements {
+            let old_id = element.id.clone();
+            let new_id = format!("e{}", uuid::Uuid::new_v4().simple());
+            element_id_map.insert(old_id, new_id.clone());
+            element.id = new_id;
+        }
+
+        // Build mapping of old IDs to new IDs for blocks
+        let mut block_id_map: HashMap<String, String> = HashMap::new();
+        for block in &mut flow.blocks {
+            let old_id = block.id.clone();
+            let new_id = format!("b{}", uuid::Uuid::new_v4().simple());
+            block_id_map.insert(old_id, new_id.clone());
+            block.id = new_id;
+        }
+
+        // Update links to use new IDs
+        for link in &mut flow.links {
+            // Update 'from' reference (format: "element_id:pad_name")
+            if let Some((old_id, pad_name)) = link.from.split_once(':') {
+                if let Some(new_id) = element_id_map.get(old_id) {
+                    link.from = format!("{}:{}", new_id, pad_name);
+                } else if let Some(new_id) = block_id_map.get(old_id) {
+                    link.from = format!("{}:{}", new_id, pad_name);
+                }
+            }
+
+            // Update 'to' reference (format: "element_id:pad_name")
+            if let Some((old_id, pad_name)) = link.to.split_once(':') {
+                if let Some(new_id) = element_id_map.get(old_id) {
+                    link.to = format!("{}:{}", new_id, pad_name);
+                } else if let Some(new_id) = block_id_map.get(old_id) {
+                    link.to = format!("{}:{}", new_id, pad_name);
+                }
+            }
+        }
+
+        flow
+    }
+
+    /// Copy a flow with regenerated IDs and create it on the backend.
+    /// Note: The backend's create_flow only takes a name, so we create first then update.
+    fn copy_flow(&mut self, flow: &Flow, ctx: &Context) {
+        let mut flow_copy = flow.clone();
+
+        // Add " (copy)" suffix to the name
+        flow_copy.name = format!("{} (copy)", flow.name);
+
+        // Regenerate all IDs
+        let flow_copy = Self::regenerate_flow_ids(flow_copy);
+
+        let api = self.api.clone();
+        let tx = self.channels.sender();
+        let ctx = ctx.clone();
+        let flow_name = flow_copy.name.clone();
+
+        self.status = format!("Copying flow '{}'...", flow.name);
+
+        spawn_task(async move {
+            // Step 1: Create an empty flow with the name
+            match api.create_flow(&flow_copy).await {
+                Ok(created_flow) => {
+                    tracing::info!(
+                        "Empty flow created: {} ({}), now updating with content...",
+                        created_flow.name,
+                        created_flow.id
+                    );
+
+                    // Step 2: Update the created flow with the full content
+                    // Use the ID from the created flow
+                    let mut full_flow = flow_copy.clone();
+                    full_flow.id = created_flow.id;
+
+                    match api.update_flow(&full_flow).await {
+                        Ok(_) => {
+                            tracing::info!(
+                                "Flow copied successfully: {} - WebSocket event will trigger refresh",
+                                flow_name
+                            );
+                            let _ = tx.send(AppMessage::FlowOperationSuccess(format!(
+                                "Flow '{}' created",
+                                flow_name
+                            )));
+                        }
+                        Err(e) => {
+                            tracing::error!("Failed to update copied flow with content: {}", e);
+                            let _ = tx.send(AppMessage::FlowOperationError(format!(
+                                "Failed to copy flow: {}",
+                                e
+                            )));
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::error!("Failed to create flow for copy: {}", e);
+                    let _ = tx.send(AppMessage::FlowOperationError(format!(
+                        "Failed to copy flow: {}",
+                        e
+                    )));
+                }
+            }
+            ctx.request_repaint();
+        });
+    }
+
     /// Render the full-screen disconnect overlay when WebSocket is not connected.
     fn render_disconnect_overlay(&mut self, ctx: &Context) {
         CentralPanel::default().show(ctx, |ui| {
@@ -2035,6 +2432,28 @@ impl eframe::App for StromApp {
                         self.check_auth_status(ctx.clone());
                     }
                 }
+                AppMessage::FlowOperationSuccess(message) => {
+                    tracing::info!("Flow operation succeeded: {}", message);
+                    self.status = message;
+                    self.error = None;
+                }
+                AppMessage::FlowOperationError(message) => {
+                    tracing::error!("Flow operation failed: {}", message);
+                    self.status = "Ready".to_string();
+                    self.error = Some(message);
+                }
+                AppMessage::LatencyLoaded { flow_id, latency } => {
+                    tracing::debug!(
+                        "Latency loaded for flow {}: {}",
+                        flow_id,
+                        latency.min_latency_formatted
+                    );
+                    self.latency_cache.insert(flow_id, latency);
+                }
+                AppMessage::LatencyNotAvailable(flow_id) => {
+                    tracing::debug!("Latency not available for flow {}", flow_id);
+                    self.latency_cache.remove(&flow_id);
+                }
                 _ => {
                     tracing::debug!("Received unhandled AppMessage variant");
                 }
@@ -2075,6 +2494,12 @@ impl eframe::App for StromApp {
             self.needs_refresh = false;
         }
 
+        // Periodically fetch latency for running flows (every 2 seconds)
+        if self.last_latency_fetch.elapsed() > std::time::Duration::from_secs(2) {
+            self.last_latency_fetch = instant::Instant::now();
+            self.fetch_latency_for_running_flows(ctx);
+        }
+
         self.render_toolbar(ctx);
         self.render_flow_list(ctx);
 
@@ -2098,5 +2523,11 @@ impl eframe::App for StromApp {
         self.render_new_flow_dialog(ctx);
         self.render_delete_confirmation_dialog(ctx);
         self.render_flow_properties_dialog(ctx);
+        self.render_import_dialog(ctx);
+
+        // Process pending flow copy (after render to avoid borrow checker issues)
+        if let Some(flow) = self.flow_pending_copy.take() {
+            self.copy_flow(&flow, ctx);
+        }
     }
 }

--- a/frontend/src/state.rs
+++ b/frontend/src/state.rs
@@ -62,6 +62,19 @@ pub enum AppMessage {
     LoginResult(crate::api::LoginResponse),
     /// Logout completed
     LogoutComplete,
+
+    /// Flow operation completed successfully
+    FlowOperationSuccess(String),
+    /// Flow operation failed
+    FlowOperationError(String),
+
+    /// Latency loaded for a flow
+    LatencyLoaded {
+        flow_id: String,
+        latency: crate::api::LatencyInfo,
+    },
+    /// Latency loading failed (flow not running)
+    LatencyNotAvailable(String),
 }
 
 /// WebSocket connection state.

--- a/types/src/api.rs
+++ b/types/src/api.rs
@@ -122,6 +122,54 @@ pub struct PadPropertiesResponse {
 }
 
 // ============================================================================
+// Latency API Types
+// ============================================================================
+
+/// Response containing pipeline latency information.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct LatencyResponse {
+    /// Minimum latency in nanoseconds
+    pub min_latency_ns: u64,
+    /// Maximum latency in nanoseconds
+    pub max_latency_ns: u64,
+    /// Whether the pipeline is a live pipeline
+    pub live: bool,
+    /// Minimum latency formatted as human-readable string (e.g., "10.5 ms")
+    pub min_latency_formatted: String,
+    /// Maximum latency formatted as human-readable string
+    pub max_latency_formatted: String,
+}
+
+impl LatencyResponse {
+    /// Create a new latency response from raw values.
+    pub fn new(min_ns: u64, max_ns: u64, live: bool) -> Self {
+        Self {
+            min_latency_ns: min_ns,
+            max_latency_ns: max_ns,
+            live,
+            min_latency_formatted: Self::format_ns(min_ns),
+            max_latency_formatted: Self::format_ns(max_ns),
+        }
+    }
+
+    /// Format nanoseconds as a human-readable string.
+    fn format_ns(ns: u64) -> String {
+        if ns == 0 {
+            "0 ns".to_string()
+        } else if ns < 1_000 {
+            format!("{} ns", ns)
+        } else if ns < 1_000_000 {
+            format!("{:.2} µs", ns as f64 / 1_000.0)
+        } else if ns < 1_000_000_000 {
+            format!("{:.2} ms", ns as f64 / 1_000_000.0)
+        } else {
+            format!("{:.2} s", ns as f64 / 1_000_000_000.0)
+        }
+    }
+}
+
+// ============================================================================
 // WebSocket Message Types
 // ============================================================================
 


### PR DESCRIPTION
## Summary

- **Import flow** - Import flows from JSON via dialog with validation
- **Export flow** - Export flows to clipboard as JSON (📤 button)
- **Copy flow** - Duplicate flows with regenerated IDs (📋 button)
- **Latency display** - Show pipeline latency in toolbar for running flows
  - Backend queries pipeline latency with fallback for non-live pipelines
  - Queries sink elements and queue buffer levels for meaningful values
  - New `/api/flows/{id}/latency` endpoint
- **Meter TTL** - Audio meter data now expires after 500ms if not updated
- **Fixed auto-layout** - Only applies to graphs with 3+ nodes (skip trivial graphs)

Also adds FlowOperationSuccess/Error status messages for user feedback.

## Test plan

- [ ] Test import flow with valid JSON
- [ ] Test import flow with invalid JSON (should show error)
- [ ] Test export flow to clipboard
- [ ] Test copy flow creates duplicate with new IDs
- [ ] Verify latency displays for running flows
- [ ] Verify meter data clears when flow stops
- [ ] Verify auto-layout only triggers for 3+ node graphs

🤖 Generated with [Claude Code](https://claude.com/claude-code)