### PR TITLE
Fix Windows build: Convert WinAPIThreadPriority to ThreadPriorityOsValue

### DIFF
--- a/backend/src/gst/thread_priority.rs
+++ b/backend/src/gst/thread_priority.rs
@@ -106,7 +106,9 @@ fn set_high_priority() -> Result<(), String> {
             set_current_thread_priority, ThreadPriority as TpThreadPriority, WinAPIThreadPriority,
         };
 
-        match set_current_thread_priority(TpThreadPriority::Os(WinAPIThreadPriority::AboveNormal)) {
+        match set_current_thread_priority(TpThreadPriority::Os(
+            WinAPIThreadPriority::AboveNormal.into(),
+        )) {
             Ok(()) => {
                 debug!("Thread priority set to High (Windows AboveNormal)");
                 Ok(())
@@ -182,8 +184,9 @@ fn set_realtime_priority() -> Result<(), String> {
             set_current_thread_priority, ThreadPriority as TpThreadPriority, WinAPIThreadPriority,
         };
 
-        match set_current_thread_priority(TpThreadPriority::Os(WinAPIThreadPriority::TimeCritical))
-        {
+        match set_current_thread_priority(TpThreadPriority::Os(
+            WinAPIThreadPriority::TimeCritical.into(),
+        )) {
             Ok(()) => {
                 info!("Thread priority set to Realtime (Windows TimeCritical)");
                 Ok(())


### PR DESCRIPTION
## Summary
- Fix Windows build error in thread_priority.rs
- Add `.into()` calls to convert `WinAPIThreadPriority` enum variants to `ThreadPriorityOsValue`

## Problem
The `thread-priority` crate's `TpThreadPriority::Os()` variant expects a `ThreadPriorityOsValue`, not a `WinAPIThreadPriority` directly.

## Changes
- Line 109-111: `WinAPIThreadPriority::AboveNormal.into()`
- Line 187-189: `WinAPIThreadPriority::TimeCritical.into()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)