### PR TITLE
fix: Remove Windows-incompatible echo hook from Trunk.toml

### DIFF
--- a/frontend/Trunk.toml
+++ b/frontend/Trunk.toml
@@ -1,8 +1,3 @@
-[[hooks]]
-stage = "build"
-command = "echo"
-command_arguments = ["Building Strom frontend..."]
-
 [build]
 target = "index.html"
 # Build output goes to backend/dist for embedding


### PR DESCRIPTION
## Summary
- Removes the Windows-incompatible echo hook from frontend/Trunk.toml that was causing build failures on Windows

## Problem
The echo hook was causing trunk builds to fail on Windows with "program not found" error because `echo` is a shell built-in on Windows, not a standalone executable. Trunk tries to spawn it as a process, which fails.

## Solution
Removed the informational echo hook since Trunk already provides sufficient build logging. This maintains the same build functionality while fixing Windows compatibility.

## Test plan
- [ ] Verify trunk build works on Windows
- [ ] Verify trunk build still works on Linux/macOS
- [ ] Confirm build output is still informative

🤖 Generated with [Claude Code](https://claude.com/claude-code)