### PR TITLE
fix: Add STROM_MEDIA_PATH env var and fix default media path

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -148,6 +148,10 @@ struct Args {
     #[arg(long, env = "STROM_BLOCKS_PATH")]
     blocks_path: Option<PathBuf>,
 
+    /// Path to media files directory (overrides --data-dir)
+    #[arg(long, env = "STROM_MEDIA_PATH")]
+    media_path: Option<PathBuf>,
+
     /// Database URL (e.g., postgresql://user:pass@localhost/strom)
     /// If set, database storage is used instead of JSON files
     /// Supported schemes: postgresql://
@@ -234,6 +238,7 @@ fn main() -> anyhow::Result<()> {
         args.data_dir.clone(),
         args.flows_path.clone(),
         args.blocks_path.clone(),
+        args.media_path.clone(),
         args.database_url.clone(),
     )
     .unwrap_or_else(|e| {

--- a/backend/src/paths.rs
+++ b/backend/src/paths.rs
@@ -68,13 +68,12 @@ impl DataPaths {
             base_dir.join("blocks.json")
         };
 
-        // Resolve media path (individual path overrides default ./media)
+        // Resolve media path (individual path overrides base_dir)
         let media_path = if let Some(path) = config.media_path {
             Self::log_path_override("media", &path, &base_dir);
             path
         } else {
-            // Default to ./media in current working directory
-            PathBuf::from("./media")
+            base_dir.join("media")
         };
 
         // Ensure media directory exists
@@ -216,6 +215,7 @@ mod tests {
         let paths = DataPaths::resolve(config).unwrap();
         assert_eq!(paths.flows_path, temp_dir.path().join("flows.json"));
         assert_eq!(paths.blocks_path, temp_dir.path().join("blocks.json"));
+        assert_eq!(paths.media_path, temp_dir.path().join("media"));
     }
 
     #[test]
@@ -231,5 +231,20 @@ mod tests {
         let paths = DataPaths::resolve(config).unwrap();
         assert_eq!(paths.flows_path, PathBuf::from("/override/flows.json"));
         assert_eq!(paths.blocks_path, temp_dir.path().join("blocks.json"));
+    }
+
+    #[test]
+    fn test_explicit_media_path_override() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let media_dir = temp_dir.path().join("custom_media");
+        let config = PathConfig {
+            data_dir: Some(temp_dir.path().to_path_buf()),
+            flows_path: None,
+            blocks_path: None,
+            media_path: Some(media_dir.clone()),
+        };
+
+        let paths = DataPaths::resolve(config).unwrap();
+        assert_eq!(paths.media_path, media_dir);
     }
 }


### PR DESCRIPTION
## Summary
- Add `--media-path` CLI argument with `STROM_MEDIA_PATH` environment variable support
- Fix default media path to use `base_dir/media` instead of hardcoded `./media`
- Fixes startup crashes in Kubernetes/containerized environments

## Problem
In v0.3.0+, the media_path configuration was added but without CLI/env var support. The default path was hardcoded to `./media` which fails in containerized environments with read-only filesystems or restricted permissions.

This caused "Permission denied (os error 13)" errors on startup when running in Kubernetes with PostgreSQL backend.

## Solution
- Add `STROM_MEDIA_PATH` env var (consistent with other `STROM_*` config vars)
- Change default to use `base_dir/media` so it respects `STROM_DATA_DIR`
- Both explicit `STROM_MEDIA_PATH` and implicit via `STROM_DATA_DIR` now work

## Test plan
- [x] All 173 existing tests pass
- [x] Added test for explicit media_path override
- [ ] Manual test in Kubernetes environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)