### PR TITLE
fix: Various improvements to WHEP input, AES67 output, and logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2930,6 +2930,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]

--- a/backend/src/api/flows.rs
+++ b/backend/src/api/flows.rs
@@ -17,7 +17,7 @@ use strom_types::{
     Flow, FlowId,
 };
 use tempfile::NamedTempFile;
-use tracing::{error, info};
+use tracing::{error, info, trace};
 use utoipa;
 
 use crate::layout;
@@ -829,7 +829,7 @@ pub async fn get_flow_latency(
     State(state): State<AppState>,
     Path(id): Path<FlowId>,
 ) -> Result<Json<LatencyResponse>, (StatusCode, Json<ErrorResponse>)> {
-    info!("Getting latency for flow {}", id);
+    trace!("Getting latency for flow {}", id);
 
     let latency = state.get_flow_latency(&id).await.ok_or_else(|| {
         (
@@ -841,9 +841,12 @@ pub async fn get_flow_latency(
     })?;
 
     let (min_ns, max_ns, live) = latency;
-    info!(
+    trace!(
         "Flow {} latency: min={}ns, max={}ns, live={}",
-        id, min_ns, max_ns, live
+        id,
+        min_ns,
+        max_ns,
+        live
     );
 
     Ok(Json(LatencyResponse::new(min_ns, max_ns, live)))
@@ -870,7 +873,7 @@ pub async fn get_flow_stats(
     State(state): State<AppState>,
     Path(id): Path<FlowId>,
 ) -> Result<Json<FlowStatsResponse>, (StatusCode, Json<ErrorResponse>)> {
-    info!("Getting statistics for flow {}", id);
+    trace!("Getting statistics for flow {}", id);
 
     let stats = state.get_flow_stats(&id).await.ok_or_else(|| {
         (
@@ -881,7 +884,7 @@ pub async fn get_flow_stats(
         )
     })?;
 
-    info!(
+    trace!(
         "Flow {} stats: {} blocks with statistics",
         id,
         stats.block_stats.len()

--- a/backend/src/blocks/builtin/aes67.rs
+++ b/backend/src/blocks/builtin/aes67.rs
@@ -480,12 +480,19 @@ impl BlockBuilder for AES67OutputBuilder {
             .build()
             .map_err(|e| BlockBuildError::ElementCreation(format!("{}: {}", payloader_type, e)))?;
 
+        // Set processing-deadline to match ptime for proper timing
+        let processing_deadline_ns = ptime_ns as u64;
+
         let udpsink = gst::ElementFactory::make("udpsink")
             .name(&udpsink_id)
             .property("host", &host)
             .property("port", port)
             .property("async", false)
-            .property("sync", false)
+            .property("sync", true)
+            .property(
+                "processing-deadline",
+                gst::ClockTime::from_nseconds(processing_deadline_ns),
+            )
             .build()
             .map_err(|e| BlockBuildError::ElementCreation(format!("udpsink: {}", e)))?;
 

--- a/backend/src/stats/collector.rs
+++ b/backend/src/stats/collector.rs
@@ -7,7 +7,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use strom_types::block::BlockInstance;
 use strom_types::stats::{BlockStats, FlowStats, Statistic};
 use strom_types::Flow;
-use tracing::{debug, info, warn};
+use tracing::{debug, trace, warn};
 
 /// Collector for pipeline statistics.
 pub struct StatsCollector;
@@ -90,7 +90,7 @@ impl StatsCollector {
             if let Ok(bin) = sdpdemux.dynamic_cast::<gst::Bin>() {
                 let jb_stats = collect_all_jitterbuffer_stats(&bin);
                 let jb_count = jb_stats.len();
-                info!("Found {} jitterbuffer(s) in {}", jb_count, sdpdemux_name);
+                trace!("Found {} jitterbuffer(s) in {}", jb_count, sdpdemux_name);
 
                 for (jb_name, stats) in jb_stats {
                     debug!("Jitterbuffer '{}' stats: {:?}", jb_name, stats);

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -27,14 +27,13 @@ uuid.workspace = true
 # Async utilities
 futures-util = { version = "0.3", default-features = false, features = ["std"] }
 
-# Cross-platform time (works on both native and WASM)
-instant = "0.1"
-
 # Logging
 tracing.workspace = true
 
 # WASM-specific dependencies
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+# Cross-platform time - needs wasm-bindgen feature for WASM
+instant = { version = "0.1", features = ["wasm-bindgen"] }
 gloo-net.workspace = true
 gloo-timers = { version = "0.3", features = ["futures"] }
 wasm-bindgen-futures = "0.4"
@@ -45,6 +44,8 @@ wasm-bindgen = "0.2"
 
 # Native-specific dependencies
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+# Cross-platform time (standard for native)
+instant = "0.1"
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync"] }
 tokio-tungstenite = "0.24"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/frontend/src/api.rs
+++ b/frontend/src/api.rs
@@ -722,10 +722,10 @@ impl ApiClient {
     /// Get WebRTC statistics from a running flow.
     pub async fn get_webrtc_stats(&self, id: FlowId) -> ApiResult<strom_types::api::WebRtcStats> {
         use strom_types::api::WebRtcStatsResponse;
-        use tracing::info;
+        use tracing::trace;
 
         let url = format!("{}/flows/{}/webrtc-stats", self.base_url, id);
-        info!("Fetching WebRTC stats from: {}", url);
+        trace!("Fetching WebRTC stats from: {}", url);
 
         let response = self
             .with_auth(self.client.get(&url))
@@ -744,7 +744,7 @@ impl ApiClient {
             .await
             .map_err(|e| ApiError::Decode(e.to_string()))?;
 
-        info!(
+        trace!(
             "Successfully fetched WebRTC stats: {} connections",
             stats_response.stats.connections.len()
         );


### PR DESCRIPTION
## Summary
- **WHEP Input**: Add capsfilter (48kHz) after liveadder, expose `mixer_latency_ms` property (default 30ms)
- **AES67 Output**: Set `processing-deadline` on udpsink to match ptime value
- **Logging**: Move verbose stats/latency/WebRTC logs to trace level
- **Frontend**: Fix WASM "env" module error by enabling wasm-bindgen feature for instant crate

## Changes

### WHEP Input block
- Added capsfilter after liveadder to enforce 48kHz sample rate for downstream compatibility
- Exposed `mixer_latency_ms` property (default 30ms instead of 200ms) for lower latency
- Fixed liveadder latency property type (expects u32 milliseconds, not ClockTime)

### AES67 Output block
- Set `processing-deadline` on udpsink to match the ptime value for proper packet timing

### Logging improvements
- Changed verbose stats, latency query, and WebRTC stats logs from `info!` to `trace!`
- Reduces log spam during normal operation while keeping debug info available

### Frontend WASM fix
- Added `wasm-bindgen` feature to `instant` crate for WASM builds
- Fixes "Failed to resolve module specifier 'env'" error in browser console

## Test plan
- [ ] Start backend and verify web UI loads without console errors
- [ ] Test WHEP input with audio stream
- [ ] Verify AES67 output timing
- [ ] Check that logs are less verbose at info level

🤖 Generated with [Claude Code](https://claude.com/claude-code)