### PR TITLE
feat: AES67 improvements - PTP clock in SDP and network interface selector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3559,6 +3559,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "network-interface"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07709a6d4eba90ab10ec170a0530b3aafc81cb8a2d380e4423ae41fc55fe5745"
+dependencies = [
+ "cc",
+ "libc",
+ "thiserror 2.0.17",
+ "winapi",
+]
+
+[[package]]
 name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5536,6 +5548,7 @@ dependencies = [
  "http-body-util",
  "libc",
  "mime_guess",
+ "network-interface",
  "nvml-wrapper",
  "openssl",
  "rust-embed",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -83,6 +83,9 @@ rust-embed = { version = "8.0", features = ["debug-embed"] }
 sysinfo = "0.37"
 nvml-wrapper = { version = "0.11", optional = true }
 
+# Network interface discovery
+network-interface = "2.0"
+
 # Optional GUI (native frontend)
 strom-frontend = { path = "../frontend", optional = true }
 eframe = { workspace = true, optional = true }

--- a/backend/src/api/flows.rs
+++ b/backend/src/api/flows.rs
@@ -561,6 +561,14 @@ pub async fn get_block_sdp(
         ));
     }
 
+    // Get PTP clock identity from flow properties if available
+    let ptp_clock_identity = flow
+        .properties
+        .ptp_info
+        .as_ref()
+        .and_then(|info| info.grandmaster_clock_id.as_ref())
+        .map(|id| crate::blocks::sdp::convert_clock_id_to_sdp_format(id));
+
     // Generate SDP (using default sample rate and channels since we can't query caps here)
     // Pass flow properties for correct clock signaling (RFC 7273)
     let sdp = crate::blocks::sdp::generate_aes67_output_sdp(
@@ -569,7 +577,7 @@ pub async fn get_block_sdp(
         None,
         None,
         Some(&flow.properties),
-        None, // PTP clock identity not available at this point
+        ptp_clock_identity.as_deref(),
     );
 
     info!("Successfully generated SDP for block {}", block_id);

--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -4,5 +4,6 @@ pub mod blocks;
 pub mod elements;
 pub mod flows;
 pub mod gst_launch;
+pub mod network;
 pub mod version;
 pub mod websocket;

--- a/backend/src/api/network.rs
+++ b/backend/src/api/network.rs
@@ -1,0 +1,23 @@
+//! Network interface API endpoints.
+
+use axum::Json;
+use strom_types::NetworkInterfacesResponse;
+
+use crate::network::discover_interfaces;
+
+/// List all network interfaces on the system.
+///
+/// Returns information about all network interfaces including name, MAC address,
+/// and IP addresses. Useful for selecting which interface to use for multicast
+/// operations (e.g., AES67 streams).
+#[utoipa::path(
+    get,
+    path = "/api/network/interfaces",
+    tag = "Network",
+    responses(
+        (status = 200, description = "List of network interfaces", body = NetworkInterfacesResponse)
+    )
+)]
+pub async fn list_interfaces() -> Json<NetworkInterfacesResponse> {
+    Json(discover_interfaces())
+}

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -19,6 +19,7 @@ pub mod events;
 pub mod gst;
 pub mod gui;
 pub mod layout;
+pub mod network;
 pub mod openapi;
 pub mod paths;
 pub mod state;
@@ -138,6 +139,8 @@ pub async fn create_app_with_state_and_auth(
             "/gst-launch/export",
             post(api::gst_launch::export_gst_launch),
         )
+        // Network interfaces
+        .route("/network/interfaces", get(api::network::list_interfaces))
         // Apply authentication middleware to all protected routes
         .layer(middleware::from_fn(auth::auth_middleware));
 

--- a/backend/src/network.rs
+++ b/backend/src/network.rs
@@ -1,0 +1,88 @@
+//! Network interface discovery.
+
+use network_interface::{Addr, NetworkInterface, NetworkInterfaceConfig};
+use strom_types::{
+    Ipv4AddressInfo, Ipv6AddressInfo, NetworkInterfaceInfo, NetworkInterfacesResponse,
+};
+use tracing::warn;
+
+/// Discover all network interfaces on the system.
+pub fn discover_interfaces() -> NetworkInterfacesResponse {
+    let interfaces = match NetworkInterface::show() {
+        Ok(interfaces) => interfaces,
+        Err(e) => {
+            warn!("Failed to discover network interfaces: {}", e);
+            return NetworkInterfacesResponse {
+                interfaces: Vec::new(),
+            };
+        }
+    };
+
+    let mut result = Vec::new();
+
+    for iface in interfaces {
+        let mut ipv4_addresses = Vec::new();
+        let mut ipv6_addresses = Vec::new();
+
+        for addr in &iface.addr {
+            match addr {
+                Addr::V4(v4) => {
+                    ipv4_addresses.push(Ipv4AddressInfo {
+                        address: v4.ip.to_string(),
+                        netmask: v4.netmask.map(|n| n.to_string()),
+                        broadcast: v4.broadcast.map(|b| b.to_string()),
+                    });
+                }
+                Addr::V6(v6) => {
+                    ipv6_addresses.push(Ipv6AddressInfo {
+                        address: v6.ip.to_string(),
+                        netmask: v6.netmask.map(|n| n.to_string()),
+                    });
+                }
+            }
+        }
+
+        // Check if this is a loopback interface
+        let is_loopback = iface.name == "lo"
+            || iface.name.starts_with("lo")
+            || ipv4_addresses.iter().any(|a| a.address == "127.0.0.1")
+            || ipv6_addresses.iter().any(|a| a.address == "::1");
+
+        // Consider interface "up" if it has any addresses
+        let is_up = !ipv4_addresses.is_empty() || !ipv6_addresses.is_empty();
+
+        result.push(NetworkInterfaceInfo {
+            name: iface.name,
+            index: iface.index,
+            mac_address: iface.mac_addr,
+            ipv4_addresses,
+            ipv6_addresses,
+            is_loopback,
+            is_up,
+        });
+    }
+
+    // Sort by index for consistent ordering
+    result.sort_by_key(|i| i.index);
+
+    NetworkInterfacesResponse { interfaces: result }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_discover_interfaces() {
+        let response = discover_interfaces();
+        // Should at least find loopback
+        assert!(
+            !response.interfaces.is_empty(),
+            "Should discover at least one interface"
+        );
+
+        // Should have a loopback interface on most systems
+        let has_loopback = response.interfaces.iter().any(|i| i.is_loopback);
+        assert!(has_loopback, "Should have a loopback interface");
+    }
+}

--- a/backend/src/openapi.rs
+++ b/backend/src/openapi.rs
@@ -12,6 +12,9 @@ use strom_types::block::{
     CreateBlockRequest, ExposedProperty, ExternalPad, ExternalPads, PropertyMapping, PropertyType,
 };
 use strom_types::flow::{FlowProperties, GStreamerClockType};
+use strom_types::network::{
+    Ipv4AddressInfo, Ipv6AddressInfo, NetworkInterfaceInfo, NetworkInterfacesResponse,
+};
 use strom_types::stats::{BlockStats, StatMetadata, StatValue, Statistic};
 use utoipa::OpenApi;
 
@@ -40,6 +43,7 @@ use utoipa::OpenApi;
         crate::api::blocks::get_categories,
         crate::api::gst_launch::parse_gst_launch,
         crate::api::gst_launch::export_gst_launch,
+        crate::api::network::list_interfaces,
         crate::api::version::get_version,
     ),
     components(
@@ -76,6 +80,10 @@ use utoipa::OpenApi;
             ParseGstLaunchResponse,
             ExportGstLaunchRequest,
             ExportGstLaunchResponse,
+            NetworkInterfacesResponse,
+            NetworkInterfaceInfo,
+            Ipv4AddressInfo,
+            Ipv6AddressInfo,
         )
     ),
     tags(
@@ -83,6 +91,7 @@ use utoipa::OpenApi;
         (name = "elements", description = "GStreamer element discovery endpoints"),
         (name = "blocks", description = "Reusable block management endpoints"),
         (name = "gst-launch", description = "gst-launch-1.0 import/export endpoints"),
+        (name = "Network", description = "Network interface discovery endpoints"),
         (name = "System", description = "System information endpoints")
     ),
     info(

--- a/frontend/src/state.rs
+++ b/frontend/src/state.rs
@@ -99,6 +99,9 @@ pub enum AppMessage {
     GstLaunchExported { pipeline: String, flow_name: String },
     /// gst-launch export failed
     GstLaunchExportError(String),
+
+    /// Network interfaces loaded from API
+    NetworkInterfacesLoaded(Vec<strom_types::NetworkInterfaceInfo>),
 }
 
 /// WebSocket connection state.

--- a/types/src/block.rs
+++ b/types/src/block.rs
@@ -27,7 +27,11 @@ pub enum PropertyType {
     UInt,
     Float,
     Bool,
-    Enum { values: Vec<EnumValue> },
+    Enum {
+        values: Vec<EnumValue>,
+    },
+    /// Network interface selector - frontend fetches available interfaces from API
+    NetworkInterface,
 }
 
 /// Block definition - metadata for creating block instances.

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -11,6 +11,7 @@ pub mod block;
 pub mod element;
 pub mod events;
 pub mod flow;
+pub mod network;
 pub mod state;
 pub mod stats;
 pub mod system_monitor;
@@ -23,6 +24,9 @@ pub use block::{
 pub use element::{Element, ElementId, Link, MediaType, PropertyValue};
 pub use events::StromEvent;
 pub use flow::{Flow, FlowId, ThreadPriority, ThreadPriorityStatus};
+pub use network::{
+    Ipv4AddressInfo, Ipv6AddressInfo, NetworkInterfaceInfo, NetworkInterfacesResponse,
+};
 pub use state::PipelineState;
 pub use stats::{
     BlockStats, BlockStatsResponse, FlowStats, FlowStatsResponse, RtpJitterbufferStats,

--- a/types/src/network.rs
+++ b/types/src/network.rs
@@ -1,0 +1,69 @@
+//! Network interface types for the Strom GStreamer flow engine.
+
+use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "openapi")]
+use utoipa::ToSchema;
+
+/// Information about a network interface.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct NetworkInterfaceInfo {
+    /// Interface name (e.g., "eth0", "enp0s3")
+    pub name: String,
+
+    /// Interface index
+    pub index: u32,
+
+    /// MAC address (if available)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mac_address: Option<String>,
+
+    /// IPv4 addresses assigned to this interface
+    pub ipv4_addresses: Vec<Ipv4AddressInfo>,
+
+    /// IPv6 addresses assigned to this interface
+    pub ipv6_addresses: Vec<Ipv6AddressInfo>,
+
+    /// Whether this interface is a loopback interface
+    pub is_loopback: bool,
+
+    /// Whether this interface appears to be up (has addresses)
+    pub is_up: bool,
+}
+
+/// IPv4 address information.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct Ipv4AddressInfo {
+    /// The IPv4 address
+    pub address: String,
+
+    /// Network mask (if available)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub netmask: Option<String>,
+
+    /// Broadcast address (if available)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub broadcast: Option<String>,
+}
+
+/// IPv6 address information.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct Ipv6AddressInfo {
+    /// The IPv6 address
+    pub address: String,
+
+    /// Network mask (if available)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub netmask: Option<String>,
+}
+
+/// Response containing list of network interfaces.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct NetworkInterfacesResponse {
+    /// List of network interfaces
+    pub interfaces: Vec<NetworkInterfaceInfo>,
+}


### PR DESCRIPTION
## Summary

- **PTP clock identity in SDP**: When a flow uses PTP synchronization, the generated SDP now includes the actual grandmaster clock ID and domain in RFC 7273 format (ts-refclk and mediaclk attributes)

- **Network interface selector**: AES67 blocks now have a dropdown to select which network interface to use for multicast traffic, making it easy to bind to the correct NIC

- **AES67 input improvements**: Set timeout-inactive-rtp-sources=false on sdpdemux to keep RTP sources alive

## Changes

### PTP Clock in SDP
- Extract grandmaster clock ID from running pipeline or flow properties
- Convert clock ID format from colon-separated to dash-separated for RFC 7273 compatibility
- Pass PTP info through to SDP generator

### Network Interface Selector
- New API endpoint `GET /api/network/interfaces` using `network-interface` crate
- New `PropertyType::NetworkInterface` for block properties
- Frontend dropdown showing interface name with IPv4 address (e.g., "eth0 (192.168.1.100)")
- Set `multicast-iface` on udpsink (output) and udpsrc elements (input via element-added handler)

### AES67 Input Block
- Set `timeout-inactive-rtp-sources=false` on sdpdemux to prevent source timeouts

## Test plan
- [ ] Create AES67 output block, verify SDP includes PTP clock ID when flow uses PTP
- [ ] Verify network interface dropdown shows available NICs
- [ ] Test multicast traffic goes out the selected interface
- [ ] Verify AES67 input works with the interface selector

🤖 Generated with [Claude Code](https://claude.com/claude-code)