### PR TITLE
fix: Add CMAKE flags for C17 standard and bust Docker cache

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -74,8 +74,9 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           # Use GitHub Actions cache (much faster than registry cache)
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Cache key v2: bust cache after C17 fix for aws-lc-sys glibc 2.38+ symbols
+          cache-from: type=gha,scope=docker-v2
+          cache-to: type=gha,mode=max,scope=docker-v2
           # Multi-platform build: amd64 (native) + arm64 (Zig cross-compilation)
           platforms: linux/amd64,linux/arm64
           # Disable provenance and SBOM to prevent build hangs

--- a/Dockerfile
+++ b/Dockerfile
@@ -121,8 +121,11 @@ RUN if [ "$BUILDPLATFORM" != "$TARGETPLATFORM" ] && [ "$TARGETARCH" = "arm64" ];
     export AARCH64_UNKNOWN_LINUX_GNU_OPENSSL_LIB_DIR=/usr/lib/aarch64-linux-gnu && \
     # Use C17 standard to avoid glibc 2.38+ C23 symbols (__isoc23_sscanf, __isoc23_strtol) \
     # that aws-lc-sys would otherwise use when built on Ubuntu 25.04 (glibc 2.41) \
+    # CFLAGS/CXXFLAGS for regular builds, CMAKE_C_FLAGS/CMAKE_CXX_FLAGS for CMake (aws-lc-sys) \
     export CFLAGS="-std=gnu17 -I/usr/include -I/usr/include/aarch64-linux-gnu" && \
     export CXXFLAGS="-std=gnu++17" && \
+    export CMAKE_C_FLAGS="-std=gnu17" && \
+    export CMAKE_CXX_FLAGS="-std=gnu++17" && \
     export RUSTFLAGS="-L /usr/lib/aarch64-linux-gnu" && \
     cargo zigbuild --release --package strom --no-default-features --features no-gui --target aarch64-unknown-linux-gnu.2.36 && \
     cargo zigbuild --release --package strom-mcp-server --target aarch64-unknown-linux-gnu.2.36 && \


### PR DESCRIPTION
## Summary
- Add `CMAKE_C_FLAGS` and `CMAKE_CXX_FLAGS` for aws-lc-sys (uses CMake, doesn't respect CFLAGS)
- Bust Docker cache by changing scope to `docker-v2` (old cache has aws-lc-sys with C23 symbols)

## Problem
The previous fix only set CFLAGS/CXXFLAGS, but aws-lc-sys builds with CMake which ignores those. The linker error persisted:
```
ld.lld: error: undefined symbol: __isoc23_sscanf
ld.lld: error: undefined symbol: __isoc23_strtol
```

## Test plan
- [ ] Docker publish workflow succeeds for ARM64

🤖 Generated with [Claude Code](https://claude.com/claude-code)