### PR TITLE
feat: Include GStreamer libexec in Windows installer

### DIFF
--- a/.github/workflows/release-msi.yml
+++ b/.github/workflows/release-msi.yml
@@ -126,6 +126,13 @@ jobs:
             Copy-Item "$gstRoot\share\*" "$bundleDir\share\" -Recurse -Force
           }
 
+          # Copy libexec files (contains gst-ptp-helper.exe for PTP clock support)
+          if (Test-Path "$gstRoot\libexec") {
+            New-Item -ItemType Directory -Path "$bundleDir\libexec" -Force | Out-Null
+            Copy-Item "$gstRoot\libexec\*" "$bundleDir\libexec\" -Recurse -Force
+            Write-Host "Copied GStreamer libexec files (including gst-ptp-helper.exe)"
+          }
+
           $size = (Get-ChildItem -Recurse "$bundleDir" | Measure-Object -Property Length -Sum).Sum / 1MB
           Write-Host "GStreamer bundle size: $([math]::Round($size, 2)) MB"
 

--- a/installer/windows/Prepare-GStreamer.ps1
+++ b/installer/windows/Prepare-GStreamer.ps1
@@ -303,6 +303,14 @@ if (Test-Path "$GstRoot\share\gstreamer-1.0") {
     Copy-Item "$GstRoot\share\gstreamer-1.0" "$OutputDir\share\" -Recurse -Force
 }
 
+# Copy libexec files (contains gst-ptp-helper.exe for PTP clock support)
+Write-Host "Copying libexec files..."
+if (Test-Path "$GstRoot\libexec") {
+    New-Item -ItemType Directory -Path "$OutputDir\libexec" -Force | Out-Null
+    Copy-Item "$GstRoot\libexec\*" "$OutputDir\libexec\" -Recurse -Force
+    Write-Host "  Copied libexec files (including gst-ptp-helper.exe)"
+}
+
 # Create registry initialization batch file
 $registryBat = @"
 @echo off
@@ -328,4 +336,5 @@ Write-Host ""
 Write-Host "Contents:"
 Write-Host "  bin/     - GStreamer tools and DLLs"
 Write-Host "  lib/     - GStreamer plugins"
+Write-Host "  libexec/ - GStreamer helper executables (gst-ptp-helper.exe)"
 Write-Host "  share/   - GStreamer data files"

--- a/installer/windows/Product.wxs
+++ b/installer/windows/Product.wxs
@@ -35,6 +35,7 @@
           <Directory Id="GstLibFolder" Name="lib">
             <Directory Id="GstPluginsFolder" Name="gstreamer-1.0" />
           </Directory>
+          <Directory Id="GstLibexecFolder" Name="libexec" />
         </Directory>
         <Directory Id="GraphvizFolder" Name="graphviz">
           <Directory Id="GvBinFolder" Name="bin" />
@@ -93,6 +94,10 @@
       <Files Include="$(var.GStreamerDir)\lib\gstreamer-1.0\**\*.dll" />
     </ComponentGroup>
 
+    <ComponentGroup Id="GStreamerLibexecFiles" Directory="GstLibexecFolder">
+      <Files Include="$(var.GStreamerDir)\libexec\**\*.*" />
+    </ComponentGroup>
+
     <!-- Graphviz files -->
     <ComponentGroup Id="GraphvizBinFiles" Directory="GvBinFolder">
       <Files Include="$(var.GraphvizDir)\bin\**\*.*" />
@@ -108,6 +113,7 @@
       <Feature Id="GStreamerFeature" Title="GStreamer Runtime" Description="GStreamer multimedia framework (required for Strom to function)" Level="1" AllowAbsent="no">
         <ComponentGroupRef Id="GStreamerBinFiles" />
         <ComponentGroupRef Id="GStreamerPluginFiles" />
+        <ComponentGroupRef Id="GStreamerLibexecFiles" />
       </Feature>
 
       <Feature Id="GraphvizFeature" Title="Graphviz" Description="Graph visualization tools for debug pipeline graphs (recommended)" Level="1">


### PR DESCRIPTION
## Summary
- Add libexec folder to Windows MSI installer bundle
- Includes `gst-ptp-helper.exe` required for PTP clock support on Windows

## Changes
- Workflow: Copy libexec folder when preparing GStreamer bundle
- Product.wxs: Add GstLibexecFolder directory and component group
- Prepare-GStreamer.ps1: Include libexec in local bundle script

## Test plan
- [ ] Trigger manual MSI build workflow
- [ ] Verify libexec folder is included in installed files
- [ ] Test PTP clock functionality on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)