### PR TITLE
feat: Implement RFC 7273 clock signaling for AES67 SDP

### DIFF
--- a/backend/src/api/flows.rs
+++ b/backend/src/api/flows.rs
@@ -457,7 +457,15 @@ pub async fn get_block_sdp(
     }
 
     // Generate SDP (using default sample rate and channels since we can't query caps here)
-    let sdp = crate::blocks::sdp::generate_aes67_output_sdp(block, &flow.name, None, None);
+    // Pass flow properties for correct clock signaling (RFC 7273)
+    let sdp = crate::blocks::sdp::generate_aes67_output_sdp(
+        block,
+        &flow.name,
+        None,
+        None,
+        Some(&flow.properties),
+        None, // PTP clock identity not available at this point
+    );
 
     info!("Successfully generated SDP for block {}", block_id);
 

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -373,11 +373,14 @@ impl AppState {
                     channels.unwrap_or(2)
                 );
 
+                // Generate SDP with flow properties for correct clock signaling (RFC 7273)
                 let sdp = crate::blocks::sdp::generate_aes67_output_sdp(
                     block,
                     &flow.name,
                     sample_rate,
                     channels,
+                    Some(&flow.properties),
+                    None, // PTP clock identity - could be obtained from pipeline clock if needed
                 );
 
                 // Initialize runtime_data if needed

--- a/types/src/flow.rs
+++ b/types/src/flow.rs
@@ -71,6 +71,10 @@ pub struct FlowProperties {
     /// PTP domain (0-255, only used when clock_type is PTP)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ptp_domain: Option<u8>,
+    /// NTP server address (hostname or IP, only used when clock_type is NTP)
+    /// If not set but clock_type is NTP, will signal as "ntp=/traceable/"
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ntp_server: Option<String>,
     /// Clock synchronization status (updated by backend for running pipelines)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub clock_sync_status: Option<ClockSyncStatus>,


### PR DESCRIPTION
- Add proper ts-refclk attribute based on pipeline clock type:
  - PTP: ptp=IEEE1588-2008:<clock-identity>:<domain>
  - NTP: ntp=<server> or ntp=/traceable/
  - Local/Monotonic/Realtime: local
- Always use mediaclk:direct=0 for direct media timing
- Set pipeline base_time=0 and start_time=None for ALL clock types (not just PTP) to ensure RTP timestamps directly correspond to the reference clock
- Add ntp_server field to FlowProperties for NTP clock signaling
- Add comprehensive tests for clock signaling functions

Combined with the existing timestamp-offset=0 on the RTP payloader, this ensures GStreamer generates correct RTP timestamps for AES67 streams that directly reflect the pipeline clock time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)