### PR TITLE
fix: Use bash shell for build steps in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,6 +179,7 @@ jobs:
           cache-on-failure: true
 
       - name: Build backend (with embedded frontend)
+        shell: bash
         run: |
           if [ "${{ matrix.platform }}" = "linux" ]; then
             # Use cargo-zigbuild for Linux to target glibc 2.31 (Ubuntu 20.04+)
@@ -189,6 +190,7 @@ jobs:
           fi
 
       - name: Build MCP server
+        shell: bash
         run: |
           if [ "${{ matrix.platform }}" = "linux" ]; then
             # Use cargo-zigbuild for Linux to target glibc 2.31 (Ubuntu 20.04+)


### PR DESCRIPTION
## Problem
Windows build was failing with:
```
ParserError: Missing '(' after 'if' in if statement.
```

This happened because bash syntax was being executed in PowerShell on Windows.

## Solution
- Add `shell: bash` to build steps that use bash if/then syntax
- This makes GitHub Actions use bash on all platforms (Linux, Windows, macOS)

## Changes
- `.github/workflows/release.yml`: Add `shell: bash` to "Build backend" and "Build MCP server" steps
- `.github/workflows/ci.yml`: Revert unnecessary Strawberry Perl addition (was a guess, not needed)

Fixes #92 release failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)