### PR TITLE
chore: Bump version to 0.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5108,7 +5108,7 @@ dependencies = [
 
 [[package]]
 name = "strom"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5162,7 +5162,7 @@ dependencies = [
 
 [[package]]
 name = "strom-frontend"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "console_error_panic_hook",
  "eframe",
@@ -5190,7 +5190,7 @@ dependencies = [
 
 [[package]]
 name = "strom-mcp-server"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "reqwest",
@@ -5204,7 +5204,7 @@ dependencies = [
 
 [[package]]
 name = "strom-types"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["types", "backend", "frontend", "mcp-server"]
 default-members = ["backend"]
 
 [workspace.package]
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Per"]


### PR DESCRIPTION
## Summary
- Bump version from 0.3.1 to 0.3.2

## Test plan
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)