### PR TITLE
fix: Use rustls instead of native-tls in MCP server

### DIFF
--- a/mcp-server/Cargo.toml
+++ b/mcp-server/Cargo.toml
@@ -9,8 +9,8 @@ authors.workspace = true
 # Async runtime
 tokio = { workspace = true }
 
-# HTTP client for calling Strom API
-reqwest = { version = "0.12", features = ["json"] }
+# HTTP client for calling Strom API (use rustls to avoid OpenSSL dependency)
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 
 # Serialization
 serde = { workspace = true }


### PR DESCRIPTION
## Summary
- Switch MCP server from native-tls (OpenSSL) to rustls-tls
- Fixes Linux cross-compilation with zigbuild

## Problem
The MCP server's `reqwest` dependency was using default features which pull in `native-tls` (OpenSSL). This fails during Linux cross-compilation with zigbuild because OpenSSL isn't available in that environment.

## Solution
Changed `mcp-server/Cargo.toml` to use:
```toml
reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
```

This matches how the backend and frontend already configure reqwest.

## Testing
- Local build passes
- Clippy passes
- No OpenSSL in dependency tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)