### PR TITLE
feat: Improve keyboard delete behavior and auto-navigate to new flows

### DIFF
--- a/frontend/src/graph.rs
+++ b/frontend/src/graph.rs
@@ -215,6 +215,11 @@ impl GraphEditor {
         self.selected_link = None;
     }
 
+    /// Check if anything is selected in the graph (element, block, or link).
+    pub fn has_selection(&self) -> bool {
+        self.selected.is_some() || self.selected_link.is_some()
+    }
+
     /// Set element metadata for rendering ports.
     pub fn set_element_info(&mut self, element_type: String, info: ElementInfo) {
         self.element_info_map.insert(element_type, info);

--- a/frontend/src/state.rs
+++ b/frontend/src/state.rs
@@ -76,6 +76,9 @@ pub enum AppMessage {
     /// Flow operation failed
     FlowOperationError(String),
 
+    /// Flow created successfully (includes flow ID to navigate to)
+    FlowCreated(strom_types::FlowId),
+
     /// Latency loaded for a flow
     LatencyLoaded {
         flow_id: String,


### PR DESCRIPTION
## Summary
- Fix keyboard delete key to properly scope between graph editor and flow selector
- Automatically navigate to newly created/imported/copied flows

## Changes

### Keyboard Delete Scoping
The delete key now works contextually:
- **With graph element/link selected** → Deletes that element/link
- **With nothing selected in graph** → Deletes the flow (with confirmation)
- **When clicking/navigating flows** → Clears graph selection automatically

Implementation:
- Added `has_selection()` method to GraphEditor to check if anything is selected
- Delete key handler now checks `!self.graph.has_selection()` before deleting flow
- Clear graph selection when clicking or navigating to different flows (6 locations)

### Auto-Navigation to New Flows
After creating, importing, or copying a flow, the UI now automatically navigates to it.

Implementation:
- Added `FlowCreated(FlowId)` message type
- Added `pending_flow_navigation` field to store flow ID to navigate to
- Flow creation/import/copy sends `FlowCreated` message with the new flow's ID
- `FlowsLoaded` handler checks for pending navigation and navigates after refresh
- This handles the async timing between flow creation and WebSocket refresh

## Benefits
1. **Prevents accidental flow deletion** when trying to delete graph items
2. **Better UX** - users immediately see their newly created/imported/copied flows

## Testing
- Manual testing confirms both features work as expected
- Pre-commit checks pass (formatting, clippy, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)