### PR TITLE
feat: Add static OpenSSL linking for Ubuntu 20.04+ compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,14 +198,16 @@ jobs:
           targets: wasm32-unknown-unknown,${{ matrix.target }}
 
       # Linux x86_64: Install GStreamer via apt (ubuntu-24.04 has 1.24+)
+      # Also install build tools for vendored OpenSSL compilation
       - name: Cache apt packages (Linux x86_64)
         if: matrix.platform == 'linux' && matrix.target == 'x86_64-unknown-linux-gnu'
         uses: awalsh128/cache-apt-pkgs-action@v1
         with:
-          packages: libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-bad1.0-dev gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-libav gstreamer1.0-tools
-          version: 1.1
+          packages: libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-bad1.0-dev gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-libav gstreamer1.0-tools perl make
+          version: 1.2
 
       # Linux ARM64: Install cross-compilation tools and ARM64 GStreamer (ubuntu-24.04 has 1.24+)
+      # Also install build tools for vendored OpenSSL compilation
       - name: Install cross-compilation tools (Linux ARM64)
         if: matrix.platform == 'linux' && matrix.target == 'aarch64-unknown-linux-gnu'
         run: |
@@ -227,7 +229,7 @@ jobs:
           deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports $(lsb_release -sc)-security main universe
           EOF
           sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu perl make
           sudo apt-get install -y libssl-dev:arm64 pkg-config:arm64 libunwind-dev:arm64
           sudo apt-get install -y libgstreamer1.0-dev:arm64 libgstreamer-plugins-base1.0-dev:arm64 libgstreamer-plugins-bad1.0-dev:arm64
           echo "PKG_CONFIG_SYSROOT_DIR=/usr/aarch64-linux-gnu" >> $GITHUB_ENV

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4029,6 +4029,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
+name = "openssl-src"
+version = "300.5.4+3.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507b3792995dae9b0df8a1c1e3771e8418b7c2d9f0baeba32e6fe8b06c7cb72"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4036,6 +4045,7 @@ checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -5509,6 +5519,7 @@ dependencies = [
  "libc",
  "mime_guess",
  "nvml-wrapper",
+ "openssl",
  "rust-embed",
  "serde",
  "serde_json",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -51,6 +51,9 @@ sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres", "uuid"
 thread-priority = "3.0.0"
 libc = "0.2"
 
+# TLS/Crypto - vendored OpenSSL for maximum compatibility (Ubuntu 20.04+)
+openssl = { version = "0.10", features = ["vendored"] }
+
 # Authentication
 bcrypt = "0.17.1"
 tower-sessions = "0.14"


### PR DESCRIPTION
## Summary
- Add static OpenSSL linking to fix Ubuntu 20.04 compatibility issue
- Binary no longer requires libssl.so.3 at runtime
- Works on Ubuntu 20.04+ (OpenSSL 1.1.1 or newer)

## Problem
The strom binary failed on Ubuntu 20.04 with:
```
strom: error while loading shared libraries: libssl.so.3: cannot open shared object file: No such file or directory
```

This happened because:
- Ubuntu 20.04 only has OpenSSL 1.1.1
- Strom was built on ubuntu-24.04 and dynamically linked against OpenSSL 3

## Solution
Static link OpenSSL using the `vendored` feature, which compiles OpenSSL from source and embeds it into the binary.

## Changes
- **backend/Cargo.toml**: Added `openssl = { version = "0.10", features = ["vendored"] }`
- **.github/workflows/ci.yml**: Added `perl` and `make` build dependencies for OpenSSL compilation
- **Cargo.lock**: Locked `openssl-src v300.5.4+3.5.4`

## Testing
- ✅ Verified with `ldd` - no libssl.so dependency
- ✅ Both strom and strom-mcp-server compile successfully
- ✅ Pre-commit hooks pass (clippy + formatting)

## Impact
- Binary size increases by ~2-3MB due to embedded OpenSSL
- Security updates require rebuilding Strom (not automatic system updates)
- Compatible with Ubuntu 20.04, 22.04, 24.04+

## Security Note
With static linking, OpenSSL security patches require rebuilding and releasing new Strom versions. Users should update Strom regularly for security fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)