### PR TITLE
chore: Release v0.2.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5499,7 +5499,7 @@ dependencies = [
 
 [[package]]
 name = "strom"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5545,7 +5545,7 @@ dependencies = [
 
 [[package]]
 name = "strom-frontend"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "console_error_panic_hook",
  "eframe",
@@ -5571,7 +5571,7 @@ dependencies = [
 
 [[package]]
 name = "strom-mcp-server"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "anyhow",
  "reqwest",
@@ -5585,7 +5585,7 @@ dependencies = [
 
 [[package]]
 name = "strom-types"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["types", "backend", "frontend", "mcp-server"]
 default-members = ["backend"]
 
 [workspace.package]
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Per"]


### PR DESCRIPTION
## Release v0.2.6

### What's New

**Static OpenSSL Linking for Ubuntu 20.04+ Compatibility**
- Binary now works on Ubuntu 20.04 without requiring libssl.so.3
- OpenSSL is statically linked (vendored) into the binary
- Compatible with Ubuntu 20.04, 22.04, 24.04+

### Changes
- Static link OpenSSL to avoid runtime dependency issues on older systems
- Add build dependencies (perl, make) for OpenSSL compilation in CI

### Impact
- Binary size increases by ~2-3MB due to embedded OpenSSL
- No more "libssl.so.3: cannot open shared object file" errors on Ubuntu 20.04

### Security Note
With static linking, OpenSSL security patches require rebuilding and releasing new Strom versions. Users should update Strom regularly for security fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)