### PR TITLE
fix: Redirect all log output to stderr to prevent command substitution issues

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -57,15 +57,15 @@ AUTO_INSTALL="${AUTO_INSTALL:-false}"
 
 # Helper functions
 log_info() {
-    echo -e "${BLUE}==>${NC} $1"
+    echo -e "${BLUE}==>${NC} $1" >&2
 }
 
 log_success() {
-    echo -e "${GREEN}==>${NC} $1"
+    echo -e "${GREEN}==>${NC} $1" >&2
 }
 
 log_warning() {
-    echo -e "${YELLOW}==>${NC} $1"
+    echo -e "${YELLOW}==>${NC} $1" >&2
 }
 
 log_error() {


### PR DESCRIPTION
## Summary
Fix critical bug where log messages were being captured in variables, causing malformed URLs and installation failures.

## Problem
When using command substitution to capture function return values:
```bash
VERSION=$(get_latest_version)
tmp_file=$(download_binary ...)
```

The `log_info`, `log_success`, and `log_warning` messages were being written to stdout and captured along with the actual return value, resulting in:

```
VERSION="==> Fetching latest version...\nv0.2.5"
```

This caused:
- Malformed download URLs
- Failed downloads
- File path errors
- Installation failures

## Root Cause
Log functions were writing to stdout (default for `echo`), which is captured by `$(...)` command substitution.

## Solution
Redirect all log output to stderr (`>&2`):

```bash
log_info() {
    echo -e "${BLUE}==>${NC} $1" >&2
}

log_success() {
    echo -e "${GREEN}==>${NC} $1" >&2
}

log_warning() {
    echo -e "${YELLOW}==>${NC} $1" >&2
}
```

This is the standard practice:
- stdout = data/return values (for piping and capture)
- stderr = user messages/logs (not captured)

## After Fix

Command substitution now works correctly:
```bash
VERSION=$(get_latest_version)
# VERSION="v0.2.5" (correct)
# Log message "==> Fetching latest version..." goes to terminal (stderr)
```

Downloads work:
```
==> Downloading strom-v0.2.5-linux-x86_64...
==> URL: https://github.com/Eyevinn/strom/releases/download/v0.2.5/strom-v0.2.5-linux-x86_64
```

## Testing
```bash
# Test installation works end-to-end
curl -sSL .../install.sh | bash

# Should see proper URLs and successful downloads
```

## Technical Notes
- `log_error()` was already using `>&2` (correct)
- Now all logging functions consistently use stderr
- Actual return values (from `echo "$value"`) still go to stdout for capture
- This is standard shell scripting practice

🤖 Generated with [Claude Code](https://claude.com/claude-code)