### PR TITLE
chore: Bump version to 0.2.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["types", "backend", "frontend", "mcp-server"]
 default-members = ["backend"]
 
 [workspace.package]
-version = "0.2.6"
+version = "0.2.7"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Per"]


### PR DESCRIPTION
## Summary
- Bump version from 0.2.6 to 0.2.7 in preparation for new release

## Changes Since v0.2.6
- Improved logging with file output and reduced verbosity (#100)
- Added WSL2-specific segfault debugging guide (#101)

This release includes important logging improvements and documentation updates.