### PR TITLE
Fix GStreamer 1.26.2 compatibility: Add libnice and update gst-plugins-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,7 +264,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
  "x11rb",
 ]
 
@@ -428,9 +428,9 @@ dependencies = [
 
 [[package]]
 name = "async-tungstenite"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee88b4c88ac8c9ea446ad43498955750a4bbe64c4392f21ccfe5d952865e318f"
+checksum = "b6f89c129ab749940f95509d84950c62092c8b4bc6e386ddb162229037a6ec91"
 dependencies = [
  "atomic-waker",
  "futures-core",
@@ -443,7 +443,7 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tungstenite 0.27.0",
+ "tungstenite",
 ]
 
 [[package]]
@@ -1178,7 +1178,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1479,7 +1479,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1832,7 +1832,7 @@ dependencies = [
 [[package]]
 name = "gio"
 version = "0.22.0"
-source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=main#4bff6b61b74e720919d14eedb2b03f999861aa2d"
+source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=main#182a397e7f9341d8430b4b9189eeef982b36c106"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1855,19 +1855,19 @@ dependencies = [
  "gobject-sys 0.21.2",
  "libc",
  "system-deps",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "gio-sys"
 version = "0.22.0"
-source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=main#4bff6b61b74e720919d14eedb2b03f999861aa2d"
+source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=main#182a397e7f9341d8430b4b9189eeef982b36c106"
 dependencies = [
  "glib-sys 0.22.0",
  "gobject-sys 0.22.0",
  "libc",
  "system-deps",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1905,7 +1905,7 @@ dependencies = [
 [[package]]
 name = "glib"
 version = "0.22.0"
-source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=main#4bff6b61b74e720919d14eedb2b03f999861aa2d"
+source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=main#182a397e7f9341d8430b4b9189eeef982b36c106"
 dependencies = [
  "bitflags 2.10.0",
  "futures-channel",
@@ -1938,7 +1938,7 @@ dependencies = [
 [[package]]
 name = "glib-macros"
 version = "0.22.0"
-source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=main#4bff6b61b74e720919d14eedb2b03f999861aa2d"
+source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=main#182a397e7f9341d8430b4b9189eeef982b36c106"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1959,7 +1959,7 @@ dependencies = [
 [[package]]
 name = "glib-sys"
 version = "0.22.0"
-source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=main#4bff6b61b74e720919d14eedb2b03f999861aa2d"
+source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=main#182a397e7f9341d8430b4b9189eeef982b36c106"
 dependencies = [
  "libc",
  "system-deps",
@@ -2103,7 +2103,7 @@ dependencies = [
 [[package]]
 name = "gobject-sys"
 version = "0.22.0"
-source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=main#4bff6b61b74e720919d14eedb2b03f999861aa2d"
+source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=main#182a397e7f9341d8430b4b9189eeef982b36c106"
 dependencies = [
  "glib-sys 0.22.0",
  "libc",
@@ -2164,7 +2164,7 @@ dependencies = [
 [[package]]
 name = "gst-plugin-version-helper"
 version = "0.8.1"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs?rev=e136005b108ec85bdc8bc533c551f56ef978e950#e136005b108ec85bdc8bc533c551f56ef978e950"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs?rev=83625619#83625619e21fa1ea3ed69dd663934cb9066556af"
 dependencies = [
  "chrono",
  "toml_edit",
@@ -2173,10 +2173,9 @@ dependencies = [
 [[package]]
 name = "gst-plugin-webrtc"
 version = "0.15.0-alpha.1"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs?rev=e136005b108ec85bdc8bc533c551f56ef978e950#e136005b108ec85bdc8bc533c551f56ef978e950"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs?rev=83625619#83625619e21fa1ea3ed69dd663934cb9066556af"
 dependencies = [
  "anyhow",
- "async-recursion",
  "async-tungstenite",
  "bytes",
  "chrono",
@@ -2223,7 +2222,7 @@ dependencies = [
 [[package]]
 name = "gst-plugin-webrtc-signalling"
 version = "0.15.0-alpha.1"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs?rev=e136005b108ec85bdc8bc533c551f56ef978e950#e136005b108ec85bdc8bc533c551f56ef978e950"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs?rev=83625619#83625619e21fa1ea3ed69dd663934cb9066556af"
 dependencies = [
  "anyhow",
  "async-tungstenite",
@@ -2249,7 +2248,7 @@ dependencies = [
 [[package]]
 name = "gst-plugin-webrtc-signalling-protocol"
 version = "0.15.0-alpha.1"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs?rev=e136005b108ec85bdc8bc533c551f56ef978e950#e136005b108ec85bdc8bc533c551f56ef978e950"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs?rev=83625619#83625619e21fa1ea3ed69dd663934cb9066556af"
 dependencies = [
  "serde",
  "serde_json",
@@ -2283,7 +2282,7 @@ dependencies = [
 [[package]]
 name = "gstreamer"
 version = "0.25.0"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=main#0753e708a3e871251aad8d75179c3c3314a8e0b0"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=main#d49c01e8d1ea68c6a15ea3520b0f2faa5048b29e"
 dependencies = [
  "cfg-if",
  "futures-channel",
@@ -2324,7 +2323,7 @@ dependencies = [
 [[package]]
 name = "gstreamer-app"
 version = "0.25.0"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=main#0753e708a3e871251aad8d75179c3c3314a8e0b0"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=main#d49c01e8d1ea68c6a15ea3520b0f2faa5048b29e"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2351,7 +2350,7 @@ dependencies = [
 [[package]]
 name = "gstreamer-app-sys"
 version = "0.25.0"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=main#0753e708a3e871251aad8d75179c3c3314a8e0b0"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=main#d49c01e8d1ea68c6a15ea3520b0f2faa5048b29e"
 dependencies = [
  "glib-sys 0.22.0",
  "gstreamer-base-sys 0.25.0",
@@ -2363,7 +2362,7 @@ dependencies = [
 [[package]]
 name = "gstreamer-audio"
 version = "0.25.0"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=main#0753e708a3e871251aad8d75179c3c3314a8e0b0"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=main#d49c01e8d1ea68c6a15ea3520b0f2faa5048b29e"
 dependencies = [
  "cfg-if",
  "glib 0.22.0",
@@ -2378,7 +2377,7 @@ dependencies = [
 [[package]]
 name = "gstreamer-audio-sys"
 version = "0.25.0"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=main#0753e708a3e871251aad8d75179c3c3314a8e0b0"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=main#d49c01e8d1ea68c6a15ea3520b0f2faa5048b29e"
 dependencies = [
  "glib-sys 0.22.0",
  "gobject-sys 0.22.0",
@@ -2405,7 +2404,7 @@ dependencies = [
 [[package]]
 name = "gstreamer-base"
 version = "0.25.0"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=main#0753e708a3e871251aad8d75179c3c3314a8e0b0"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=main#d49c01e8d1ea68c6a15ea3520b0f2faa5048b29e"
 dependencies = [
  "atomic_refcell",
  "cfg-if",
@@ -2431,7 +2430,7 @@ dependencies = [
 [[package]]
 name = "gstreamer-base-sys"
 version = "0.25.0"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=main#0753e708a3e871251aad8d75179c3c3314a8e0b0"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=main#d49c01e8d1ea68c6a15ea3520b0f2faa5048b29e"
 dependencies = [
  "glib-sys 0.22.0",
  "gobject-sys 0.22.0",
@@ -2455,7 +2454,7 @@ dependencies = [
 [[package]]
 name = "gstreamer-net"
 version = "0.25.0"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=main#0753e708a3e871251aad8d75179c3c3314a8e0b0"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=main#d49c01e8d1ea68c6a15ea3520b0f2faa5048b29e"
 dependencies = [
  "gio 0.22.0",
  "glib 0.22.0",
@@ -2479,7 +2478,7 @@ dependencies = [
 [[package]]
 name = "gstreamer-net-sys"
 version = "0.25.0"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=main#0753e708a3e871251aad8d75179c3c3314a8e0b0"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=main#d49c01e8d1ea68c6a15ea3520b0f2faa5048b29e"
 dependencies = [
  "gio-sys 0.22.0",
  "glib-sys 0.22.0",
@@ -2491,7 +2490,7 @@ dependencies = [
 [[package]]
 name = "gstreamer-rtp"
 version = "0.25.0"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=main#0753e708a3e871251aad8d75179c3c3314a8e0b0"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=main#d49c01e8d1ea68c6a15ea3520b0f2faa5048b29e"
 dependencies = [
  "glib 0.22.0",
  "gstreamer 0.25.0",
@@ -2502,7 +2501,7 @@ dependencies = [
 [[package]]
 name = "gstreamer-rtp-sys"
 version = "0.25.0"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=main#0753e708a3e871251aad8d75179c3c3314a8e0b0"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=main#d49c01e8d1ea68c6a15ea3520b0f2faa5048b29e"
 dependencies = [
  "glib-sys 0.22.0",
  "gstreamer-base-sys 0.25.0",
@@ -2514,7 +2513,7 @@ dependencies = [
 [[package]]
 name = "gstreamer-sdp"
 version = "0.25.0"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=main#0753e708a3e871251aad8d75179c3c3314a8e0b0"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=main#d49c01e8d1ea68c6a15ea3520b0f2faa5048b29e"
 dependencies = [
  "glib 0.22.0",
  "gstreamer 0.25.0",
@@ -2524,7 +2523,7 @@ dependencies = [
 [[package]]
 name = "gstreamer-sdp-sys"
 version = "0.25.0"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=main#0753e708a3e871251aad8d75179c3c3314a8e0b0"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=main#d49c01e8d1ea68c6a15ea3520b0f2faa5048b29e"
 dependencies = [
  "glib-sys 0.22.0",
  "gstreamer-sys 0.25.0",
@@ -2548,7 +2547,7 @@ dependencies = [
 [[package]]
 name = "gstreamer-sys"
 version = "0.25.0"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=main#0753e708a3e871251aad8d75179c3c3314a8e0b0"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=main#d49c01e8d1ea68c6a15ea3520b0f2faa5048b29e"
 dependencies = [
  "cfg-if",
  "glib-sys 0.22.0",
@@ -2560,7 +2559,7 @@ dependencies = [
 [[package]]
 name = "gstreamer-utils"
 version = "0.25.0"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=main#0753e708a3e871251aad8d75179c3c3314a8e0b0"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=main#d49c01e8d1ea68c6a15ea3520b0f2faa5048b29e"
 dependencies = [
  "gstreamer 0.25.0",
  "gstreamer-app 0.25.0",
@@ -2571,7 +2570,7 @@ dependencies = [
 [[package]]
 name = "gstreamer-video"
 version = "0.25.0"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=main#0753e708a3e871251aad8d75179c3c3314a8e0b0"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=main#d49c01e8d1ea68c6a15ea3520b0f2faa5048b29e"
 dependencies = [
  "cfg-if",
  "futures-channel",
@@ -2587,7 +2586,7 @@ dependencies = [
 [[package]]
 name = "gstreamer-video-sys"
 version = "0.25.0"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=main#0753e708a3e871251aad8d75179c3c3314a8e0b0"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=main#d49c01e8d1ea68c6a15ea3520b0f2faa5048b29e"
 dependencies = [
  "glib-sys 0.22.0",
  "gobject-sys 0.22.0",
@@ -2600,7 +2599,7 @@ dependencies = [
 [[package]]
 name = "gstreamer-webrtc"
 version = "0.25.0"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=main#0753e708a3e871251aad8d75179c3c3314a8e0b0"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=main#d49c01e8d1ea68c6a15ea3520b0f2faa5048b29e"
 dependencies = [
  "glib 0.22.0",
  "gstreamer 0.25.0",
@@ -2612,7 +2611,7 @@ dependencies = [
 [[package]]
 name = "gstreamer-webrtc-sys"
 version = "0.25.0"
-source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=main#0753e708a3e871251aad8d75179c3c3314a8e0b0"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs?branch=main#d49c01e8d1ea68c6a15ea3520b0f2faa5048b29e"
 dependencies = [
  "glib-sys 0.22.0",
  "gstreamer-sdp-sys",
@@ -2908,7 +2907,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -3505,7 +3504,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4307,7 +4306,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4621,7 +4620,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5475,7 +5474,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5735,7 +5734,7 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite 0.28.0",
+ "tungstenite",
 ]
 
 [[package]]
@@ -6012,9 +6011,9 @@ checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 
 [[package]]
 name = "tungstenite"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadc29d668c91fcc564941132e17b28a7ceb2f3ebf0b9dae3e03fd7a6748eb0d"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
  "bytes",
  "data-encoding",
@@ -6027,23 +6026,6 @@ dependencies = [
  "sha1",
  "thiserror 2.0.17",
  "url",
- "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
-dependencies = [
- "bytes",
- "data-encoding",
- "http",
- "httparse",
- "log",
- "rand 0.9.2",
- "sha1",
- "thiserror 2.0.17",
  "utf-8",
 ]
 
@@ -6738,7 +6720,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6803,19 +6785,6 @@ dependencies = [
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ tower-http = { version = "0.6", features = ["fs", "cors", "trace"] }
 gstreamer = "0.24.3"
 gstreamer-app = "0.24.2"
 gstreamer-net = "0.24.2"
-gst-plugin-webrtc = { git = "https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs", features = ["whep", "whip"], rev = "e136005b108ec85bdc8bc533c551f56ef978e950" }
+gst-plugin-webrtc = { git = "https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs", features = ["whep", "whip"], rev = "83625619" }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 utoipa = { version = "5.4", features = ["axum_extras", "uuid"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,6 +80,7 @@ RUN apt-get update && apt-get install -y \
     gstreamer1.0-plugins-bad \
     gstreamer1.0-plugins-ugly \
     gstreamer1.0-libav \
+    gstreamer1.0-nice \
     gstreamer1.0-tools \
     graphviz \
     ca-certificates \


### PR DESCRIPTION
## Problem
Docker images using GStreamer 1.26.2 (Debian trixie) were experiencing two critical issues:

1. **Missing libnice dependency**: `Failed to request pad from webrtcbin`
   - webrtcbin requires libnice library for ICE transport
   - Package was available in trixie but not installed in Dockerfile

2. **gst-plugins-rs panic**: `.unwrap()` on `sync_state_with_parent` failure
   ```
   thread 'tokio-runtime-worker' panicked at /usr/local/cargo/git/checkouts/gst-plugins-rs-b9642f372a0151a2/e136005/net/webrtc/src/webrtcsrc/imp.rs:1712:38:
   called `Result::unwrap()` on an `Err` value: BoolError { message: "Failed to sync state with parent" }
   ```

## Solution

### 1. Add libnice to Docker runtime dependencies
Added `gstreamer1.0-nice` package to Dockerfile (line 83):
```dockerfile
gstreamer1.0-libav \
gstreamer1.0-nice \
gstreamer1.0-tools \
```

This installs the ICE library plugin that webrtcbin needs for WebRTC transport.

### 2. Update gst-plugin-webrtc dependency
Updated `Cargo.toml` from commit `e136005b` (Oct 14, 2025) to `83625619` (Nov 26, 2025):
```toml
gst-plugin-webrtc = { git = "https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs", features = ["whep", "whip"], rev = "83625619" }
```

The updated version includes:
- Better error handling (no more unwrap panics)
- WebRTC renegotiation support
- Compatibility fixes for GStreamer 1.26.2

## Testing

✅ Built Docker image with both fixes  
✅ Verified libnice elements are available (`nicesrc`, `nicesink`)  
✅ Container starts successfully with GStreamer 1.26.2  
✅ No more "Failed to request pad from webrtcbin" errors  
✅ No more unwrap panics in gst-plugins-rs  

## Related Issues

Fixes compatibility with GStreamer 1.26.2 in Docker deployments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)