### PR TITLE
debug: Add verbose output to MSI extraction

### DIFF
--- a/.github/workflows/release-msi.yml
+++ b/.github/workflows/release-msi.yml
@@ -118,7 +118,8 @@ jobs:
             exit 1
           }
 
-          $gstRoot = "gst-temp\gstreamer\1.0\msvc_x86_64"
+          # GStreamer MSI extracts to PFiles64/gstreamer/... structure
+          $gstRoot = "gst-temp\PFiles64\gstreamer\1.0\msvc_x86_64"
 
           # Verify extraction succeeded
           if (-not (Test-Path "$gstRoot\bin")) {


### PR DESCRIPTION
Add debug output to troubleshoot GStreamer MSI extraction failure in CI.