### PR TITLE
chore: Bump version to 0.2.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5517,7 +5517,7 @@ dependencies = [
 
 [[package]]
 name = "strom"
-version = "0.2.6"
+version = "0.2.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5565,7 +5565,7 @@ dependencies = [
 
 [[package]]
 name = "strom-frontend"
-version = "0.2.6"
+version = "0.2.8"
 dependencies = [
  "console_error_panic_hook",
  "eframe",
@@ -5591,7 +5591,7 @@ dependencies = [
 
 [[package]]
 name = "strom-mcp-server"
-version = "0.2.6"
+version = "0.2.8"
 dependencies = [
  "anyhow",
  "reqwest",
@@ -5605,7 +5605,7 @@ dependencies = [
 
 [[package]]
 name = "strom-types"
-version = "0.2.6"
+version = "0.2.8"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["types", "backend", "frontend", "mcp-server"]
 default-members = ["backend"]
 
 [workspace.package]
-version = "0.2.7"
+version = "0.2.8"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Per"]


### PR DESCRIPTION
## Summary
Bump version to 0.2.8 for release.

## What's New in v0.2.8

### Features
- Add Blackmagic DeckLink SDI/HDMI block support (#99)
- Add visual compositor layout editor (MVP/POC) (#104)

### Fixes
- Pin Windows GStreamer to 1.24.13 in CI workflows (#105)
- Add libssl-dev to CI and release workflows (#103)

---

After merging, create and push the tag:
```bash
git checkout main && git pull
git tag -a v0.2.8 -m "Release v0.2.8"
git push origin v0.2.8
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)