### PR TITLE
fix: Use connect_message for bus handlers to allow multiple handlers

### DIFF
--- a/backend/src/api/websocket.rs
+++ b/backend/src/api/websocket.rs
@@ -50,9 +50,10 @@ async fn handle_socket(socket: WebSocket, broadcaster: EventBroadcaster) {
 
     info!("WebSocket client connected");
 
-    // Send a welcome message immediately to confirm connection
-    let welcome_msg = r#"{"type":"connected","message":"Welcome to Strom WebSocket"}"#;
-    if let Err(e) = sender.send(Message::Text(welcome_msg.into())).await {
+    // Send a Ping event immediately to confirm connection
+    // This is a valid StromEvent that the frontend can parse
+    let welcome_event = StromEvent::Ping;
+    if let Err(e) = send_event(&mut sender, welcome_event).await {
         error!("Failed to send welcome message: {}", e);
         return;
     }

--- a/backend/src/blocks/builtin/aes67.rs
+++ b/backend/src/blocks/builtin/aes67.rs
@@ -337,7 +337,7 @@ impl BlockBuilder for AES67InputBuilder {
                         format!("{}:sink", audioresample_id),
                     ),
                 ],
-                bus_watch_setup: None,
+                bus_message_handler: None,
             })
         } else {
             // No decode - output RTP stream directly
@@ -350,7 +350,7 @@ impl BlockBuilder for AES67InputBuilder {
                     format!("{}:src", filesrc_id),
                     format!("{}:sink", sdpdemux_id),
                 )],
-                bus_watch_setup: None,
+                bus_message_handler: None,
             })
         }
     }
@@ -525,7 +525,7 @@ impl BlockBuilder for AES67OutputBuilder {
                 (udpsink_id, udpsink),
             ],
             internal_links,
-            bus_watch_setup: None,
+            bus_message_handler: None,
         })
     }
 }

--- a/backend/src/blocks/builtin/whep.rs
+++ b/backend/src/blocks/builtin/whep.rs
@@ -359,7 +359,7 @@ impl BlockBuilder for WHEPInputBuilder {
                 (output_audioresample_id, output_audioresample),
             ],
             internal_links,
-            bus_watch_setup: None,
+            bus_message_handler: None,
         })
     }
 }

--- a/backend/src/blocks/builtin/whip.rs
+++ b/backend/src/blocks/builtin/whip.rs
@@ -129,7 +129,7 @@ impl BlockBuilder for WHIPOutputBuilder {
                 (whipclientsink_id, whipclientsink),
             ],
             internal_links,
-            bus_watch_setup: None,
+            bus_message_handler: None,
         })
     }
 }

--- a/backend/src/blocks/mod.rs
+++ b/backend/src/blocks/mod.rs
@@ -6,5 +6,5 @@ pub mod registry;
 pub mod sdp;
 pub mod storage;
 
-pub use builder::{BlockBuildError, BlockBuildResult, BlockBuilder, BusWatchSetupFn};
+pub use builder::{BlockBuildError, BlockBuildResult, BlockBuilder, BusMessageConnectFn};
 pub use registry::BlockRegistry;

--- a/backend/src/gst/block_expansion.rs
+++ b/backend/src/gst/block_expansion.rs
@@ -1,7 +1,7 @@
 //! Block expansion logic - converts block instances to GStreamer elements using BlockBuilder trait.
 
 use crate::blocks::builtin;
-use crate::blocks::BusWatchSetupFn;
+use crate::blocks::BusMessageConnectFn;
 use gstreamer as gst;
 use strom_types::{BlockInstance, ExternalPad, Link};
 use tracing::debug;
@@ -14,8 +14,8 @@ pub struct ExpandedPipeline {
     pub gst_elements: Vec<(String, gst::Element)>,
     /// Links between all elements
     pub links: Vec<Link>,
-    /// Bus watch setup functions from blocks
-    pub bus_watch_setups: Vec<BusWatchSetupFn>,
+    /// Bus message handler connection functions from blocks
+    pub bus_message_handlers: Vec<BusMessageConnectFn>,
 }
 
 /// Expand block instances into GStreamer elements using BlockBuilder trait.
@@ -30,7 +30,7 @@ pub async fn expand_blocks(
 ) -> Result<ExpandedPipeline, PipelineError> {
     let mut gst_elements = Vec::new();
     let mut all_links = Vec::new();
-    let mut bus_watch_setups = Vec::new();
+    let mut bus_message_handlers = Vec::new();
 
     debug!("Expanding {} block instance(s)", blocks.len());
 
@@ -74,13 +74,10 @@ pub async fn expand_blocks(
             all_links.push(Link { from, to });
         }
 
-        // Collect bus watch setup function if provided
-        if let Some(bus_watch_setup) = build_result.bus_watch_setup {
-            debug!(
-                "Block {} provided a bus watch setup function",
-                block_instance.id
-            );
-            bus_watch_setups.push(bus_watch_setup);
+        // Collect bus message handler connection function if provided
+        if let Some(bus_message_handler) = build_result.bus_message_handler {
+            debug!("Block {} provided a bus message handler", block_instance.id);
+            bus_message_handlers.push(bus_message_handler);
         }
     }
 
@@ -94,16 +91,16 @@ pub async fn expand_blocks(
     }
 
     debug!(
-        "Block expansion complete: {} GStreamer elements, {} links, {} bus watch setups",
+        "Block expansion complete: {} GStreamer elements, {} links, {} bus message handlers",
         gst_elements.len(),
         all_links.len(),
-        bus_watch_setups.len()
+        bus_message_handlers.len()
     );
 
     Ok(ExpandedPipeline {
         gst_elements,
         links: all_links,
-        bus_watch_setups,
+        bus_message_handlers,
     })
 }
 

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -29,7 +29,7 @@ struct AppStateInner {
     cached_elements: RwLock<Vec<ElementInfo>>,
     /// Active pipelines
     pipelines: RwLock<HashMap<FlowId, PipelineManager>>,
-    /// Event broadcaster for SSE
+    /// Event broadcaster for real-time updates
     events: EventBroadcaster,
     /// Block registry
     block_registry: BlockRegistry,

--- a/claude.md
+++ b/claude.md
@@ -15,3 +15,5 @@
 
 
 don't suggest blacklisting elements when troubleshooting segfaults. 
+
+when investigating pipeline errors and similar gstreamer issues, use GST_DEBUG to see more logs. 

--- a/types/src/events.rs
+++ b/types/src/events.rs
@@ -1,4 +1,4 @@
-//! Server-Sent Events for real-time updates across clients.
+//! Events for real-time updates across clients.
 
 use crate::element::PropertyValue;
 use crate::FlowId;
@@ -71,18 +71,6 @@ pub enum StromEvent {
 }
 
 impl StromEvent {
-    /// Convert event to SSE format (data: <json>\n\n)
-    pub fn to_sse_message(&self) -> String {
-        match serde_json::to_string(self) {
-            Ok(json) => format!("data: {}\n\n", json),
-            Err(e) => {
-                // Can't use tracing in types crate
-                eprintln!("Failed to serialize event: {}", e);
-                format!("data: {{\"type\":\"Error\",\"message\":\"{}\"}}\n\n", e)
-            }
-        }
-    }
-
     /// Get a human-readable description of the event
     pub fn description(&self) -> String {
         match self {


### PR DESCRIPTION
- Fix "Bus already has a watch" error that occurred when blocks (like Meter) tried to add their own bus message handlers
- GStreamer only allows one add_watch() per bus, but connect_message() allows multiple handlers via signal mechanism
- Change BusWatchSetupFn to BusMessageConnectFn returning SignalHandlerId
- Update meter block to use add_signal_watch() + connect_message()
- Update pipeline.rs to use connect_message() for main handler too
- Remove unused bus_watch field from PipelineManager
- Fix WebSocket welcome message to use valid StromEvent::Ping
- Remove SSE references from comments (we use WebSocket now)

🤖 Generated with [Claude Code](https://claude.com/claude-code)