### PR TITLE
fix: skip GL compositor when only Mesa software rendering is available

### DIFF
--- a/backend/src/blocks/builtin/compositor.rs
+++ b/backend/src/blocks/builtin/compositor.rs
@@ -18,6 +18,7 @@
 //! CPU backend chain: queue -> videoconvert -> [thumb_tee] -> compositor -> capsfilter
 
 use crate::blocks::{BlockBuildContext, BlockBuildError, BlockBuildResult, BlockBuilder};
+use crate::gpu;
 use gstreamer as gst;
 use gstreamer::prelude::*;
 use std::collections::HashMap;
@@ -25,7 +26,7 @@ use strom_types::{
     block::*, common_video_resolution_enum_values, element::ElementPadRef, parse_resolution_string,
     PropertyValue, *,
 };
-use tracing::{debug, info, warn};
+use tracing::{debug, info};
 
 /// Backend selection for the compositor.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -208,11 +209,13 @@ fn select_compositor(
             }
         }
         CompositorPreference::Auto => {
-            if has_gl {
+            // Only pick GL when a real hardware GPU is available.
+            // Mesa software renderers (llvmpipe) are slower than the CPU compositor.
+            if has_gl && gpu::has_hardware_gl() {
                 debug!("Auto-selected GPU (OpenGL) compositor");
                 Ok(CompositorBackend::OpenGL)
             } else if has_software {
-                warn!("GPU compositor unavailable, falling back to CPU compositor");
+                debug!("Auto-selected CPU compositor (no hardware GL)");
                 Ok(CompositorBackend::Software)
             } else {
                 Err(BlockBuildError::InvalidConfiguration(

--- a/backend/src/blocks/builtin/vision_mixer/elements.rs
+++ b/backend/src/blocks/builtin/vision_mixer/elements.rs
@@ -1,6 +1,7 @@
 //! GStreamer element factory helpers for the vision mixer block.
 
 use crate::blocks::BlockBuildError;
+use crate::gpu;
 use gstreamer as gst;
 use gstreamer::prelude::*;
 use tracing::{debug, info};
@@ -26,12 +27,14 @@ pub fn select_backend(preference: &str) -> Result<CompositorBackend, BlockBuildE
         }
         "cpu" => Ok(CompositorBackend::Software),
         _ => {
-            // Auto: prefer GPU, fallback to CPU
-            if gst::ElementFactory::find("glvideomixerelement").is_some() {
+            // Auto: prefer GPU, but only if a real hardware GL renderer is available.
+            // Mesa software renderers (llvmpipe) are slower than the CPU compositor.
+            if gst::ElementFactory::find("glvideomixerelement").is_some() && gpu::has_hardware_gl()
+            {
                 info!("Vision mixer: using GPU (OpenGL) backend");
                 Ok(CompositorBackend::OpenGL)
             } else {
-                info!("Vision mixer: GPU unavailable, falling back to CPU backend");
+                info!("Vision mixer: no hardware GL, using CPU backend");
                 Ok(CompositorBackend::Software)
             }
         }

--- a/backend/src/gpu.rs
+++ b/backend/src/gpu.rs
@@ -85,6 +85,20 @@ pub fn gl_renderer_info() -> Option<GlRendererInfo> {
     GL_RENDERER_INFO.get().cloned().flatten()
 }
 
+/// Returns true if a hardware-accelerated GL renderer was detected at startup.
+/// Returns false if GL probe failed, hasn't run, or detected a software renderer
+/// (Mesa llvmpipe/softpipe/swrast). Used by compositor auto-selection to avoid
+/// choosing glvideomixerelement when it would run slower than CPU compositor.
+pub fn has_hardware_gl() -> bool {
+    match gl_renderer_info() {
+        Some(info) => {
+            let r = info.renderer.to_lowercase();
+            !r.contains("llvmpipe") && !r.contains("softpipe") && !r.contains("swrast")
+        }
+        None => false,
+    }
+}
+
 /// Probe the OpenGL renderer via GStreamer's GL context API.
 ///
 /// Creates a minimal in-process pipeline (`videotestsrc ! glupload ! appsink`),


### PR DESCRIPTION
## Summary
- Auto-selection for compositor backend checked only if `glvideomixerelement` existed in the GStreamer registry, but Mesa makes it always available via llvmpipe software rendering
- This caused auto mode to pick the GL path even without a real GPU, which is slower than the CPU `compositor` due to GL API overhead on software rendering
- Adds `gpu::has_hardware_gl()` that checks the GL renderer string probed at startup and rejects llvmpipe/softpipe/swrast — both vision mixer and compositor block now require a hardware GL renderer before choosing `glvideomixerelement`

## Test plan
- [ ] Verify on a system without GPU that auto mode selects CPU compositor
- [ ] Verify on a system with NVIDIA GPU that auto mode still selects GL compositor
- [ ] Verify that explicit `"gpu"` preference still forces GL even on Mesa (no behavior change for explicit selection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)