### PR TITLE
feat: Add configurable default property values for GStreamer elements

### DIFF
--- a/.strom.toml.example
+++ b/.strom.toml.example
@@ -50,3 +50,25 @@ port = 8080
 # CLI: --blocks-path <PATH>
 # Env: STROM_STORAGE_BLOCKS_PATH
 # blocks_path = "./custom/blocks.json"
+
+# GStreamer Element Default Properties
+# Override default property values for specific GStreamer elements.
+# These defaults are applied to elements when they are created, but can be
+# overridden by per-flow properties.
+#
+# Strom has built-in defaults for common streaming elements:
+#   - audiotestsrc: is-live = true
+#   - videotestsrc: is-live = true
+#
+# You can add your own defaults or override the built-in ones:
+#
+# [element_defaults.rtpjitterbuffer]
+# latency = 200
+# do-lost = true
+#
+# [element_defaults.x264enc]
+# speed-preset = "ultrafast"
+# tune = "zerolatency"
+#
+# [element_defaults.compositor]
+# background = "black"

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -6,8 +6,10 @@ use figment::{
     Figment,
 };
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::env;
 use std::path::PathBuf;
+use strom_types::element::PropertyValue;
 
 /// Configuration structure that matches the TOML file format.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -16,6 +18,10 @@ struct ConfigFile {
     server: ServerConfig,
     #[serde(default)]
     storage: StorageConfig,
+    /// Custom default property values for GStreamer elements.
+    /// Format: element_defaults.{element_type}.{property_name} = value
+    #[serde(default)]
+    element_defaults: HashMap<String, HashMap<String, PropertyValue>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -36,6 +42,28 @@ fn default_port() -> u16 {
     strom_types::DEFAULT_PORT
 }
 
+/// Get hardcoded default property values for GStreamer elements.
+///
+/// These are sensible defaults for Strom that override GStreamer's built-in defaults.
+/// Users can further override these via config files or per-flow properties.
+fn get_hardcoded_element_defaults() -> HashMap<String, HashMap<String, PropertyValue>> {
+    let mut defaults = HashMap::new();
+
+    // audiotestsrc: Set is-live=true for live streaming behavior
+    defaults.insert(
+        "audiotestsrc".to_string(),
+        HashMap::from([("is-live".to_string(), PropertyValue::Bool(true))]),
+    );
+
+    // videotestsrc: Set is-live=true for live streaming behavior
+    defaults.insert(
+        "videotestsrc".to_string(),
+        HashMap::from([("is-live".to_string(), PropertyValue::Bool(true))]),
+    );
+
+    defaults
+}
+
 /// Application configuration.
 #[derive(Debug, Clone)]
 pub struct Config {
@@ -48,6 +76,9 @@ pub struct Config {
     /// PostgreSQL database URL (if set, PostgreSQL is used instead of JSON files)
     /// Format: postgresql://user:password@host/database_name
     pub database_url: Option<String>,
+    /// Default property values for GStreamer elements.
+    /// Combines hardcoded defaults with user config overrides.
+    pub element_defaults: HashMap<String, HashMap<String, PropertyValue>>,
 }
 
 impl Config {
@@ -78,6 +109,7 @@ impl Config {
                 port: strom_types::DEFAULT_PORT,
             },
             storage: StorageConfig::default(),
+            element_defaults: HashMap::new(),
         }));
 
         // 2. Merge user config file if it exists
@@ -129,11 +161,21 @@ impl Config {
         };
         let data_paths = DataPaths::resolve(path_config)?;
 
+        // Merge element defaults: hardcoded < config file
+        let mut element_defaults = get_hardcoded_element_defaults();
+        for (element_type, properties) in config_file.element_defaults {
+            element_defaults
+                .entry(element_type)
+                .or_default()
+                .extend(properties);
+        }
+
         Ok(Self {
             port: config_file.server.port,
             flows_path: data_paths.flows_path,
             blocks_path: data_paths.blocks_path,
             database_url: config_file.storage.database_url,
+            element_defaults,
         })
     }
 
@@ -160,6 +202,7 @@ impl Config {
             flows_path: data_paths.flows_path,
             blocks_path: data_paths.blocks_path,
             database_url,
+            element_defaults: get_hardcoded_element_defaults(),
         })
     }
 
@@ -192,6 +235,7 @@ impl Default for Config {
                 flows_path: PathBuf::from("flows.json"),
                 blocks_path: PathBuf::from("blocks.json"),
                 database_url: None,
+                element_defaults: get_hardcoded_element_defaults(),
             }
         })
     }

--- a/backend/src/gst/pipeline.rs
+++ b/backend/src/gst/pipeline.rs
@@ -81,6 +81,8 @@ pub struct PipelineManager {
     block_message_connect_fns: Vec<crate::blocks::BusMessageConnectFn>,
     /// Thread priority state tracker (tracks whether priority was successfully set)
     thread_priority_state: Option<ThreadPriorityState>,
+    /// Default property values for GStreamer elements (element_type -> property -> value)
+    element_defaults: HashMap<String, HashMap<String, PropertyValue>>,
 }
 
 impl PipelineManager {
@@ -89,6 +91,7 @@ impl PipelineManager {
         flow: &Flow,
         events: EventBroadcaster,
         _block_registry: &BlockRegistry,
+        element_defaults: HashMap<String, HashMap<String, PropertyValue>>,
     ) -> Result<Self, PipelineError> {
         info!("Creating pipeline for flow: {} ({})", flow.name, flow.id);
         info!(
@@ -115,6 +118,7 @@ impl PipelineManager {
             block_message_handlers: Vec::new(),
             block_message_connect_fns: Vec::new(),
             thread_priority_state: None,
+            element_defaults,
         };
 
         // Expand blocks into GStreamer elements
@@ -438,9 +442,25 @@ impl PipelineManager {
             element_def.id
         );
 
-        // Set properties
+        // Apply element defaults first (if any)
+        if let Some(defaults) = self.element_defaults.get(&element_def.element_type) {
+            info!(
+                "add_element: Applying {} default properties for element type '{}'",
+                defaults.len(),
+                element_def.element_type
+            );
+            for (prop_name, prop_value) in defaults {
+                info!(
+                    "add_element: Setting default property {}.{} = {:?}",
+                    element_def.id, prop_name, prop_value
+                );
+                self.set_property(&element, &element_def.id, prop_name, prop_value)?;
+            }
+        }
+
+        // Set user-provided properties (these override defaults)
         info!(
-            "add_element: Setting {} properties for element {}",
+            "add_element: Setting {} user properties for element {}",
             element_def.properties.len(),
             element_def.id
         );
@@ -2838,7 +2858,7 @@ mod tests {
         let flow = create_test_flow();
         let events = EventBroadcaster::default();
         let registry = BlockRegistry::new("test_blocks.json");
-        let manager = PipelineManager::new(&flow, events, &registry);
+        let manager = PipelineManager::new(&flow, events, &registry, HashMap::new());
         assert!(manager.is_ok());
     }
 
@@ -2848,7 +2868,7 @@ mod tests {
         let flow = create_test_flow();
         let events = EventBroadcaster::default();
         let registry = BlockRegistry::new("test_blocks.json");
-        let mut manager = PipelineManager::new(&flow, events, &registry).unwrap();
+        let mut manager = PipelineManager::new(&flow, events, &registry, HashMap::new()).unwrap();
 
         // Start pipeline
         let state = manager.start();
@@ -2873,7 +2893,7 @@ mod tests {
 
         let events = EventBroadcaster::default();
         let registry = BlockRegistry::new("test_blocks.json");
-        let manager = PipelineManager::new(&flow, events, &registry);
+        let manager = PipelineManager::new(&flow, events, &registry, HashMap::new());
         assert!(manager.is_err());
     }
 
@@ -2919,7 +2939,7 @@ mod tests {
 
         let events = EventBroadcaster::default();
         let registry = BlockRegistry::new("test_blocks.json");
-        let manager = PipelineManager::new(&flow, events, &registry);
+        let manager = PipelineManager::new(&flow, events, &registry, HashMap::new());
         assert!(manager.is_ok());
 
         let manager = manager.unwrap();
@@ -2937,7 +2957,7 @@ mod tests {
 
         let events = EventBroadcaster::default();
         let registry = BlockRegistry::new("test_blocks.json");
-        let manager = PipelineManager::new(&flow, events, &registry).unwrap();
+        let manager = PipelineManager::new(&flow, events, &registry, HashMap::new()).unwrap();
 
         // Should have only 2 original elements, no tee
         assert_eq!(manager.elements.len(), 2);

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -256,12 +256,20 @@ fn run_with_gui(
         // Create application with persistent storage
         let state = if let Some(ref db_url) = config.database_url {
             info!("Using PostgreSQL storage");
-            AppState::with_postgres_storage(db_url, &config.blocks_path)
-                .await
-                .expect("Failed to initialize PostgreSQL storage")
+            AppState::with_postgres_storage(
+                db_url,
+                &config.blocks_path,
+                config.element_defaults.clone(),
+            )
+            .await
+            .expect("Failed to initialize PostgreSQL storage")
         } else {
             info!("Using JSON file storage");
-            AppState::with_json_storage(&config.flows_path, &config.blocks_path)
+            AppState::with_json_storage(
+                &config.flows_path,
+                &config.blocks_path,
+                config.element_defaults.clone(),
+            )
         };
         state
             .load_from_storage()
@@ -360,10 +368,19 @@ async fn run_headless(
     // Create application with persistent storage
     let state = if let Some(ref db_url) = config.database_url {
         info!("Using PostgreSQL storage");
-        AppState::with_postgres_storage(db_url, &config.blocks_path).await?
+        AppState::with_postgres_storage(
+            db_url,
+            &config.blocks_path,
+            config.element_defaults.clone(),
+        )
+        .await?
     } else {
         info!("Using JSON file storage");
-        AppState::with_json_storage(&config.flows_path, &config.blocks_path)
+        AppState::with_json_storage(
+            &config.flows_path,
+            &config.blocks_path,
+            config.element_defaults.clone(),
+        )
     };
     state.load_from_storage().await?;
 

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -33,11 +33,17 @@ struct AppStateInner {
     events: EventBroadcaster,
     /// Block registry
     block_registry: BlockRegistry,
+    /// Default property values for GStreamer elements
+    element_defaults: HashMap<String, HashMap<String, PropertyValue>>,
 }
 
 impl AppState {
     /// Create new application state with the given storage backend.
-    pub fn new(storage: impl Storage + 'static, blocks_path: impl Into<PathBuf>) -> Self {
+    pub fn new(
+        storage: impl Storage + 'static,
+        blocks_path: impl Into<PathBuf>,
+        element_defaults: HashMap<String, HashMap<String, PropertyValue>>,
+    ) -> Self {
         Self {
             inner: Arc::new(AppStateInner {
                 flows: RwLock::new(HashMap::new()),
@@ -47,6 +53,7 @@ impl AppState {
                 pipelines: RwLock::new(HashMap::new()),
                 events: EventBroadcaster::default(),
                 block_registry: BlockRegistry::new(blocks_path),
+                element_defaults,
             }),
         }
     }
@@ -65,8 +72,13 @@ impl AppState {
     pub fn with_json_storage(
         flows_path: impl AsRef<std::path::Path>,
         blocks_path: impl Into<PathBuf>,
+        element_defaults: HashMap<String, HashMap<String, PropertyValue>>,
     ) -> Self {
-        Self::new(JsonFileStorage::new(flows_path), blocks_path)
+        Self::new(
+            JsonFileStorage::new(flows_path),
+            blocks_path,
+            element_defaults,
+        )
     }
 
     /// Create new application state with PostgreSQL storage.
@@ -76,13 +88,14 @@ impl AppState {
     pub async fn with_postgres_storage(
         database_url: &str,
         blocks_path: impl Into<PathBuf>,
+        element_defaults: HashMap<String, HashMap<String, PropertyValue>>,
     ) -> anyhow::Result<Self> {
         use crate::storage::PostgresStorage;
 
         let storage = PostgresStorage::new(database_url).await?;
         storage.run_migrations().await?;
 
-        Ok(Self::new(storage, blocks_path))
+        Ok(Self::new(storage, blocks_path, element_defaults))
     }
 
     /// Load flows from storage into memory.
@@ -342,8 +355,12 @@ impl AppState {
 
         // Create pipeline with event broadcaster and block registry
         info!("Creating PipelineManager (this may block)...");
-        let mut manager =
-            PipelineManager::new(&flow, self.inner.events.clone(), &self.inner.block_registry)?;
+        let mut manager = PipelineManager::new(
+            &flow,
+            self.inner.events.clone(),
+            &self.inner.block_registry,
+            self.inner.element_defaults.clone(),
+        )?;
         info!("PipelineManager created successfully");
 
         // Start pipeline
@@ -690,6 +707,6 @@ impl AppState {
 
 impl Default for AppState {
     fn default() -> Self {
-        Self::with_json_storage("flows.json", "blocks.json")
+        Self::with_json_storage("flows.json", "blocks.json", HashMap::new())
     }
 }


### PR DESCRIPTION
## Summary

Adds support for overriding GStreamer element default property values at the application level. This resolves the issue where GStreamer's built-in defaults don't work optimally for streaming applications (e.g., `audiotestsrc` and `videotestsrc` have `is-live=false` by default, which is incorrect for live streaming).

## Changes

### Hardcoded Defaults
- **audiotestsrc**: Set `is-live=true` for proper live streaming behavior
- **videotestsrc**: Set `is-live=true` for proper live streaming behavior

These are automatically applied to all instances of these elements.

### Config File Support
Added `[element_defaults]` section to TOML config:

```toml
[element_defaults.rtpjitterbuffer]
latency = 200
do-lost = true

[element_defaults.x264enc]
speed-preset = "ultrafast"
tune = "zerolatency"
```

### Property Application Order
1. GStreamer built-in defaults
2. Strom hardcoded defaults
3. Config file `element_defaults`
4. Per-flow element properties

Each layer can override the previous, providing flexibility while ensuring sensible defaults out-of-box.

## Implementation Details

- Added `get_hardcoded_element_defaults()` function in `backend/src/config.rs`
- Added `element_defaults` field to `ConfigFile`, `Config`, `AppStateInner`, and `PipelineManager`
- Updated `PipelineManager::add_element()` to apply element defaults before user properties
- Updated all AppState constructors and main.rs to thread element_defaults through
- Updated all tests to pass empty element_defaults
- Updated `.strom.toml.example` with documentation and examples

## Test Plan

- [x] Code compiles without errors
- [x] All existing tests pass
- [x] Pre-commit checks (fmt + clippy) pass
- [ ] Manual testing: Create flow with audiotestsrc without setting is-live, verify it defaults to true
- [ ] Manual testing: Create `.strom.toml` with custom element defaults, verify they are applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)