### PR TITLE
chore: Bump version to 0.3.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5314,7 +5314,7 @@ dependencies = [
 
 [[package]]
 name = "strom"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5370,7 +5370,7 @@ dependencies = [
 
 [[package]]
 name = "strom-frontend"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "chrono",
  "console_error_panic_hook",
@@ -5399,7 +5399,7 @@ dependencies = [
 
 [[package]]
 name = "strom-mcp-server"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "reqwest 0.13.1",
@@ -5413,7 +5413,7 @@ dependencies = [
 
 [[package]]
 name = "strom-types"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "serde",
  "serde_json",
@@ -7697,9 +7697,9 @@ checksum = "40990edd51aae2c2b6907af74ffb635029d5788228222c4bb811e9351c0caad3"
 
 [[package]]
 name = "zmij"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aac060176f7020d62c3bcc1cdbcec619d54f48b07ad1963a3f80ce7a0c17755f"
+checksum = "de9211a9f64b825911bdf0240f58b7a8dac217fe260fc61f080a07f61372fbd5"
 
 [[package]]
 name = "zopfli"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["types", "backend", "frontend", "mcp-server"]
 default-members = ["backend"]
 
 [workspace.package]
-version = "0.3.5"
+version = "0.3.6"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Per"]


### PR DESCRIPTION
## Summary
- Bump version from 0.3.5 to 0.3.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)