### PR TITLE
chore: Bump version to 0.3.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5213,7 +5213,7 @@ dependencies = [
 
 [[package]]
 name = "strom"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5270,7 +5270,7 @@ dependencies = [
 
 [[package]]
 name = "strom-frontend"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "chrono",
  "console_error_panic_hook",
@@ -5299,7 +5299,7 @@ dependencies = [
 
 [[package]]
 name = "strom-mcp-server"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "reqwest",
@@ -5313,7 +5313,7 @@ dependencies = [
 
 [[package]]
 name = "strom-types"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["types", "backend", "frontend", "mcp-server"]
 default-members = ["backend"]
 
 [workspace.package]
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Per"]


### PR DESCRIPTION
## Summary
- Bump workspace version from 0.3.4 to 0.3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)