### PR TITLE
Trigger Docker publish on tag creation

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,17 +1,15 @@
 name: Docker Publish
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v*.*.*'
   workflow_dispatch:
     inputs:
       tag:
         description: 'Tag to build (e.g., v0.1.0) or leave empty for current branch'
         required: false
         type: string
-  push:
-    branches:
-      - 'fix/docker-publish'  # Temporary: trigger on this branch for testing
 
 env:
   REGISTRY: docker.io


### PR DESCRIPTION
## Summary
- Change docker-publish workflow to trigger on tag creation (`v*.*.*`)
- Remove dependency on release being published first
- Remove temporary test branch trigger

## Rationale
Previously, the Docker publish workflow waited for the GitHub release to be fully published before starting. This meant:
1. Release workflow runs (builds binaries)
2. Release is created and published
3. Docker publish workflow starts

Now both workflows trigger simultaneously when a version tag is pushed, allowing Docker images to be built in parallel with the release artifacts.

## Changes
- Changed trigger from `release: types: [published]` to `push: tags: v*.*.*`
- Removed temporary `fix/docker-publish` branch trigger
- Kept `workflow_dispatch` for manual triggering if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)