### PR TITLE
fix: Default is-live=true for videotestsrc and audiotestsrc

### DIFF
--- a/backend/src/gst/discovery.rs
+++ b/backend/src/gst/discovery.rs
@@ -1262,6 +1262,19 @@ impl ElementDiscovery {
             });
         }
 
+        // Override default for is-live on test sources to be true
+        // This makes test sources behave like live sources by default
+        let factory_name = factory.name();
+        if factory_name == "videotestsrc" || factory_name == "audiotestsrc" {
+            for prop in &mut properties {
+                if prop.name == "is-live" {
+                    prop.default_value = Some(PropertyValue::Bool(true));
+                    debug!("Overriding is-live default to true for {}", factory_name);
+                    break;
+                }
+            }
+        }
+
         Ok(properties)
     }
 }

--- a/backend/src/gst/pipeline.rs
+++ b/backend/src/gst/pipeline.rs
@@ -699,6 +699,15 @@ impl PipelineManager {
             debug!("Enabled QoS on element {}", element_def.id);
         }
 
+        // Default is-live=true for test sources (unless explicitly set by user)
+        if (element_def.element_type == "videotestsrc"
+            || element_def.element_type == "audiotestsrc")
+            && !element_def.properties.contains_key("is-live")
+        {
+            element.set_property("is-live", true);
+            debug!("Enabled is-live on test source {}", element_def.id);
+        }
+
         // Set properties
         if !element_def.properties.is_empty() {
             debug!(


### PR DESCRIPTION
## Summary
- Default `is-live=true` for `videotestsrc` and `audiotestsrc` elements so they behave like live sources by default
- Property remains user-editable (can be set to false if needed)

## Details
Two changes to ensure consistency:
1. **discovery.rs**: Override the default value shown in the UI so users see `is-live: true` as the default
2. **pipeline.rs**: Set `is-live=true` on the GStreamer element at runtime if not explicitly set by user

## Test plan
- [ ] Add a videotestsrc to a flow, verify is-live shows as true in properties
- [ ] Start the flow, verify it behaves as a live source
- [ ] Set is-live to false, verify the override works

🤖 Generated with [Claude Code](https://claude.com/claude-code)