### PR TITLE
feat: Add resolution dropdown to GL compositor, share common resolutions

### DIFF
--- a/backend/src/blocks/builtin/videoformat.rs
+++ b/backend/src/blocks/builtin/videoformat.rs
@@ -16,7 +16,10 @@
 use crate::blocks::{BlockBuildError, BlockBuildResult, BlockBuilder};
 use gstreamer as gst;
 use std::collections::HashMap;
-use strom_types::{block::*, element::ElementPadRef, EnumValue, PropertyValue, *};
+use strom_types::{
+    block::*, common_video_resolution_enum_values, element::ElementPadRef, EnumValue,
+    PropertyValue, *,
+};
 use tracing::info;
 
 /// Video Format block builder.
@@ -164,20 +167,7 @@ fn videoformat_definition() -> BlockDefinition {
                 label: "Resolution".to_string(),
                 description: "Video resolution - creates videoscale element. Leave empty to pass through.".to_string(),
                 property_type: PropertyType::Enum {
-                    values: vec![
-                        EnumValue { value: "".to_string(), label: Some("-".to_string()) },
-                        EnumValue { value: "7680x4320".to_string(), label: Some("8K UHD (7680x4320)".to_string()) },
-                        EnumValue { value: "4096x2160".to_string(), label: Some("4K DCI (4096x2160)".to_string()) },
-                        EnumValue { value: "3840x2160".to_string(), label: Some("4K UHD (3840x2160)".to_string()) },
-                        EnumValue { value: "2560x1440".to_string(), label: Some("QHD / 1440p (2560x1440)".to_string()) },
-                        EnumValue { value: "1920x1080".to_string(), label: Some("Full HD (1920x1080)".to_string()) },
-                        EnumValue { value: "1600x900".to_string(), label: Some("HD+ (1600x900)".to_string()) },
-                        EnumValue { value: "1280x720".to_string(), label: Some("HD (1280x720)".to_string()) },
-                        EnumValue { value: "720x576".to_string(), label: Some("PAL SD (720x576)".to_string()) },
-                        EnumValue { value: "720x480".to_string(), label: Some("NTSC SD (720x480)".to_string()) },
-                        EnumValue { value: "640x480".to_string(), label: Some("VGA (640x480)".to_string()) },
-                        EnumValue { value: "320x240".to_string(), label: Some("QVGA (320x240)".to_string()) },
-                    ],
+                    values: common_video_resolution_enum_values(true), // include empty "-" option
                 },
                 default_value: Some(PropertyValue::String("".to_string())),
                 mapping: PropertyMapping {

--- a/frontend/src/app.rs
+++ b/frontend/src/app.rs
@@ -3732,26 +3732,18 @@ impl eframe::App for StromApp {
 
                 // Find the block
                 if let Some(block) = flow.blocks.iter().find(|b| b.id == block_id) {
-                    // Extract properties
-                    let output_width = block
+                    // Extract resolution from output_resolution property
+                    // Default to 1920x1080 (Full HD) if not set or can't be parsed
+                    let (output_width, output_height) = block
                         .properties
-                        .get("output_width")
+                        .get("output_resolution")
                         .and_then(|v| match v {
-                            strom_types::PropertyValue::UInt(u) => Some(*u as u32),
-                            strom_types::PropertyValue::Int(i) if *i > 0 => Some(*i as u32),
+                            strom_types::PropertyValue::String(s) if !s.is_empty() => {
+                                strom_types::parse_resolution_string(s)
+                            }
                             _ => None,
                         })
-                        .unwrap_or(1920);
-
-                    let output_height = block
-                        .properties
-                        .get("output_height")
-                        .and_then(|v| match v {
-                            strom_types::PropertyValue::UInt(u) => Some(*u as u32),
-                            strom_types::PropertyValue::Int(i) if *i > 0 => Some(*i as u32),
-                            _ => None,
-                        })
-                        .unwrap_or(1080);
+                        .unwrap_or((1920, 1080));
 
                     let num_inputs = block
                         .properties

--- a/types/src/block.rs
+++ b/types/src/block.rs
@@ -225,3 +225,57 @@ pub struct BlockListResponse {
 pub struct BlockCategoriesResponse {
     pub categories: Vec<String>,
 }
+
+/// Common video resolutions for use in block property dropdowns.
+/// Ordered from largest to smallest.
+pub const COMMON_VIDEO_RESOLUTIONS: &[(&str, &str)] = &[
+    ("7680x4320", "8K UHD (7680x4320)"),
+    ("4096x2160", "4K DCI (4096x2160)"),
+    ("3840x2160", "4K UHD (3840x2160)"),
+    ("2560x1440", "QHD / 1440p (2560x1440)"),
+    ("1920x1080", "Full HD (1920x1080)"),
+    ("1600x900", "HD+ (1600x900)"),
+    ("1280x720", "HD (1280x720)"),
+    ("720x576", "PAL SD (720x576)"),
+    ("720x480", "NTSC SD (720x480)"),
+    ("640x480", "VGA (640x480)"),
+    ("640x360", "nHD (640x360)"),
+    ("320x240", "QVGA (320x240)"),
+];
+
+/// Get common video resolutions as EnumValue list for block properties.
+/// Set `include_empty` to true to add an empty "-" option at the start.
+pub fn common_video_resolution_enum_values(include_empty: bool) -> Vec<EnumValue> {
+    let mut values = Vec::new();
+
+    if include_empty {
+        values.push(EnumValue {
+            value: String::new(),
+            label: Some("-".to_string()),
+        });
+    }
+
+    for (value, label) in COMMON_VIDEO_RESOLUTIONS {
+        values.push(EnumValue {
+            value: (*value).to_string(),
+            label: Some((*label).to_string()),
+        });
+    }
+
+    values
+}
+
+/// Parse a resolution string like "1920x1080" into (width, height).
+/// Returns None if parsing fails.
+pub fn parse_resolution_string(s: &str) -> Option<(u32, u32)> {
+    if s.is_empty() {
+        return None;
+    }
+    let parts: Vec<&str> = s.split('x').collect();
+    if parts.len() == 2 {
+        if let (Ok(w), Ok(h)) = (parts[0].parse::<u32>(), parts[1].parse::<u32>()) {
+            return Some((w, h));
+        }
+    }
+    None
+}

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -18,8 +18,9 @@ pub mod system_monitor;
 
 // Re-export commonly used types
 pub use block::{
-    BlockDefinition, BlockInstance, BlockListResponse, BlockResponse, CreateBlockRequest,
-    EnumValue, ExposedProperty, ExternalPad, ExternalPads, PropertyMapping, PropertyType,
+    common_video_resolution_enum_values, parse_resolution_string, BlockDefinition, BlockInstance,
+    BlockListResponse, BlockResponse, CreateBlockRequest, EnumValue, ExposedProperty, ExternalPad,
+    ExternalPads, PropertyMapping, PropertyType, COMMON_VIDEO_RESOLUTIONS,
 };
 pub use element::{Element, ElementId, Link, MediaType, PropertyValue};
 pub use events::StromEvent;


### PR DESCRIPTION
## Summary
- Add shared video resolution utilities to types crate for reuse across blocks
- Replace separate output_width/output_height with unified output_resolution dropdown in GL compositor
- Update Video Format block to use shared resolution values
- Resolutions ordered from largest to smallest (8K → QVGA)

## Changes

### Types Crate (`types/src/block.rs`)
- Added `COMMON_VIDEO_RESOLUTIONS` constant with common presets
- Added `common_video_resolution_enum_values(include_empty)` helper
- Added `parse_resolution_string()` for parsing "WIDTHxHEIGHT" format

### GL Compositor Block
- Replaced `output_width` + `output_height` UInt fields with single `output_resolution` enum dropdown
- Defaults to Full HD (1920x1080) when not set
- Removed fallback to legacy properties that could cause issues with stale values

### Video Format Block  
- Now uses shared `common_video_resolution_enum_values(true)` (includes empty "-" for passthrough)

### Frontend
- Updated compositor editor to parse new `output_resolution` property format

## Test plan
- [ ] Create new GL compositor block, verify resolution dropdown shows presets
- [ ] Select different resolutions, verify pipeline starts correctly
- [ ] Open compositor layout editor, verify canvas size matches selected resolution
- [ ] Create Video Format block, verify resolution dropdown works with passthrough option

🤖 Generated with [Claude Code](https://claude.com/claude-code)