### PR TITLE
fix: Use system OpenSSL instead of vendored for release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,6 +128,8 @@ jobs:
         run: |
           # Tell zig linker where to find x86_64 libraries
           echo "RUSTFLAGS=-L /usr/lib/x86_64-linux-gnu" >> $GITHUB_ENV
+          # Use system OpenSSL instead of vendored (vendored uses glibc 2.38+ symbols)
+          echo "OPENSSL_NO_VENDOR=1" >> $GITHUB_ENV
 
       # Linux ARM64: Install cross-compilation tools and ARM64 GStreamer (ubuntu-24.04 has 1.24+)
       - name: Install cross-compilation tools (Linux ARM64)
@@ -158,11 +160,19 @@ jobs:
           echo "AARCH64_UNKNOWN_LINUX_GNU_OPENSSL_LIB_DIR=/usr/lib/aarch64-linux-gnu" >> $GITHUB_ENV
           # Tell zig linker where to find ARM64 libraries
           echo "RUSTFLAGS=-L /usr/lib/aarch64-linux-gnu" >> $GITHUB_ENV
+          # Use system OpenSSL instead of vendored (vendored uses glibc 2.38+ symbols)
+          echo "OPENSSL_NO_VENDOR=1" >> $GITHUB_ENV
 
-      # Windows: Install Strawberry Perl (needed for OpenSSL build)
-      - name: Install Strawberry Perl (Windows)
+      # Windows: Install OpenSSL (use vcpkg for prebuilt binaries)
+      - name: Install OpenSSL (Windows)
         if: matrix.platform == 'windows'
-        run: choco install strawberryperl --yes --no-progress
+        run: |
+          # Install OpenSSL via vcpkg
+          vcpkg install openssl:x64-windows-static-md
+          # Set environment variables for openssl-sys crate
+          echo "OPENSSL_DIR=C:\vcpkg\installed\x64-windows-static-md" >> $env:GITHUB_ENV
+          echo "OPENSSL_STATIC=1" >> $env:GITHUB_ENV
+          echo "OPENSSL_NO_VENDOR=1" >> $env:GITHUB_ENV
 
       # Windows: Install GStreamer directly from freedesktop.org
       # Chocolatey package is broken (downloads removed versions), so we install MSIs directly


### PR DESCRIPTION
## Summary
- Use system OpenSSL instead of vendored for all release builds
- Fixes Linux zigbuild and Windows build failures

## Problem
The vendored OpenSSL uses glibc 2.38+ symbols (`__isoc23_strtol`) which causes link errors when targeting glibc 2.31:

```
ld.lld: error: undefined symbol: __isoc23_strtol
>>> referenced by libdefault-lib-rand_unix.o:(wait_random_seeded) in archive .../libopenssl_sys-*.rlib
```

## Solution

### Linux (x86_64 & ARM64)
- Add `OPENSSL_NO_VENDOR=1` environment variable
- Uses pre-installed `libssl-dev` (x86_64) and `libssl-dev:arm64` (ARM64)

### Windows
- Install OpenSSL via vcpkg (`openssl:x64-windows-static-md`)
- Set `OPENSSL_DIR`, `OPENSSL_STATIC=1`, `OPENSSL_NO_VENDOR=1`
- Removes need for Strawberry Perl (no more vendored OpenSSL build)

## Test plan
- [ ] Linux x86_64 build succeeds (zigbuild + system OpenSSL)
- [ ] Linux ARM64 build succeeds (zigbuild + system OpenSSL)
- [ ] Windows build succeeds (vcpkg OpenSSL)
- [ ] macOS build succeeds (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)