### PR TITLE
fix: Use C17 standard to avoid glibc 2.38+ C23 symbols in ARM64 cross-compile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -119,7 +119,10 @@ RUN if [ "$BUILDPLATFORM" != "$TARGETPLATFORM" ] && [ "$TARGETARCH" = "arm64" ];
     export PKG_CONFIG_ALLOW_CROSS=1 && \
     export PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig && \
     export AARCH64_UNKNOWN_LINUX_GNU_OPENSSL_LIB_DIR=/usr/lib/aarch64-linux-gnu && \
-    export CFLAGS="-I/usr/include -I/usr/include/aarch64-linux-gnu" && \
+    # Use C17 standard to avoid glibc 2.38+ C23 symbols (__isoc23_sscanf, __isoc23_strtol) \
+    # that aws-lc-sys would otherwise use when built on Ubuntu 25.04 (glibc 2.41) \
+    export CFLAGS="-std=gnu17 -I/usr/include -I/usr/include/aarch64-linux-gnu" && \
+    export CXXFLAGS="-std=gnu++17" && \
     export RUSTFLAGS="-L /usr/lib/aarch64-linux-gnu" && \
     cargo zigbuild --release --package strom --no-default-features --features no-gui --target aarch64-unknown-linux-gnu.2.36 && \
     cargo zigbuild --release --package strom-mcp-server --target aarch64-unknown-linux-gnu.2.36 && \


### PR DESCRIPTION
## Summary
- Fix ARM64 Docker build failure caused by `aws-lc-sys` using C23 symbols (`__isoc23_sscanf`, `__isoc23_strtol`)
- These symbols exist in glibc 2.38+ but we target glibc 2.36 for Raspberry Pi compatibility
- Solution: Set `CFLAGS=-std=gnu17` and `CXXFLAGS=-std=gnu++17` during cross-compilation

## Problem
```
ld.lld: error: undefined symbol: __isoc23_sscanf
ld.lld: error: undefined symbol: __isoc23_strtol
```

Ubuntu 25.04 (glibc 2.41) defaults to C23, causing `aws-lc-sys` to use these newer libc functions that don't exist in glibc 2.36.

## Test plan
- [ ] Docker publish workflow succeeds for both amd64 and arm64

🤖 Generated with [Claude Code](https://claude.com/claude-code)