### PR TITLE
fix: Use correct rust-toolchain action name

### DIFF
--- a/.github/workflows/test-arm64-native.yml
+++ b/.github/workflows/test-arm64-native.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Install GStreamer dependencies
         run: |


### PR DESCRIPTION
Fix typo: `dtolnay/rust-action` → `dtolnay/rust-toolchain`