### PR TITLE
Add framerate and GL passthrough properties to vision mixer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6683,7 +6683,7 @@ dependencies = [
 
 [[package]]
 name = "strom"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "agua-gst",
  "anyhow",
@@ -6758,7 +6758,7 @@ dependencies = [
 
 [[package]]
 name = "strom-frontend"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "base64",
  "chrono",
@@ -6794,7 +6794,7 @@ dependencies = [
 
 [[package]]
 name = "strom-mcp-server"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "anyhow",
  "reqwest 0.13.2",
@@ -6808,7 +6808,7 @@ dependencies = [
 
 [[package]]
 name = "strom-types"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "garde",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["types", "backend", "frontend", "mcp-server"]
 default-members = ["backend"]
 
 [workspace.package]
-version = "0.4.6"
+version = "0.4.7"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Per Enstedt <per.enstedt@eyevinn.se>"]

--- a/backend/src/blocks/builtin/videoformat.rs
+++ b/backend/src/blocks/builtin/videoformat.rs
@@ -18,8 +18,8 @@ use crate::gpu::video_convert_mode;
 use gstreamer as gst;
 use std::collections::HashMap;
 use strom_types::{
-    block::*, common_video_pixel_format_enum_values, common_video_resolution_enum_values,
-    element::ElementPadRef, PropertyValue, *,
+    block::*, common_video_framerate_enum_values, common_video_pixel_format_enum_values,
+    common_video_resolution_enum_values, element::ElementPadRef, PropertyValue, *,
 };
 use tracing::info;
 
@@ -73,14 +73,19 @@ impl BlockBuilder for VideoFormatBuilder {
             }
         }
 
-        // Add framerate if specified
+        // Add framerate if specified (supports both fraction "25/1" and legacy decimal "25" formats)
         if let Some(fps) = framerate {
-            // Convert decimal framerates to proper fractions
-            let framerate_fraction = match fps {
-                "23.976" => "24000/1001".to_string(),
-                "29.97" => "30000/1001".to_string(),
-                "59.94" => "60000/1001".to_string(),
-                _ => format!("{}/1", fps),
+            let framerate_fraction = if fps.contains('/') {
+                // Already in fraction format (e.g. "25/1", "30000/1001")
+                fps.to_string()
+            } else {
+                // Legacy decimal format — convert to fraction
+                match fps {
+                    "23.976" => "24000/1001".to_string(),
+                    "29.97" => "30000/1001".to_string(),
+                    "59.94" => "60000/1001".to_string(),
+                    _ => format!("{}/1", fps),
+                }
             };
             caps_fields.push(format!("framerate={}", framerate_fraction));
         }
@@ -193,20 +198,7 @@ fn videoformat_definition() -> BlockDefinition {
                 label: "Framerate".to_string(),
                 description: "Framerate in fps - creates videorate element. Leave empty to pass through.".to_string(),
                 property_type: PropertyType::Enum {
-                    values: vec![
-                        EnumValue { value: "".to_string(), label: Some("-".to_string()) },
-                        EnumValue { value: "10".to_string(), label: Some("10 fps".to_string()) },
-                        EnumValue { value: "15".to_string(), label: Some("15 fps".to_string()) },
-                        EnumValue { value: "23.976".to_string(), label: Some("23.976 fps (24000/1001)".to_string()) },
-                        EnumValue { value: "24".to_string(), label: Some("24 fps".to_string()) },
-                        EnumValue { value: "25".to_string(), label: Some("25 fps".to_string()) },
-                        EnumValue { value: "29.97".to_string(), label: Some("29.97 fps (30000/1001)".to_string()) },
-                        EnumValue { value: "30".to_string(), label: Some("30 fps".to_string()) },
-                        EnumValue { value: "50".to_string(), label: Some("50 fps".to_string()) },
-                        EnumValue { value: "59.94".to_string(), label: Some("59.94 fps (60000/1001)".to_string()) },
-                        EnumValue { value: "60".to_string(), label: Some("60 fps".to_string()) },
-                        EnumValue { value: "120".to_string(), label: Some("120 fps".to_string()) },
-                    ],
+                    values: common_video_framerate_enum_values(true),
                 },
                 default_value: Some(PropertyValue::String("".to_string())),
                 mapping: PropertyMapping {

--- a/backend/src/blocks/builtin/vision_mixer/builder.rs
+++ b/backend/src/blocks/builtin/vision_mixer/builder.rs
@@ -74,7 +74,6 @@ impl BlockBuilder for VisionMixerBuilder {
         let pgm_input = properties::parse_initial_pgm(props, num_inputs);
         let pvw_input = properties::parse_initial_pvw(props, num_inputs);
         let labels = properties::parse_input_labels(props, num_inputs);
-        let force_live = properties::parse_bool(props, "force_live", true);
         let latency_ms = properties::parse_u64(props, "latency", vision_mixer::DEFAULT_LATENCY_MS);
         let min_upstream_ms = properties::parse_u64(
             props,
@@ -91,10 +90,22 @@ impl BlockBuilder for VisionMixerBuilder {
             "multiview_resolution",
             vision_mixer::DEFAULT_MULTIVIEW_RESOLUTION,
         );
+        let pgm_framerate = properties::parse_framerate(
+            props,
+            "pgm_framerate",
+            vision_mixer::DEFAULT_PGM_FRAMERATE,
+        );
+        let mv_framerate = properties::parse_framerate(
+            props,
+            "multiview_framerate",
+            vision_mixer::DEFAULT_MULTIVIEW_FRAMERATE,
+        );
 
         let num_dsk_inputs = properties::parse_num_dsk_inputs(props);
 
         let output_format = properties::parse_output_format(props);
+        let gl_download =
+            properties::parse_bool(props, "gl_download", vision_mixer::DEFAULT_GL_DOWNLOAD);
 
         let pref = props
             .get("compositor_preference")
@@ -106,8 +117,10 @@ impl BlockBuilder for VisionMixerBuilder {
         let backend = elements::select_backend(pref)?;
 
         info!(
-            "Building vision mixer: {} inputs, PGM={}x{}, MV={}x{}, backend={:?}, pgm={}, pvw={}",
-            num_inputs, pgm_w, pgm_h, mv_w, mv_h, backend, pgm_input, pvw_input
+            "Building vision mixer: {} inputs, PGM={}x{}@{}/{}, MV={}x{}@{}/{}, backend={:?}, pgm={}, pvw={}",
+            num_inputs, pgm_w, pgm_h, pgm_framerate.0, pgm_framerate.1,
+            mv_w, mv_h, mv_framerate.0, mv_framerate.1,
+            backend, pgm_input, pvw_input
         );
 
         let p = PipelineParams {
@@ -117,15 +130,17 @@ impl BlockBuilder for VisionMixerBuilder {
             pgm_input,
             pvw_input,
             labels: &labels,
-            force_live,
             latency_ms,
             min_upstream_ms,
             pgm_w,
             pgm_h,
             mv_w,
             mv_h,
+            pgm_framerate,
+            mv_framerate,
             backend,
             output_format,
+            gl_download,
         };
 
         match backend {
@@ -143,15 +158,17 @@ struct PipelineParams<'a> {
     pgm_input: usize,
     pvw_input: usize,
     labels: &'a [String],
-    force_live: bool,
     latency_ms: u64,
     min_upstream_ms: u64,
     pgm_w: u32,
     pgm_h: u32,
     mv_w: u32,
     mv_h: u32,
+    pgm_framerate: (i32, i32),
+    mv_framerate: (i32, i32),
     backend: CompositorBackend,
     output_format: Option<String>,
+    gl_download: bool,
 }
 
 impl<'a> PipelineParams<'a> {
@@ -160,11 +177,31 @@ impl<'a> PipelineParams<'a> {
         format!("{}:{}", self.instance_id, name)
     }
 
-    /// Build output caps with resolution and optional pixel format.
-    fn output_caps(&self, width: u32, height: u32) -> gst::Caps {
+    /// Build PGM output caps with resolution, framerate, and optional pixel format.
+    fn pgm_caps(&self) -> gst::Caps {
         let mut builder = gst::Caps::builder("video/x-raw")
-            .field("width", width as i32)
-            .field("height", height as i32)
+            .field("width", self.pgm_w as i32)
+            .field("height", self.pgm_h as i32)
+            .field(
+                "framerate",
+                gst::Fraction::new(self.pgm_framerate.0, self.pgm_framerate.1),
+            )
+            .field("pixel-aspect-ratio", gst::Fraction::new(1, 1));
+        if let Some(ref fmt) = self.output_format {
+            builder = builder.field("format", fmt.as_str());
+        }
+        builder.build()
+    }
+
+    /// Build multiview output caps with resolution, framerate, and optional pixel format.
+    fn mv_caps(&self) -> gst::Caps {
+        let mut builder = gst::Caps::builder("video/x-raw")
+            .field("width", self.mv_w as i32)
+            .field("height", self.mv_h as i32)
+            .field(
+                "framerate",
+                gst::Fraction::new(self.mv_framerate.0, self.mv_framerate.1),
+            )
             .field("pixel-aspect-ratio", gst::Fraction::new(1, 1));
         if let Some(ref fmt) = self.output_format {
             builder = builder.field("format", fmt.as_str());
@@ -185,10 +222,8 @@ fn build_gpu_pipeline(
     let mut links: Vec<(ElementPadRef, ElementPadRef)> = Vec::new();
 
     // --- Create compositors (no pre-requested pads — the linker auto-creates them) ---
-    let dist_comp =
-        elements::make_dist_compositor(p.backend, p.force_live, p.latency_ms, p.min_upstream_ms)?;
-    let mv_comp =
-        elements::make_mv_compositor(p.backend, p.force_live, p.latency_ms, p.min_upstream_ms)?;
+    let dist_comp = elements::make_dist_compositor(p.backend, p.latency_ms, p.min_upstream_ms)?;
+    let mv_comp = elements::make_mv_compositor(p.backend, p.latency_ms, p.min_upstream_ms)?;
 
     dist_comp.set_property("name", p.id("mixer"));
     mv_comp.set_property("name", p.id("mv_comp"));
@@ -202,27 +237,17 @@ fn build_gpu_pipeline(
     let mv_layout = layout::compute_layout(p.mv_w, p.mv_h, p.num_inputs);
 
     // --- Distribution output chain ---
-    // mixer → queue_post_dist → tee_pgm → gldownload → capsfilter → queue_dist_out
     // queue_post_dist decouples the compositor from downstream processing.
+    // With gl_download=true:  mixer → queue_post_dist → tee_pgm → gldownload → capsfilter → queue_dist_out
+    // With gl_download=false: mixer → queue_post_dist → tee_pgm → queue_dist_out (GL memory passthrough)
     let q_post_dist_id = p.id("queue_post_dist");
     let queue_post_dist = elements::make_queue(&q_post_dist_id)?;
     let tee_pgm_id = p.id("tee_pgm");
     let tee_pgm = elements::make_tee(&tee_pgm_id)?;
-    let dl_dist_id = p.id("gldownload_dist");
-    let gldownload_dist = elements::make_element("gldownload", "gldownload_dist")?;
-    gldownload_dist.set_property("name", &dl_dist_id);
-    let cf_dist_id = p.id("capsfilter_dist");
-    let capsfilter_dist = gst::ElementFactory::make("capsfilter")
-        .name(&cf_dist_id)
-        .property("caps", p.output_caps(p.pgm_w, p.pgm_h))
-        .build()
-        .map_err(|e| BlockBuildError::ElementCreation(format!("capsfilter_dist: {}", e)))?;
     let q_dist_out_id = p.id("queue_dist_out");
     let queue_dist_out = elements::make_queue(&q_dist_out_id)?;
     elems.push((q_post_dist_id.clone(), queue_post_dist));
     elems.push((tee_pgm_id.clone(), tee_pgm));
-    elems.push((dl_dist_id.clone(), gldownload_dist));
-    elems.push((cf_dist_id.clone(), capsfilter_dist));
     elems.push((q_dist_out_id.clone(), queue_dist_out));
     links.push((
         ElementPadRef::pad(&mixer_id, "src"),
@@ -232,32 +257,36 @@ fn build_gpu_pipeline(
         ElementPadRef::pad(&q_post_dist_id, "src"),
         ElementPadRef::pad(&tee_pgm_id, "sink"),
     ));
-    links.push((
-        ElementPadRef::pad(&tee_pgm_id, "src_0"),
-        ElementPadRef::pad(&dl_dist_id, "sink"),
-    ));
-    links.push((
-        ElementPadRef::pad(&dl_dist_id, "src"),
-        ElementPadRef::pad(&cf_dist_id, "sink"),
-    ));
-    links.push((
-        ElementPadRef::pad(&cf_dist_id, "src"),
-        ElementPadRef::pad(&q_dist_out_id, "sink"),
-    ));
-
-    // Fakesink on tee_pgm to ensure PGM pipeline always has a pulling sink
-    let fs_pgm_id = p.id("fakesink_pgm");
-    let fakesink_pgm = gst::ElementFactory::make("fakesink")
-        .name(&fs_pgm_id)
-        .property("async", false)
-        .property("sync", false)
-        .build()
-        .map_err(|e| BlockBuildError::ElementCreation(format!("fakesink_pgm: {}", e)))?;
-    elems.push((fs_pgm_id.clone(), fakesink_pgm));
-    links.push((
-        ElementPadRef::pad(&tee_pgm_id, "src_1"),
-        ElementPadRef::pad(&fs_pgm_id, "sink"),
-    ));
+    if p.gl_download {
+        let dl_dist_id = p.id("gldownload_dist");
+        let gldownload_dist = elements::make_element("gldownload", "gldownload_dist")?;
+        gldownload_dist.set_property("name", &dl_dist_id);
+        let cf_dist_id = p.id("capsfilter_dist");
+        let capsfilter_dist = gst::ElementFactory::make("capsfilter")
+            .name(&cf_dist_id)
+            .property("caps", p.pgm_caps())
+            .build()
+            .map_err(|e| BlockBuildError::ElementCreation(format!("capsfilter_dist: {}", e)))?;
+        elems.push((dl_dist_id.clone(), gldownload_dist));
+        elems.push((cf_dist_id.clone(), capsfilter_dist));
+        links.push((
+            ElementPadRef::pad(&tee_pgm_id, "src_0"),
+            ElementPadRef::pad(&dl_dist_id, "sink"),
+        ));
+        links.push((
+            ElementPadRef::pad(&dl_dist_id, "src"),
+            ElementPadRef::pad(&cf_dist_id, "sink"),
+        ));
+        links.push((
+            ElementPadRef::pad(&cf_dist_id, "src"),
+            ElementPadRef::pad(&q_dist_out_id, "sink"),
+        ));
+    } else {
+        links.push((
+            ElementPadRef::pad(&tee_pgm_id, "src_0"),
+            ElementPadRef::pad(&q_dist_out_id, "sink"),
+        ));
+    }
 
     // Queue to decouple tee_pgm from the multiview compositor (separate thread)
     let q_pgm_mv_id = p.id("queue_pgm_mv");
@@ -290,28 +319,17 @@ fn build_gpu_pipeline(
     }
 
     // --- Multiview output chain ---
-    // mv_comp → queue_post_mv → gldownload → capsfilter → tee_mv → queue_mv_out
     // queue_post_mv decouples the compositor from downstream processing.
+    // With gl_download=true:  mv_comp → queue_post_mv → gldownload → capsfilter → tee_mv → queue_mv_out
+    // With gl_download=false: mv_comp → queue_post_mv → tee_mv → queue_mv_out (GL memory passthrough)
     let q_post_mv_id = p.id("queue_post_mv");
     let queue_post_mv = elements::make_queue(&q_post_mv_id)?;
-    let dl_id = p.id("gldownload_mv");
-    let cf_mv_id = p.id("capsfilter_mv");
     let tee_mv_id = p.id("tee_mv");
-    let q_mv_out_id = p.id("queue_mv_out");
-
-    let gldownload_mv = elements::make_element("gldownload", "gldownload_mv")?;
-    gldownload_mv.set_property("name", &dl_id);
-    let capsfilter_mv = gst::ElementFactory::make("capsfilter")
-        .name(&cf_mv_id)
-        .property("caps", p.output_caps(p.mv_w, p.mv_h))
-        .build()
-        .map_err(|e| BlockBuildError::ElementCreation(format!("capsfilter_mv: {}", e)))?;
     let tee_mv = elements::make_tee(&tee_mv_id)?;
+    let q_mv_out_id = p.id("queue_mv_out");
     let queue_mv_out = elements::make_queue(&q_mv_out_id)?;
 
     elems.push((q_post_mv_id.clone(), queue_post_mv));
-    elems.push((dl_id.clone(), gldownload_mv));
-    elems.push((cf_mv_id.clone(), capsfilter_mv));
     elems.push((tee_mv_id.clone(), tee_mv));
     elems.push((q_mv_out_id.clone(), queue_mv_out));
 
@@ -319,42 +337,46 @@ fn build_gpu_pipeline(
         ElementPadRef::pad(&mv_comp_id, "src"),
         ElementPadRef::pad(&q_post_mv_id, "sink"),
     ));
-    links.push((
-        ElementPadRef::pad(&q_post_mv_id, "src"),
-        ElementPadRef::pad(&dl_id, "sink"),
-    ));
-    links.push((
-        ElementPadRef::pad(&dl_id, "src"),
-        ElementPadRef::pad(&cf_mv_id, "sink"),
-    ));
-    links.push((
-        ElementPadRef::pad(&cf_mv_id, "src"),
-        ElementPadRef::pad(&tee_mv_id, "sink"),
-    ));
+    if p.gl_download {
+        let dl_id = p.id("gldownload_mv");
+        let gldownload_mv = elements::make_element("gldownload", "gldownload_mv")?;
+        gldownload_mv.set_property("name", &dl_id);
+        let cf_mv_id = p.id("capsfilter_mv");
+        let capsfilter_mv = gst::ElementFactory::make("capsfilter")
+            .name(&cf_mv_id)
+            .property("caps", p.mv_caps())
+            .build()
+            .map_err(|e| BlockBuildError::ElementCreation(format!("capsfilter_mv: {}", e)))?;
+        elems.push((dl_id.clone(), gldownload_mv));
+        elems.push((cf_mv_id.clone(), capsfilter_mv));
+        links.push((
+            ElementPadRef::pad(&q_post_mv_id, "src"),
+            ElementPadRef::pad(&dl_id, "sink"),
+        ));
+        links.push((
+            ElementPadRef::pad(&dl_id, "src"),
+            ElementPadRef::pad(&cf_mv_id, "sink"),
+        ));
+        links.push((
+            ElementPadRef::pad(&cf_mv_id, "src"),
+            ElementPadRef::pad(&tee_mv_id, "sink"),
+        ));
+    } else {
+        links.push((
+            ElementPadRef::pad(&q_post_mv_id, "src"),
+            ElementPadRef::pad(&tee_mv_id, "sink"),
+        ));
+    }
     links.push((
         ElementPadRef::pad(&tee_mv_id, "src_0"),
         ElementPadRef::pad(&q_mv_out_id, "sink"),
     ));
 
-    // Fakesink on tee_mv to ensure MV pipeline always has a pulling sink
-    let fs_mv_id = p.id("fakesink_mv");
-    let fakesink_mv = gst::ElementFactory::make("fakesink")
-        .name(&fs_mv_id)
-        .property("async", false)
-        .property("sync", false)
-        .build()
-        .map_err(|e| BlockBuildError::ElementCreation(format!("fakesink_mv: {}", e)))?;
-    elems.push((fs_mv_id.clone(), fakesink_mv));
-    links.push((
-        ElementPadRef::pad(&tee_mv_id, "src_1"),
-        ElementPadRef::pad(&fs_mv_id, "sink"),
-    ));
-
     // --- Overlay appsrc → glupload → mv_comp (composited in GPU at high zorder) ---
     let appsrc_overlay_id = p.id("appsrc_overlay");
     let overlay_caps_str = format!(
-        "video/x-raw,format=RGBA,width={},height={},pixel-aspect-ratio=1/1,framerate={}/1,interlace-mode=progressive,multiview-mode=mono",
-        p.mv_w, p.mv_h, vision_mixer::OVERLAY_FRAMERATE
+        "video/x-raw,format=RGBA,width={},height={},pixel-aspect-ratio=1/1,framerate={}/{},interlace-mode=progressive,multiview-mode=mono",
+        p.mv_w, p.mv_h, p.mv_framerate.0, p.mv_framerate.1
     );
     let overlay_caps: gst::Caps = overlay_caps_str
         .parse()
@@ -470,10 +492,9 @@ fn build_gpu_pipeline(
         ));
     }
 
-    // Multiview PGM big display: tee_pgm.src_2 → queue_pgm_mv → mv_comp.sink_N
-    // (src_1 is used by fakesink_pgm)
+    // Multiview PGM big display: tee_pgm.src_1 → queue_pgm_mv → mv_comp.sink_N
     links.push((
-        ElementPadRef::pad(&tee_pgm_id, "src_2"),
+        ElementPadRef::pad(&tee_pgm_id, "src_1"),
         ElementPadRef::pad(&q_pgm_mv_id, "sink"),
     ));
     links.push((
@@ -532,10 +553,8 @@ fn build_cpu_pipeline(
     let mut elems: Vec<(String, gst::Element)> = Vec::new();
     let mut links: Vec<(ElementPadRef, ElementPadRef)> = Vec::new();
 
-    let dist_comp =
-        elements::make_dist_compositor(p.backend, p.force_live, p.latency_ms, p.min_upstream_ms)?;
-    let mv_comp =
-        elements::make_mv_compositor(p.backend, p.force_live, p.latency_ms, p.min_upstream_ms)?;
+    let dist_comp = elements::make_dist_compositor(p.backend, p.latency_ms, p.min_upstream_ms)?;
+    let mv_comp = elements::make_mv_compositor(p.backend, p.latency_ms, p.min_upstream_ms)?;
 
     dist_comp.set_property("name", p.id("mixer"));
     mv_comp.set_property("name", p.id("mv_comp"));
@@ -553,7 +572,7 @@ fn build_cpu_pipeline(
     let cf_dist_id = p.id("capsfilter_dist");
     let capsfilter_dist = gst::ElementFactory::make("capsfilter")
         .name(&cf_dist_id)
-        .property("caps", p.output_caps(p.pgm_w, p.pgm_h))
+        .property("caps", p.pgm_caps())
         .build()
         .map_err(|e| BlockBuildError::ElementCreation(format!("capsfilter_dist: {}", e)))?;
     let tee_pgm_id = p.id("tee_pgm");
@@ -577,20 +596,6 @@ fn build_cpu_pipeline(
         ElementPadRef::pad(&q_dist_out_id, "sink"),
     ));
 
-    // Fakesink on tee_pgm to ensure PGM pipeline always has a pulling sink
-    let fs_pgm_id = p.id("fakesink_pgm");
-    let fakesink_pgm = gst::ElementFactory::make("fakesink")
-        .name(&fs_pgm_id)
-        .property("async", false)
-        .property("sync", false)
-        .build()
-        .map_err(|e| BlockBuildError::ElementCreation(format!("fakesink_pgm: {}", e)))?;
-    elems.push((fs_pgm_id.clone(), fakesink_pgm));
-    links.push((
-        ElementPadRef::pad(&tee_pgm_id, "src_1"),
-        ElementPadRef::pad(&fs_pgm_id, "sink"),
-    ));
-
     // Queue + capsfilter to decouple tee_pgm from the multiview compositor.
     // The capsfilter breaks the caps negotiation cycle: PGM compositor → tee →
     // queue_pgm_mv → mv_comp → (feedback). Without it, tee forwards caps queries
@@ -603,7 +608,7 @@ fn build_cpu_pipeline(
     let cf_pgm_mv_id = p.id("capsfilter_pgm_mv");
     let capsfilter_pgm_mv = gst::ElementFactory::make("capsfilter")
         .name(&cf_pgm_mv_id)
-        .property("caps", p.output_caps(p.pgm_w, p.pgm_h))
+        .property("caps", p.pgm_caps())
         .build()
         .map_err(|e| BlockBuildError::ElementCreation(format!("capsfilter_pgm_mv: {}", e)))?;
     elems.push((q_pgm_mv_id.clone(), queue_pgm_mv));
@@ -654,7 +659,7 @@ fn build_cpu_pipeline(
     let cf_mv_id = p.id("capsfilter_mv");
     let capsfilter_mv = gst::ElementFactory::make("capsfilter")
         .name(&cf_mv_id)
-        .property("caps", p.output_caps(p.mv_w, p.mv_h))
+        .property("caps", p.mv_caps())
         .build()
         .map_err(|e| BlockBuildError::ElementCreation(format!("capsfilter_mv: {}", e)))?;
     let tee_mv_id = p.id("tee_mv");
@@ -679,25 +684,11 @@ fn build_cpu_pipeline(
         ElementPadRef::pad(&q_mv_out_id, "sink"),
     ));
 
-    // Fakesink on tee_mv to ensure MV pipeline always has a pulling sink
-    let fs_mv_id = p.id("fakesink_mv");
-    let fakesink_mv = gst::ElementFactory::make("fakesink")
-        .name(&fs_mv_id)
-        .property("async", false)
-        .property("sync", false)
-        .build()
-        .map_err(|e| BlockBuildError::ElementCreation(format!("fakesink_mv: {}", e)))?;
-    elems.push((fs_mv_id.clone(), fakesink_mv));
-    links.push((
-        ElementPadRef::pad(&tee_mv_id, "src_1"),
-        ElementPadRef::pad(&fs_mv_id, "sink"),
-    ));
-
     // --- Overlay appsrc → mv_comp (CPU compositor accepts raw BGRA directly) ---
     let appsrc_overlay_id = p.id("appsrc_overlay");
     let overlay_caps_str = format!(
-        "video/x-raw,format=RGBA,width={},height={},pixel-aspect-ratio=1/1,framerate={}/1,interlace-mode=progressive,multiview-mode=mono",
-        p.mv_w, p.mv_h, vision_mixer::OVERLAY_FRAMERATE
+        "video/x-raw,format=RGBA,width={},height={},pixel-aspect-ratio=1/1,framerate={}/{},interlace-mode=progressive,multiview-mode=mono",
+        p.mv_w, p.mv_h, p.mv_framerate.0, p.mv_framerate.1
     );
     let overlay_caps: gst::Caps = overlay_caps_str
         .parse()
@@ -889,10 +880,10 @@ fn build_cpu_pipeline(
         ElementPadRef::pad(&mv_comp_id, format!("sink_{}", overlay_pad_idx)),
     ));
 
-    // Multiview PGM big display: tee_pgm.src_2 → queue_pgm_mv → capsfilter_pgm_mv → mv_comp.sink_N
-    // (src_1 is used by fakesink_pgm; capsfilter breaks caps query cycle back to PGM compositor)
+    // Multiview PGM big display: tee_pgm.src_1 → queue_pgm_mv → capsfilter_pgm_mv → mv_comp.sink_N
+    // (capsfilter breaks caps query cycle back to PGM compositor)
     links.push((
-        ElementPadRef::pad(&tee_pgm_id, "src_2"),
+        ElementPadRef::pad(&tee_pgm_id, "src_1"),
         ElementPadRef::pad(&q_pgm_mv_id, "sink"),
     ));
     links.push((

--- a/backend/src/blocks/builtin/vision_mixer/definition.rs
+++ b/backend/src/blocks/builtin/vision_mixer/definition.rs
@@ -3,8 +3,8 @@
 use strom_types::block::*;
 use strom_types::vision_mixer::*;
 use strom_types::{
-    common_video_pixel_format_enum_values, common_video_resolution_enum_values, MediaType,
-    PropertyValue,
+    common_video_framerate_enum_values, common_video_pixel_format_enum_values,
+    common_video_resolution_enum_values, MediaType, PropertyValue,
 };
 
 /// Get block definitions for the vision mixer.
@@ -116,16 +116,38 @@ fn vision_mixer_definition() -> BlockDefinition {
             },
             live: false,
         },
-        // Force live
+        // PGM output framerate
         ExposedProperty {
-            name: "force_live".to_string(),
-            label: "Force Live".to_string(),
-            description: "Force compositors into live mode".to_string(),
-            property_type: PropertyType::Bool,
-            default_value: Some(PropertyValue::Bool(true)),
+            name: "pgm_framerate".to_string(),
+            label: "PGM Framerate".to_string(),
+            description: "Distribution/PGM output framerate".to_string(),
+            property_type: PropertyType::Enum {
+                values: common_video_framerate_enum_values(false),
+            },
+            default_value: Some(PropertyValue::String(
+                DEFAULT_PGM_FRAMERATE.to_string(),
+            )),
             mapping: PropertyMapping {
                 element_id: "_block".to_string(),
-                property_name: "force_live".to_string(),
+                property_name: "pgm_framerate".to_string(),
+                transform: None,
+            },
+            live: false,
+        },
+        // Multiview output framerate
+        ExposedProperty {
+            name: "multiview_framerate".to_string(),
+            label: "Multiview Framerate".to_string(),
+            description: "Multiview monitor output framerate".to_string(),
+            property_type: PropertyType::Enum {
+                values: common_video_framerate_enum_values(false),
+            },
+            default_value: Some(PropertyValue::String(
+                DEFAULT_MULTIVIEW_FRAMERATE.to_string(),
+            )),
+            mapping: PropertyMapping {
+                element_id: "_block".to_string(),
+                property_name: "multiview_framerate".to_string(),
                 transform: None,
             },
             live: false,
@@ -210,6 +232,20 @@ fn vision_mixer_definition() -> BlockDefinition {
             mapping: PropertyMapping {
                 element_id: "_block".to_string(),
                 property_name: "output_format".to_string(),
+                transform: None,
+            },
+            live: false,
+        },
+        // GL download (GPU path only)
+        ExposedProperty {
+            name: "gl_download".to_string(),
+            label: "GL Download".to_string(),
+            description: "Download GPU memory to system memory on output. Disable to pass GL memory downstream (GPU path only).".to_string(),
+            property_type: PropertyType::Bool,
+            default_value: Some(PropertyValue::Bool(DEFAULT_GL_DOWNLOAD)),
+            mapping: PropertyMapping {
+                element_id: "_block".to_string(),
+                property_name: "gl_download".to_string(),
                 transform: None,
             },
             live: false,

--- a/backend/src/blocks/builtin/vision_mixer/elements.rs
+++ b/backend/src/blocks/builtin/vision_mixer/elements.rs
@@ -41,7 +41,6 @@ pub fn select_backend(preference: &str) -> Result<CompositorBackend, BlockBuildE
 /// Create the distribution (PGM) compositor element.
 pub fn make_dist_compositor(
     backend: CompositorBackend,
-    force_live: bool,
     latency_ms: u64,
     min_upstream_latency_ms: u64,
 ) -> Result<gst::Element, BlockBuildError> {
@@ -52,7 +51,7 @@ pub fn make_dist_compositor(
 
     let mixer = gst::ElementFactory::make(element_type)
         .name("mixer")
-        .property("force-live", force_live)
+        .property("force-live", true)
         .build()
         .map_err(|e| BlockBuildError::ElementCreation(format!("{}: {}", element_type, e)))?;
 
@@ -71,7 +70,6 @@ pub fn make_dist_compositor(
 /// Create the multiview compositor element.
 pub fn make_mv_compositor(
     backend: CompositorBackend,
-    force_live: bool,
     latency_ms: u64,
     min_upstream_latency_ms: u64,
 ) -> Result<gst::Element, BlockBuildError> {
@@ -82,12 +80,11 @@ pub fn make_mv_compositor(
 
     let mixer = gst::ElementFactory::make(element_type)
         .name("mv_comp")
-        .property("force-live", force_live)
+        .property("force-live", true)
         .build()
         .map_err(|e| BlockBuildError::ElementCreation(format!("{}: {}", element_type, e)))?;
 
     apply_post_build_properties(&mixer, latency_ms, min_upstream_latency_ms);
-    // Black background for multiview
     if mixer.find_property("background").is_some() {
         mixer.set_property_from_str("background", "black");
     }

--- a/backend/src/blocks/builtin/vision_mixer/properties.rs
+++ b/backend/src/blocks/builtin/vision_mixer/properties.rs
@@ -159,3 +159,45 @@ pub fn parse_u64(properties: &HashMap<String, PropertyValue>, key: &str, default
         })
         .unwrap_or(default)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_framerate_string_valid_fractions() {
+        assert_eq!(parse_framerate_string("25/1"), Some((25, 1)));
+        assert_eq!(parse_framerate_string("30000/1001"), Some((30000, 1001)));
+        assert_eq!(parse_framerate_string("1/1"), Some((1, 1)));
+    }
+
+    #[test]
+    fn parse_framerate_string_rejects_invalid() {
+        assert_eq!(parse_framerate_string("0/1"), None);
+        assert_eq!(parse_framerate_string("25/0"), None);
+        assert_eq!(parse_framerate_string("-1/1"), None);
+        assert_eq!(parse_framerate_string("25"), None);
+        assert_eq!(parse_framerate_string(""), None);
+        assert_eq!(parse_framerate_string("abc/def"), None);
+    }
+
+    #[test]
+    fn parse_framerate_uses_property_value() {
+        let mut props = HashMap::new();
+        props.insert("fps".to_string(), PropertyValue::String("60/1".to_string()));
+        assert_eq!(parse_framerate(&props, "fps", "25/1"), (60, 1));
+    }
+
+    #[test]
+    fn parse_framerate_falls_back_to_default() {
+        let props = HashMap::new();
+        assert_eq!(parse_framerate(&props, "fps", "25/1"), (25, 1));
+    }
+
+    #[test]
+    fn parse_framerate_invalid_value_falls_back_to_default() {
+        let mut props = HashMap::new();
+        props.insert("fps".to_string(), PropertyValue::String("nope".to_string()));
+        assert_eq!(parse_framerate(&props, "fps", "30/1"), (30, 1));
+    }
+}

--- a/backend/src/blocks/builtin/vision_mixer/properties.rs
+++ b/backend/src/blocks/builtin/vision_mixer/properties.rs
@@ -117,6 +117,36 @@ pub fn parse_output_format(properties: &HashMap<String, PropertyValue>) -> Optio
     })
 }
 
+/// Parse a framerate string "N/D" into (numerator, denominator).
+pub fn parse_framerate(
+    properties: &HashMap<String, PropertyValue>,
+    key: &str,
+    default: &str,
+) -> (i32, i32) {
+    let s = properties
+        .get(key)
+        .and_then(|v| match v {
+            PropertyValue::String(s) if !s.is_empty() => Some(s.as_str()),
+            _ => None,
+        })
+        .unwrap_or(default);
+    parse_framerate_string(s).unwrap_or_else(|| {
+        parse_framerate_string(default).expect("default framerate must be valid")
+    })
+}
+
+fn parse_framerate_string(s: &str) -> Option<(i32, i32)> {
+    let parts: Vec<&str> = s.split('/').collect();
+    if parts.len() == 2 {
+        let n = parts[0].parse::<i32>().ok()?;
+        let d = parts[1].parse::<i32>().ok()?;
+        if n > 0 && d > 0 {
+            return Some((n, d));
+        }
+    }
+    None
+}
+
 /// Parse a u64 property with a default.
 pub fn parse_u64(properties: &HashMap<String, PropertyValue>, key: &str, default: u64) -> u64 {
     properties

--- a/types/src/block.rs
+++ b/types/src/block.rs
@@ -422,6 +422,44 @@ pub fn common_video_pixel_format_enum_values(include_empty: bool) -> Vec<EnumVal
     values
 }
 
+/// Common video framerates for use in block property dropdowns.
+/// Each entry is (fraction_string, label) where fraction_string is "N/D" format.
+pub const COMMON_VIDEO_FRAMERATES: &[(&str, &str)] = &[
+    ("10/1", "10 fps"),
+    ("15/1", "15 fps"),
+    ("24000/1001", "23.976 fps"),
+    ("24/1", "24 fps"),
+    ("25/1", "25 fps"),
+    ("30000/1001", "29.97 fps"),
+    ("30/1", "30 fps"),
+    ("50/1", "50 fps"),
+    ("60000/1001", "59.94 fps"),
+    ("60/1", "60 fps"),
+    ("120/1", "120 fps"),
+];
+
+/// Get common video framerates as EnumValue list for block properties.
+/// Set `include_empty` to true to add an empty "-" option at the start.
+pub fn common_video_framerate_enum_values(include_empty: bool) -> Vec<EnumValue> {
+    let mut values = Vec::new();
+
+    if include_empty {
+        values.push(EnumValue {
+            value: String::new(),
+            label: Some("-".to_string()),
+        });
+    }
+
+    for (value, label) in COMMON_VIDEO_FRAMERATES {
+        values.push(EnumValue {
+            value: (*value).to_string(),
+            label: Some((*label).to_string()),
+        });
+    }
+
+    values
+}
+
 /// Parse a resolution string like "1920x1080" into (width, height).
 /// Returns None if parsing fails.
 pub fn parse_resolution_string(s: &str) -> Option<(u32, u32)> {

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -30,12 +30,13 @@ pub mod whip;
 
 // Re-export commonly used types
 pub use block::{
-    common_video_pixel_format_enum_values, common_video_resolution_enum_values,
-    parse_resolution_string, BlockDefinition, BlockInstance, BlockListResponse, BlockResponse,
-    CreateBlockRequest, EnumValue, ExposedProperty, ExternalPad, ExternalPads, PropertyMapping,
-    PropertyType, COMMON_VIDEO_RESOLUTIONS, DEFAULT_AES67_INPUT_BUFFER_DURATION_MS,
-    DEFAULT_EFP_BUCKET_TIMEOUT, DEFAULT_EFP_HOL_TIMEOUT, DEFAULT_EFP_MTU, DEFAULT_OPUS_BITRATE,
-    DEFAULT_OPUS_COMPLEXITY, DEFAULT_SRT_INPUT_URI, DEFAULT_SRT_LATENCY_MS, DEFAULT_SRT_OUTPUT_URI,
+    common_video_framerate_enum_values, common_video_pixel_format_enum_values,
+    common_video_resolution_enum_values, parse_resolution_string, BlockDefinition, BlockInstance,
+    BlockListResponse, BlockResponse, CreateBlockRequest, EnumValue, ExposedProperty, ExternalPad,
+    ExternalPads, PropertyMapping, PropertyType, COMMON_VIDEO_RESOLUTIONS,
+    DEFAULT_AES67_INPUT_BUFFER_DURATION_MS, DEFAULT_EFP_BUCKET_TIMEOUT, DEFAULT_EFP_HOL_TIMEOUT,
+    DEFAULT_EFP_MTU, DEFAULT_OPUS_BITRATE, DEFAULT_OPUS_COMPLEXITY, DEFAULT_SRT_INPUT_URI,
+    DEFAULT_SRT_LATENCY_MS, DEFAULT_SRT_OUTPUT_URI,
 };
 pub use element::{Element, ElementId, Link, MediaType, PropertyValue};
 pub use events::StromEvent;

--- a/types/src/vision_mixer.rs
+++ b/types/src/vision_mixer.rs
@@ -45,6 +45,15 @@ pub const DEFAULT_LATENCY_MS: u64 = 20;
 /// Default minimum upstream latency in milliseconds.
 pub const DEFAULT_MIN_UPSTREAM_LATENCY_MS: u64 = 20;
 
+/// Default PGM output framerate (fps as "numerator/denominator").
+pub const DEFAULT_PGM_FRAMERATE: &str = "30/1";
+
+/// Default multiview output framerate.
+pub const DEFAULT_MULTIVIEW_FRAMERATE: &str = "30/1";
+
+/// Whether to download GPU memory to system memory on output (GPU path only).
+pub const DEFAULT_GL_DOWNLOAD: bool = true;
+
 // --- Z-order constants for compositor pads ---
 
 /// Z-order for thumbnail pads on the multiview compositor.


### PR DESCRIPTION
## Summary
- Add separate PGM and multiview framerate properties to the vision mixer (fraction format `N/D`, default `30/1`)
- Add `gl_download` toggle to skip gldownload/capsfilter in the GPU pipeline, allowing GL memory passthrough to downstream blocks
- Hardcode `force-live=true` on compositors (was always the default, now no longer user-configurable)
- Extract shared `COMMON_VIDEO_FRAMERATES` and `common_video_framerate_enum_values()` into `strom-types`, reused by videoformat block
- Remove redundant fakesink elements from tee branches in both GPU and CPU pipelines

## Test plan
- [ ] Verify vision mixer starts with default framerate (30 fps) on both PGM and multiview outputs
- [ ] Change PGM framerate to 25/1 and confirm output caps update
- [ ] Test GL download disabled: downstream GL-capable block receives GL memory buffers
- [ ] Test GL download enabled (default): downstream receives system memory as before
- [ ] Verify CPU pipeline path still works (no gldownload toggle effect)
- [ ] Run `cargo test` — includes new `parse_framerate` unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)