### PR TITLE
chore: bump version to 0.3.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5108,7 +5108,7 @@ dependencies = [
 
 [[package]]
 name = "strom"
-version = "0.3.2"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5162,7 +5162,7 @@ dependencies = [
 
 [[package]]
 name = "strom-frontend"
-version = "0.3.2"
+version = "0.3.4"
 dependencies = [
  "chrono",
  "console_error_panic_hook",
@@ -5191,7 +5191,7 @@ dependencies = [
 
 [[package]]
 name = "strom-mcp-server"
-version = "0.3.2"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "reqwest",
@@ -5205,7 +5205,7 @@ dependencies = [
 
 [[package]]
 name = "strom-types"
-version = "0.3.2"
+version = "0.3.4"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["types", "backend", "frontend", "mcp-server"]
 default-members = ["backend"]
 
 [workspace.package]
-version = "0.3.2"
+version = "0.3.4"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Per"]


### PR DESCRIPTION
## Summary
- Bump cargo workspace version from 0.3.2 to 0.3.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)