### PR TITLE
chore: bump version to 0.2.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5048,7 +5048,7 @@ dependencies = [
 
 [[package]]
 name = "strom"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5099,7 +5099,7 @@ dependencies = [
 
 [[package]]
 name = "strom-frontend"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "console_error_panic_hook",
  "eframe",
@@ -5125,7 +5125,7 @@ dependencies = [
 
 [[package]]
 name = "strom-mcp-server"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "anyhow",
  "reqwest",
@@ -5139,7 +5139,7 @@ dependencies = [
 
 [[package]]
 name = "strom-types"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["types", "backend", "frontend", "mcp-server"]
 default-members = ["backend"]
 
 [workspace.package]
-version = "0.2.11"
+version = "0.2.12"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Per"]


### PR DESCRIPTION
## Summary
- Bump version to 0.2.12 for release

🤖 Generated with [Claude Code](https://claude.com/claude-code)