### PR TITLE
fix: Normalize ICE server URLs for GStreamer and browser compatibility

### DIFF
--- a/backend/src/blocks/builtin/whep.rs
+++ b/backend/src/blocks/builtin/whep.rs
@@ -179,10 +179,10 @@ fn build_whepsrc(
 
     // Set properties directly on whepsrc (no signaller child)
     whepsrc.set_property("whep-endpoint", &whep_endpoint);
-    if let Some(stun) = stun_server {
+    if let Some(ref stun) = stun_server {
         whepsrc.set_property("stun-server", stun);
     }
-    if let Some(turn) = turn_server {
+    if let Some(ref turn) = turn_server {
         whepsrc.set_property("turn-server", turn);
     }
 
@@ -364,10 +364,10 @@ fn build_whepclientsrc(
         .map_err(|e| BlockBuildError::ElementCreation(format!("whepclientsrc: {}", e)))?;
 
     // Set ICE server properties on the source
-    if let Some(stun) = stun_server {
+    if let Some(ref stun) = stun_server {
         whepclientsrc.set_property("stun-server", stun);
     }
-    if let Some(turn) = turn_server {
+    if let Some(ref turn) = turn_server {
         whepclientsrc.set_property("turn-server", turn);
     }
 
@@ -727,10 +727,10 @@ fn build_whepserversink(
 
     // Set ICE server properties
     // Note: webrtcsink-based elements use "turn-servers" (plural, array) not "turn-server"
-    if let Some(stun) = stun_server {
+    if let Some(ref stun) = stun_server {
         whepserversink.set_property("stun-server", stun);
     }
-    if let Some(turn) = turn_server {
+    if let Some(ref turn) = turn_server {
         let turn_servers = gst::Array::new([turn]);
         whepserversink.set_property("turn-servers", turn_servers);
     }

--- a/backend/src/blocks/builtin/whip.rs
+++ b/backend/src/blocks/builtin/whip.rs
@@ -106,10 +106,10 @@ fn build_whipclientsink(
 
     // Set ICE server properties
     // Note: webrtcsink-based elements use "turn-servers" (plural, array) not "turn-server"
-    if let Some(stun) = stun_server {
+    if let Some(ref stun) = stun_server {
         whipclientsink.set_property("stun-server", stun);
     }
-    if let Some(turn) = turn_server {
+    if let Some(ref turn) = turn_server {
         let turn_servers = gst::Array::new([turn]);
         whipclientsink.set_property("turn-servers", turn_servers);
     }
@@ -232,10 +232,10 @@ fn build_whipsink(
 
     // Set properties directly on whipsink (no signaller child)
     whipsink.set_property("whip-endpoint", &whip_endpoint);
-    if let Some(stun) = stun_server {
+    if let Some(ref stun) = stun_server {
         whipsink.set_property("stun-server", stun);
     }
-    if let Some(turn) = turn_server {
+    if let Some(ref turn) = turn_server {
         whipsink.set_property("turn-server", turn);
     }
 

--- a/docs/WHEP_OUTPUT_BLOCK.md
+++ b/docs/WHEP_OUTPUT_BLOCK.md
@@ -122,14 +122,6 @@ Unique identifier for the WHEP endpoint. Used in the URL path.
 - Must be unique across all running flows
 - URL-safe characters recommended
 
-### `stun_server` (String, Optional)
-
-STUN server URL for NAT traversal.
-
-**Default:** `stun://stun.l.google.com:19302`
-
-**Format:** `stun://hostname:port` or `turn://hostname:port`
-
 ### `auth_token` (String, Optional)
 
 Bearer token for WHEP authentication (passed to whepserversink).
@@ -268,17 +260,19 @@ The frontend includes a Links page accessible from the navigation menu that prov
 
 Connect audio source to `audio_in` pad. Stream available at `/whep/radio-stream`.
 
-### Example 2: Video Stream with Custom STUN
+### Example 2: Video-Only Stream
 
 ```json
 {
   "block_type": "builtin.whep_output",
   "properties": {
-    "endpoint_id": "camera-feed",
-    "stun_server": "stun://stun.example.com:3478"
+    "endpoint_id": "camera-feed"
   }
 }
 ```
+
+**Note:** STUN/TURN servers are configured server-wide via `ice_servers` in `.strom.toml` or
+the `STROM_SERVER_ICE_SERVERS` environment variable. See configuration documentation.
 
 ### Example 3: Full Audio+Video Stream
 


### PR DESCRIPTION
## Summary
- Normalize all ICE URLs to RFC 7064/7065 format (`stun:`, `turn:`) on config load
- Convert to GStreamer format (`stun://`, `turn://`) only when building pipelines
- Handle both formats in browser API for defensive compatibility
- Add tests for URL normalization
- Remove obsolete `stun_server` property from WHEP_OUTPUT_BLOCK docs

## Problem
GStreamer expects URLs with double slashes (`turn://user:pass@host`) while browsers expect RFC format (`turn:host` with separate credentials). Previously, if users entered URLs in GStreamer format, TURN authentication would fail silently.

## Solution
- Config layer normalizes all ICE URLs to RFC format on load
- `builder.rs` converts to GStreamer format only when setting element properties
- Browser API handles both formats defensively

## Test plan
- [x] All 187 unit tests pass
- [x] Verified TURN authentication works with coturn server
- [x] Both URL formats (`turn:` and `turn://`) work in config

🤖 Generated with [Claude Code](https://claude.com/claude-code)