### PR TITLE
feat: Use native ARM64 runners for Docker builds

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -16,10 +16,11 @@ env:
   IMAGE_NAME: eyevinntechnology/strom
 
 jobs:
-  docker-publish:
-    name: Build and Push to Docker Hub
+  # Build AMD64 image natively on x86_64 runner
+  build-amd64:
+    name: Build AMD64
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 60
     permissions:
       contents: read
       packages: write
@@ -33,11 +34,7 @@ jobs:
         run: |
           echo "==> Disk space before cleanup"
           df -h
-          echo "==> Removing unnecessary files"
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
           sudo docker image prune --all --force
           echo "==> Disk space after cleanup"
           df -h
@@ -51,34 +48,128 @@ jobs:
           username: ${{ secrets.HUB_DOCKER_USERNAME }}
           password: ${{ secrets.HUB_DOCKER_PASSWORD }}
 
-      - name: Extract metadata (tags, labels)
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.IMAGE_NAME }}
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=ref,event=branch
+      - name: Extract version
+        id: version
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+          else
+            echo "version=dev-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          fi
 
-      - name: Build and push Docker image
+      - name: Build and push AMD64 image
         uses: docker/build-push-action@v5
         env:
-          # Enable verbose output for debugging build progress
           BUILDKIT_PROGRESS: plain
         with:
           context: .
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          # Use GitHub Actions cache (much faster than registry cache)
-          # Cache key v2: bust cache after C17 fix for aws-lc-sys glibc 2.38+ symbols
-          cache-from: type=gha,scope=docker-v2
-          cache-to: type=gha,mode=max,scope=docker-v2
-          # Multi-platform build: amd64 (native) + arm64 (Zig cross-compilation)
-          platforms: linux/amd64,linux/arm64
-          # Disable provenance and SBOM to prevent build hangs
+          tags: ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}-amd64
+          platforms: linux/amd64
+          cache-from: type=gha,scope=docker-amd64
+          cache-to: type=gha,mode=max,scope=docker-amd64
           provenance: false
           sbom: false
+
+  # Build ARM64 image natively on ARM64 runner (no cross-compilation!)
+  build-arm64:
+    name: Build ARM64
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.HUB_DOCKER_USERNAME }}
+          password: ${{ secrets.HUB_DOCKER_PASSWORD }}
+
+      - name: Extract version
+        id: version
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+          else
+            echo "version=dev-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build and push ARM64 image
+        uses: docker/build-push-action@v5
+        env:
+          BUILDKIT_PROGRESS: plain
+        with:
+          context: .
+          push: true
+          tags: ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}-arm64
+          platforms: linux/arm64
+          cache-from: type=gha,scope=docker-arm64
+          cache-to: type=gha,mode=max,scope=docker-arm64
+          provenance: false
+          sbom: false
+
+  # Create multi-arch manifest combining AMD64 and ARM64 images
+  create-manifest:
+    name: Create Multi-arch Manifest
+    needs: [build-amd64, build-arm64]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.HUB_DOCKER_USERNAME }}
+          password: ${{ secrets.HUB_DOCKER_PASSWORD }}
+
+      - name: Extract metadata
+        id: meta
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/v}
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
+            # Generate all tag variations for releases
+            MAJOR=$(echo $VERSION | cut -d. -f1)
+            MINOR=$(echo $VERSION | cut -d. -f2)
+            echo "tags=${{ env.IMAGE_NAME }}:${VERSION},${{ env.IMAGE_NAME }}:${MAJOR}.${MINOR},${{ env.IMAGE_NAME }}:${MAJOR},${{ env.IMAGE_NAME }}:latest" >> $GITHUB_OUTPUT
+          else
+            VERSION="dev-$(echo $GITHUB_SHA | head -c7)"
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
+            echo "tags=${{ env.IMAGE_NAME }}:${VERSION}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create and push multi-arch manifest
+        run: |
+          # Create manifest from platform-specific images
+          docker buildx imagetools create \
+            --tag ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }} \
+            ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}-amd64 \
+            ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}-arm64
+
+          # Create additional tags for releases
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            IFS=',' read -ra TAGS <<< "${{ steps.meta.outputs.tags }}"
+            for TAG in "${TAGS[@]}"; do
+              if [[ "$TAG" != "${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}" ]]; then
+                docker buildx imagetools create \
+                  --tag "$TAG" \
+                  ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}-amd64 \
+                  ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}-arm64
+              fi
+            done
+          fi
+
+      - name: Verify manifest
+        run: |
+          echo "==> Inspecting multi-arch manifest"
+          docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}


### PR DESCRIPTION
## Summary
- Split Docker multi-arch builds into parallel native jobs
- AMD64 builds on `ubuntu-latest` (native x86_64)
- ARM64 builds on `ubuntu-24.04-arm` (native ARM64)
- Multi-arch manifest created from platform-specific images

## Changes

### Architecture
**Before:** Single job with buildx cross-compilation (AMD64 → ARM64 via Zig)
**After:** Parallel native jobs + manifest creation

```
build-amd64 (ubuntu-latest)      ─┐
                                  ├─> create-manifest
build-arm64 (ubuntu-24.04-arm)   ─┘
```

### Benefits
| Aspect | Before | After |
|--------|--------|-------|
| ARM64 build | Cross-compilation via Zig | Native on ARM64 runner |
| Build speed | Sequential (120min timeout) | Parallel (60min each) |
| C23 symbols | Requires CMAKE workarounds | Not an issue (native glibc) |
| Caching | Single shared cache | Separate per-architecture |

### Tags Generated
For tag `v0.3.6`:
- `eyevinntechnology/strom:0.3.6` (multi-arch)
- `eyevinntechnology/strom:0.3` (multi-arch)
- `eyevinntechnology/strom:0` (multi-arch)
- `eyevinntechnology/strom:latest` (multi-arch)
- `eyevinntechnology/strom:0.3.6-amd64` (platform-specific)
- `eyevinntechnology/strom:0.3.6-arm64` (platform-specific)

## Test plan
- [ ] Trigger workflow manually via `workflow_dispatch`
- [ ] Verify AMD64 build succeeds on `ubuntu-latest`
- [ ] Verify ARM64 build succeeds on `ubuntu-24.04-arm`
- [ ] Verify multi-arch manifest is created correctly
- [ ] Test `docker pull` on both platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)