### PR TITLE
fix: Disable nvidia feature when cross-compiling for ARM64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -121,7 +121,7 @@ RUN if [ "$BUILDPLATFORM" != "$TARGETPLATFORM" ] && [ "$TARGETARCH" = "arm64" ];
     export AARCH64_UNKNOWN_LINUX_GNU_OPENSSL_LIB_DIR=/usr/lib/aarch64-linux-gnu && \
     export CFLAGS="-I/usr/include -I/usr/include/aarch64-linux-gnu" && \
     export RUSTFLAGS="-L /usr/lib/aarch64-linux-gnu" && \
-    cargo zigbuild --release --package strom --features no-gui --target aarch64-unknown-linux-gnu.2.36 && \
+    cargo zigbuild --release --package strom --no-default-features --features no-gui --target aarch64-unknown-linux-gnu.2.36 && \
     cargo zigbuild --release --package strom-mcp-server --target aarch64-unknown-linux-gnu.2.36 && \
     # Move binaries to expected location (cargo-zigbuild puts them in target/aarch64-unknown-linux-gnu/release)
     mkdir -p target/release && \


### PR DESCRIPTION
The build was using `--features no-gui` which adds to default features,
but `nvidia` is a default feature that includes nvml-wrapper. This crate
requires NVIDIA's NVML library which cannot cross-compile to ARM64
without proper ARM64 libraries.

Changed to `--no-default-features --features no-gui` to explicitly
disable the nvidia feature during ARM64 cross-compilation.