### PR TITLE
chore: Bump version to 0.3.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["types", "backend", "frontend", "mcp-server"]
 default-members = ["backend"]
 
 [workspace.package]
-version = "0.3.6"
+version = "0.3.7"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Per"]


### PR DESCRIPTION
## Summary
- Bump version to 0.3.7 for release

## Changes in v0.3.7
- Native ARM64 runners for CI, Release, and Docker workflows
- Parallel Docker builds (AMD64 + ARM64)
- glibc 2.31 targeting via cargo-zigbuild for release binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)