### PR TITLE
fix: Remove unused import from storage.rs

### DIFF
--- a/backend/src/blocks/storage.rs
+++ b/backend/src/blocks/storage.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use strom_types::BlockDefinition;
 use thiserror::Error;
 use tokio::fs;
-use tracing::{debug, error, info};
+use tracing::{debug, info};
 
 #[derive(Error, Debug)]
 pub enum StorageError {


### PR DESCRIPTION
## Summary
- Removes unused `error` import from `tracing` in `backend/src/blocks/storage.rs`
- Fixes CI clippy failure on main

## Test plan
- [x] Clippy passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)