### PR TITLE
fix: Reduce log verbosity for element state changes and WebSocket lag

### DIFF
--- a/backend/src/api/websocket.rs
+++ b/backend/src/api/websocket.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use strom_types::StromEvent;
 use tokio::select;
 use tokio::time::interval;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info};
 
 use crate::events::EventBroadcaster;
 use crate::state::AppState;
@@ -71,7 +71,7 @@ async fn handle_socket(socket: WebSocket, broadcaster: EventBroadcaster) {
                         }
                     }
                     Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
-                        warn!("Client is lagging, skipped {} events", skipped);
+                        debug!("Client is lagging, skipped {} events", skipped);
                         // Try to continue despite lag
                     }
                     Err(tokio::sync::broadcast::error::RecvError::Closed) => {

--- a/backend/src/gst/pipeline.rs
+++ b/backend/src/gst/pipeline.rs
@@ -363,8 +363,8 @@ impl PipelineManager {
                                 pending_state
                             );
                         } else {
-                            // Log all element state changes for debugging
-                            info!(
+                            // Log element state changes at debug level to avoid log spam
+                            debug!(
                                 "Element '{}' in pipeline '{}' state changed: {:?} -> {:?} (pending: {:?})",
                                 source_name,
                                 flow_name,


### PR DESCRIPTION
## Summary
- Change element state change logging from `info!` to `debug!` level (pipeline-level state changes remain at info for visibility)
- Change "Client is lagging" WebSocket warning to `debug!` level (expected behavior during pipeline startup bursts)
- Remove unused `warn` import from websocket.rs

## Problem
During pipeline startup, hundreds of log lines were generated:
- Every GStreamer element state transition (Null->Ready->Paused->Playing) was logged at INFO level
- WebSocket clients received "lagging" warnings during startup bursts when they couldn't keep up with the flood of events

## Solution
- Element state changes: moved to DEBUG level (pipeline-level changes remain at INFO)
- WebSocket lag warnings: moved to DEBUG level since it's not an error condition

## Before/After
**Before:** Hundreds of `state changed` logs + dozens of `lagging` warnings per pipeline start
**After:** Only 3 pipeline state transitions logged per flow (Null->Ready->Paused->Playing)

## Test plan
- [x] Run `RUST_LOG=info cargo run -p strom-backend` and verify clean startup logs
- [x] Verify pipeline state changes still logged at INFO level
- [x] Verify no "Client is lagging" warnings at INFO level
- [x] Pre-commit hooks pass (fmt + clippy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)