### PR TITLE
feat: Improve video encoder for low-latency streaming

### DIFF
--- a/backend/src/blocks/builtin/videoenc.rs
+++ b/backend/src/blocks/builtin/videoenc.rs
@@ -62,17 +62,8 @@ impl BlockBuilder for VideoEncBuilder {
         // Parse encoder preference (optional, default: auto)
         let preference = parse_encoder_preference(properties);
 
-        // Parse allow_software_fallback (optional, default: true)
-        let allow_software_fallback = properties
-            .get("allow_software_fallback")
-            .and_then(|v| match v {
-                PropertyValue::Bool(b) => Some(*b),
-                _ => None,
-            })
-            .unwrap_or(true);
-
         // Select best available encoder
-        let encoder_name = select_encoder(codec, preference, allow_software_fallback)?;
+        let encoder_name = select_encoder(codec, preference)?;
         info!(
             "🎞️ Selected encoder '{}' for codec {:?} with preference {:?}",
             encoder_name, codec, preference
@@ -94,7 +85,15 @@ impl BlockBuilder for VideoEncBuilder {
                 PropertyValue::String(s) => Some(s.as_str()),
                 _ => None,
             })
-            .unwrap_or("medium");
+            .unwrap_or("ultrafast");
+
+        let tune = properties
+            .get("tune")
+            .and_then(|v| match v {
+                PropertyValue::String(s) => Some(s.as_str()),
+                _ => None,
+            })
+            .unwrap_or("zerolatency");
 
         let rate_control = parse_rate_control(properties);
 
@@ -128,6 +127,7 @@ impl BlockBuilder for VideoEncBuilder {
             &encoder_name,
             bitrate,
             quality_preset,
+            tune,
             rate_control,
             keyframe_interval,
         );
@@ -226,11 +226,7 @@ fn parse_rate_control(properties: &HashMap<String, PropertyValue>) -> RateContro
 }
 
 /// Select the best available encoder for the given codec and preference.
-fn select_encoder(
-    codec: Codec,
-    preference: EncoderPreference,
-    allow_software_fallback: bool,
-) -> Result<String, BlockBuildError> {
+fn select_encoder(codec: Codec, preference: EncoderPreference) -> Result<String, BlockBuildError> {
     let registry = gst::Registry::get();
 
     // Get priority list of encoders to try
@@ -266,28 +262,21 @@ fn select_encoder(
             )))
         }
         EncoderPreference::Auto => {
-            if allow_software_fallback {
-                // Try software encoders as fallback
-                let software_list = get_software_encoder_list(codec);
-                for encoder_name in &software_list {
-                    if registry
-                        .find_feature(encoder_name, gst::ElementFactory::static_type())
-                        .is_some()
-                    {
-                        warn!("⚠️ Using software fallback encoder: {}", encoder_name);
-                        return Ok(encoder_name.to_string());
-                    }
+            // Try software encoders as fallback
+            let software_list = get_software_encoder_list(codec);
+            for encoder_name in &software_list {
+                if registry
+                    .find_feature(encoder_name, gst::ElementFactory::static_type())
+                    .is_some()
+                {
+                    warn!("⚠️ Using software fallback encoder: {}", encoder_name);
+                    return Ok(encoder_name.to_string());
                 }
-                Err(BlockBuildError::InvalidConfiguration(format!(
-                    "No encoder available for {:?} (tried hardware and software)",
-                    codec
-                )))
-            } else {
-                Err(BlockBuildError::InvalidConfiguration(format!(
-                    "No hardware encoder available for {:?} and software fallback is disabled",
-                    codec
-                )))
             }
+            Err(BlockBuildError::InvalidConfiguration(format!(
+                "No encoder available for {:?} (tried hardware and software)",
+                codec
+            )))
         }
     }
 }
@@ -371,6 +360,7 @@ fn set_encoder_properties(
     encoder_name: &str,
     bitrate: u32,
     quality_preset: &str,
+    tune: &str,
     rate_control: RateControl,
     keyframe_interval: u32,
 ) {
@@ -381,6 +371,8 @@ fn set_encoder_properties(
         // x264/x265: speed-preset (enum property) - use set_property_from_str for enum
         let preset_nick = map_quality_preset_x264(quality_preset);
         encoder.set_property_from_str("speed-preset", preset_nick);
+        // x264/x265: tune (enum property) - optimize for specific use case
+        encoder.set_property_from_str("tune", tune);
     } else if encoder_name.starts_with("nv") {
         // NVENC encoders: bitrate in kbps
         encoder.set_property("bitrate", bitrate);
@@ -473,8 +465,8 @@ fn set_encoder_properties(
     }
 
     info!(
-        "🎞️ Set encoder properties: bitrate={} kbps, preset={}, rate_control={:?}, gop={}",
-        bitrate, quality_preset, rate_control, keyframe_interval
+        "🎞️ Set encoder properties: bitrate={} kbps, preset={}, tune={}, rate_control={:?}, gop={}",
+        bitrate, quality_preset, tune, rate_control, keyframe_interval
     );
 }
 
@@ -678,10 +670,31 @@ fn videoenc_definition() -> BlockDefinition {
                         EnumValue { value: "veryslow".to_string(), label: Some("Very Slow".to_string()) },
                     ],
                 },
-                default_value: Some(PropertyValue::String("medium".to_string())),
+                default_value: Some(PropertyValue::String("ultrafast".to_string())),
                 mapping: PropertyMapping {
                     element_id: "_block".to_string(),
                     property_name: "quality_preset".to_string(),
+                    transform: None,
+                },
+            },
+            ExposedProperty {
+                name: "tune".to_string(),
+                label: "Tune".to_string(),
+                description: "Optimize encoder for specific use case (x264/x265 only). Zero latency disables look-ahead for minimal delay.".to_string(),
+                property_type: PropertyType::Enum {
+                    values: vec![
+                        EnumValue { value: "zerolatency".to_string(), label: Some("Zero Latency (streaming/real-time)".to_string()) },
+                        EnumValue { value: "film".to_string(), label: Some("Film (high quality)".to_string()) },
+                        EnumValue { value: "animation".to_string(), label: Some("Animation".to_string()) },
+                        EnumValue { value: "grain".to_string(), label: Some("Grain (preserve film grain)".to_string()) },
+                        EnumValue { value: "stillimage".to_string(), label: Some("Still Image".to_string()) },
+                        EnumValue { value: "fastdecode".to_string(), label: Some("Fast Decode".to_string()) },
+                    ],
+                },
+                default_value: Some(PropertyValue::String("zerolatency".to_string())),
+                mapping: PropertyMapping {
+                    element_id: "_block".to_string(),
+                    property_name: "tune".to_string(),
                     transform: None,
                 },
             },
@@ -712,18 +725,6 @@ fn videoenc_definition() -> BlockDefinition {
                 mapping: PropertyMapping {
                     element_id: "_block".to_string(),
                     property_name: "keyframe_interval".to_string(),
-                    transform: None,
-                },
-            },
-            ExposedProperty {
-                name: "allow_software_fallback".to_string(),
-                label: "Allow Software Fallback".to_string(),
-                description: "Allow fallback to software encoding if no hardware encoder is available (only relevant for Auto/Hardware modes)".to_string(),
-                property_type: PropertyType::Bool,
-                default_value: Some(PropertyValue::Bool(true)),
-                mapping: PropertyMapping {
-                    element_id: "_block".to_string(),
-                    property_name: "allow_software_fallback".to_string(),
                     transform: None,
                 },
             },

--- a/backend/src/blocks/builtin/videoenc/tests.rs
+++ b/backend/src/blocks/builtin/videoenc/tests.rs
@@ -186,7 +186,7 @@ fn test_encoder_selection_software_only() {
     init_gst();
 
     // Software-only should only try software encoders
-    let result = select_encoder(Codec::H264, EncoderPreference::SoftwareOnly, true);
+    let result = select_encoder(Codec::H264, EncoderPreference::SoftwareOnly);
 
     match result {
         Ok(encoder) => {
@@ -207,7 +207,7 @@ fn test_encoder_selection_with_fallback() {
     init_gst();
 
     // Auto mode with fallback should find something
-    let result = select_encoder(Codec::H264, EncoderPreference::Auto, true);
+    let result = select_encoder(Codec::H264, EncoderPreference::Auto);
 
     assert!(
         result.is_ok(),
@@ -248,7 +248,15 @@ fn test_encoder_property_setting_x264() {
         .expect("Should create x264enc");
 
     // Test that we can set properties without panicking
-    set_encoder_properties(&encoder, "x264enc", 4000, "medium", RateControl::VBR, 60);
+    set_encoder_properties(
+        &encoder,
+        "x264enc",
+        4000,
+        "medium",
+        "zerolatency",
+        RateControl::VBR,
+        60,
+    );
 
     // Verify bitrate was set
     let bitrate: u32 = encoder.property("bitrate");
@@ -280,7 +288,15 @@ fn test_encoder_property_setting_nvenc() {
             .unwrap_or_else(|_| panic!("Should create {}", encoder_name));
 
         // Test property setting without panicking
-        set_encoder_properties(&encoder, encoder_name, 4000, "medium", RateControl::VBR, 60);
+        set_encoder_properties(
+            &encoder,
+            encoder_name,
+            4000,
+            "medium",
+            "zerolatency",
+            RateControl::VBR,
+            60,
+        );
 
         // Verify bitrate
         let bitrate: u32 = encoder.property("bitrate");
@@ -318,7 +334,15 @@ fn test_gop_size_properties() {
             "x264enc should have key-int-max property"
         );
 
-        set_encoder_properties(&encoder, "x264enc", 4000, "medium", RateControl::VBR, 60);
+        set_encoder_properties(
+            &encoder,
+            "x264enc",
+            4000,
+            "medium",
+            "zerolatency",
+            RateControl::VBR,
+            60,
+        );
 
         // x264enc's key-int-max is u32 (guint), not i32 (gint)
         let gop: u32 = encoder.property("key-int-max");
@@ -338,7 +362,15 @@ fn test_gop_size_properties() {
                 encoder_name
             );
 
-            set_encoder_properties(&encoder, encoder_name, 4000, "medium", RateControl::VBR, 60);
+            set_encoder_properties(
+                &encoder,
+                encoder_name,
+                4000,
+                "medium",
+                "zerolatency",
+                RateControl::VBR,
+                60,
+            );
 
             let gop: i32 = encoder.property("gop-size");
             assert_eq!(
@@ -371,6 +403,7 @@ fn test_gop_size_type_casting() {
             "x264enc",
             4000,
             "medium",
+            "zerolatency",
             RateControl::VBR,
             *gop_value,
         );
@@ -460,7 +493,15 @@ fn test_all_available_encoders() {
             .unwrap_or_else(|_| panic!("Should create {}", encoder_name));
 
         // Test basic property setting
-        set_encoder_properties(&encoder, encoder_name, 4000, "medium", RateControl::VBR, 60);
+        set_encoder_properties(
+            &encoder,
+            encoder_name,
+            4000,
+            "medium",
+            "zerolatency",
+            RateControl::VBR,
+            60,
+        );
 
         println!("✓ {} configured successfully", encoder_name);
     }


### PR DESCRIPTION
## Summary
- Remove redundant "allow_software_fallback" property - now controlled via encoder_preference
- Change quality preset default from "medium" to "ultrafast" for better real-time performance
- Add tune property with "zerolatency" default for minimal encoding delay

## Changes

### 1. Remove Redundant Property
The `allow_software_fallback` property was redundant with the `encoder_preference` setting:
- `encoder_preference="auto"` → tries hardware first, then software (always has fallback)
- `encoder_preference="hardware"` → hardware only, no fallback
- `encoder_preference="software"` → software only

This simplifies configuration and eliminates confusion about when software fallback occurs.

### 2. Change Quality Preset Default
Changed from `"medium"` to `"ultrafast"`:
- Prioritizes encoding speed for real-time streaming
- Reduces CPU usage and encoding latency
- Better default for live streaming applications
- Users can still select slower presets for offline encoding scenarios

### 3. Add Tune Property
New configurable tune parameter for x264/x265 software encoders:
- **Default**: `"zerolatency"` - disables look-ahead and B-frames for minimal delay
- **Options**: zerolatency, film, animation, grain, stillimage, fastdecode
- Only affects software encoders (hardware encoders have built-in low latency)
- Exposed in block metadata for UI configuration

## Implementation Details

**Code Changes** (`backend/src/blocks/builtin/videoenc.rs`):
- Removed `allow_software_fallback` parameter from `select_encoder()` function
- Added `tune` property parsing with "zerolatency" default
- Updated `set_encoder_properties()` to set tune on x264/x265 encoders
- Added tune to exposed properties with 6 tune options
- Updated logging to include tune setting

**Documentation Changes** (`docs/VIDEO_ENCODER_BLOCK.md`):
- Removed references to `allow_software_fallback` property
- Added new tune property section with full documentation
- Updated examples to reflect new defaults and tune usage
- Updated troubleshooting to recommend using encoder_preference

**Test Updates** (`backend/src/blocks/builtin/videoenc/tests.rs`):
- Updated function calls to match new signatures
- Added "zerolatency" parameter to all test cases

## Benefits

### For Streaming Applications
- **Lower latency**: zerolatency tune eliminates look-ahead buffering
- **Better performance**: ultrafast preset reduces CPU usage
- **Simpler configuration**: one setting (encoder_preference) controls fallback behavior

### For Quality-Focused Applications  
- **Still configurable**: users can select slower presets and different tune options
- **No functionality lost**: all previous capabilities remain available

## Testing

All tests pass including:
- Encoder selection logic with new function signature
- Property setting with tune parameter
- GOP size configuration
- Available encoder detection and configuration

## Test Plan
- [x] Code compiles without errors
- [x] All unit tests pass
- [x] cargo fmt and cargo clippy pass
- [x] Documentation updated
- [ ] Manual testing with live video stream (verify low latency)
- [ ] Test on system with hardware encoders (NVENC/QSV)
- [ ] Test on system with only software encoders

🤖 Generated with [Claude Code](https://claude.com/claude-code)