### PR TITLE
fix: Use GitHub-hosted GStreamer MSI files for Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,22 +238,22 @@ jobs:
           echo "PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig" >> $GITHUB_ENV
           echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
 
-      # Windows: Install GStreamer directly from freedesktop.org
-      # Chocolatey package is broken (downloads removed versions), so we install MSIs directly
+      # Windows: Install GStreamer from our GitHub release mirror
+      # (freedesktop.org has bot protection that blocks CI downloads)
       - name: Install GStreamer (Windows)
         if: matrix.platform == 'windows'
         run: |
           $GSTREAMER_VERSION = "1.24.13"
-          $BASE_URL = "https://gstreamer.freedesktop.org/data/pkg/windows/$GSTREAMER_VERSION/msvc"
+          $BASE_URL = "https://github.com/Eyevinn/strom/releases/download/gstreamer-deps"
 
-          # Download and install runtime
-          Write-Host "Downloading GStreamer runtime..."
+          # Download and install runtime from our GitHub mirror
+          Write-Host "Downloading GStreamer runtime from GitHub mirror..."
           Invoke-WebRequest -Uri "$BASE_URL/gstreamer-1.0-msvc-x86_64-$GSTREAMER_VERSION.msi" -OutFile gstreamer.msi
           Write-Host "Installing GStreamer runtime..."
           Start-Process msiexec.exe -Wait -ArgumentList '/i gstreamer.msi /quiet /qn INSTALLDIR=D:\gstreamer'
 
-          # Download and install development files
-          Write-Host "Downloading GStreamer development files..."
+          # Download and install development files from our GitHub mirror
+          Write-Host "Downloading GStreamer development files from GitHub mirror..."
           Invoke-WebRequest -Uri "$BASE_URL/gstreamer-1.0-devel-msvc-x86_64-$GSTREAMER_VERSION.msi" -OutFile gstreamer-devel.msi
           Write-Host "Installing GStreamer development files..."
           Start-Process msiexec.exe -Wait -ArgumentList '/i gstreamer-devel.msi /quiet /qn INSTALLDIR=D:\gstreamer'
@@ -267,10 +267,14 @@ jobs:
           echo "PKG_CONFIG_PATH=D:\gstreamer\1.0\msvc_x86_64\lib\pkgconfig" >> $env:GITHUB_ENV
 
       # macOS: Install GStreamer via Homebrew
+      # Set PKG_CONFIG_PATH to ensure correct library paths are found
       - name: Install GStreamer (macOS)
         if: matrix.platform == 'macos'
         run: |
-          brew install gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly gst-libav
+          brew install gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly gst-libav pkg-config
+          # Set pkg-config paths for GStreamer and GLib (Homebrew paths)
+          echo "PKG_CONFIG_PATH=$(brew --prefix)/lib/pkgconfig:$(brew --prefix gstreamer)/lib/pkgconfig:$(brew --prefix glib)/lib/pkgconfig" >> $GITHUB_ENV
+          echo "LIBRARY_PATH=$(brew --prefix)/lib" >> $GITHUB_ENV
 
       # Download the pre-built frontend from the frontend build job
       - name: Download frontend dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,22 +164,22 @@ jobs:
         if: matrix.platform == 'windows'
         run: choco install strawberryperl --yes --no-progress
 
-      # Windows: Install GStreamer directly from freedesktop.org
-      # Chocolatey package is broken (downloads removed versions), so we install MSIs directly
+      # Windows: Install GStreamer from our GitHub release mirror
+      # (freedesktop.org has bot protection that blocks CI downloads)
       - name: Install GStreamer (Windows)
         if: matrix.platform == 'windows'
         run: |
           $GSTREAMER_VERSION = "1.24.13"
-          $BASE_URL = "https://gstreamer.freedesktop.org/data/pkg/windows/$GSTREAMER_VERSION/msvc"
+          $BASE_URL = "https://github.com/Eyevinn/strom/releases/download/gstreamer-deps"
 
-          # Download and install runtime
-          Write-Host "Downloading GStreamer runtime..."
+          # Download and install runtime from our GitHub mirror
+          Write-Host "Downloading GStreamer runtime from GitHub mirror..."
           Invoke-WebRequest -Uri "$BASE_URL/gstreamer-1.0-msvc-x86_64-$GSTREAMER_VERSION.msi" -OutFile gstreamer.msi
           Write-Host "Installing GStreamer runtime..."
           Start-Process msiexec.exe -Wait -ArgumentList '/i gstreamer.msi /quiet /qn INSTALLDIR=D:\gstreamer'
 
-          # Download and install development files
-          Write-Host "Downloading GStreamer development files..."
+          # Download and install development files from our GitHub mirror
+          Write-Host "Downloading GStreamer development files from GitHub mirror..."
           Invoke-WebRequest -Uri "$BASE_URL/gstreamer-1.0-devel-msvc-x86_64-$GSTREAMER_VERSION.msi" -OutFile gstreamer-devel.msi
           Write-Host "Installing GStreamer development files..."
           Start-Process msiexec.exe -Wait -ArgumentList '/i gstreamer-devel.msi /quiet /qn INSTALLDIR=D:\gstreamer'
@@ -193,10 +193,14 @@ jobs:
           echo "PKG_CONFIG_PATH=D:\gstreamer\1.0\msvc_x86_64\lib\pkgconfig" >> $env:GITHUB_ENV
 
       # macOS: Install GStreamer via Homebrew
+      # Set PKG_CONFIG_PATH to ensure correct library paths are found
       - name: Install GStreamer (macOS)
         if: matrix.platform == 'macos'
         run: |
-          brew install gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly gst-libav
+          brew install gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly gst-libav pkg-config
+          # Set pkg-config paths for GStreamer and GLib (Homebrew paths)
+          echo "PKG_CONFIG_PATH=$(brew --prefix)/lib/pkgconfig:$(brew --prefix gstreamer)/lib/pkgconfig:$(brew --prefix glib)/lib/pkgconfig" >> $GITHUB_ENV
+          echo "LIBRARY_PATH=$(brew --prefix)/lib" >> $GITHUB_ENV
 
       # Download the pre-built frontend from the frontend build job
       - name: Download frontend dist


### PR DESCRIPTION
## Summary
- Windows CI was failing because gstreamer.freedesktop.org added bot protection that blocks automated downloads
- macOS CI was failing due to Homebrew glib version changes causing library path issues

## Changes
- Windows: Download GStreamer MSI files from our GitHub release mirror (`gstreamer-deps` release) instead of freedesktop.org
- macOS: Add explicit `PKG_CONFIG_PATH` and `LIBRARY_PATH` for Homebrew-installed GStreamer/GLib

## GStreamer Mirror
The MSI files (v1.24.13 MSVC x86_64) are hosted at:
https://github.com/Eyevinn/strom/releases/tag/gstreamer-deps

## Test plan
- [ ] Windows CI build passes
- [ ] macOS CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)