### PR TITLE
fix: Add GStreamer v1_20 feature flag for Ubuntu 22.04 compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,9 @@ tokio = { version = "1.48", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 futures = "0.3"
 tower-http = { version = "0.6", features = ["fs", "cors", "trace"] }
-gstreamer = "0.24.4"
-gstreamer-app = "0.24.2"
-gstreamer-net = "0.24.4"
+gstreamer = { version = "0.24.4", features = ["v1_20"] }
+gstreamer-app = { version = "0.24.2", features = ["v1_20"] }
+gstreamer-net = { version = "0.24.4", features = ["v1_20"] }
 gst-plugin-webrtc = { git = "https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs", features = ["whep", "whip"], rev = "83625619" }
 gst-plugin-inter = { git = "https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs", rev = "83625619" }
 tracing = "0.1"


### PR DESCRIPTION
## Summary
- Adds explicit `v1_20` feature flag to gstreamer-rs crates to ensure compatibility with GStreamer 1.20 (Ubuntu 22.04)
- Fixes runtime symbol lookup error: `undefined symbol: gst_navigation_modifier_type_get_type`
- No functionality loss since the codebase doesn't use any GStreamer 1.22+ APIs

## Test plan
- [x] Verified code compiles with `cargo check`
- [ ] Test on Ubuntu 22.04 with GStreamer 1.20

🤖 Generated with [Claude Code](https://claude.com/claude-code)