### PR TITLE
fix: Only apply nvcodec fix for amd64 architecture

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -137,27 +137,44 @@ fi
 FROM ubuntu:plucky AS runtime
 WORKDIR /app
 
-# Install only GStreamer runtime dependencies
-# Note: Using plucky-proposed to get gstreamer1.0-plugins-bad 1.26.0-1ubuntu2.2+
+# Get target architecture for conditional package installation
+ARG TARGETARCH
+
+# Install GStreamer runtime dependencies
+# For amd64: Use plucky-proposed to get gstreamer1.0-plugins-bad 1.26.0-1ubuntu2.2+
 # which fixes the nvcodec plugin (Bug #2109413 - was accidentally disabled on amd64)
-# Must pin BOTH libgstreamer-plugins-bad1.0-0 and gstreamer1.0-plugins-bad versions
+# For arm64: Use standard packages (nvcodec was incorrectly enabled there, but harmless)
 ENV DEBIAN_FRONTEND=noninteractive
-RUN echo "deb http://archive.ubuntu.com/ubuntu plucky-proposed main universe" > /etc/apt/sources.list.d/proposed.list && \
-    apt-get update && apt-get install -y \
-    libgstreamer1.0-0 \
-    libgstreamer-plugins-base1.0-0 \
-    gstreamer1.0-plugins-base \
-    gstreamer1.0-plugins-good \
-    libgstreamer-plugins-bad1.0-0=1.26.0-1ubuntu2.2 \
-    gstreamer1.0-plugins-bad=1.26.0-1ubuntu2.2 \
-    gstreamer1.0-plugins-ugly \
-    gstreamer1.0-libav \
-    gstreamer1.0-nice \
-    gstreamer1.0-tools \
-    graphviz \
-    ca-certificates \
-    && rm /etc/apt/sources.list.d/proposed.list \
-    && rm -rf /var/lib/apt/lists/*
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+        echo "deb http://archive.ubuntu.com/ubuntu plucky-proposed main universe" > /etc/apt/sources.list.d/proposed.list && \
+        apt-get update && apt-get install -y \
+            libgstreamer1.0-0 \
+            libgstreamer-plugins-base1.0-0 \
+            gstreamer1.0-plugins-base \
+            gstreamer1.0-plugins-good \
+            libgstreamer-plugins-bad1.0-0=1.26.0-1ubuntu2.2 \
+            gstreamer1.0-plugins-bad=1.26.0-1ubuntu2.2 \
+            gstreamer1.0-plugins-ugly \
+            gstreamer1.0-libav \
+            gstreamer1.0-nice \
+            gstreamer1.0-tools \
+            graphviz \
+            ca-certificates && \
+        rm /etc/apt/sources.list.d/proposed.list; \
+    else \
+        apt-get update && apt-get install -y \
+            libgstreamer1.0-0 \
+            libgstreamer-plugins-base1.0-0 \
+            gstreamer1.0-plugins-base \
+            gstreamer1.0-plugins-good \
+            gstreamer1.0-plugins-bad \
+            gstreamer1.0-plugins-ugly \
+            gstreamer1.0-libav \
+            gstreamer1.0-nice \
+            gstreamer1.0-tools \
+            graphviz \
+            ca-certificates; \
+    fi && rm -rf /var/lib/apt/lists/*
 
 # Copy the compiled binaries from backend-builder to /app
 COPY --from=backend-builder /app/target/release/strom /app/strom


### PR DESCRIPTION
## Summary

The plucky-proposed package pinning for gstreamer1.0-plugins-bad is only needed for amd64 where nvcodec was accidentally disabled (Bug #2109413). ARM64 should use standard packages.

## Changes

- Add `ARG TARGETARCH` to runtime stage
- Conditionally apply proposed repo and version pinning only for amd64
- ARM64 uses standard package versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)