### PR TITLE
fix: Use lighter gray background in MSI installer

### DIFF
--- a/.github/workflows/release-msi.yml
+++ b/.github/workflows/release-msi.yml
@@ -166,7 +166,7 @@ jobs:
           Add-Type -AssemblyName System.Drawing
           $banner = New-Object System.Drawing.Bitmap(493, 58)
           $g = [System.Drawing.Graphics]::FromImage($banner)
-          $g.Clear([System.Drawing.Color]::FromArgb(45, 45, 48))
+          $g.Clear([System.Drawing.Color]::FromArgb(110, 110, 115))
           $font = New-Object System.Drawing.Font("Segoe UI", 18, [System.Drawing.FontStyle]::Bold)
           $brush = [System.Drawing.Brushes]::White
           $g.DrawString("Strom", $font, $brush, 340, 14)
@@ -178,7 +178,7 @@ jobs:
           # Create dialog image (493x312)
           $dialog = New-Object System.Drawing.Bitmap(493, 312)
           $g = [System.Drawing.Graphics]::FromImage($dialog)
-          $g.Clear([System.Drawing.Color]::FromArgb(45, 45, 48))
+          $g.Clear([System.Drawing.Color]::FromArgb(110, 110, 115))
           $font = New-Object System.Drawing.Font("Segoe UI", 32, [System.Drawing.FontStyle]::Bold)
           $brush = [System.Drawing.Brushes]::White
           $g.DrawString("Strom", $font, $brush, 30, 80)


### PR DESCRIPTION
## Summary
- Change MSI installer background color from dark gray (RGB 45, 45, 48) to medium gray (RGB 110, 110, 115)
- Improves contrast for both white and black text in the installer UI

## Test plan
- [x] Run the MSI workflow manually to verify the new background color
- [x] Confirm both white and black text are readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)