### PR TITLE
fix: Allow scripts/setup in Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -46,8 +46,9 @@ temp/
 # CI/CD files
 .github/workflows/
 
-# Development scripts
+# Development scripts (except setup scripts bundled in image)
 scripts/
+!scripts/setup/
 
 # Test data
 test-data/
@@ -57,5 +58,6 @@ core-dumps/
 *.core
 gst-debug.log
 
-# Test and development scripts
+# Test and development scripts (except setup scripts)
 *.sh
+!scripts/setup/**/*.sh


### PR DESCRIPTION
## Summary
- Add exceptions to `.dockerignore` for `scripts/setup/` folder
- Fixes Docker build failure from PR #192

The `scripts/` folder was excluded, preventing the new `COPY scripts/setup` from working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)