### PR TITLE
fix: Use echo -e for color codes in configuration menu

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -350,19 +350,19 @@ show_config_menu() {
     echo ""
     echo "Current settings:"
     echo ""
-    echo "  1. Binary:           ${GREEN}${BINARY_NAME}${NC}"
-    echo "  2. Version:          ${GREEN}${VERSION}${NC}"
-    echo "  3. Install GStreamer: ${GREEN}$([ "$SKIP_GSTREAMER" = "false" ] && echo "Yes" || echo "No")${NC}"
-    echo "  4. GStreamer Type:   ${GREEN}${GSTREAMER_INSTALL_TYPE}${NC} (minimal/full)"
-    echo "  5. Install Graphviz: ${GREEN}$([ "$SKIP_GRAPHVIZ" = "false" ] && echo "Yes" || echo "No")${NC}"
+    echo -e "  1. Binary:            ${GREEN}${BINARY_NAME}${NC}"
+    echo -e "  2. Version:           ${GREEN}${VERSION}${NC}"
+    echo -e "  3. Install GStreamer: ${GREEN}$([ "$SKIP_GSTREAMER" = "false" ] && echo "Yes" || echo "No")${NC}"
+    echo -e "  4. GStreamer Type:    ${GREEN}${GSTREAMER_INSTALL_TYPE}${NC} (minimal/full)"
+    echo -e "  5. Install Graphviz:  ${GREEN}$([ "$SKIP_GRAPHVIZ" = "false" ] && echo "Yes" || echo "No")${NC}"
     if [ -n "$INSTALL_DIR" ]; then
-        echo "  6. Install Directory: ${GREEN}${INSTALL_DIR}${NC}"
+        echo -e "  6. Install Directory: ${GREEN}${INSTALL_DIR}${NC}"
     else
-        echo "  6. Install Directory: ${GREEN}auto (/usr/local/bin or ~/.local/bin)${NC}"
+        echo -e "  6. Install Directory: ${GREEN}auto (/usr/local/bin or ~/.local/bin)${NC}"
     fi
     echo ""
-    echo "  ${GREEN}c${NC}. Continue with these settings"
-    echo "  ${GREEN}q${NC}. Quit"
+    echo -e "  ${GREEN}c${NC}. Continue with these settings"
+    echo -e "  ${GREEN}q${NC}. Quit"
     echo ""
     echo -n "Enter option to change (or 'c' to continue): "
 


### PR DESCRIPTION
## Summary
Fix ANSI color codes not being interpreted in the interactive configuration menu.

## Problem
When running the installer, raw escape codes were displayed instead of colors:
```
  1. Binary:           \033[0;32mstrom\033[0m
  2. Version:          \033[0;32mlatest\033[0m
  3. Install GStreamer: \033[0;32mYes\033[0m
```

## Solution
Added `-e` flag to all `echo` commands that contain color variables in `show_config_menu()`.

Changed from:
```bash
echo "  1. Binary:           ${GREEN}${BINARY_NAME}${NC}"
```

To:
```bash
echo -e "  1. Binary:            ${GREEN}${BINARY_NAME}${NC}"
```

## After Fix
Menu now displays properly with colors:
```
  1. Binary:            strom         (in green)
  2. Version:           latest        (in green)
  3. Install GStreamer: Yes           (in green)
  4. GStreamer Type:    full          (in green)
  5. Install Graphviz:  Yes           (in green)
  6. Install Directory: auto (/usr/local/bin or ~/.local/bin) (in green)

  c. Continue with these settings      (c in green)
  q. Quit                              (q in green)
```

## Testing
Tested in Docker container:
```bash
docker run -it ubuntu:20.04 bash
apt-get update && apt-get install -y curl
bash <(curl -sSL https://raw.githubusercontent.com/Eyevinn/strom/fix/menu-color-output/install.sh)
```

Colors now display correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)