### PR TITLE
fix: Use is_synced() for PTP/NTP clock sync status

### DIFF
--- a/backend/src/gst/pipeline.rs
+++ b/backend/src/gst/pipeline.rs
@@ -1345,34 +1345,36 @@ impl PipelineManager {
         use strom_types::flow::{ClockSyncStatus, GStreamerClockType};
 
         match self.properties.clock_type {
-            GStreamerClockType::Ptp | GStreamerClockType::Ntp => {
-                // Get the pipeline's clock
+            GStreamerClockType::Ptp => {
+                // For PTP clocks, use the is_synced() method from gst::Clock trait
+                // This returns true only when the clock has synchronized with a PTP master
                 if let Some(clock) = self.pipeline.clock() {
-                    // For PTP/NTP clocks, check if they're synced
-                    // Try to get the "synced" property (may not exist on all clock types)
-                    if clock.has_property("synced") {
-                        let synced = clock.property::<bool>("synced");
-                        if synced {
-                            ClockSyncStatus::Synced
-                        } else {
-                            ClockSyncStatus::NotSynced
-                        }
+                    if clock.is_synced() {
+                        ClockSyncStatus::Synced
                     } else {
-                        // Property doesn't exist, fall back to checking if clock is working
-                        let time = clock.time();
-                        if time.is_some() {
-                            // Clock is providing time, assume synced
-                            ClockSyncStatus::Synced
-                        } else {
-                            ClockSyncStatus::NotSynced
-                        }
+                        ClockSyncStatus::NotSynced
                     }
                 } else {
-                    ClockSyncStatus::Unknown
+                    // No clock set yet
+                    ClockSyncStatus::NotSynced
+                }
+            }
+            GStreamerClockType::Ntp => {
+                // For NTP clocks, use the is_synced() method from gst::Clock trait
+                // Note: NTP clock not fully implemented yet, so this is best-effort
+                if let Some(clock) = self.pipeline.clock() {
+                    if clock.is_synced() {
+                        ClockSyncStatus::Synced
+                    } else {
+                        ClockSyncStatus::NotSynced
+                    }
+                } else {
+                    ClockSyncStatus::NotSynced
                 }
             }
             _ => {
-                // For other clock types, sync status is not applicable
+                // For other clock types (Monotonic, Realtime, PipelineDefault),
+                // sync status is not applicable - these are local clocks
                 ClockSyncStatus::Unknown
             }
         }


### PR DESCRIPTION
## Summary
- Fix PTP clock incorrectly showing "Synced" when no PTP master is present
- Use `clock.is_synced()` from `gst::Clock` trait instead of manual property checks
- Apply same fix to NTP clock sync detection

## Problem
The previous implementation incorrectly reported PTP clocks as "Synced" even when no PTP master was present on the network because:

1. PTP clocks don't have a "synced" property
2. The fallback checked if `clock.time()` returned a value
3. PTP clocks always provide time (using local fallback) even before sync

## Solution
Use `clock.is_synced()` from the `gst::Clock` trait, which properly tracks whether network clocks (PTP, NTP) have synchronized with a master.

## Test plan
- [ ] Start a flow with PTP clock selected
- [ ] Verify it shows "Not Synced" when no PTP master is on the network
- [ ] Verify it shows "Synced" when a PTP master is available and sync is achieved

🤖 Generated with [Claude Code](https://claude.com/claude-code)