### PR TITLE
fix: Remove invalid sha tag from Docker publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -51,7 +51,6 @@ jobs:
             type=semver,pattern={{major}}
             type=raw,value=latest,enable={{is_default_branch}}
             type=ref,event=branch
-            type=sha,prefix={{branch}}-
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5


### PR DESCRIPTION
## Summary
- Fix Docker image tag format error in release workflow
- Remove sha tag type that was causing invalid tags like "-a84f376"

## Problem
The Docker publish workflow was failing on release events with error:
```
ERROR: failed to build: invalid tag "***/strom:-a84f376": invalid reference format
```

This was caused by `type=sha,prefix={{branch}}-` at line 54. When triggered by a release event, `{{branch}}` is empty, resulting in invalid tags like `-a84f376`.

## Solution
Removed the sha tag type entirely. It was not needed for releases (we have semver tags) and was only useful for branch builds (which already have `type=ref,event=branch`).

## Testing
After merge, the release workflow should succeed with proper tags:
- v0.1.6
- 0.1
- 0
- latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)