### PR TITLE
feat: Use Zig for glibc-targeted Linux builds in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,24 @@ jobs:
         with:
           targets: wasm32-unknown-unknown,${{ matrix.target }}
 
+      # Linux: Install Zig for glibc-targeted builds (supports both x86_64 and ARM64)
+      - name: Install Zig (Linux)
+        if: matrix.platform == 'linux'
+        run: |
+          ZIG_VERSION="0.13.0"
+          ZIG_TARBALL="zig-linux-x86_64-${ZIG_VERSION}.tar.xz"
+          curl -L "https://ziglang.org/download/${ZIG_VERSION}/${ZIG_TARBALL}" -o "/tmp/${ZIG_TARBALL}"
+          sudo tar -xf "/tmp/${ZIG_TARBALL}" -C /usr/local
+          sudo mv /usr/local/zig-linux-x86_64-${ZIG_VERSION} /usr/local/zig
+          sudo ln -s /usr/local/zig/zig /usr/local/bin/zig
+          rm "/tmp/${ZIG_TARBALL}"
+          zig version
+
+      # Linux: Install cargo-zigbuild for glibc-targeted compilation
+      - name: Install cargo-zigbuild (Linux)
+        if: matrix.platform == 'linux'
+        run: cargo install --locked cargo-zigbuild
+
       # Linux x86_64: Install GStreamer via apt (ubuntu-24.04 has 1.24+)
       - name: Cache apt packages (Linux x86_64)
         if: matrix.platform == 'linux' && matrix.target == 'x86_64-unknown-linux-gnu'
@@ -126,12 +144,11 @@ jobs:
           deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports $(lsb_release -sc)-security main universe
           EOF
           sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
           sudo apt-get install -y libssl-dev:arm64 pkg-config:arm64 libunwind-dev:arm64
           sudo apt-get install -y libgstreamer1.0-dev:arm64 libgstreamer-plugins-base1.0-dev:arm64 libgstreamer-plugins-bad1.0-dev:arm64
-          echo "PKG_CONFIG_SYSROOT_DIR=/usr/aarch64-linux-gnu" >> $GITHUB_ENV
+          echo "PKG_CONFIG_ALLOW_CROSS=1" >> $GITHUB_ENV
           echo "PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig" >> $GITHUB_ENV
-          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+          echo "AARCH64_UNKNOWN_LINUX_GNU_OPENSSL_LIB_DIR=/usr/lib/aarch64-linux-gnu" >> $GITHUB_ENV
 
       # Windows: Install GStreamer and pkg-config via Chocolatey
       - name: Install GStreamer (Windows)
@@ -162,10 +179,24 @@ jobs:
           cache-on-failure: true
 
       - name: Build backend (with embedded frontend)
-        run: cargo build --release --package strom --target ${{ matrix.target }}
+        run: |
+          if [ "${{ matrix.platform }}" = "linux" ]; then
+            # Use cargo-zigbuild for Linux to target glibc 2.31 (Ubuntu 20.04+)
+            cargo zigbuild --release --package strom --target ${{ matrix.target }}.2.31
+          else
+            # Use standard cargo build for non-Linux platforms
+            cargo build --release --package strom --target ${{ matrix.target }}
+          fi
 
       - name: Build MCP server
-        run: cargo build --release --package strom-mcp-server --target ${{ matrix.target }}
+        run: |
+          if [ "${{ matrix.platform }}" = "linux" ]; then
+            # Use cargo-zigbuild for Linux to target glibc 2.31 (Ubuntu 20.04+)
+            cargo zigbuild --release --package strom-mcp-server --target ${{ matrix.target }}.2.31
+          else
+            # Use standard cargo build for non-Linux platforms
+            cargo build --release --package strom-mcp-server --target ${{ matrix.target }}
+          fi
 
       - name: Upload backend binary
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- Migrate Linux x86_64 and ARM64 release builds to use `cargo-zigbuild` with glibc 2.31 targeting
- Enables broader Linux distribution compatibility for release binaries
- Aligns CI approach with Dockerfile's existing Zig cross-compilation strategy

## Changes

### CI Workflow (`.github/workflows/release.yml`)
- **Add Zig 0.13.0 installation** for both Linux x86_64 and ARM64 builds
- **Install cargo-zigbuild** for glibc-targeted Rust compilation
- **Remove gcc-aarch64-linux-gnu dependency** - Zig handles cross-compilation internally
- **Update build commands**:
  - Linux: `cargo zigbuild --target <target>.2.31` (targets glibc 2.31)
  - Windows/macOS: unchanged (standard `cargo build`)
- **Simplified ARM64 cross-compilation** - cleaner setup without GCC toolchain

## Benefits

### Compatibility Improvements
| Platform | Before (ubuntu-24.04) | After (Zig + glibc 2.31) |
|----------|----------------------|--------------------------|
| glibc version | 2.39 | **2.31** |
| Ubuntu | 24.04+ | **20.04+** |
| Debian | 13+ | **11+** |
| RHEL/Rocky | 10+ | **8+** |

### Technical Advantages
- **Broader compatibility**: Binaries work on Ubuntu 20.04+ (LTS) instead of 24.04+
- **Consistent approach**: Matches Dockerfile's Zig-based cross-compilation (currently uses `.2.36`)
- **Cleaner ARM64 builds**: No GCC cross-compiler complexity
- **Future-proof**: Easy to adjust glibc target version if needed

## Testing Strategy

To test this PR, we need to verify:

1. **Build succeeds in CI** - All platforms (Linux x86_64, ARM64, Windows, macOS)
2. **Binary compatibility** - Test on older Linux distributions:
   - Ubuntu 20.04 (glibc 2.31)
   - Ubuntu 22.04 (glibc 2.35)
   - Debian 11 (glibc 2.31)
3. **Functionality** - Binaries work correctly (GStreamer, WebUI, etc.)
4. **Binary size** - Check for unexpected size changes

### Manual Testing Commands
```bash
# On Ubuntu 20.04 or similar:
wget <artifact-url>
chmod +x strom-*-linux-x86_64
./strom-*-linux-x86_64 --version
./strom-*-linux-x86_64 --headless

# Check glibc dependency
ldd strom-*-linux-x86_64 | grep libc
```

## Notes
- This PR only changes Linux builds; Windows and macOS remain unchanged
- Dockerfile already uses Zig with glibc 2.36 targeting - this brings CI in line
- Future consideration: Could also update Dockerfile to use glibc 2.31 for even broader compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)