### PR TITLE
fix: Set DEBIAN_FRONTEND=noninteractive for all apt-get commands

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -197,7 +197,7 @@ install_gstreamer() {
     case "$os" in
         linux)
             if command -v apt-get >/dev/null 2>&1; then
-                run_elevated apt-get update
+                run_elevated env DEBIAN_FRONTEND=noninteractive apt-get update
 
                 # Minimal: core libraries + basic plugins
                 local packages=(
@@ -225,7 +225,7 @@ install_gstreamer() {
                     )
                 fi
 
-                run_elevated apt-get install -y "${packages[@]}"
+                run_elevated env DEBIAN_FRONTEND=noninteractive apt-get install -y "${packages[@]}"
                 log_success "GStreamer installed successfully"
             elif command -v dnf >/dev/null 2>&1; then
                 local packages=(
@@ -297,8 +297,8 @@ install_graphviz() {
     case "$os" in
         linux)
             if command -v apt-get >/dev/null 2>&1; then
-                run_elevated apt-get update
-                run_elevated apt-get install -y graphviz
+                run_elevated env DEBIAN_FRONTEND=noninteractive apt-get update
+                run_elevated env DEBIAN_FRONTEND=noninteractive apt-get install -y graphviz
                 log_success "Graphviz installed successfully"
             elif command -v dnf >/dev/null 2>&1; then
                 run_elevated dnf install -y graphviz


### PR DESCRIPTION
## Summary
Prevent interactive prompts during apt package installation by setting `DEBIAN_FRONTEND=noninteractive`.

## Problem
During installation, some packages (particularly `tzdata`) prompt for user configuration:
```
Configuring tzdata
------------------

Please select the geographic area in which you live...

  1. Africa      4. Australia  7. Atlantic  10. Pacific  13. Etc
  2. America     5. Arctic     8. Europe    11. SystemV  14. Legacy
  3. Antarctica  6. Asia       9. Indian    12. US
Geographic area:
```

This interrupts the installation flow and is problematic for:
- Docker containers
- Automated installations
- CI/CD pipelines
- Unattended installs

## Solution
Set `DEBIAN_FRONTEND=noninteractive` for all `apt-get` commands:

```bash
run_elevated env DEBIAN_FRONTEND=noninteractive apt-get update
run_elevated env DEBIAN_FRONTEND=noninteractive apt-get install -y "${packages[@]}"
```

This tells apt to use default values instead of prompting for configuration.

## Changes
- All `apt-get update` commands now use `DEBIAN_FRONTEND=noninteractive`
- All `apt-get install` commands now use `DEBIAN_FRONTEND=noninteractive`
- Applied to both GStreamer and Graphviz installation

## Testing
```bash
# Should install without any prompts
docker run -it ubuntu:20.04 bash -c "
  apt-get update && apt-get install -y curl &&
  curl -sSL .../install.sh | bash
"
```

## Note
This is standard practice for automated package installation and matches Docker best practices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)