### PR TITLE
feat: Add warnings for non-live test sources

### DIFF
--- a/backend/src/api/flows.rs
+++ b/backend/src/api/flows.rs
@@ -15,7 +15,8 @@ use strom_types::{
         PadPropertiesResponse, SourceFlowInfo, UpdateFlowPropertiesRequest,
         UpdatePadPropertyRequest, UpdatePropertyRequest, WebRtcStatsResponse,
     },
-    Flow, FlowId,
+    flow::{FlowWarning, FlowWarningCode},
+    Flow, FlowId, PropertyValue,
 };
 use tracing::{error, info, trace};
 
@@ -67,6 +68,52 @@ fn is_pad_valid(
     false
 }
 
+/// Compute warnings for potential flow configuration issues.
+///
+/// Detects configurations that may cause CPU saturation, such as test sources
+/// without is-live=true that will run as fast as possible instead of real-time.
+fn compute_flow_warnings(flow: &Flow) -> Vec<FlowWarning> {
+    let mut warnings = Vec::new();
+
+    // Known test sources that should have is-live=true for live streaming
+    // Without is-live=true, these sources produce buffers as fast as possible,
+    // which can saturate the CPU.
+    const TEST_SOURCES: &[&str] = &["audiotestsrc", "videotestsrc"];
+
+    for element in &flow.elements {
+        if TEST_SOURCES.contains(&element.element_type.as_str()) {
+            // Check if is-live is set to true
+            let is_live = element
+                .properties
+                .get("is-live")
+                .and_then(|v| match v {
+                    PropertyValue::Bool(b) => Some(*b),
+                    _ => None,
+                })
+                .unwrap_or(false);
+
+            if !is_live {
+                warnings.push(FlowWarning {
+                    element_id: Some(element.id.clone()),
+                    code: FlowWarningCode::NonLiveTestSource,
+                    message: format!(
+                        "{}: Consider setting is-live=true for real-time output. \
+                         Without it, the pipeline runs as fast as possible which may saturate the CPU.",
+                        element.id
+                    ),
+                });
+            }
+        }
+    }
+
+    warnings
+}
+
+/// Apply computed warnings to a flow's properties.
+fn apply_warnings_to_flow(flow: &mut Flow) {
+    flow.properties.warnings = compute_flow_warnings(flow);
+}
+
 /// List all flows.
 #[utoipa::path(
     get,
@@ -77,7 +124,11 @@ fn is_pad_valid(
     )
 )]
 pub async fn list_flows(State(state): State<AppState>) -> Json<FlowListResponse> {
-    let flows = state.get_flows().await;
+    let mut flows = state.get_flows().await;
+    // Compute warnings for each flow
+    for flow in &mut flows {
+        apply_warnings_to_flow(flow);
+    }
     Json(FlowListResponse { flows })
 }
 
@@ -98,7 +149,6 @@ pub async fn get_available_sources(
     State(state): State<AppState>,
 ) -> Json<AvailableSourcesResponse> {
     use strom_types::element::MediaType;
-    use strom_types::PropertyValue;
 
     // Get all active channels from registry to check which are running
     let active_channels = state.channels().list_all().await;
@@ -174,7 +224,10 @@ pub async fn get_flow(
     Path(id): Path<FlowId>,
 ) -> Result<Json<FlowResponse>, (StatusCode, Json<ErrorResponse>)> {
     match state.get_flow(&id).await {
-        Some(flow) => Ok(Json(FlowResponse { flow })),
+        Some(mut flow) => {
+            apply_warnings_to_flow(&mut flow);
+            Ok(Json(FlowResponse { flow }))
+        }
         None => Err((
             StatusCode::NOT_FOUND,
             Json(ErrorResponse::new("Flow not found")),
@@ -386,6 +439,9 @@ pub async fn update_flow(
         }
     }
 
+    // Apply warnings to the response
+    apply_warnings_to_flow(&mut flow);
+
     Ok(Json(FlowResponse { flow }))
 }
 
@@ -457,7 +513,10 @@ pub async fn start_flow(
 
     // Return updated flow with state
     match state.get_flow(&id).await {
-        Some(flow) => Ok(Json(FlowResponse { flow })),
+        Some(mut flow) => {
+            apply_warnings_to_flow(&mut flow);
+            Ok(Json(FlowResponse { flow }))
+        }
         None => Err((
             StatusCode::NOT_FOUND,
             Json(ErrorResponse::new("Flow not found")),
@@ -496,7 +555,10 @@ pub async fn stop_flow(
 
     // Return updated flow with state
     match state.get_flow(&id).await {
-        Some(flow) => Ok(Json(FlowResponse { flow })),
+        Some(mut flow) => {
+            apply_warnings_to_flow(&mut flow);
+            Ok(Json(FlowResponse { flow }))
+        }
         None => Err((
             StatusCode::NOT_FOUND,
             Json(ErrorResponse::new("Flow not found")),
@@ -999,6 +1061,9 @@ pub async fn update_flow_properties(
     }
 
     info!("Successfully updated properties for flow {}", id);
+
+    // Apply warnings to the response
+    apply_warnings_to_flow(&mut flow);
 
     Ok(Json(FlowResponse { flow }))
 }

--- a/frontend/src/app.rs
+++ b/frontend/src/app.rs
@@ -2296,6 +2296,28 @@ impl StromApp {
                             }
                         }
 
+                        // Show warning indicator if flow has configuration warnings
+                        if !flow.properties.warnings.is_empty() {
+                            let warning_label = child_ui
+                                .colored_label(Color32::from_rgb(255, 180, 0), "⚠")
+                                .interact(egui::Sense::click());
+
+                            warning_label.on_hover_ui(|ui| {
+                                ui.label(
+                                    egui::RichText::new("Configuration Warnings")
+                                        .strong()
+                                        .color(Color32::from_rgb(255, 180, 0)),
+                                );
+                                ui.separator();
+                                for warning in &flow.properties.warnings {
+                                    ui.horizontal(|ui| {
+                                        ui.colored_label(Color32::from_rgb(255, 180, 0), "•");
+                                        ui.label(&warning.message);
+                                    });
+                                }
+                            });
+                        }
+
                         child_ui.add_space(4.0);
 
                         // Show flow name with hover tooltip - make it clickable too

--- a/frontend/src/properties.rs
+++ b/frontend/src/properties.rs
@@ -918,6 +918,30 @@ impl PropertyInspector {
             });
         }
 
+        // Show contextual hints for important properties on specific element types
+        // Test sources (audiotestsrc, videotestsrc) with is-live=false can cause CPU saturation
+        if prop_name == "is-live"
+            && (element.element_type == "audiotestsrc" || element.element_type == "videotestsrc")
+        {
+            let is_live = element
+                .properties
+                .get("is-live")
+                .and_then(|v| match v {
+                    PropertyValue::Bool(b) => Some(*b),
+                    _ => None,
+                })
+                .unwrap_or(false);
+
+            if !is_live {
+                ui.indent(prop_name, |ui| {
+                    ui.horizontal(|ui| {
+                        ui.colored_label(Color32::from_rgb(255, 180, 0), "⚠");
+                        ui.small("Set to true for live streaming to prevent CPU saturation");
+                    });
+                });
+            }
+        }
+
         // Add spacing after each property
         ui.add_space(8.0);
     }

--- a/types/src/flow.rs
+++ b/types/src/flow.rs
@@ -96,6 +96,38 @@ pub enum ClockSyncStatus {
     Unknown,
 }
 
+/// Warning code for flow configuration issues.
+///
+/// These codes allow programmatic handling of warnings while the
+/// human-readable message provides details for users.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum FlowWarningCode {
+    /// Test source (audiotestsrc, videotestsrc) without is-live=true
+    /// may cause CPU saturation by running as fast as possible
+    NonLiveTestSource,
+    /// File source may process data as fast as possible without rate limiting
+    NonLiveFileSource,
+}
+
+/// Warning about potential flow configuration issues.
+///
+/// Warnings are informational and don't prevent flow execution,
+/// but alert users to configurations that may cause problems
+/// (e.g., CPU saturation from non-live pipelines).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct FlowWarning {
+    /// ID of the element this warning relates to (None for flow-level warnings)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub element_id: Option<String>,
+    /// Warning code for programmatic handling
+    pub code: FlowWarningCode,
+    /// Human-readable warning message
+    pub message: String,
+}
+
 /// PTP clock information (IEEE 1588).
 ///
 /// Contains detailed information about the PTP clock state including
@@ -225,6 +257,13 @@ pub struct FlowProperties {
     /// (set to true when starting a flow, false when manually stopping it)
     #[serde(default)]
     pub auto_restart: bool,
+
+    /// Warnings about potential configuration issues (computed by backend)
+    ///
+    /// These are informational warnings that don't prevent flow execution,
+    /// such as test sources without is-live=true that may cause CPU saturation.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<FlowWarning>,
 }
 
 /// A complete GStreamer pipeline definition.


### PR DESCRIPTION
## Summary

- Add informational warnings when users create flows with `audiotestsrc` or `videotestsrc` without setting `is-live=true`
- Without this property, these sources run as fast as possible, which can saturate the CPU
- Warnings are displayed in the flow list and property inspector

## Changes

- Add `FlowWarning` and `FlowWarningCode` types to track configuration issues
- Add `warnings` field to `FlowProperties` (computed by backend on each API response)
- Detect non-live test sources and generate warnings
- Display warning indicator (⚠) in flow list with hover tooltip showing details
- Show contextual hint in property inspector for `is-live` property on test sources

## Behavior

Warnings are **informational only** and don't prevent flow execution, as non-live processing is sometimes intentional (e.g., for transcoding workloads).

## Test plan

- [ ] Create a flow with `audiotestsrc` - verify warning appears in flow list
- [ ] Set `is-live=true` on the element - verify warning disappears
- [ ] Check property inspector shows hint for `is-live` property
- [ ] Verify flow can still be started with warnings present

🤖 Generated with [Claude Code](https://claude.com/claude-code)