### PR TITLE
fix: Remove OpenSSL dependency, use rustls everywhere

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,5 +35,7 @@ utoipa-swagger-ui = { version = "9.0", features = ["axum"] }
 # Frontend
 egui = "0.33"
 eframe = { version = "0.33", features = ["default_fonts", "glow", "persistence"] }
-reqwest = { version = "0.12", features = ["json"] }
+# Use rustls instead of native-tls to avoid OpenSSL dependency
+# This enables cross-compilation with zigbuild to older glibc versions
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 gloo-net = { version = "0.6", features = ["websocket"] }

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -53,9 +53,6 @@ sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres", "uuid"
 thread-priority = "3.0.0"
 libc = "0.2"
 
-# TLS/Crypto - vendored OpenSSL for maximum compatibility (Ubuntu 20.04+)
-openssl = { version = "0.10", features = ["vendored"] }
-
 # Authentication
 bcrypt = "0.17.1"
 tower-sessions = "0.14"


### PR DESCRIPTION
## Summary
- Remove OpenSSL dependency entirely
- Use rustls for all TLS operations

## Problem
Release builds were failing when using zigbuild to target glibc 2.31:

```
ld.lld: error: undefined symbol: __isoc23_strtol
>>> referenced by libopenssl_sys-*.rlib
```

The vendored OpenSSL was compiled with Ubuntu 24.04's glibc 2.39 headers, which use `__isoc23_strtol` (a glibc 2.38+ function). When zigbuild links against glibc 2.31, this symbol doesn't exist.

## Solution
Remove OpenSSL entirely and use rustls:

1. **Remove direct openssl dependency** from `backend/Cargo.toml`
2. **Configure reqwest** to use `rustls-tls` instead of `native-tls` (which uses OpenSSL)
3. **sqlx** already uses rustls (`runtime-tokio-rustls`)

### Benefits
- ✅ Cross-compilation to older glibc with zigbuild works
- ✅ Simpler builds (no C compiler needed for OpenSSL)
- ✅ Better Windows compatibility (no OpenSSL build issues)
- ✅ Smaller dependency tree

### Verification
```bash
$ cargo tree -i openssl-sys
openssl-sys not found in dependencies!
```

## Test plan
- [x] `cargo check` passes
- [x] OpenSSL removed from dependency tree
- [ ] CI passes (Linux, Windows, macOS)
- [ ] Release workflow passes with zigbuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)