### PR TITLE
fix: Add libssl-dev to CI and release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,8 @@ jobs:
       - name: Cache apt packages
         uses: awalsh128/cache-apt-pkgs-action@v1
         with:
-          packages: libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-bad1.0-dev gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-libav gstreamer1.0-tools
-          version: 1.1
+          packages: libssl-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-bad1.0-dev gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-libav gstreamer1.0-tools
+          version: 1.2
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
@@ -99,8 +99,8 @@ jobs:
       - name: Cache apt packages
         uses: awalsh128/cache-apt-pkgs-action@v1
         with:
-          packages: libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-bad1.0-dev gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-libav gstreamer1.0-tools
-          version: 1.1
+          packages: libssl-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-bad1.0-dev gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-libav gstreamer1.0-tools
+          version: 1.2
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
@@ -203,8 +203,8 @@ jobs:
         if: matrix.platform == 'linux' && matrix.target == 'x86_64-unknown-linux-gnu'
         uses: awalsh128/cache-apt-pkgs-action@v1
         with:
-          packages: libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-bad1.0-dev gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-libav gstreamer1.0-tools perl make
-          version: 1.2
+          packages: libssl-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-bad1.0-dev gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-libav gstreamer1.0-tools perl make
+          version: 1.3
 
       # Linux ARM64: Install cross-compilation tools and ARM64 GStreamer (ubuntu-24.04 has 1.24+)
       # Also install build tools for vendored OpenSSL compilation

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,8 +119,8 @@ jobs:
         if: matrix.platform == 'linux' && matrix.target == 'x86_64-unknown-linux-gnu'
         uses: awalsh128/cache-apt-pkgs-action@v1
         with:
-          packages: libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-bad1.0-dev gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-libav gstreamer1.0-tools
-          version: 1.1
+          packages: libssl-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-bad1.0-dev gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-libav gstreamer1.0-tools
+          version: 1.2
 
       # Linux ARM64: Install cross-compilation tools and ARM64 GStreamer (ubuntu-24.04 has 1.24+)
       - name: Install cross-compilation tools (Linux ARM64)


### PR DESCRIPTION
## Summary
- Add `libssl-dev` package to CI and release workflows to fix Linux build failures
- Required for OpenSSL embedding in binary

## Changes

### CI Workflow
- Added `libssl-dev` to clippy and test job apt packages
- Added `libssl-dev` to Linux x86_64 build job
- Bumped apt cache version to `1.2` and `1.3` to invalidate old caches

### Release Workflow
- Added `libssl-dev` to Linux x86_64 build step
- Bumped apt cache version to `1.2` to invalidate old cache

## Context
The Docker publish workflow already includes `libssl-dev` in the Dockerfile (line 89, 98), but CI and release workflows were missing it, causing Linux builds to fail. This brings the workflows in line with the Docker build.

## Test Plan
- [x] Verify CI passes on this PR
- [ ] Verify future release builds succeed with these changes