### PR TITLE
fix: Auto-detect piped stdin and enable automated mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,30 +34,32 @@
 Install Strom with a single command:
 
 ```bash
-# Interactive install (DEFAULT) - shows configuration menu
+# Interactive install (RECOMMENDED) - shows configuration menu
 bash <(curl -sSL https://raw.githubusercontent.com/Eyevinn/strom/main/install.sh)
 
-# Automated install (for CI/CD) - skips menu, uses defaults
-curl -sSL https://raw.githubusercontent.com/Eyevinn/strom/main/install.sh | AUTO_INSTALL=true bash
+# Quick install - auto-detects piped mode, skips menu
+curl -sSL https://raw.githubusercontent.com/Eyevinn/strom/main/install.sh | bash
 
 # Automated with minimal GStreamer
-curl -sSL https://raw.githubusercontent.com/Eyevinn/strom/main/install.sh | AUTO_INSTALL=true GSTREAMER_INSTALL_TYPE=minimal bash
+curl -sSL https://raw.githubusercontent.com/Eyevinn/strom/main/install.sh | GSTREAMER_INSTALL_TYPE=minimal bash
 
 # Automated binary only (skip dependencies)
-curl -sSL https://raw.githubusercontent.com/Eyevinn/strom/main/install.sh | AUTO_INSTALL=true SKIP_GSTREAMER=true SKIP_GRAPHVIZ=true bash
+curl -sSL https://raw.githubusercontent.com/Eyevinn/strom/main/install.sh | SKIP_GSTREAMER=true SKIP_GRAPHVIZ=true bash
 ```
 
-**Default behavior (interactive mode):**
+**Interactive mode (recommended):**
+- Use: `bash <(curl -sSL ...)`
 - Shows configuration menu to customize installation
 - Choose binary (strom or strom-mcp-server)
 - Select GStreamer type (minimal or full)
 - Configure version and install location
 - Human-friendly with clear defaults
 
-**Automated mode (`AUTO_INSTALL=true`):**
-- Skips interactive menu
+**Automated mode (quick install):**
+- Use: `curl -sSL ... | bash`
+- Auto-detects piped stdin and skips menu
 - Uses defaults or environment variables
-- Perfect for CI/CD and scripts
+- Perfect for quick installs, CI/CD, and scripts
 
 The script will:
 - Detect your OS and architecture automatically

--- a/install.sh
+++ b/install.sh
@@ -3,13 +3,17 @@
 # Strom Installer Script
 #
 # Usage:
-#   # Interactive mode (default, for humans):
+#   # Interactive mode (RECOMMENDED for humans):
 #   bash <(curl -sSL https://raw.githubusercontent.com/Eyevinn/strom/main/install.sh)
 #   # Shows configuration menu before installation
 #
-#   # Automated mode (for CI/CD):
+#   # Automated mode (for CI/CD or quick install):
+#   curl -sSL https://raw.githubusercontent.com/Eyevinn/strom/main/install.sh | bash
+#   # Auto-detects piped stdin and skips menu, uses defaults
+#
+#   # Explicit automated mode:
 #   curl -sSL https://raw.githubusercontent.com/Eyevinn/strom/main/install.sh | AUTO_INSTALL=true bash
-#   # Skips menu, uses defaults or environment variables
+#   # Same as above, explicitly set
 #
 # Options (set as environment variables):
 #   AUTO_INSTALL             - Skip interactive menu (default: false, menu shown by default)
@@ -340,6 +344,16 @@ show_config_menu() {
     # Skip menu if AUTO_INSTALL is set (for automation)
     if [ "$AUTO_INSTALL" = "true" ]; then
         log_info "Auto-install mode enabled, skipping configuration menu..."
+        return
+    fi
+
+    # Auto-enable AUTO_INSTALL if stdin is not a terminal (piped from curl)
+    if [ ! -t 0 ]; then
+        log_warning "Stdin is not a terminal (script is piped)"
+        log_info "Automatically enabling AUTO_INSTALL mode..."
+        log_info "For interactive mode, use: bash <(curl -sSL ...)"
+        echo ""
+        AUTO_INSTALL="true"
         return
     fi
 


### PR DESCRIPTION
## Summary
Automatically detect when the script is piped and enable automated mode, preventing the script from hanging while trying to read user input.

## Problem
When running:
```bash
curl -sSL https://raw.githubusercontent.com/Eyevinn/strom/main/install.sh | bash
```

The script would:
1. Show the interactive configuration menu
2. Try to read input with `read -r choice`
3. Hang/exit immediately because stdin is the pipe from curl (not the terminal)
4. User couldn't interact with the menu or proceed with installation

## Root Cause
When piping to bash (`curl ... | bash`), stdin is connected to the pipe output from curl, not the user's terminal. The `read` command cannot get keyboard input.

## Solution
Added detection in `show_config_menu()`:
```bash
# Auto-enable AUTO_INSTALL if stdin is not a terminal (piped from curl)
if [ ! -t 0 ]; then
    log_warning "Stdin is not a terminal (script is piped)"
    log_info "Automatically enabling AUTO_INSTALL mode..."
    log_info "For interactive mode, use: bash <(curl -sSL ...)"
    echo ""
    AUTO_INSTALL="true"
    return
fi
```

## Behavior After Fix

### Interactive Mode (stdin is terminal):
```bash
bash <(curl -sSL .../install.sh)
```
- Shows configuration menu
- User can interact and customize settings
- **Recommended for humans**

### Automated Mode (stdin is piped):
```bash
curl -sSL .../install.sh | bash
```
- Detects piped stdin
- Automatically enables AUTO_INSTALL
- Shows friendly message
- Proceeds with defaults
- **Works for quick installs and CI/CD**

## Example Output

When piped:
```
==> Strom Installer

==> Detected: linux-x86_64
==> Stdin is not a terminal (script is piped)
==> Automatically enabling AUTO_INSTALL mode...
==> For interactive mode, use: bash <(curl -sSL ...)

==> Version: v0.2.5
==> Installing GStreamer (full)...
```

## Testing
```bash
# Test automated (should skip menu)
docker run -it ubuntu:20.04 bash -c "
  apt-get update && apt-get install -y curl &&
  curl -sSL .../install.sh | bash
"

# Test interactive (should show menu)
docker run -it ubuntu:20.04 bash -c "
  apt-get update && apt-get install -y curl &&
  bash <(curl -sSL .../install.sh)
"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)