### PR TITLE
fix: Use gst-launch-1.0.exe on Windows for CUDA interop test

### DIFF
--- a/backend/src/gpu.rs
+++ b/backend/src/gpu.rs
@@ -124,7 +124,12 @@ fn test_cuda_gl_interop() -> Result<(), String> {
 
     // Run gst-launch-1.0 with GST_DEBUG to capture warnings
     // Pipeline: videotestsrc ! glupload ! glcolorconvert ! video/x-raw(memory:GLMemory),format=NV12 ! nvh264enc ! fakesink
-    let mut cmd = Command::new("gst-launch-1.0");
+    let gst_launch = if cfg!(windows) {
+        "gst-launch-1.0.exe"
+    } else {
+        "gst-launch-1.0"
+    };
+    let mut cmd = Command::new(gst_launch);
     cmd.env("GST_DEBUG", "nvenc:3,nvencoder:3,cudautils:3");
 
     // Pass through GL environment variables for headless support


### PR DESCRIPTION
## Summary
- Fix CUDA-GL interop test failing on Windows due to missing `.exe` extension
- Use `gst-launch-1.0.exe` on Windows, `gst-launch-1.0` on Linux/macOS

## Problem
On Windows, the CUDA interop test was failing with:
```
WARN CUDA-GL interop failed: Failed to run gst-launch-1.0: program not found
```

## Solution
Use conditional compilation to select the correct executable name:
```rust
let gst_launch = if cfg!(windows) {
    "gst-launch-1.0.exe"
} else {
    "gst-launch-1.0"
};
```

## Test plan
- [x] Compiles on Linux
- [x] Test on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)