### PR TITLE
fix: Remove libssl-dev from ARM64 cross-compilation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,7 +230,9 @@ jobs:
           EOF
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu perl make
-          sudo apt-get install -y libssl-dev:arm64 pkg-config:arm64 libunwind-dev:arm64
+          # Install linux-libc-dev:arm64 first to resolve dependency conflicts
+          sudo apt-get install -y linux-libc-dev:arm64
+          sudo apt-get install -y pkg-config:arm64 libunwind-dev:arm64
           sudo apt-get install -y libgstreamer1.0-dev:arm64 libgstreamer-plugins-base1.0-dev:arm64 libgstreamer-plugins-bad1.0-dev:arm64
           echo "PKG_CONFIG_SYSROOT_DIR=/usr/aarch64-linux-gnu" >> $GITHUB_ENV
           echo "PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig" >> $GITHUB_ENV


### PR DESCRIPTION
## Summary
- Remove `libssl-dev:arm64` from ARM64 cross-compilation CI step
- Strom uses rustls instead of OpenSSL, so this dependency is not needed
- Fixes CI failure caused by `libc6-dev:arm64` dependency conflicts with `linux-libc-dev:arm64`

## Test plan
- [ ] Verify ARM64 Linux build succeeds in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)