### PR TITLE
fix: Build only AMD64 Docker images to reduce publish time

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -63,7 +63,7 @@ jobs:
           # Use GitHub Actions cache (much faster than registry cache)
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           # Disable provenance and SBOM to prevent build hangs
           provenance: false
           sbom: false


### PR DESCRIPTION
## Summary
- Remove ARM64 platform from Docker publish workflow
- Keep only AMD64 to significantly reduce build and publish time

## Changes
Changed `platforms: linux/amd64,linux/arm64` to `platforms: linux/amd64` in `.github/workflows/docker-publish.yml`.

ARM64 builds take considerably longer than AMD64 builds, and by focusing on AMD64 only, we can speed up the Docker publish process significantly.

## Testing
- Workflow syntax is valid
- Pre-commit checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)