### PR TITLE
chore: Bump version to 0.1.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4812,7 +4812,7 @@ checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 
 [[package]]
 name = "strom-backend"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4852,7 +4852,7 @@ dependencies = [
 
 [[package]]
 name = "strom-frontend"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "console_error_panic_hook",
  "eframe",
@@ -4878,7 +4878,7 @@ dependencies = [
 
 [[package]]
 name = "strom-mcp-server"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "reqwest",
@@ -4892,7 +4892,7 @@ dependencies = [
 
 [[package]]
 name = "strom-types"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["types", "backend", "frontend", "mcp-server"]
 default-members = ["backend"]
 
 [workspace.package]
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Per"]


### PR DESCRIPTION
## Summary
- Bump workspace version from 0.1.4 to 0.1.5

## Test plan
- [x] All packages rebuild successfully
- [x] Pre-commit checks pass (fmt, clippy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)