### PR TITLE
ci: Add test workflow for native ARM64 builds on Ubuntu 22.04

### DIFF
--- a/.github/workflows/test-arm64-native.yml
+++ b/.github/workflows/test-arm64-native.yml
@@ -1,0 +1,76 @@
+name: Test ARM64 Native Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      build_docker:
+        description: 'Also build Docker image (slower)'
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  test-arm64-native:
+    name: Test native ARM64 build on Ubuntu 22.04
+    runs-on: ubuntu-22.04-arm
+    timeout-minutes: 60
+    steps:
+      - name: System info
+        run: |
+          echo "==> Architecture"
+          uname -m
+          echo "==> OS Release"
+          cat /etc/os-release
+          echo "==> glibc version"
+          ldd --version | head -1
+          echo "==> CPU info"
+          nproc
+          cat /proc/cpuinfo | grep "model name" | head -1 || true
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-action@stable
+
+      - name: Install GStreamer dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libgstreamer1.0-dev \
+            libgstreamer-plugins-base1.0-dev \
+            libgstreamer-plugins-bad1.0-dev \
+            libssl-dev \
+            pkg-config
+
+      - name: Build backend (native ARM64)
+        run: |
+          echo "==> Building strom backend natively on ARM64"
+          cargo build --release --package strom --features no-gui
+          echo "==> Build complete!"
+          ls -la target/release/strom
+          file target/release/strom
+          echo "==> Checking linked libraries"
+          ldd target/release/strom | head -20
+
+      - name: Build MCP server
+        run: |
+          cargo build --release --package strom-mcp-server
+          ls -la target/release/strom-mcp-server
+          file target/release/strom-mcp-server
+
+      - name: Upload ARM64 binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: strom-arm64-native-ubuntu2204
+          path: |
+            target/release/strom
+            target/release/strom-mcp-server
+
+      - name: Build Docker image (ARM64 only)
+        if: ${{ inputs.build_docker }}
+        run: |
+          echo "==> Building Docker image natively on ARM64"
+          docker build --platform linux/arm64 -t strom-arm64-test .
+          echo "==> Docker build complete!"
+          docker images strom-arm64-test


### PR DESCRIPTION
## Summary
- Add manual workflow to test native ARM64 builds using GitHub's free `ubuntu-22.04-arm` runner
- Ubuntu 22.04 has glibc 2.35 - even better compatibility than our current 2.36 target!

## What it does
1. Reports system info (arch, glibc version, CPU)
2. Builds `strom` and `strom-mcp-server` natively on ARM64
3. Uploads binaries as artifacts
4. Optionally builds Docker image

## Usage
Go to Actions → "Test ARM64 Native Build" → Run workflow

## Why
If this works well, we could switch from Zig cross-compilation to native ARM64 builds, which would:
- Avoid glibc version mismatch issues (like the C23 symbols problem)
- Potentially faster builds (no emulation overhead)
- Simpler Dockerfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)