### PR TITLE
fix: Replace std::time with instant crate for WASM compatibility

### DIFF
--- a/frontend/clippy.toml
+++ b/frontend/clippy.toml
@@ -1,0 +1,7 @@
+# Clippy configuration for the frontend crate
+# These types don't work in WASM - use the `instant` crate instead
+
+disallowed-types = [
+    { path = "std::time::Instant", reason = "Use `instant::Instant` instead - std::time::Instant doesn't work in WASM" },
+    { path = "std::time::SystemTime", reason = "SystemTime::now() doesn't work in WASM. Use `uuid` for unique IDs or `js_sys::Date` for wall-clock time" },
+]

--- a/frontend/src/app.rs
+++ b/frontend/src/app.rs
@@ -254,7 +254,7 @@ pub struct StromApp {
     show_system_monitor: bool,
     /// Last time WebRTC stats were polled
     #[cfg(not(target_arch = "wasm32"))]
-    last_webrtc_poll: std::time::Instant,
+    last_webrtc_poll: instant::Instant,
     /// Current theme preference
     theme_preference: ThemePreference,
     /// Version information from the backend
@@ -466,7 +466,7 @@ impl StromApp {
             qos_stats: crate::qos_monitor::QoSStore::new(),
             flow_start_times: std::collections::HashMap::new(),
             show_system_monitor: false,
-            last_webrtc_poll: std::time::Instant::now(),
+            last_webrtc_poll: instant::Instant::now(),
             theme_preference: ThemePreference::System,
             version_info: None,
             login_screen: LoginScreen::default(),
@@ -3304,12 +3304,8 @@ impl StromApp {
                     }
 
                     // Step 2: Create a new flow with a name based on first element
-                    // Add timestamp to make each import unique
-                    use std::time::{SystemTime, UNIX_EPOCH};
-                    let timestamp = SystemTime::now()
-                        .duration_since(UNIX_EPOCH)
-                        .unwrap()
-                        .as_secs();
+                    // Add random suffix to make each import unique
+                    let unique_id = &uuid::Uuid::new_v4().to_string()[..8];
                     let flow_name = format!(
                         "Imported: {} ({})",
                         parsed
@@ -3317,7 +3313,7 @@ impl StromApp {
                             .first()
                             .map(|e| e.element_type.as_str())
                             .unwrap_or("pipeline"),
-                        timestamp
+                        unique_id
                     );
 
                     let mut new_flow = Flow::new(&flow_name);
@@ -4339,7 +4335,7 @@ impl eframe::App for StromApp {
             let poll_interval = std::time::Duration::from_secs(1);
             if self.last_webrtc_poll.elapsed() >= poll_interval {
                 self.poll_webrtc_stats(ctx);
-                self.last_webrtc_poll = std::time::Instant::now();
+                self.last_webrtc_poll = instant::Instant::now();
             }
         }
 

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -3,6 +3,7 @@
 //! This module exposes the frontend application for embedding in native mode.
 
 #![warn(clippy::all, rust_2018_idioms)]
+#![deny(clippy::disallowed_types)]
 #![allow(dead_code)]
 
 mod api;

--- a/frontend/src/webrtc_stats.rs
+++ b/frontend/src/webrtc_stats.rs
@@ -1,6 +1,7 @@
 //! WebRTC statistics visualization widget.
 
 use egui::{Color32, Ui};
+use instant::Instant;
 use std::collections::HashMap;
 use strom_types::api::{RtpStreamStats, WebRtcConnectionStats, WebRtcStats};
 use strom_types::FlowId;
@@ -16,7 +17,7 @@ pub struct WebRtcStatsKey {
 pub struct WebRtcStatsStore {
     data: HashMap<WebRtcStatsKey, WebRtcStats>,
     /// Timestamp of last update for each flow
-    last_update: HashMap<FlowId, std::time::Instant>,
+    last_update: HashMap<FlowId, Instant>,
 }
 
 impl WebRtcStatsStore {
@@ -31,7 +32,7 @@ impl WebRtcStatsStore {
     pub fn update(&mut self, flow_id: FlowId, stats: WebRtcStats) {
         let key = WebRtcStatsKey { flow_id };
         self.data.insert(key, stats);
-        self.last_update.insert(flow_id, std::time::Instant::now());
+        self.last_update.insert(flow_id, Instant::now());
     }
 
     /// Get WebRTC stats for a specific flow.


### PR DESCRIPTION
## Summary
- Fixes "time not implemented on this platform" console error in WebAssembly
- Replaces `std::time::Instant` with `instant::Instant` in frontend code
- Uses `uuid` for unique imported flow names instead of `SystemTime::now()`
- Adds compile-time lint to prevent future `std::time::Instant` and `std::time::SystemTime` usage in frontend

## Test plan
- [ ] Verify WASM build works without console errors
- [ ] Test importing a gst-launch pipeline (should have random suffix in name)
- [ ] Verify WebRTC stats staleness detection still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)