### PR TITLE
feat: Add Windows MSI installer with bundled GStreamer and Graphviz

### DIFF
--- a/.github/workflows/release-msi.yml
+++ b/.github/workflows/release-msi.yml
@@ -1,0 +1,237 @@
+name: Build Windows MSI Installer
+
+on:
+  # Trigger after the main release workflow completes
+  workflow_run:
+    workflows: ["Release"]
+    types:
+      - completed
+  # Allow manual triggering for testing
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to build (e.g., 0.3.10)'
+        required: true
+        type: string
+
+env:
+  GSTREAMER_VERSION: "1.24.13"
+  GRAPHVIZ_VERSION: "12.2.1"
+
+jobs:
+  build-msi:
+    name: Build MSI Installer
+    runs-on: windows-latest
+    # Only run if release was successful (or manual trigger)
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Determine version
+        id: version
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            VERSION="${{ inputs.version }}"
+          else
+            # Get version from the triggering workflow's tag
+            VERSION=$(echo "${{ github.event.workflow_run.head_branch }}" | sed 's/^v//')
+            if [ -z "$VERSION" ] || [ "$VERSION" == "main" ]; then
+              # Fallback: get latest tag
+              VERSION=$(git describe --tags --abbrev=0 | sed 's/^v//')
+            fi
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Building MSI for version: $VERSION"
+
+      - name: Download Strom binaries from release
+        shell: pwsh
+        run: |
+          $version = "${{ steps.version.outputs.version }}"
+          $baseUrl = "https://github.com/${{ github.repository }}/releases/download/v$version"
+
+          New-Item -ItemType Directory -Path "binaries" -Force | Out-Null
+
+          Write-Host "Downloading strom-v$version-windows-x86_64.exe..."
+          Invoke-WebRequest -Uri "$baseUrl/strom-v$version-windows-x86_64.exe" -OutFile "binaries/strom.exe"
+
+          Write-Host "Downloading strom-mcp-server-v$version-windows-x86_64.exe..."
+          Invoke-WebRequest -Uri "$baseUrl/strom-mcp-server-v$version-windows-x86_64.exe" -OutFile "binaries/strom-mcp-server.exe"
+
+          Write-Host "Downloaded binaries:"
+          Get-ChildItem binaries/
+
+      - name: Download GStreamer runtime
+        shell: pwsh
+        run: |
+          $version = "${{ env.GSTREAMER_VERSION }}"
+          $baseUrl = "https://github.com/${{ github.repository }}/releases/download/gstreamer-deps"
+
+          Write-Host "Downloading GStreamer $version runtime MSI..."
+          Invoke-WebRequest -Uri "$baseUrl/gstreamer-1.0-msvc-x86_64-$version.msi" -OutFile "gstreamer.msi"
+
+          Write-Host "Download complete: $((Get-Item gstreamer.msi).Length / 1MB) MB"
+
+      - name: Download Graphviz
+        shell: pwsh
+        run: |
+          $version = "${{ env.GRAPHVIZ_VERSION }}"
+          $zipFile = "windows_10_cmake_Release_graphviz-install-$version-win64.zip"
+          $url = "https://gitlab.com/api/v4/projects/4207231/packages/generic/graphviz-releases/$version/$zipFile"
+
+          Write-Host "Downloading Graphviz $version..."
+          Invoke-WebRequest -Uri $url -OutFile "graphviz.zip"
+
+          Write-Host "Download complete: $((Get-Item graphviz.zip).Length / 1MB) MB"
+
+      - name: Prepare GStreamer bundle
+        shell: pwsh
+        run: |
+          $buildDir = "installer/windows/build"
+          New-Item -ItemType Directory -Path $buildDir -Force | Out-Null
+
+          # Extract GStreamer MSI
+          Write-Host "Extracting GStreamer MSI..."
+          $installArgs = "/a `"$((Get-Location).Path)\gstreamer.msi`" /qn TARGETDIR=`"$((Get-Location).Path)\gst-temp`""
+          Start-Process msiexec.exe -ArgumentList $installArgs -Wait -NoNewWindow
+
+          $gstRoot = "gst-temp\gstreamer\1.0\msvc_x86_64"
+
+          # Create bundle directories
+          $bundleDir = "$buildDir\gstreamer-bundle"
+          New-Item -ItemType Directory -Path "$bundleDir\bin" -Force | Out-Null
+          New-Item -ItemType Directory -Path "$bundleDir\lib\gstreamer-1.0" -Force | Out-Null
+
+          # Copy all bin files (DLLs and tools)
+          Write-Host "Copying GStreamer bin files..."
+          Copy-Item "$gstRoot\bin\*" "$bundleDir\bin\" -Force
+
+          # Copy all plugins
+          Write-Host "Copying GStreamer plugins..."
+          Copy-Item "$gstRoot\lib\gstreamer-1.0\*.dll" "$bundleDir\lib\gstreamer-1.0\" -Force
+
+          # Copy share files if they exist
+          if (Test-Path "$gstRoot\share") {
+            New-Item -ItemType Directory -Path "$bundleDir\share" -Force | Out-Null
+            Copy-Item "$gstRoot\share\*" "$bundleDir\share\" -Recurse -Force
+          }
+
+          $size = (Get-ChildItem -Recurse "$bundleDir" | Measure-Object -Property Length -Sum).Sum / 1MB
+          Write-Host "GStreamer bundle size: $([math]::Round($size, 2)) MB"
+
+      - name: Prepare Graphviz bundle
+        shell: pwsh
+        run: |
+          $buildDir = "installer/windows/build"
+
+          # Extract Graphviz
+          Write-Host "Extracting Graphviz..."
+          Expand-Archive -Path "graphviz.zip" -DestinationPath "gv-temp" -Force
+
+          $gvRoot = Get-ChildItem "gv-temp" -Directory | Select-Object -First 1
+
+          # Create bundle directory
+          $bundleDir = "$buildDir\graphviz-bundle"
+          New-Item -ItemType Directory -Path "$bundleDir\bin" -Force | Out-Null
+
+          # Copy bin files
+          Write-Host "Copying Graphviz files..."
+          Copy-Item "$($gvRoot.FullName)\bin\*" "$bundleDir\bin\" -Force
+
+          $size = (Get-ChildItem -Recurse "$bundleDir" | Measure-Object -Property Length -Sum).Sum / 1MB
+          Write-Host "Graphviz bundle size: $([math]::Round($size, 2)) MB"
+
+      - name: Install WiX Toolset
+        shell: pwsh
+        run: |
+          dotnet tool install --global wix --version 5.0.1
+          wix extension add WixToolset.UI.wixext/5.0.1 -g
+
+      - name: Build MSI installer
+        shell: pwsh
+        run: |
+          $version = "${{ steps.version.outputs.version }}"
+          $buildDir = "installer/windows/build"
+
+          # Copy WiX source files
+          Copy-Item "installer/windows/Product.wxs" "$buildDir/" -Force
+          Copy-Item "installer/windows/License.rtf" "$buildDir/" -Force
+
+          # Create banner image (493x58)
+          Add-Type -AssemblyName System.Drawing
+          $banner = New-Object System.Drawing.Bitmap(493, 58)
+          $g = [System.Drawing.Graphics]::FromImage($banner)
+          $g.Clear([System.Drawing.Color]::FromArgb(45, 45, 48))
+          $font = New-Object System.Drawing.Font("Segoe UI", 18, [System.Drawing.FontStyle]::Bold)
+          $brush = [System.Drawing.Brushes]::White
+          $g.DrawString("Strom", $font, $brush, 340, 14)
+          $font.Dispose()
+          $g.Dispose()
+          $banner.Save("$buildDir\banner.bmp", [System.Drawing.Imaging.ImageFormat]::Bmp)
+          $banner.Dispose()
+
+          # Create dialog image (493x312)
+          $dialog = New-Object System.Drawing.Bitmap(493, 312)
+          $g = [System.Drawing.Graphics]::FromImage($dialog)
+          $g.Clear([System.Drawing.Color]::FromArgb(45, 45, 48))
+          $font = New-Object System.Drawing.Font("Segoe UI", 32, [System.Drawing.FontStyle]::Bold)
+          $brush = [System.Drawing.Brushes]::White
+          $g.DrawString("Strom", $font, $brush, 30, 80)
+          $font2 = New-Object System.Drawing.Font("Segoe UI", 11)
+          $g.DrawString("GStreamer Flow Engine", $font2, $brush, 30, 130)
+          $g.DrawString("Visual pipeline management", $font2, $brush, 30, 155)
+          $font.Dispose()
+          $font2.Dispose()
+          $g.Dispose()
+          $dialog.Save("$buildDir\dialog.bmp", [System.Drawing.Imaging.ImageFormat]::Bmp)
+          $dialog.Dispose()
+
+          # Get absolute paths
+          $absStromExe = (Resolve-Path "binaries/strom.exe").Path
+          $absStromMcpServerExe = (Resolve-Path "binaries/strom-mcp-server.exe").Path
+          $absGstDir = (Resolve-Path "$buildDir/gstreamer-bundle").Path
+          $absGvDir = (Resolve-Path "$buildDir/graphviz-bundle").Path
+
+          # Build MSI
+          Push-Location $buildDir
+
+          Write-Host "Building MSI with WiX..."
+          Write-Host "  ProductVersion: $version"
+          Write-Host "  StromExe: $absStromExe"
+          Write-Host "  GStreamerDir: $absGstDir"
+          Write-Host "  GraphvizDir: $absGvDir"
+
+          wix build `
+            -d ProductVersion="$version" `
+            -d StromExe="$absStromExe" `
+            -d StromMcpServerExe="$absStromMcpServerExe" `
+            -d GStreamerDir="$absGstDir" `
+            -d GraphvizDir="$absGvDir" `
+            -ext WixToolset.UI.wixext `
+            -o "strom-$version-windows-x86_64.msi" `
+            Product.wxs
+
+          Pop-Location
+
+          # Report results
+          $msiPath = "$buildDir/strom-$version-windows-x86_64.msi"
+          $msiSize = (Get-Item $msiPath).Length / 1MB
+          Write-Host "MSI built successfully: $([math]::Round($msiSize, 2)) MB"
+
+      - name: Upload MSI artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: strom-msi-${{ steps.version.outputs.version }}
+          path: installer/windows/build/strom-${{ steps.version.outputs.version }}-windows-x86_64.msi
+          retention-days: 90
+
+      - name: Upload MSI to release
+        if: github.event_name != 'workflow_dispatch' || github.event.inputs.upload_to_release == 'true'
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: v${{ steps.version.outputs.version }}
+          files: installer/windows/build/strom-${{ steps.version.outputs.version }}-windows-x86_64.msi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -71,10 +71,11 @@ chmod +x strom-v*-linux-x86_64
 
 # macOS
 # Download and run the macOS binary
-
-# Windows
-# Download and run the .exe file
 ```
+
+**Windows:** Download the MSI installer (`strom-*-windows-x86_64.msi`) for a one-click installation that bundles GStreamer and Graphviz. After installation, launch "Strom" from the Start Menu.
+
+Alternatively, download the standalone `.exe` and install [GStreamer](https://gstreamer.freedesktop.org/download/) manually.
 
 Open your browser to `http://localhost:8080` to access the web UI.
 

--- a/installer/windows/Build-Installer.ps1
+++ b/installer/windows/Build-Installer.ps1
@@ -1,0 +1,192 @@
+<#
+.SYNOPSIS
+    Builds the Strom MSI installer with bundled dependencies.
+
+.DESCRIPTION
+    This script orchestrates the complete MSI build process:
+    1. Prepares the GStreamer runtime bundle
+    2. Prepares the Graphviz bundle
+    3. Compiles the WiX installer
+
+.PARAMETER Version
+    Product version (e.g., "0.3.10")
+
+.PARAMETER StromExe
+    Path to the strom.exe binary
+
+.PARAMETER StromMcpServerExe
+    Path to the strom-mcp-server.exe binary
+
+.PARAMETER FullGStreamer
+    Include all GStreamer plugins (larger bundle)
+
+.PARAMETER SkipDependencies
+    Skip downloading dependencies (use existing bundles)
+#>
+
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$Version,
+
+    [Parameter(Mandatory=$true)]
+    [string]$StromExe,
+
+    [Parameter(Mandatory=$true)]
+    [string]$StromMcpServerExe,
+
+    [switch]$FullGStreamer,
+    [switch]$SkipDependencies
+)
+
+$ErrorActionPreference = "Stop"
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$BuildDir = "$ScriptDir\build"
+$OutputDir = "$ScriptDir\output"
+
+Write-Host "============================================" -ForegroundColor Cyan
+Write-Host "  Strom MSI Installer Build" -ForegroundColor Cyan
+Write-Host "============================================" -ForegroundColor Cyan
+Write-Host ""
+Write-Host "Version:        $Version"
+Write-Host "Strom:          $StromExe"
+Write-Host "MCP Server:     $StromMcpServerExe"
+Write-Host "GStreamer mode: $(if ($FullGStreamer) { 'Full' } else { 'Minimal' })"
+Write-Host ""
+
+# Validate input files
+if (-not (Test-Path $StromExe)) {
+    Write-Error "Strom executable not found: $StromExe"
+    exit 1
+}
+if (-not (Test-Path $StromMcpServerExe)) {
+    Write-Error "Strom MCP Server executable not found: $StromMcpServerExe"
+    exit 1
+}
+
+# Create build directories
+New-Item -ItemType Directory -Path $BuildDir -Force | Out-Null
+New-Item -ItemType Directory -Path $OutputDir -Force | Out-Null
+
+Push-Location $BuildDir
+
+try {
+    # Step 1: Prepare GStreamer bundle
+    if (-not $SkipDependencies) {
+        Write-Host ""
+        Write-Host "Step 1/3: Preparing GStreamer bundle..." -ForegroundColor Yellow
+        $gstArgs = @{
+            OutputDir = "gstreamer-bundle"
+        }
+        if ($FullGStreamer) {
+            $gstArgs.Full = $true
+        }
+        & "$ScriptDir\Prepare-GStreamer.ps1" @gstArgs
+    } else {
+        Write-Host "Step 1/3: Skipping GStreamer bundle (using existing)..." -ForegroundColor Yellow
+    }
+
+    # Step 2: Prepare Graphviz bundle
+    if (-not $SkipDependencies) {
+        Write-Host ""
+        Write-Host "Step 2/3: Preparing Graphviz bundle..." -ForegroundColor Yellow
+        & "$ScriptDir\Prepare-Graphviz.ps1" -OutputDir "graphviz-bundle"
+    } else {
+        Write-Host "Step 2/3: Skipping Graphviz bundle (using existing)..." -ForegroundColor Yellow
+    }
+
+    # Step 3: Build WiX installer
+    Write-Host ""
+    Write-Host "Step 3/3: Building WiX installer..." -ForegroundColor Yellow
+
+    # Check for WiX
+    $wixPath = Get-Command "wix" -ErrorAction SilentlyContinue
+    if (-not $wixPath) {
+        Write-Error "WiX Toolset not found. Install with: dotnet tool install --global wix"
+        exit 1
+    }
+
+    # Copy WiX source files to build dir
+    Copy-Item "$ScriptDir\Product.wxs" $BuildDir -Force
+    Copy-Item "$ScriptDir\License.rtf" $BuildDir -Force
+
+    # Create placeholder images if they don't exist
+    if (-not (Test-Path "$ScriptDir\banner.bmp")) {
+        Write-Host "  Creating placeholder banner image..."
+        # Create a simple 493x58 banner (WiX standard size)
+        Add-Type -AssemblyName System.Drawing
+        $banner = New-Object System.Drawing.Bitmap(493, 58)
+        $g = [System.Drawing.Graphics]::FromImage($banner)
+        $g.Clear([System.Drawing.Color]::FromArgb(45, 45, 48))
+        $font = New-Object System.Drawing.Font("Arial", 20, [System.Drawing.FontStyle]::Bold)
+        $brush = [System.Drawing.Brushes]::White
+        $g.DrawString("Strom", $font, $brush, 320, 12)
+        $font.Dispose()
+        $g.Dispose()
+        $banner.Save("$BuildDir\banner.bmp", [System.Drawing.Imaging.ImageFormat]::Bmp)
+        $banner.Dispose()
+    } else {
+        Copy-Item "$ScriptDir\banner.bmp" $BuildDir -Force
+    }
+
+    if (-not (Test-Path "$ScriptDir\dialog.bmp")) {
+        Write-Host "  Creating placeholder dialog image..."
+        # Create a simple 493x312 dialog background (WiX standard size)
+        Add-Type -AssemblyName System.Drawing
+        $dialog = New-Object System.Drawing.Bitmap(493, 312)
+        $g = [System.Drawing.Graphics]::FromImage($dialog)
+        $g.Clear([System.Drawing.Color]::FromArgb(45, 45, 48))
+        $font = New-Object System.Drawing.Font("Arial", 36, [System.Drawing.FontStyle]::Bold)
+        $brush = [System.Drawing.Brushes]::White
+        $g.DrawString("Strom", $font, $brush, 30, 100)
+        $font2 = New-Object System.Drawing.Font("Arial", 12)
+        $g.DrawString("GStreamer Flow Engine", $font2, $brush, 30, 160)
+        $font.Dispose()
+        $font2.Dispose()
+        $g.Dispose()
+        $dialog.Save("$BuildDir\dialog.bmp", [System.Drawing.Imaging.ImageFormat]::Bmp)
+        $dialog.Dispose()
+    } else {
+        Copy-Item "$ScriptDir\dialog.bmp" $BuildDir -Force
+    }
+
+    # Convert paths to absolute
+    $absStromExe = (Resolve-Path $StromExe).Path
+    $absStromMcpServerExe = (Resolve-Path $StromMcpServerExe).Path
+    $absGstDir = (Resolve-Path "gstreamer-bundle").Path
+    $absGvDir = (Resolve-Path "graphviz-bundle").Path
+
+    # Build MSI using WiX
+    Write-Host "  Compiling WiX installer..."
+
+    $msiName = "strom-$Version-windows-x86_64.msi"
+
+    wix build `
+        -d ProductVersion="$Version" `
+        -d StromExe="$absStromExe" `
+        -d StromMcpServerExe="$absStromMcpServerExe" `
+        -d GStreamerDir="$absGstDir" `
+        -d GraphvizDir="$absGvDir" `
+        -ext WixToolset.UI.wixext `
+        -o "$OutputDir\$msiName" `
+        Product.wxs
+
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "WiX build failed with exit code $LASTEXITCODE"
+        exit 1
+    }
+
+    # Report results
+    $msiSize = (Get-Item "$OutputDir\$msiName").Length / 1MB
+    Write-Host ""
+    Write-Host "============================================" -ForegroundColor Green
+    Write-Host "  Build Complete!" -ForegroundColor Green
+    Write-Host "============================================" -ForegroundColor Green
+    Write-Host ""
+    Write-Host "MSI Installer: $OutputDir\$msiName"
+    Write-Host "Size: $([math]::Round($msiSize, 2)) MB"
+    Write-Host ""
+
+} finally {
+    Pop-Location
+}

--- a/installer/windows/License.rtf
+++ b/installer/windows/License.rtf
@@ -1,0 +1,24 @@
+{\rtf1\ansi\deff0\nouicompat{\fonttbl{\f0\fswiss\fcharset0 Arial;}}
+{\*\generator Riched20 10.0.19041}\viewkind4\uc1
+\pard\sa200\sl276\slmult1\b\f0\fs28 MIT License\b0\fs22\par
+\par
+Copyright (c) 2024 Eyevinn Technology AB\par
+\par
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\par
+\par
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\par
+\par
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\par
+\par
+\b\fs24 Third-Party Components\b0\fs22\par
+\par
+This installer includes the following third-party components:\par
+\par
+\b GStreamer\b0  - LGPL v2.1+\par
+GStreamer is a library for constructing graphs of media-handling components.\par
+https://gstreamer.freedesktop.org/\par
+\par
+\b Graphviz\b0  - Eclipse Public License v1.0\par
+Graphviz is open source graph visualization software.\par
+https://graphviz.org/\par
+}

--- a/installer/windows/Prepare-GStreamer.ps1
+++ b/installer/windows/Prepare-GStreamer.ps1
@@ -1,0 +1,331 @@
+<#
+.SYNOPSIS
+    Prepares a minimal GStreamer runtime bundle for the Strom MSI installer.
+
+.DESCRIPTION
+    Downloads the GStreamer runtime MSI and extracts only the necessary
+    components for Strom to function. This creates a smaller bundle by
+    excluding development files, documentation, and unused plugins.
+
+.PARAMETER Version
+    GStreamer version to download (default: 1.24.13)
+
+.PARAMETER OutputDir
+    Directory to extract files to (default: gstreamer-bundle)
+
+.PARAMETER Full
+    If specified, includes all plugins (larger bundle, ~300MB)
+    Otherwise, includes only essential plugins (~150MB)
+#>
+
+param(
+    [string]$Version = "1.24.13",
+    [string]$OutputDir = "gstreamer-bundle",
+    [switch]$Full
+)
+
+$ErrorActionPreference = "Stop"
+
+# GStreamer download URL from Eyevinn mirror (freedesktop.org blocks CI)
+$BaseUrl = "https://github.com/Eyevinn/strom/releases/download/gstreamer-deps"
+$MsiFile = "gstreamer-1.0-msvc-x86_64-$Version.msi"
+$MsiUrl = "$BaseUrl/$MsiFile"
+
+# Temporary extraction directory
+$TempDir = "gstreamer-temp"
+$GstRoot = "$TempDir\gstreamer\1.0\msvc_x86_64"
+
+Write-Host "=== Preparing GStreamer Runtime Bundle ===" -ForegroundColor Cyan
+Write-Host "Version: $Version"
+Write-Host "Output: $OutputDir"
+Write-Host "Mode: $(if ($Full) { 'Full (all plugins)' } else { 'Minimal (essential plugins)' })"
+Write-Host ""
+
+# Clean up previous runs
+if (Test-Path $TempDir) {
+    Write-Host "Cleaning up previous extraction..."
+    Remove-Item -Recurse -Force $TempDir
+}
+if (Test-Path $OutputDir) {
+    Remove-Item -Recurse -Force $OutputDir
+}
+
+# Download GStreamer MSI
+if (-not (Test-Path $MsiFile)) {
+    Write-Host "Downloading GStreamer runtime from $MsiUrl..."
+    Invoke-WebRequest -Uri $MsiUrl -OutFile $MsiFile -UseBasicParsing
+    Write-Host "Download complete: $((Get-Item $MsiFile).Length / 1MB) MB"
+} else {
+    Write-Host "Using existing download: $MsiFile"
+}
+
+# Extract MSI using msiexec to a temp directory
+Write-Host "Extracting GStreamer MSI..."
+$installArgs = "/a `"$((Get-Location).Path)\$MsiFile`" /qn TARGETDIR=`"$((Get-Location).Path)\$TempDir`""
+Start-Process msiexec.exe -ArgumentList $installArgs -Wait -NoNewWindow
+
+if (-not (Test-Path $GstRoot)) {
+    Write-Error "Extraction failed - GStreamer root not found at $GstRoot"
+    exit 1
+}
+
+# Create output directory structure
+New-Item -ItemType Directory -Path "$OutputDir\bin" -Force | Out-Null
+New-Item -ItemType Directory -Path "$OutputDir\lib\gstreamer-1.0" -Force | Out-Null
+New-Item -ItemType Directory -Path "$OutputDir\share" -Force | Out-Null
+
+# Essential DLLs to include (core runtime)
+$EssentialDlls = @(
+    # GStreamer core
+    "gstreamer-1.0-0.dll",
+    "gstbase-1.0-0.dll",
+    "gstcontroller-1.0-0.dll",
+    "gstnet-1.0-0.dll",
+    "gstcheck-1.0-0.dll",
+
+    # GStreamer libraries
+    "gstapp-1.0-0.dll",
+    "gstaudio-1.0-0.dll",
+    "gstvideo-1.0-0.dll",
+    "gstpbutils-1.0-0.dll",
+    "gstrtp-1.0-0.dll",
+    "gstrtsp-1.0-0.dll",
+    "gstsdp-1.0-0.dll",
+    "gsttag-1.0-0.dll",
+    "gstgl-1.0-0.dll",
+    "gstwebrtc-1.0-0.dll",
+    "gstcodecs-1.0-0.dll",
+    "gstcodecparsers-1.0-0.dll",
+    "gstsctp-1.0-0.dll",
+    "gstplay-1.0-0.dll",
+    "gstplayer-1.0-0.dll",
+    "gstriff-1.0-0.dll",
+    "gstfft-1.0-0.dll",
+    "gstallocators-1.0-0.dll",
+    "gstinsertbin-1.0-0.dll",
+    "gstmpegts-1.0-0.dll",
+    "gstadaptivedemux-1.0-0.dll",
+    "gstbadaudio-1.0-0.dll",
+    "gstisoff-1.0-0.dll",
+    "gsturidownloader-1.0-0.dll",
+
+    # GLib and dependencies
+    "glib-2.0-0.dll",
+    "gobject-2.0-0.dll",
+    "gmodule-2.0-0.dll",
+    "gio-2.0-0.dll",
+    "gthread-2.0-0.dll",
+    "intl-8.dll",
+    "pcre2-8-0.dll",
+    "ffi-8.dll",
+    "z1.dll",
+    "zlib1.dll",
+
+    # SSL/TLS
+    "libssl-3-x64.dll",
+    "libcrypto-3-x64.dll",
+
+    # Audio/Video codecs
+    "avcodec-61.dll",
+    "avformat-61.dll",
+    "avutil-59.dll",
+    "swresample-5.dll",
+    "swscale-8.dll",
+    "avfilter-10.dll",
+
+    # Image formats
+    "jpeg62.dll",
+    "libpng16.dll",
+
+    # Other dependencies
+    "orc-0.4-0.dll",
+    "libnice-0.dll",
+    "soup-3.0-0.dll",
+    "json-glib-1.0-0.dll",
+    "libxml2.dll",
+    "iconv-2.dll",
+    "lzma.dll",
+    "bz2.dll",
+    "opus.dll",
+    "libsrtp2.dll",
+    "graphene-1.0-0.dll",
+    "cairo.dll",
+    "cairo-gobject.dll",
+    "pango-1.0-0.dll",
+    "pangocairo-1.0-0.dll",
+    "pangoft2-1.0-0.dll",
+    "pangowin32-1.0-0.dll",
+    "harfbuzz.dll",
+    "freetype.dll",
+    "fontconfig-1.dll",
+    "expat.dll",
+    "pixman-1-0.dll"
+)
+
+# Essential plugins for Strom
+$EssentialPlugins = @(
+    # Core plugins
+    "gstcoreelements.dll",
+    "gsttypefindfunctions.dll",
+    "gstplayback.dll",
+    "gstautodetect.dll",
+    "gstapp.dll",
+
+    # Network/Streaming
+    "gstrtp.dll",
+    "gstrtpmanager.dll",
+    "gstrtsp.dll",
+    "gstudp.dll",
+    "gsttcp.dll",
+    "gstsoup.dll",
+    "gstwebrtc.dll",
+    "gstdtls.dll",
+    "gstnice.dll",
+    "gstsctp.dll",
+    "gstsrtp.dll",
+    "gstrist.dll",
+    "gsthls.dll",
+    "gstdash.dll",
+    "gstinter.dll",
+
+    # Video
+    "gstvideoconvertscale.dll",
+    "gstvideofilter.dll",
+    "gstvideotestsrc.dll",
+    "gstvideoparsersbad.dll",
+    "gstrawparse.dll",
+    "gstvideorate.dll",
+    "gstd3d11.dll",
+    "gstd3d12.dll",
+    "gstnvcodec.dll",
+    "gstqsv.dll",
+    "gstamfcodec.dll",
+    "gstopenh264.dll",
+    "gstx264.dll",
+    "gstx265.dll",
+    "gstvpx.dll",
+    "gstav1.dll",
+    "gstaom.dll",
+    "gstsvtav1.dll",
+    "gstlibav.dll",
+    "gstdeinterlace.dll",
+    "gstimagefreeze.dll",
+    "gstdebug.dll",
+
+    # Audio
+    "gstaudioconvert.dll",
+    "gstaudioresample.dll",
+    "gstaudiotestsrc.dll",
+    "gstaudiomixer.dll",
+    "gstvolume.dll",
+    "gstopus.dll",
+    "gstwasapi.dll",
+    "gstwasapi2.dll",
+    "gstdirectsound.dll",
+    "gstlame.dll",
+    "gstaudiofx.dll",
+
+    # Muxers/Demuxers
+    "gstmatroska.dll",
+    "gstmpegtsdemux.dll",
+    "gstmpegtsmux.dll",
+    "gstisomp4.dll",
+    "gstflv.dll",
+    "gstogg.dll",
+    "gstavi.dll",
+    "gstmultifile.dll",
+
+    # Image
+    "gstpng.dll",
+    "gstjpeg.dll",
+
+    # OpenGL
+    "gstopengl.dll",
+
+    # Encoding
+    "gstvideobox.dll",
+    "gstcompositor.dll",
+    "gstencoding.dll",
+
+    # Utils
+    "gstgio.dll",
+    "gstaudioparsers.dll",
+    "gstadaptivedemux2.dll"
+)
+
+# Copy executables
+Write-Host "Copying GStreamer tools..."
+$tools = @("gst-launch-1.0.exe", "gst-inspect-1.0.exe", "gst-discoverer-1.0.exe", "gst-typefind-1.0.exe")
+foreach ($tool in $tools) {
+    $src = "$GstRoot\bin\$tool"
+    if (Test-Path $src) {
+        Copy-Item $src "$OutputDir\bin\" -Force
+    }
+}
+
+# Copy DLLs
+Write-Host "Copying runtime DLLs..."
+$copied = 0
+$srcBin = "$GstRoot\bin"
+$dllFiles = Get-ChildItem "$srcBin\*.dll" -File
+
+foreach ($dll in $dllFiles) {
+    $include = $Full -or ($EssentialDlls -contains $dll.Name)
+
+    if ($include) {
+        Copy-Item $dll.FullName "$OutputDir\bin\" -Force
+        $copied++
+    }
+}
+Write-Host "  Copied $copied DLLs"
+
+# Copy plugins
+Write-Host "Copying GStreamer plugins..."
+$copiedPlugins = 0
+$srcPlugins = "$GstRoot\lib\gstreamer-1.0"
+$pluginFiles = Get-ChildItem "$srcPlugins\*.dll" -File -ErrorAction SilentlyContinue
+
+if ($pluginFiles) {
+    foreach ($plugin in $pluginFiles) {
+        $include = $Full -or ($EssentialPlugins -contains $plugin.Name)
+
+        if ($include) {
+            Copy-Item $plugin.FullName "$OutputDir\lib\gstreamer-1.0\" -Force
+            $copiedPlugins++
+        }
+    }
+}
+Write-Host "  Copied $copiedPlugins plugins"
+
+# Copy share files (GStreamer registry, etc.)
+Write-Host "Copying share files..."
+if (Test-Path "$GstRoot\share\gstreamer-1.0") {
+    Copy-Item "$GstRoot\share\gstreamer-1.0" "$OutputDir\share\" -Recurse -Force
+}
+
+# Create registry initialization batch file
+$registryBat = @"
+@echo off
+REM Initialize GStreamer registry for Strom
+set GST_PLUGIN_PATH=%~dp0..\lib\gstreamer-1.0
+set PATH=%~dp0;%PATH%
+gst-inspect-1.0.exe --version
+echo GStreamer registry initialized.
+"@
+$registryBat | Out-File -FilePath "$OutputDir\bin\init-gstreamer.bat" -Encoding ASCII
+
+# Clean up temp directory
+Write-Host "Cleaning up..."
+Remove-Item -Recurse -Force $TempDir
+
+# Report size
+$totalSize = (Get-ChildItem -Recurse $OutputDir | Measure-Object -Property Length -Sum).Sum / 1MB
+Write-Host ""
+Write-Host "=== Bundle Complete ===" -ForegroundColor Green
+Write-Host "Total size: $([math]::Round($totalSize, 2)) MB"
+Write-Host "Location: $OutputDir"
+Write-Host ""
+Write-Host "Contents:"
+Write-Host "  bin/     - GStreamer tools and DLLs"
+Write-Host "  lib/     - GStreamer plugins"
+Write-Host "  share/   - GStreamer data files"

--- a/installer/windows/Prepare-Graphviz.ps1
+++ b/installer/windows/Prepare-Graphviz.ps1
@@ -1,0 +1,139 @@
+<#
+.SYNOPSIS
+    Prepares a minimal Graphviz bundle for the Strom MSI installer.
+
+.DESCRIPTION
+    Downloads Graphviz and extracts only the necessary components
+    for DOT graph visualization in Strom.
+
+.PARAMETER Version
+    Graphviz version to download (default: 12.2.1)
+
+.PARAMETER OutputDir
+    Directory to extract files to (default: graphviz-bundle)
+#>
+
+param(
+    [string]$Version = "12.2.1",
+    [string]$OutputDir = "graphviz-bundle"
+)
+
+$ErrorActionPreference = "Stop"
+
+# Graphviz download URL
+$ZipFile = "windows_10_cmake_Release_graphviz-install-$Version-win64.zip"
+$ZipUrl = "https://gitlab.com/api/v4/projects/4207231/packages/generic/graphviz-releases/$Version/$ZipFile"
+
+# Temp extraction directory
+$TempDir = "graphviz-temp"
+
+Write-Host "=== Preparing Graphviz Bundle ===" -ForegroundColor Cyan
+Write-Host "Version: $Version"
+Write-Host "Output: $OutputDir"
+Write-Host ""
+
+# Clean up previous runs
+if (Test-Path $TempDir) {
+    Write-Host "Cleaning up previous extraction..."
+    Remove-Item -Recurse -Force $TempDir
+}
+if (Test-Path $OutputDir) {
+    Remove-Item -Recurse -Force $OutputDir
+}
+
+# Download Graphviz
+if (-not (Test-Path $ZipFile)) {
+    Write-Host "Downloading Graphviz from $ZipUrl..."
+    Invoke-WebRequest -Uri $ZipUrl -OutFile $ZipFile -UseBasicParsing
+    Write-Host "Download complete: $((Get-Item $ZipFile).Length / 1MB) MB"
+} else {
+    Write-Host "Using existing download: $ZipFile"
+}
+
+# Extract ZIP
+Write-Host "Extracting Graphviz..."
+Expand-Archive -Path $ZipFile -DestinationPath $TempDir -Force
+
+# Find the extracted directory (it's nested)
+$extractedDir = Get-ChildItem $TempDir -Directory | Select-Object -First 1
+
+if (-not $extractedDir) {
+    Write-Error "Extraction failed - no directory found in $TempDir"
+    exit 1
+}
+
+$gvRoot = $extractedDir.FullName
+
+# Create output directory structure
+New-Item -ItemType Directory -Path "$OutputDir\bin" -Force | Out-Null
+
+# Essential executables for DOT graph generation
+$EssentialExes = @(
+    "dot.exe",
+    "neato.exe",
+    "circo.exe",
+    "fdp.exe",
+    "sfdp.exe",
+    "twopi.exe"
+)
+
+# Essential DLLs
+$EssentialDlls = @(
+    "cdt.dll",
+    "cgraph.dll",
+    "gvc.dll",
+    "gvplugin_core.dll",
+    "gvplugin_dot_layout.dll",
+    "gvplugin_gd.dll",
+    "gvplugin_neato_layout.dll",
+    "gvplugin_pango.dll",
+    "pathplan.dll",
+    "xdot.dll",
+    # Dependencies
+    "expat.dll",
+    "libpng16.dll",
+    "zlib1.dll"
+)
+
+# Copy executables
+Write-Host "Copying Graphviz tools..."
+$srcBin = "$gvRoot\bin"
+foreach ($exe in $EssentialExes) {
+    $src = "$srcBin\$exe"
+    if (Test-Path $src) {
+        Copy-Item $src "$OutputDir\bin\" -Force
+        Write-Host "  $exe"
+    }
+}
+
+# Copy DLLs
+Write-Host "Copying runtime DLLs..."
+$dllFiles = Get-ChildItem "$srcBin\*.dll" -File -ErrorAction SilentlyContinue
+
+if ($dllFiles) {
+    foreach ($dll in $dllFiles) {
+        Copy-Item $dll.FullName "$OutputDir\bin\" -Force
+    }
+    Write-Host "  Copied $($dllFiles.Count) DLLs"
+}
+
+# Copy config file if exists
+$configFile = "$gvRoot\bin\config6"
+if (Test-Path $configFile) {
+    Copy-Item $configFile "$OutputDir\bin\" -Force
+    Write-Host "  Copied config6"
+}
+
+# Clean up temp directory
+Write-Host "Cleaning up..."
+Remove-Item -Recurse -Force $TempDir
+
+# Report size
+$totalSize = (Get-ChildItem -Recurse $OutputDir | Measure-Object -Property Length -Sum).Sum / 1MB
+Write-Host ""
+Write-Host "=== Bundle Complete ===" -ForegroundColor Green
+Write-Host "Total size: $([math]::Round($totalSize, 2)) MB"
+Write-Host "Location: $OutputDir"
+Write-Host ""
+Write-Host "Contents:"
+Write-Host "  bin/     - Graphviz tools (dot, neato, etc.) and DLLs"

--- a/installer/windows/Product.wxs
+++ b/installer/windows/Product.wxs
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs"
+     xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
+
+  <Package Name="Strom"
+           Manufacturer="Eyevinn Technology"
+           Version="$(var.ProductVersion)"
+           UpgradeCode="E8A3B5C7-9D2F-4E1A-8C6B-5F7D9E3A2B1C"
+           Language="1033"
+           Codepage="1252"
+           InstallerVersion="500"
+           Compressed="yes"
+           Scope="perMachine">
+
+    <SummaryInformation Description="Strom - GStreamer Flow Engine"
+                        Manufacturer="Eyevinn Technology" />
+
+    <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed."
+                  AllowSameVersionUpgrades="yes" />
+
+    <MediaTemplate EmbedCab="yes" CompressionLevel="high" />
+
+    <!-- Custom icons -->
+    <Icon Id="StromIcon.exe" SourceFile="$(var.StromExe)" />
+    <Property Id="ARPPRODUCTICON" Value="StromIcon.exe" />
+    <Property Id="ARPHELPLINK" Value="https://github.com/Eyevinn/strom" />
+    <Property Id="ARPURLINFOABOUT" Value="https://www.eyevinntechnology.se" />
+
+    <!-- Installation directory structure -->
+    <StandardDirectory Id="ProgramFiles64Folder">
+      <Directory Id="INSTALLFOLDER" Name="Strom">
+        <Directory Id="BinFolder" Name="bin" />
+        <Directory Id="GStreamerFolder" Name="gstreamer">
+          <Directory Id="GstBinFolder" Name="bin" />
+          <Directory Id="GstLibFolder" Name="lib">
+            <Directory Id="GstPluginsFolder" Name="gstreamer-1.0" />
+          </Directory>
+        </Directory>
+        <Directory Id="GraphvizFolder" Name="graphviz">
+          <Directory Id="GvBinFolder" Name="bin" />
+        </Directory>
+      </Directory>
+    </StandardDirectory>
+
+    <!-- Start Menu shortcuts -->
+    <StandardDirectory Id="ProgramMenuFolder">
+      <Directory Id="ApplicationProgramsFolder" Name="Strom" />
+    </StandardDirectory>
+
+    <!-- Main Strom executables -->
+    <Component Id="StromExe" Directory="BinFolder" Guid="A1B2C3D4-E5F6-7890-ABCD-EF1234567890">
+      <File Id="strom.exe" Source="$(var.StromExe)" KeyPath="yes" />
+    </Component>
+
+    <Component Id="StromMcpServerExe" Directory="BinFolder" Guid="B2C3D4E5-F6A7-8901-BCDE-F12345678901">
+      <File Id="strom_mcp_server.exe" Source="$(var.StromMcpServerExe)" KeyPath="yes" />
+    </Component>
+
+    <!-- Environment variables -->
+    <Component Id="PathEnvironment" Directory="INSTALLFOLDER" Guid="C3D4E5F6-A7B8-9012-CDEF-123456789012">
+      <Environment Id="PATH_BIN" Name="PATH" Value="[BinFolder]" Permanent="no" Part="last" Action="set" System="yes" />
+      <Environment Id="PATH_GST" Name="PATH" Value="[GstBinFolder]" Permanent="no" Part="last" Action="set" System="yes" />
+      <Environment Id="PATH_GV" Name="PATH" Value="[GvBinFolder]" Permanent="no" Part="last" Action="set" System="yes" />
+      <Environment Id="GST_PLUGIN_PATH" Name="GST_PLUGIN_PATH" Value="[GstPluginsFolder]" Permanent="no" Part="all" Action="set" System="yes" />
+      <CreateFolder />
+    </Component>
+
+    <!-- Start Menu shortcuts -->
+    <Component Id="ApplicationShortcut" Directory="ApplicationProgramsFolder" Guid="D4E5F6A7-B8C9-0123-DEF0-234567890123">
+      <Shortcut Id="ApplicationStartMenuShortcut"
+                Name="Strom"
+                Description="GStreamer Flow Engine"
+                Target="[BinFolder]strom.exe"
+                WorkingDirectory="BinFolder"
+                Icon="StromIcon.exe" />
+      <Shortcut Id="ApplicationStartMenuShortcutHeadless"
+                Name="Strom (Web UI)"
+                Description="GStreamer Flow Engine - Web UI mode"
+                Target="[BinFolder]strom.exe"
+                Arguments="--headless"
+                WorkingDirectory="BinFolder"
+                Icon="StromIcon.exe" />
+      <RemoveFolder Id="CleanUpShortCut" On="uninstall" />
+      <RegistryValue Root="HKCU" Key="Software\Eyevinn\Strom" Name="installed" Type="integer" Value="1" KeyPath="yes" />
+    </Component>
+
+    <!-- GStreamer bin directory files -->
+    <Component Id="GStreamerBinFiles" Directory="GstBinFolder" Guid="E5F6A7B8-C9D0-1234-EF01-345678901234">
+      <Files Include="$(var.GStreamerDir)\bin\*.*" />
+    </Component>
+
+    <!-- GStreamer plugins -->
+    <Component Id="GStreamerPluginFiles" Directory="GstPluginsFolder" Guid="F6A7B8C9-D0E1-2345-F012-456789012345">
+      <Files Include="$(var.GStreamerDir)\lib\gstreamer-1.0\*.dll" />
+    </Component>
+
+    <!-- Graphviz bin directory files -->
+    <Component Id="GraphvizBinFiles" Directory="GvBinFolder" Guid="A7B8C9D0-E1F2-3456-0123-567890123456">
+      <Files Include="$(var.GraphvizDir)\bin\*.*" />
+    </Component>
+
+    <!-- Main Feature -->
+    <Feature Id="MainFeature" Title="Strom" Description="GStreamer Flow Engine - visual pipeline management" Level="1" ConfigurableDirectory="INSTALLFOLDER">
+      <ComponentRef Id="StromExe" />
+      <ComponentRef Id="StromMcpServerExe" />
+      <ComponentRef Id="PathEnvironment" />
+      <ComponentRef Id="ApplicationShortcut" />
+
+      <Feature Id="GStreamerFeature" Title="GStreamer Runtime" Description="GStreamer multimedia framework (required for Strom to function)" Level="1" Absent="disallow">
+        <ComponentRef Id="GStreamerBinFiles" />
+        <ComponentRef Id="GStreamerPluginFiles" />
+      </Feature>
+
+      <Feature Id="GraphvizFeature" Title="Graphviz" Description="Graph visualization tools for debug pipeline graphs (recommended)" Level="1">
+        <ComponentRef Id="GraphvizBinFiles" />
+      </Feature>
+    </Feature>
+
+    <!-- UI configuration -->
+    <ui:WixUI Id="WixUI_FeatureTree" />
+    <WixVariable Id="WixUILicenseRtf" Value="License.rtf" />
+    <WixVariable Id="WixUIBannerBmp" Value="banner.bmp" />
+    <WixVariable Id="WixUIDialogBmp" Value="dialog.bmp" />
+
+  </Package>
+</Wix>

--- a/installer/windows/README.md
+++ b/installer/windows/README.md
@@ -1,0 +1,121 @@
+# Strom Windows MSI Installer
+
+This directory contains the configuration and scripts for building a Windows MSI installer that bundles Strom with all required dependencies.
+
+## What's Included in the Installer
+
+The MSI installer bundles:
+
+| Component | Description | Size (approx) |
+|-----------|-------------|---------------|
+| **strom.exe** | Main Strom application | ~15 MB |
+| **strom-mcp-server.exe** | MCP server for LLM integration | ~5 MB |
+| **GStreamer Runtime** | Multimedia framework (all plugins) | ~300 MB |
+| **Graphviz** | Graph visualization for debug graphs | ~30 MB |
+
+Total installer size: **~350 MB**
+
+## Installation Features
+
+- **One-click install** - No manual dependency setup
+- **Start Menu shortcuts** - Launch Strom or Strom (Web UI mode)
+- **Environment variables** - Automatically configured PATH and GST_PLUGIN_PATH
+- **Feature selection** - Option to skip Graphviz if not needed
+- **Clean uninstall** - Removes all components and environment variables
+
+## Building Locally
+
+### Prerequisites
+
+1. **Windows 10/11** (64-bit)
+2. **.NET SDK 6.0+** (for WiX)
+3. **WiX Toolset v5**:
+   ```powershell
+   dotnet tool install --global wix
+   wix extension add WixToolset.UI.wixext -g
+   ```
+
+### Build Steps
+
+1. **Download or build Strom binaries**:
+   ```powershell
+   # Or use pre-built binaries from a release
+   cargo build --release --package strom
+   cargo build --release --package strom-mcp-server
+   ```
+
+2. **Run the build script**:
+   ```powershell
+   cd installer/windows
+   .\Build-Installer.ps1 -Version "0.3.10" `
+       -StromExe "..\..\target\release\strom.exe" `
+       -StromMcpServerExe "..\..\target\release\strom-mcp-server.exe"
+   ```
+
+3. **Find the MSI** in `installer/windows/output/`
+
+### Build Options
+
+```powershell
+# Full GStreamer (all plugins, larger bundle)
+.\Build-Installer.ps1 -Version "0.3.10" -StromExe "..." -StromMcpServerExe "..." -FullGStreamer
+
+# Skip downloading dependencies (use existing bundles)
+.\Build-Installer.ps1 -Version "0.3.10" -StromExe "..." -StromMcpServerExe "..." -SkipDependencies
+```
+
+## Automated Builds
+
+The MSI is automatically built by GitHub Actions when a new release is created:
+
+1. The `release.yml` workflow builds the Windows binaries
+2. The `release-msi.yml` workflow:
+   - Downloads the release binaries
+   - Bundles GStreamer and Graphviz
+   - Builds and uploads the MSI to the GitHub release
+
+## File Structure
+
+```
+installer/windows/
+├── Product.wxs              # WiX installer definition
+├── License.rtf              # License shown during installation
+├── Build-Installer.ps1      # Main build orchestration script
+├── Prepare-GStreamer.ps1    # GStreamer bundle preparation
+├── Prepare-Graphviz.ps1     # Graphviz bundle preparation
+└── README.md                # This file
+```
+
+## Installation Paths
+
+When installed, Strom uses the following directory structure:
+
+```
+C:\Program Files\Strom\
+├── bin\                     # Strom executables
+│   ├── strom.exe
+│   └── strom-mcp-server.exe
+├── gstreamer\
+│   ├── bin\                 # GStreamer DLLs and tools
+│   └── lib\gstreamer-1.0\   # GStreamer plugins
+└── graphviz\
+    └── bin\                 # Graphviz executables
+```
+
+## Environment Variables
+
+The installer sets the following system environment variables:
+
+- **PATH**: Adds `bin\`, `gstreamer\bin\`, and `graphviz\bin\`
+- **GST_PLUGIN_PATH**: Points to `gstreamer\lib\gstreamer-1.0\`
+
+## Troubleshooting
+
+### MSI build fails with "file not found"
+Ensure all source paths are absolute paths and the files exist.
+
+### GStreamer plugins not loading
+Run `gst-inspect-1.0 --version` to verify GStreamer is working. Check that `GST_PLUGIN_PATH` is set correctly.
+
+### Graphviz dot command not found
+Verify Graphviz bin directory is in PATH. The `dot.exe` command should be accessible from any terminal.


### PR DESCRIPTION
Create a complete MSI installer infrastructure for Windows that bundles:
- Strom executables (strom.exe, strom-mcp-server.exe)
- GStreamer runtime (~300MB with all plugins)
- Graphviz for debug graph visualization

Components added:
- installer/windows/Product.wxs: WiX v5 installer definition
- installer/windows/License.rtf: MIT license with third-party notices
- installer/windows/Build-Installer.ps1: Build orchestration script
- installer/windows/Prepare-GStreamer.ps1: GStreamer bundle preparation
- installer/windows/Prepare-Graphviz.ps1: Graphviz bundle preparation
- .github/workflows/release-msi.yml: Automated MSI build on release

Features:
- One-click installation with all dependencies
- Start Menu shortcuts (GUI and headless modes)
- Automatic PATH and GST_PLUGIN_PATH configuration
- Feature selection (can skip Graphviz)
- Clean uninstall removes all components