### PR TITLE
chore: Bump version to 0.2.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5292,7 +5292,7 @@ dependencies = [
 
 [[package]]
 name = "strom"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5333,7 +5333,7 @@ dependencies = [
 
 [[package]]
 name = "strom-frontend"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "console_error_panic_hook",
  "eframe",
@@ -5359,7 +5359,7 @@ dependencies = [
 
 [[package]]
 name = "strom-mcp-server"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "reqwest",
@@ -5373,7 +5373,7 @@ dependencies = [
 
 [[package]]
 name = "strom-types"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["types", "backend", "frontend", "mcp-server"]
 default-members = ["backend"]
 
 [workspace.package]
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Per"]


### PR DESCRIPTION
## Summary
- Bump version from 0.2.3 to 0.2.4
- Prepare for release with WHEP ghostpad fix

## Changes
- Updated version in workspace Cargo.toml
- Updated Cargo.lock

🤖 Generated with [Claude Code](https://claude.com/claude-code)