### PR TITLE
fix: Use autovideoconvert for GPU-accelerated color conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5314,7 +5314,7 @@ dependencies = [
 
 [[package]]
 name = "strom"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5370,7 +5370,7 @@ dependencies = [
 
 [[package]]
 name = "strom-frontend"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "chrono",
  "console_error_panic_hook",
@@ -5399,7 +5399,7 @@ dependencies = [
 
 [[package]]
 name = "strom-mcp-server"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "anyhow",
  "reqwest 0.13.1",
@@ -5413,7 +5413,7 @@ dependencies = [
 
 [[package]]
 name = "strom-types"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "serde",
  "serde_json",

--- a/backend/src/blocks/builtin/decklink.rs
+++ b/backend/src/blocks/builtin/decklink.rs
@@ -48,7 +48,7 @@ impl BlockBuilder for DeckLinkVideoInputBuilder {
 
         // Create elements with namespaced IDs
         let videosrc_id = format!("{}:decklinkvideosrc", instance_id);
-        let videoconvert_id = format!("{}:videoconvert", instance_id);
+        let videoconvert_id = format!("{}:autovideoconvert", instance_id);
         let capsfilter_id = format!("{}:capsfilter", instance_id);
 
         let videosrc = gst::ElementFactory::make("decklinkvideosrc")
@@ -59,10 +59,10 @@ impl BlockBuilder for DeckLinkVideoInputBuilder {
             .build()
             .map_err(|e| BlockBuildError::ElementCreation(format!("decklinkvideosrc: {}", e)))?;
 
-        let videoconvert = gst::ElementFactory::make("videoconvert")
+        let videoconvert = gst::ElementFactory::make("autovideoconvert")
             .name(&videoconvert_id)
             .build()
-            .map_err(|e| BlockBuildError::ElementCreation(format!("videoconvert: {}", e)))?;
+            .map_err(|e| BlockBuildError::ElementCreation(format!("autovideoconvert: {}", e)))?;
 
         // Capsfilter with generic video/x-raw caps (no specific format restriction)
         let caps = gst::Caps::builder("video/x-raw").build();
@@ -77,7 +77,7 @@ impl BlockBuilder for DeckLinkVideoInputBuilder {
             device_number, mode, connection
         );
 
-        // Chain: decklinkvideosrc -> videoconvert -> capsfilter
+        // Chain: decklinkvideosrc -> autovideoconvert -> capsfilter
         let internal_links = vec![
             (
                 ElementPadRef::pad(&videosrc_id, "src"),
@@ -238,13 +238,13 @@ impl BlockBuilder for DeckLinkVideoOutputBuilder {
             .unwrap_or("auto");
 
         // Create elements with namespaced IDs
-        let videoconvert_id = format!("{}:videoconvert", instance_id);
+        let videoconvert_id = format!("{}:autovideoconvert", instance_id);
         let videosink_id = format!("{}:decklinkvideosink", instance_id);
 
-        let videoconvert = gst::ElementFactory::make("videoconvert")
+        let videoconvert = gst::ElementFactory::make("autovideoconvert")
             .name(&videoconvert_id)
             .build()
-            .map_err(|e| BlockBuildError::ElementCreation(format!("videoconvert: {}", e)))?;
+            .map_err(|e| BlockBuildError::ElementCreation(format!("autovideoconvert: {}", e)))?;
 
         let videosink = gst::ElementFactory::make("decklinkvideosink")
             .name(&videosink_id)
@@ -258,7 +258,7 @@ impl BlockBuilder for DeckLinkVideoOutputBuilder {
             device_number, mode
         );
 
-        // Chain: videoconvert -> decklinkvideosink
+        // Chain: autovideoconvert -> decklinkvideosink
         let internal_links = vec![(
             ElementPadRef::pad(&videoconvert_id, "src"),
             ElementPadRef::pad(&videosink_id, "sink"),
@@ -693,7 +693,7 @@ fn decklink_video_output_definition() -> BlockDefinition {
             inputs: vec![ExternalPad {
                 name: "video_in".to_string(),
                 media_type: MediaType::Video,
-                internal_element_id: "videoconvert".to_string(),
+                internal_element_id: "autovideoconvert".to_string(),
                 internal_pad_name: "sink".to_string(),
             }],
             outputs: vec![],

--- a/backend/src/blocks/builtin/glcompositor.rs
+++ b/backend/src/blocks/builtin/glcompositor.rs
@@ -1,5 +1,8 @@
 //! OpenGL video compositor block for combining multiple video inputs.
 //!
+//! **DEPRECATED**: Use `builtin.compositor` (Video Compositor) instead, which supports
+//! both GPU and CPU backends with automatic fallback.
+//!
 //! This block uses GStreamer's `glvideomixerelement` to composite multiple video streams
 //! with hardware-accelerated OpenGL rendering. Each input can be positioned, sized, and
 //! blended independently with configurable properties.
@@ -773,9 +776,9 @@ fn glcompositor_definition() -> BlockDefinition {
 
     BlockDefinition {
         id: "builtin.glcompositor".to_string(),
-        name: "OpenGL Video Compositor".to_string(),
-        description: "Hardware-accelerated OpenGL video compositor. Note: Consider using the new 'Video Compositor' block instead, which supports both GPU and CPU backends with automatic fallback.".to_string(),
-        category: "Video".to_string(),
+        name: "[Deprecated] OpenGL Compositor".to_string(),
+        description: "DEPRECATED: Use 'Video Compositor' instead, which supports both GPU and CPU backends with automatic fallback. This block will be removed in a future release.".to_string(),
+        category: "Deprecated".to_string(),
         exposed_properties,
         // External pads are computed dynamically based on num_inputs
         external_pads: ExternalPads {

--- a/backend/src/blocks/builtin/ndi.rs
+++ b/backend/src/blocks/builtin/ndi.rs
@@ -200,14 +200,14 @@ impl BlockBuilder for NDIInputBuilder {
         match mode.as_str() {
             "combined" => {
                 // Video path
-                let videoconvert_id = format!("{}:videoconvert", instance_id);
+                let videoconvert_id = format!("{}:autovideoconvert", instance_id);
                 let videocaps_id = format!("{}:videocapsfilter", instance_id);
 
-                let videoconvert = gst::ElementFactory::make("videoconvert")
+                let videoconvert = gst::ElementFactory::make("autovideoconvert")
                     .name(&videoconvert_id)
                     .build()
                     .map_err(|e| {
-                        BlockBuildError::ElementCreation(format!("videoconvert: {}", e))
+                        BlockBuildError::ElementCreation(format!("autovideoconvert: {}", e))
                     })?;
 
                 let video_caps = gst::Caps::builder("video/x-raw").build();
@@ -284,14 +284,14 @@ impl BlockBuilder for NDIInputBuilder {
                 );
             }
             "video" => {
-                let videoconvert_id = format!("{}:videoconvert", instance_id);
+                let videoconvert_id = format!("{}:autovideoconvert", instance_id);
                 let capsfilter_id = format!("{}:capsfilter", instance_id);
 
-                let videoconvert = gst::ElementFactory::make("videoconvert")
+                let videoconvert = gst::ElementFactory::make("autovideoconvert")
                     .name(&videoconvert_id)
                     .build()
                     .map_err(|e| {
-                        BlockBuildError::ElementCreation(format!("videoconvert: {}", e))
+                        BlockBuildError::ElementCreation(format!("autovideoconvert: {}", e))
                     })?;
 
                 let caps = gst::Caps::builder("video/x-raw").build();
@@ -412,7 +412,7 @@ impl BlockBuilder for NDIOutputBuilder {
                 ExternalPad {
                     name: "video_in".to_string(),
                     media_type: MediaType::Video,
-                    internal_element_id: "videoconvert".to_string(),
+                    internal_element_id: "autovideoconvert".to_string(),
                     internal_pad_name: "sink".to_string(),
                 },
                 ExternalPad {
@@ -425,7 +425,7 @@ impl BlockBuilder for NDIOutputBuilder {
             "video" => vec![ExternalPad {
                 name: "video_in".to_string(),
                 media_type: MediaType::Video,
-                internal_element_id: "videoconvert".to_string(),
+                internal_element_id: "autovideoconvert".to_string(),
                 internal_pad_name: "sink".to_string(),
             }],
             "audio" => vec![ExternalPad {
@@ -474,12 +474,12 @@ impl BlockBuilder for NDIOutputBuilder {
         match mode.as_str() {
             "combined" => {
                 // Video path
-                let videoconvert_id = format!("{}:videoconvert", instance_id);
-                let videoconvert = gst::ElementFactory::make("videoconvert")
+                let videoconvert_id = format!("{}:autovideoconvert", instance_id);
+                let videoconvert = gst::ElementFactory::make("autovideoconvert")
                     .name(&videoconvert_id)
                     .build()
                     .map_err(|e| {
-                        BlockBuildError::ElementCreation(format!("videoconvert: {}", e))
+                        BlockBuildError::ElementCreation(format!("autovideoconvert: {}", e))
                     })?;
 
                 // Audio path
@@ -555,14 +555,14 @@ impl BlockBuilder for NDIOutputBuilder {
                 info!("NDI Output (combined) configured: ndi_name={}", ndi_name);
             }
             "video" => {
-                let videoconvert_id = format!("{}:videoconvert", instance_id);
+                let videoconvert_id = format!("{}:autovideoconvert", instance_id);
                 let ndisink_id = format!("{}:ndisink", instance_id);
 
-                let videoconvert = gst::ElementFactory::make("videoconvert")
+                let videoconvert = gst::ElementFactory::make("autovideoconvert")
                     .name(&videoconvert_id)
                     .build()
                     .map_err(|e| {
-                        BlockBuildError::ElementCreation(format!("videoconvert: {}", e))
+                        BlockBuildError::ElementCreation(format!("autovideoconvert: {}", e))
                     })?;
 
                 let ndisink = gst::ElementFactory::make("ndisink")
@@ -839,7 +839,7 @@ fn ndi_output_definition() -> BlockDefinition {
                 ExternalPad {
                     name: "video_in".to_string(),
                     media_type: MediaType::Video,
-                    internal_element_id: "videoconvert".to_string(),
+                    internal_element_id: "autovideoconvert".to_string(),
                     internal_pad_name: "sink".to_string(),
                 },
                 ExternalPad {

--- a/backend/src/blocks/builtin/videoenc.rs
+++ b/backend/src/blocks/builtin/videoenc.rs
@@ -10,8 +10,8 @@
 //! - AV1
 //! - VP9
 //!
-//! The block creates a chain: videoconvert -> encoder -> parser -> capsfilter
-//! - videoconvert: Ensures compatible pixel format for the encoder
+//! The block creates a chain: autovideoconvert -> encoder -> parser -> capsfilter
+//! - autovideoconvert: Auto-selects best converter (GPU-accelerated when available)
 //! - encoder: Selected hardware or software encoder
 //! - parser: Codec-specific parser (h264parse, h265parse, etc.) for proper stream formatting
 //! - capsfilter: Sets output caps for proper codec negotiation
@@ -108,14 +108,16 @@ impl BlockBuilder for VideoEncBuilder {
             .unwrap_or(60);
 
         // Create elements
-        let convert_id = format!("{}:videoconvert", instance_id);
+        let convert_id = format!("{}:autovideoconvert", instance_id);
         let encoder_id = format!("{}:encoder", instance_id);
         let capsfilter_id = format!("{}:capsfilter", instance_id);
 
-        let videoconvert = gst::ElementFactory::make("videoconvert")
+        // Use autovideoconvert instead of videoconvert to support GPU-accelerated
+        // color conversion when using hardware encoders (fixes issue #188)
+        let videoconvert = gst::ElementFactory::make("autovideoconvert")
             .name(&convert_id)
             .build()
-            .map_err(|e| BlockBuildError::ElementCreation(format!("videoconvert: {}", e)))?;
+            .map_err(|e| BlockBuildError::ElementCreation(format!("autovideoconvert: {}", e)))?;
 
         let encoder = gst::ElementFactory::make(&encoder_name)
             .name(&encoder_id)
@@ -162,11 +164,11 @@ impl BlockBuilder for VideoEncBuilder {
             .map_err(|e| BlockBuildError::ElementCreation(format!("capsfilter: {}", e)))?;
 
         info!(
-            "🎞️ VideoEncoder block created (chain: videoconvert -> {} -> {} -> capsfilter [{}])",
+            "🎞️ VideoEncoder block created (chain: autovideoconvert -> {} -> {} -> capsfilter [{}])",
             encoder_name, parser_name, caps_str
         );
 
-        // Chain: videoconvert -> encoder -> parser -> capsfilter
+        // Chain: autovideoconvert -> encoder -> parser -> capsfilter
         let internal_links = vec![
             (
                 ElementPadRef::pad(&convert_id, "src"),
@@ -839,7 +841,7 @@ fn videoenc_definition() -> BlockDefinition {
             inputs: vec![ExternalPad {
                 name: "video_in".to_string(),
                 media_type: MediaType::Video,
-                internal_element_id: "videoconvert".to_string(),
+                internal_element_id: "autovideoconvert".to_string(),
                 internal_pad_name: "sink".to_string(),
             }],
             outputs: vec![ExternalPad {

--- a/backend/src/blocks/builtin/videoenc/tests.rs
+++ b/backend/src/blocks/builtin/videoenc/tests.rs
@@ -534,7 +534,7 @@ fn test_build_video_encoder_block() {
             assert_eq!(
                 block_result.elements.len(),
                 4,
-                "Should create 4 elements (videoconvert, encoder, parser, capsfilter)"
+                "Should create 4 elements (autovideoconvert, encoder, parser, capsfilter)"
             );
             assert_eq!(
                 block_result.internal_links.len(),

--- a/backend/src/blocks/builtin/videoformat.rs
+++ b/backend/src/blocks/builtin/videoformat.rs
@@ -6,7 +6,7 @@
 //! - Color format (pixel format) - enforced by caps
 //!
 //! All properties are optional. The block creates a fixed chain of elements:
-//! videoscale -> videoconvert -> capsfilter
+//! videoscale -> autovideoconvert -> capsfilter
 //!
 //! TEMPORARY: videorate element removed to avoid frame duplication issues.
 //!
@@ -92,7 +92,7 @@ impl BlockBuilder for VideoFormatBuilder {
         // Always create all elements for consistent external pad references
         // Elements will just pass through if their respective properties aren't set
         let scale_id = format!("{}:videoscale", instance_id);
-        let convert_id = format!("{}:videoconvert", instance_id);
+        let convert_id = format!("{}:autovideoconvert", instance_id);
         let capsfilter_id = format!("{}:capsfilter", instance_id);
 
         let videoscale = gst::ElementFactory::make("videoscale")
@@ -106,10 +106,10 @@ impl BlockBuilder for VideoFormatBuilder {
         //     .build()
         //     .map_err(|e| BlockBuildError::ElementCreation(format!("videorate: {}", e)))?;
 
-        let videoconvert = gst::ElementFactory::make("videoconvert")
+        let videoconvert = gst::ElementFactory::make("autovideoconvert")
             .name(&convert_id)
             .build()
-            .map_err(|e| BlockBuildError::ElementCreation(format!("videoconvert: {}", e)))?;
+            .map_err(|e| BlockBuildError::ElementCreation(format!("autovideoconvert: {}", e)))?;
 
         // capsfilter with caps (only constraints specified properties)
         let caps = caps_str.parse::<gst::Caps>().map_err(|_| {
@@ -122,9 +122,9 @@ impl BlockBuilder for VideoFormatBuilder {
             .build()
             .map_err(|e| BlockBuildError::ElementCreation(format!("capsfilter: {}", e)))?;
 
-        info!("🎬 VideoFormat block created (chain: videoscale -> videoconvert -> capsfilter) [videorate TEMPORARILY REMOVED]");
+        info!("🎬 VideoFormat block created (chain: videoscale -> autovideoconvert -> capsfilter) [videorate TEMPORARILY REMOVED]");
 
-        // Chain: videoscale -> videoconvert -> capsfilter (videorate temporarily removed)
+        // Chain: videoscale -> autovideoconvert -> capsfilter (videorate temporarily removed)
         let internal_links = vec![
             (
                 ElementPadRef::pad(&scale_id, "src"),
@@ -206,7 +206,7 @@ fn videoformat_definition() -> BlockDefinition {
             ExposedProperty {
                 name: "format".to_string(),
                 label: "Pixel Format".to_string(),
-                description: "Pixel format/color space - creates videoconvert element. Leave empty to pass through.".to_string(),
+                description: "Pixel format/color space - creates autovideoconvert element. Leave empty to pass through.".to_string(),
                 property_type: PropertyType::Enum {
                     values: vec![
                         EnumValue { value: "".to_string(), label: Some("-".to_string()) },

--- a/docs/VIDEO_ENCODER_BLOCK.md
+++ b/docs/VIDEO_ENCODER_BLOCK.md
@@ -22,16 +22,16 @@ The Video Encoder block (`builtin.videoenc`) provides automatic hardware-acceler
 ### Block Structure
 
 ```
-┌──────────────┐    ┌─────────┐    ┌────────────┐
-│ videoconvert │───▶│ encoder │───▶│ capsfilter │
-└──────────────┘    └─────────┘    └────────────┘
-      ▲                                    │
-      │                                    ▼
- video_in                           encoded_out
+┌──────────────────┐    ┌─────────┐    ┌────────────┐
+│ autovideoconvert │───▶│ encoder │───▶│ capsfilter │
+└──────────────────┘    └─────────┘    └────────────┘
+        ▲                                    │
+        │                                    ▼
+   video_in                           encoded_out
 ```
 
 **Elements:**
-1. **videoconvert**: Ensures compatible pixel format for the selected encoder
+1. **autovideoconvert**: Auto-selects best converter (GPU-accelerated when available)
 2. **encoder**: Dynamically selected hardware or software encoder element
 3. **capsfilter**: Sets output caps for proper codec negotiation
 
@@ -384,7 +384,7 @@ The block logs encoder selection and configuration:
 🎞️ Building VideoEncoder block instance: block_id
 🎞️ Selected encoder 'nvh264enc' for codec H264 with preference Auto
 🎞️ Set encoder properties: bitrate=4000 kbps, preset=medium, rate_control=Vbr, gop=60
-🎞️ VideoEncoder block created (chain: videoconvert -> nvh264enc -> capsfilter [video/x-h264])
+🎞️ VideoEncoder block created (chain: autovideoconvert -> nvh264enc -> capsfilter [video/x-h264])
 ```
 
 ## Testing


### PR DESCRIPTION
## Summary
- Replace `videoconvert` with `autovideoconvert` in video processing blocks
- Enables GPU-accelerated color conversion when available
- Fixes hardware encoder compatibility issues

Fixes #188

## Problem
The `videoconvert` element is software-only and can't keep up with hardware encoding pipelines. When using H.265 hardware encoding with Decklink input, the pipeline failed with:
```
streaming stopped, reason not-linked (-1)
'videoconvert' falling behind 92.3%
```

## Solution
`autovideoconvert` automatically selects the best available converter:
- `glcolorconvert` for OpenGL pipelines
- CUDA converters for NVIDIA hardware
- Falls back to software `videoconvert` when needed

## Updated Blocks
| Block | File |
|-------|------|
| Video Encoder | `videoenc.rs` |
| Video Format | `videoformat.rs` |
| DeckLink In/Out | `decklink.rs` |
| NDI In/Out | `ndi.rs` |

Note: Compositor block intentionally kept with `videoconvert` for CPU-based compositing.

## Test plan
- [x] Code compiles
- [x] All existing tests pass
- [ ] Test H.265 hardware encoding with Decklink input (user reported fix)
- [ ] Test other hardware encoder workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)