### PR TITLE
chore: Bump version to 0.2.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5492,7 +5492,7 @@ dependencies = [
 
 [[package]]
 name = "strom"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5543,7 +5543,7 @@ dependencies = [
 
 [[package]]
 name = "strom-frontend"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "console_error_panic_hook",
  "eframe",
@@ -5569,7 +5569,7 @@ dependencies = [
 
 [[package]]
 name = "strom-mcp-server"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "anyhow",
  "reqwest",
@@ -5583,7 +5583,7 @@ dependencies = [
 
 [[package]]
 name = "strom-types"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["types", "backend", "frontend", "mcp-server"]
 default-members = ["backend"]
 
 [workspace.package]
-version = "0.2.10"
+version = "0.2.11"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Per"]


### PR DESCRIPTION
## Summary
- Bump version from 0.2.10 to 0.2.11

🤖 Generated with [Claude Code](https://claude.com/claude-code)