### PR TITLE
feat: Add thread priority configuration for GStreamer streaming threads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4825,6 +4825,7 @@ dependencies = [
  "gstreamer-app 0.24.2",
  "gstreamer-net 0.24.2",
  "http-body-util",
+ "libc",
  "mime_guess",
  "rust-embed",
  "serde",
@@ -4833,6 +4834,7 @@ dependencies = [
  "strom-types",
  "tempfile",
  "thiserror 1.0.69",
+ "thread-priority",
  "tokio",
  "tokio-stream",
  "tower",
@@ -5059,6 +5061,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread-priority"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe075d7053dae61ac5413a34ea7d4913b6e6207844fd726bdd858b37ff72bf5"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "winapi",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -43,6 +43,10 @@ anyhow = "1.0"
 thiserror = "1.0"
 async-trait = "0.1"
 
+# Thread priority management
+thread-priority = "1.2"
+libc = "0.2"
+
 # Authentication
 bcrypt = "0.15"
 tower-sessions = "0.14"

--- a/backend/src/gst/mod.rs
+++ b/backend/src/gst/mod.rs
@@ -3,6 +3,8 @@
 mod block_expansion;
 pub mod discovery;
 pub mod pipeline;
+pub mod thread_priority;
 
 pub use discovery::ElementDiscovery;
 pub use pipeline::{PipelineError, PipelineManager};
+pub use thread_priority::{setup_thread_priority_handler, ThreadPriorityState};

--- a/backend/src/gst/pipeline.rs
+++ b/backend/src/gst/pipeline.rs
@@ -2,11 +2,13 @@
 
 use crate::blocks::BlockRegistry;
 use crate::events::EventBroadcaster;
+use crate::gst::thread_priority::{self, ThreadPriorityState};
 use gstreamer as gst;
 use gstreamer::glib;
 use gstreamer::prelude::*;
 use gstreamer_net as gst_net;
 use std::collections::HashMap;
+use strom_types::flow::ThreadPriorityStatus;
 use strom_types::{Element, Flow, FlowId, Link, PipelineState, PropertyValue, StromEvent};
 use thiserror::Error;
 use tracing::{debug, error, info, warn};
@@ -78,6 +80,8 @@ pub struct PipelineManager {
     block_bus_watches: Vec<gst::bus::BusWatchGuard>,
     /// Bus watch setup functions from blocks (called when pipeline starts)
     block_bus_watch_setups: Vec<crate::blocks::BusWatchSetupFn>,
+    /// Thread priority state tracker (tracks whether priority was successfully set)
+    thread_priority_state: Option<ThreadPriorityState>,
 }
 
 impl PipelineManager {
@@ -112,6 +116,7 @@ impl PipelineManager {
             pad_properties: HashMap::new(),
             block_bus_watches: Vec::new(),
             block_bus_watch_setups: Vec::new(),
+            thread_priority_state: None,
         };
 
         // Expand blocks into GStreamer elements
@@ -1162,6 +1167,19 @@ impl PipelineManager {
         info!("Starting pipeline: {}", self.flow_name);
         info!("Pipeline has {} elements", self.elements.len());
 
+        // Set up thread priority handler FIRST (before any state changes)
+        // This must be done before the pipeline starts so we catch all thread enter events
+        info!(
+            "Setting up thread priority handler (requested: {:?})...",
+            self.properties.thread_priority
+        );
+        let priority_state = thread_priority::setup_thread_priority_handler(
+            &self.pipeline,
+            self.properties.thread_priority,
+        );
+        self.thread_priority_state = Some(priority_state);
+        info!("Thread priority handler installed");
+
         // Set up bus watch before starting
         info!("Setting up bus watch...");
         self.setup_bus_watch();
@@ -1264,6 +1282,10 @@ impl PipelineManager {
         // Remove bus watch when stopped to free resources
         self.remove_bus_watch();
 
+        // Remove thread priority handler
+        thread_priority::remove_thread_priority_handler(&self.pipeline);
+        self.thread_priority_state = None;
+
         Ok(PipelineState::Null)
     }
 
@@ -1294,6 +1316,14 @@ impl PipelineManager {
     /// Get the flow ID this pipeline manages.
     pub fn flow_id(&self) -> FlowId {
         self.flow_id
+    }
+
+    /// Get the thread priority status for this pipeline.
+    /// Returns None if pipeline hasn't been started yet.
+    pub fn get_thread_priority_status(&self) -> Option<ThreadPriorityStatus> {
+        self.thread_priority_state
+            .as_ref()
+            .map(|state| state.get_status())
     }
 
     /// Get the clock synchronization status for this pipeline.

--- a/backend/src/gst/thread_priority.rs
+++ b/backend/src/gst/thread_priority.rs
@@ -1,0 +1,370 @@
+//! Thread priority management for GStreamer streaming threads.
+//!
+//! This module provides functionality to set thread priorities on GStreamer's
+//! internal streaming threads using the bus sync handler mechanism.
+
+use gstreamer as gst;
+use gstreamer::prelude::*;
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::Arc;
+use strom_types::flow::{ThreadPriority, ThreadPriorityStatus};
+use tracing::{debug, error, info, warn};
+
+/// Shared state for tracking thread priority configuration across threads.
+#[derive(Debug, Clone)]
+pub struct ThreadPriorityState {
+    /// The requested priority level
+    requested: ThreadPriority,
+    /// Whether at least one priority setting succeeded
+    achieved: Arc<AtomicBool>,
+    /// First error encountered (if any)
+    error: Arc<std::sync::Mutex<Option<String>>>,
+    /// Number of threads configured
+    threads_configured: Arc<AtomicU32>,
+}
+
+impl ThreadPriorityState {
+    /// Create a new thread priority state tracker.
+    pub fn new(requested: ThreadPriority) -> Self {
+        Self {
+            requested,
+            achieved: Arc::new(AtomicBool::new(false)),
+            error: Arc::new(std::sync::Mutex::new(None)),
+            threads_configured: Arc::new(AtomicU32::new(0)),
+        }
+    }
+
+    /// Record a successful priority configuration.
+    fn record_success(&self) {
+        self.achieved.store(true, Ordering::SeqCst);
+        self.threads_configured.fetch_add(1, Ordering::SeqCst);
+    }
+
+    /// Record a failed priority configuration.
+    fn record_failure(&self, error_msg: String) {
+        // Only store the first error
+        let mut error = self.error.lock().unwrap();
+        if error.is_none() {
+            *error = Some(error_msg);
+        }
+    }
+
+    /// Get the current status.
+    pub fn get_status(&self) -> ThreadPriorityStatus {
+        ThreadPriorityStatus {
+            requested: self.requested,
+            achieved: self.achieved.load(Ordering::SeqCst),
+            error: self.error.lock().unwrap().clone(),
+            threads_configured: self.threads_configured.load(Ordering::SeqCst),
+        }
+    }
+}
+
+/// Set thread priority for the current thread.
+///
+/// Returns Ok(()) if priority was set successfully, Err with description otherwise.
+pub fn set_current_thread_priority(priority: ThreadPriority) -> Result<(), String> {
+    match priority {
+        ThreadPriority::Normal => {
+            // Normal priority - nothing to do
+            debug!("Thread priority set to Normal (no change)");
+            Ok(())
+        }
+        ThreadPriority::High => set_high_priority(),
+        ThreadPriority::Realtime => set_realtime_priority(),
+    }
+}
+
+/// Set high priority (elevated but not realtime).
+/// Uses nice value or increased thread priority.
+fn set_high_priority() -> Result<(), String> {
+    #[cfg(target_os = "linux")]
+    {
+        use thread_priority::{set_current_thread_priority, ThreadPriority as TpThreadPriority};
+
+        // Try to set a high priority (but not realtime)
+        // ThreadPriority values go from 0-99, we use a moderate high value
+        match set_current_thread_priority(TpThreadPriority::Crossplatform(
+            80u8.try_into()
+                .map_err(|e| format!("Invalid priority value: {}", e))?,
+        )) {
+            Ok(()) => {
+                debug!("Thread priority set to High (crossplatform 80)");
+                Ok(())
+            }
+            Err(e) => {
+                // Fall back to trying nice value
+                warn!("Could not set crossplatform priority, trying nice: {}", e);
+                set_nice_value(-10)
+            }
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        use thread_priority::{
+            set_current_thread_priority, ThreadPriority as TpThreadPriority, WinAPIThreadPriority,
+        };
+
+        match set_current_thread_priority(TpThreadPriority::Os(WinAPIThreadPriority::AboveNormal)) {
+            Ok(()) => {
+                debug!("Thread priority set to High (Windows AboveNormal)");
+                Ok(())
+            }
+            Err(e) => Err(format!("Failed to set high priority on Windows: {}", e)),
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        use thread_priority::{set_current_thread_priority, ThreadPriority as TpThreadPriority};
+
+        match set_current_thread_priority(TpThreadPriority::Crossplatform(
+            80u8.try_into()
+                .map_err(|e| format!("Invalid priority value: {}", e))?,
+        )) {
+            Ok(()) => {
+                debug!("Thread priority set to High (macOS crossplatform 80)");
+                Ok(())
+            }
+            Err(e) => Err(format!("Failed to set high priority on macOS: {}", e)),
+        }
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "windows", target_os = "macos")))]
+    {
+        warn!("High thread priority not supported on this platform");
+        Ok(())
+    }
+}
+
+/// Set realtime priority (SCHED_FIFO on Linux).
+fn set_realtime_priority() -> Result<(), String> {
+    #[cfg(target_os = "linux")]
+    {
+        use thread_priority::{
+            set_thread_priority_and_policy, thread_native_id, RealtimeThreadSchedulePolicy,
+            ThreadPriority as TpThreadPriority, ThreadSchedulePolicy,
+        };
+
+        let thread_id = thread_native_id();
+
+        // Use SCHED_FIFO with priority 50 (middle of 1-99 range)
+        // This gives good realtime performance without being too aggressive
+        match set_thread_priority_and_policy(
+            thread_id,
+            TpThreadPriority::Crossplatform(
+                50u8.try_into()
+                    .map_err(|e| format!("Invalid priority: {}", e))?,
+            ),
+            ThreadSchedulePolicy::Realtime(RealtimeThreadSchedulePolicy::Fifo),
+        ) {
+            Ok(()) => {
+                info!("Thread priority set to Realtime (SCHED_FIFO priority 50)");
+                Ok(())
+            }
+            Err(e) => {
+                let err_msg = format!(
+                    "Failed to set realtime priority: {}. \
+                     This typically requires root privileges or CAP_SYS_NICE capability. \
+                     You can grant this with: sudo setcap cap_sys_nice+ep <binary>",
+                    e
+                );
+                error!("{}", err_msg);
+                Err(err_msg)
+            }
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        use thread_priority::{
+            set_current_thread_priority, ThreadPriority as TpThreadPriority, WinAPIThreadPriority,
+        };
+
+        match set_current_thread_priority(TpThreadPriority::Os(WinAPIThreadPriority::TimeCritical))
+        {
+            Ok(()) => {
+                info!("Thread priority set to Realtime (Windows TimeCritical)");
+                Ok(())
+            }
+            Err(e) => Err(format!("Failed to set realtime priority on Windows: {}", e)),
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        // macOS doesn't support SCHED_FIFO directly, use highest possible priority
+        use thread_priority::{set_current_thread_priority, ThreadPriority as TpThreadPriority};
+
+        match set_current_thread_priority(TpThreadPriority::Max) {
+            Ok(()) => {
+                info!("Thread priority set to Realtime (macOS Max)");
+                Ok(())
+            }
+            Err(e) => Err(format!("Failed to set realtime priority on macOS: {}", e)),
+        }
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "windows", target_os = "macos")))]
+    {
+        Err("Realtime thread priority not supported on this platform".to_string())
+    }
+}
+
+/// Set nice value on Linux (fallback for high priority).
+#[cfg(target_os = "linux")]
+fn set_nice_value(nice: i32) -> Result<(), String> {
+    // Use libc to set nice value for current thread
+    // Note: setpriority affects the calling thread when using PRIO_PROCESS with 0
+    unsafe {
+        let result = libc::setpriority(libc::PRIO_PROCESS, 0, nice);
+        if result == 0 {
+            debug!("Set nice value to {}", nice);
+            Ok(())
+        } else {
+            let errno = *libc::__errno_location();
+            Err(format!(
+                "Failed to set nice value to {}: errno {}",
+                nice, errno
+            ))
+        }
+    }
+}
+
+/// Set up a sync handler on the pipeline bus to configure thread priorities.
+///
+/// The sync handler is called in the context of the thread that posts the message,
+/// which allows us to set the priority of GStreamer's streaming threads as they
+/// enter their processing loops.
+pub fn setup_thread_priority_handler(
+    pipeline: &gst::Pipeline,
+    priority: ThreadPriority,
+) -> ThreadPriorityState {
+    let state = ThreadPriorityState::new(priority);
+
+    if matches!(priority, ThreadPriority::Normal) {
+        // No need to set up handler for normal priority
+        info!("Thread priority set to Normal - no sync handler needed");
+        state.achieved.store(true, Ordering::SeqCst);
+        return state;
+    }
+
+    let Some(bus) = pipeline.bus() else {
+        error!("Pipeline has no bus - cannot set up thread priority handler");
+        state.record_failure("Pipeline has no bus".to_string());
+        return state;
+    };
+
+    let state_clone = state.clone();
+    let flow_name = pipeline.name().to_string();
+
+    bus.set_sync_handler(move |_bus, msg| {
+        use gst::MessageView;
+
+        if let MessageView::StreamStatus(status) = msg.view() {
+            let (status_type, owner_element) = status.get();
+
+            // We're interested in the Enter event - this is when the thread
+            // is about to enter its processing loop
+            if status_type == gst::StreamStatusType::Enter {
+                let owner = owner_element.name().to_string();
+
+                debug!(
+                    "Thread entering streaming loop for element '{}' in pipeline '{}'",
+                    owner, flow_name
+                );
+
+                // Set thread priority
+                match set_current_thread_priority(state_clone.requested) {
+                    Ok(()) => {
+                        info!(
+                            "Set {:?} priority for streaming thread (element: {}, pipeline: {})",
+                            state_clone.requested, owner, flow_name
+                        );
+                        state_clone.record_success();
+                    }
+                    Err(e) => {
+                        warn!(
+                            "Failed to set {:?} priority for streaming thread (element: {}, pipeline: {}): {}",
+                            state_clone.requested, owner, flow_name, e
+                        );
+                        state_clone.record_failure(e);
+                    }
+                }
+            }
+        }
+
+        // Pass the message to the async handler
+        gst::BusSyncReply::Pass
+    });
+
+    info!(
+        "Thread priority sync handler installed for pipeline '{}' (requested: {:?})",
+        pipeline.name(),
+        priority
+    );
+
+    state
+}
+
+/// Remove the sync handler from the pipeline bus.
+pub fn remove_thread_priority_handler(pipeline: &gst::Pipeline) {
+    if let Some(bus) = pipeline.bus() {
+        bus.unset_sync_handler();
+        debug!(
+            "Thread priority sync handler removed from pipeline '{}'",
+            pipeline.name()
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_thread_priority_state() {
+        let state = ThreadPriorityState::new(ThreadPriority::High);
+
+        // Initially not achieved
+        let status = state.get_status();
+        assert!(!status.achieved);
+        assert_eq!(status.threads_configured, 0);
+        assert!(status.error.is_none());
+
+        // Record success
+        state.record_success();
+        let status = state.get_status();
+        assert!(status.achieved);
+        assert_eq!(status.threads_configured, 1);
+
+        // Record another success
+        state.record_success();
+        let status = state.get_status();
+        assert_eq!(status.threads_configured, 2);
+    }
+
+    #[test]
+    fn test_thread_priority_state_failure() {
+        let state = ThreadPriorityState::new(ThreadPriority::Realtime);
+
+        // Record failure
+        state.record_failure("Permission denied".to_string());
+        let status = state.get_status();
+        assert!(!status.achieved);
+        assert_eq!(status.error, Some("Permission denied".to_string()));
+
+        // Second failure doesn't overwrite first
+        state.record_failure("Another error".to_string());
+        let status = state.get_status();
+        assert_eq!(status.error, Some("Permission denied".to_string()));
+    }
+
+    #[test]
+    fn test_set_normal_priority() {
+        // Normal priority should always succeed
+        let result = set_current_thread_priority(ThreadPriority::Normal);
+        assert!(result.is_ok());
+    }
+}

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -127,10 +127,11 @@ impl AppState {
             .values()
             .map(|flow| {
                 let mut flow = flow.clone();
-                // Update state and clock sync status for running pipelines
+                // Update state, clock sync status, and thread priority status for running pipelines
                 if let Some(pipeline) = pipelines.get(&flow.id) {
                     flow.state = Some(pipeline.get_state());
                     flow.properties.clock_sync_status = Some(pipeline.get_clock_sync_status());
+                    flow.properties.thread_priority_status = pipeline.get_thread_priority_status();
                 }
                 flow
             })
@@ -144,10 +145,11 @@ impl AppState {
 
         flows.get(id).map(|flow| {
             let mut flow = flow.clone();
-            // Update state and clock sync status for running pipeline
+            // Update state, clock sync status, and thread priority status for running pipeline
             if let Some(pipeline) = pipelines.get(id) {
                 flow.state = Some(pipeline.get_state());
                 flow.properties.clock_sync_status = Some(pipeline.get_clock_sync_status());
+                flow.properties.thread_priority_status = pipeline.get_thread_priority_status();
             }
             flow
         })

--- a/frontend/src/app.rs
+++ b/frontend/src/app.rs
@@ -85,6 +85,8 @@ pub struct StromApp {
     properties_clock_type_buffer: strom_types::flow::GStreamerClockType,
     /// Temporary PTP domain buffer for properties dialog
     properties_ptp_domain_buffer: String,
+    /// Temporary thread priority for properties dialog
+    properties_thread_priority_buffer: strom_types::flow::ThreadPriority,
     /// Shutdown flag for Ctrl+C handling (native mode only)
     #[cfg(not(target_arch = "wasm32"))]
     shutdown_flag: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
@@ -194,6 +196,7 @@ impl StromApp {
             properties_description_buffer: String::new(),
             properties_clock_type_buffer: strom_types::flow::GStreamerClockType::Monotonic,
             properties_ptp_domain_buffer: String::new(),
+            properties_thread_priority_buffer: strom_types::flow::ThreadPriority::High,
             meter_data: MeterDataStore::new(),
             theme_preference: ThemePreference::System,
             version_info: None,
@@ -255,6 +258,7 @@ impl StromApp {
             properties_description_buffer: String::new(),
             properties_clock_type_buffer: strom_types::flow::GStreamerClockType::Monotonic,
             properties_ptp_domain_buffer: String::new(),
+            properties_thread_priority_buffer: strom_types::flow::ThreadPriority::High,
             shutdown_flag,
             port,
             auth_token,
@@ -1224,6 +1228,8 @@ impl StromApp {
                                         .ptp_domain
                                         .map(|d| d.to_string())
                                         .unwrap_or_else(|| "0".to_string());
+                                    self.properties_thread_priority_buffer =
+                                        flow.properties.thread_priority;
                                 }
 
                                 // Show clock type indicator (before settings gear)
@@ -1266,6 +1272,31 @@ impl StromApp {
                                                     .color(text_color),
                                             ));
                                         });
+                                }
+
+                                // Show thread priority warning indicator if priority not achieved
+                                if let Some(ref status) = flow.properties.thread_priority_status {
+                                    if !status.achieved && status.error.is_some() {
+                                        let warning_color = Color32::from_rgb(255, 165, 0);
+                                        let tooltip = status
+                                            .error
+                                            .as_ref()
+                                            .map(|e| format!("Thread priority not set: {}", e))
+                                            .unwrap_or_else(|| {
+                                                "Thread priority warning".to_string()
+                                            });
+
+                                        ui.add_space(2.0);
+                                        ui.add(
+                                            egui::Label::new(
+                                                egui::RichText::new("⚠")
+                                                    .size(12.0)
+                                                    .color(warning_color),
+                                            )
+                                            .sense(egui::Sense::hover()),
+                                        )
+                                        .on_hover_text(tooltip);
+                                    }
                                 }
                             },
                         );
@@ -1733,6 +1764,60 @@ impl StromApp {
                 }
 
                 ui.add_space(15.0);
+                ui.separator();
+                ui.add_space(10.0);
+
+                // Thread Priority
+                ui.label("Thread Priority:");
+                ui.horizontal(|ui| {
+                    use strom_types::flow::ThreadPriority;
+
+                    egui::ComboBox::from_id_salt("thread_priority_selector")
+                        .selected_text(format!("{:?}", self.properties_thread_priority_buffer))
+                        .show_ui(ui, |ui| {
+                            ui.selectable_value(
+                                &mut self.properties_thread_priority_buffer,
+                                ThreadPriority::Normal,
+                                "Normal",
+                            );
+                            ui.selectable_value(
+                                &mut self.properties_thread_priority_buffer,
+                                ThreadPriority::High,
+                                "High (recommended)",
+                            );
+                            ui.selectable_value(
+                                &mut self.properties_thread_priority_buffer,
+                                ThreadPriority::Realtime,
+                                "Realtime (requires privileges)",
+                            );
+                        });
+                });
+
+                // Show description of selected thread priority
+                ui.label(self.properties_thread_priority_buffer.description());
+
+                // Show thread priority status for running pipelines
+                if let Some(flow) = self.flows.get(idx) {
+                    if let Some(ref status) = flow.properties.thread_priority_status {
+                        ui.add_space(5.0);
+                        ui.horizontal(|ui| {
+                            ui.label("Status:");
+                            if status.achieved {
+                                ui.colored_label(
+                                    Color32::from_rgb(0, 200, 0),
+                                    format!("● Achieved ({} threads)", status.threads_configured),
+                                );
+                            } else if let Some(ref err) = status.error {
+                                ui.colored_label(Color32::from_rgb(255, 165, 0), "● Warning");
+                                ui.label(format!("- {}", err));
+                            } else {
+                                ui.colored_label(Color32::GRAY, "● Not set");
+                            }
+                        });
+                    }
+                }
+
+                ui.add_space(15.0);
 
                 // Buttons
                 ui.horizontal(|ui| {
@@ -1759,6 +1844,10 @@ impl StromApp {
                             } else {
                                 None
                             };
+
+                            // Set thread priority
+                            flow.properties.thread_priority =
+                                self.properties_thread_priority_buffer;
 
                             let flow_clone = flow.clone();
                             let api = self.api.clone();

--- a/types/src/flow.rs
+++ b/types/src/flow.rs
@@ -12,6 +12,55 @@ use utoipa::ToSchema;
 /// Unique identifier for a flow.
 pub type FlowId = Uuid;
 
+/// Thread priority level for GStreamer streaming threads.
+///
+/// Controls the scheduling priority of GStreamer's internal streaming threads.
+/// Higher priorities help ensure smooth media processing under system load.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum ThreadPriority {
+    /// Normal priority (default OS scheduling, no elevation)
+    Normal,
+    /// Elevated priority (nice -10 equivalent, good for most use cases)
+    #[default]
+    High,
+    /// Real-time priority (SCHED_FIFO, requires privileges)
+    /// Warning: May require root or CAP_SYS_NICE capability
+    Realtime,
+}
+
+impl ThreadPriority {
+    /// Get the human-readable description of this priority level.
+    pub fn description(&self) -> &'static str {
+        match self {
+            Self::Normal => "Normal - default OS scheduling",
+            Self::High => "High - elevated priority (recommended)",
+            Self::Realtime => "Realtime - SCHED_FIFO (requires privileges)",
+        }
+    }
+
+    /// Get all available priority levels.
+    pub fn all() -> &'static [ThreadPriority] {
+        &[Self::Normal, Self::High, Self::Realtime]
+    }
+}
+
+/// Status of thread priority configuration for a running pipeline.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct ThreadPriorityStatus {
+    /// The requested thread priority level
+    pub requested: ThreadPriority,
+    /// Whether the requested priority was successfully applied
+    pub achieved: bool,
+    /// Error message if priority could not be set (empty if achieved)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    /// Number of threads that had priority set
+    pub threads_configured: u32,
+}
+
 /// GStreamer clock type selection.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
@@ -74,6 +123,15 @@ pub struct FlowProperties {
     /// Clock synchronization status (updated by backend for running pipelines)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub clock_sync_status: Option<ClockSyncStatus>,
+
+    /// Thread priority for GStreamer streaming threads
+    /// Default is High (elevated but not realtime)
+    #[serde(default)]
+    pub thread_priority: ThreadPriority,
+
+    /// Status of thread priority configuration (updated by backend when pipeline starts)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thread_priority_status: Option<ThreadPriorityStatus>,
 
     /// Whether this flow should be automatically restarted when the backend starts
     /// (set to true when starting a flow, false when manually stopping it)

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -20,5 +20,5 @@ pub use block::{
 };
 pub use element::{Element, ElementId, Link, MediaType, PropertyValue};
 pub use events::StromEvent;
-pub use flow::{Flow, FlowId};
+pub use flow::{Flow, FlowId, ThreadPriority, ThreadPriorityStatus};
 pub use state::PipelineState;


### PR DESCRIPTION
Add ability to configure thread priority per flow with visual feedback:

Types:
- Add ThreadPriority enum (Normal, High, Realtime)
- Add ThreadPriorityStatus for tracking achieved state
- Add thread_priority and thread_priority_status to FlowProperties

Backend:
- New thread_priority module with sync handler for StreamStatus::Enter
- Set priority on actual GStreamer streaming threads as they start
- Support High (nice -10/crossplatform 80) and Realtime (SCHED_FIFO)
- Soft failure: pipeline starts even if priority can't be set

Frontend:
- Thread priority selector in flow properties dialog
- Status indicator showing achieved/warning state
- Warning icon in flow list when priority not achieved

Default is High priority. Realtime requires root or CAP_SYS_NICE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)