### PR TITLE
fix: Extend Docker publish timeout to 2 hours

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -19,7 +19,7 @@ jobs:
   docker-publish:
     name: Build and Push to Docker Hub
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 120
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
ARM64 Docker builds are taking longer than 1 hour. Extend timeout from 60 minutes to 120 minutes.