### PR TITLE
feat: Add Ctrl+C/V shortcuts for copy/paste in graph editor

### DIFF
--- a/frontend/src/app.rs
+++ b/frontend/src/app.rs
@@ -1519,6 +1519,16 @@ impl StromApp {
             ctx.open_url(egui::OpenUrl::new_tab("https://github.com/Eyevinn/strom"));
         }
 
+        // Ctrl+C - Copy selected element/block in graph
+        if ctx.input(|i| i.modifiers.command && i.key_pressed(egui::Key::C)) {
+            self.graph.copy_selected();
+        }
+
+        // Ctrl+V - Paste element/block in graph
+        if ctx.input(|i| i.modifiers.command && i.key_pressed(egui::Key::V)) {
+            self.graph.paste_clipboard();
+        }
+
         // Shift+F9 - Stop Flow (must be checked before plain F9)
         if ctx.input(|i| i.modifiers.shift && i.key_pressed(egui::Key::F9)) {
             self.stop_flow(ctx);
@@ -2491,6 +2501,7 @@ impl StromApp {
                     self.graph.remove_selected(); // Remove selected element (if any)
                     self.graph.remove_selected_link(); // Remove selected link (if any)
                 }
+
             } else {
                 ui.vertical_centered(|ui| {
                     ui.add_space(100.0);


### PR DESCRIPTION
## Summary
- Add Ctrl+C keyboard shortcut to copy selected element or block in graph editor
- Add Ctrl+V keyboard shortcut to paste copied item at 30px offset with new unique ID
- Pasted item automatically becomes selected

## Test plan
- [ ] Select an element in the graph, press Ctrl+C, then Ctrl+V - should duplicate it
- [ ] Select a block in the graph, press Ctrl+C, then Ctrl+V - should duplicate it
- [ ] Verify pasted items have unique IDs and don't share connections
- [ ] Test in text fields - Ctrl+C/V should still work normally for text

🤖 Generated with [Claude Code](https://claude.com/claude-code)