### PR TITLE
chore: Update default GStreamer to 1.26.10 in installer script

### DIFF
--- a/installer/windows/Prepare-GStreamer.ps1
+++ b/installer/windows/Prepare-GStreamer.ps1
@@ -8,7 +8,7 @@
     excluding development files, documentation, and unused plugins.
 
 .PARAMETER Version
-    GStreamer version to download (default: 1.24.13)
+    GStreamer version to download (default: 1.26.10)
 
 .PARAMETER OutputDir
     Directory to extract files to (default: gstreamer-bundle)
@@ -19,7 +19,7 @@
 #>
 
 param(
-    [string]$Version = "1.24.13",
+    [string]$Version = "1.26.10",
     [string]$OutputDir = "gstreamer-bundle",
     [switch]$Full
 )


### PR DESCRIPTION
## Summary
- Update default GStreamer version from 1.24.13 to 1.26.10 in `Prepare-GStreamer.ps1`

This aligns the local installer script with the CI/release workflows updated in #238.

🤖 Generated with [Claude Code](https://claude.com/claude-code)