### PR TITLE
chore: Bump version to 0.2.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5429,7 +5429,7 @@ dependencies = [
 
 [[package]]
 name = "strom"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5478,7 +5478,7 @@ dependencies = [
 
 [[package]]
 name = "strom-frontend"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "console_error_panic_hook",
  "eframe",
@@ -5504,7 +5504,7 @@ dependencies = [
 
 [[package]]
 name = "strom-mcp-server"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "anyhow",
  "reqwest",
@@ -5518,7 +5518,7 @@ dependencies = [
 
 [[package]]
 name = "strom-types"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["types", "backend", "frontend", "mcp-server"]
 default-members = ["backend"]
 
 [workspace.package]
-version = "0.2.9"
+version = "0.2.10"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Per"]


### PR DESCRIPTION
## Summary
- Bumps version to 0.2.10 for release

🤖 Generated with [Claude Code](https://claude.com/claude-code)