### PR TITLE
fix: Hardcode Docker image name to eyevinntechnology/strom

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,7 +15,7 @@ on:
 
 env:
   REGISTRY: docker.io
-  IMAGE_NAME: ${{ secrets.HUB_DOCKER_USERNAME }}/strom
+  IMAGE_NAME: eyevinntechnology/strom
 
 jobs:
   docker-publish:


### PR DESCRIPTION
## Summary
- Hardcode Docker image name to `eyevinntechnology/strom`
- Remove dependency on `HUB_DOCKER_USERNAME` secret for image name

## Changes
Updated `.github/workflows/docker-publish.yml` line 18 from:
```yaml
IMAGE_NAME: ${{ secrets.HUB_DOCKER_USERNAME }}/strom
```
to:
```yaml
IMAGE_NAME: eyevinntechnology/strom
```

## Rationale
Using a hardcoded image name provides clarity and prevents potential mismatches if the secret changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)