### PR TITLE
fix: Update Trunk.toml to use non-deprecated addresses field

### DIFF
--- a/frontend/Trunk.toml
+++ b/frontend/Trunk.toml
@@ -9,5 +9,5 @@ target = "index.html"
 dist = "../backend/dist"
 
 [serve]
-address = "127.0.0.1"
+addresses = ["127.0.0.1"]
 port = 8095


### PR DESCRIPTION
## Summary
- Updates `address` to `addresses` array in Trunk.toml to fix deprecation warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)