### PR TITLE
fix: frontend UI fixes and session handling

### DIFF
--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -99,7 +99,8 @@ pub async fn create_app_with_config(
     let session_store = MemoryStore::default();
     let session_layer = SessionManagerLayer::new(session_store)
         .with_expiry(Expiry::OnInactivity(Duration::hours(24)))
-        .with_secure(false);
+        .with_secure(false)
+        .with_always_save(true);
 
     // Build protected API router (requires authentication)
     let protected_api_router = Router::new()

--- a/frontend/src/api/mod.rs
+++ b/frontend/src/api/mod.rs
@@ -28,6 +28,13 @@ pub enum ApiError {
     Decode(String),
 }
 
+impl ApiError {
+    /// Returns true if this is a 401 Unauthorized error (session expired).
+    pub fn is_unauthorized(&self) -> bool {
+        matches!(self, ApiError::Http(401, _))
+    }
+}
+
 impl std::fmt::Display for ApiError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/frontend/src/app/data_loading.rs
+++ b/frontend/src/app/data_loading.rs
@@ -19,8 +19,12 @@ impl StromApp {
                     let _ = tx.send(AppMessage::ElementsLoaded(elements));
                 }
                 Err(e) => {
-                    tracing::error!("Failed to load elements: {}", e);
-                    let _ = tx.send(AppMessage::ElementsError(e.to_string()));
+                    if e.is_unauthorized() {
+                        let _ = tx.send(AppMessage::SessionExpired);
+                    } else {
+                        tracing::error!("Failed to load elements: {}", e);
+                        let _ = tx.send(AppMessage::ElementsError(e.to_string()));
+                    }
                 }
             }
             ctx.request_repaint();
@@ -43,8 +47,12 @@ impl StromApp {
                     let _ = tx.send(AppMessage::BlocksLoaded(blocks));
                 }
                 Err(e) => {
-                    tracing::error!("Failed to load blocks: {}", e);
-                    let _ = tx.send(AppMessage::BlocksError(e.to_string()));
+                    if e.is_unauthorized() {
+                        let _ = tx.send(AppMessage::SessionExpired);
+                    } else {
+                        tracing::error!("Failed to load blocks: {}", e);
+                        let _ = tx.send(AppMessage::BlocksError(e.to_string()));
+                    }
                 }
             }
             ctx.request_repaint();
@@ -235,13 +243,18 @@ impl StromApp {
                     let _ = tx.send(AppMessage::AuthStatusLoaded(status));
                 }
                 Err(e) => {
-                    tracing::warn!("Failed to check auth status: {}", e);
-                    // Assume auth is not required if check fails
-                    let _ = tx.send(AppMessage::AuthStatusLoaded(AuthStatusResponse {
-                        authenticated: true,
-                        auth_required: false,
-                        methods: vec![],
-                    }));
+                    if e.is_unauthorized() {
+                        tracing::warn!("Auth status check returned 401 - session expired");
+                        let _ = tx.send(AppMessage::SessionExpired);
+                    } else {
+                        tracing::warn!("Failed to check auth status: {}", e);
+                        // Assume auth is not required if check fails (network error, etc.)
+                        let _ = tx.send(AppMessage::AuthStatusLoaded(AuthStatusResponse {
+                            authenticated: true,
+                            auth_required: false,
+                            methods: vec![],
+                        }));
+                    }
                 }
             }
             ctx.request_repaint();

--- a/frontend/src/app/dialogs.rs
+++ b/frontend/src/app/dialogs.rs
@@ -389,9 +389,11 @@ impl StromApp {
         egui::Window::new(format!("{} {} - Properties", egui_phosphor::regular::GEAR, flow_name))
             .collapsible(false)
             .resizable(true)
+            .movable(true)
             .default_width(400.0)
             .default_height(500.0)
-            .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
+            .pivot(egui::Align2::CENTER_CENTER)
+            .default_pos(ui.ctx().content_rect().center())
             .show(ui.ctx(), |ui| {
                 egui::ScrollArea::vertical()
                     .max_height(ui.available_height() - 50.0) // Leave room for buttons

--- a/frontend/src/app/flow_ops.rs
+++ b/frontend/src/app/flow_ops.rs
@@ -26,8 +26,12 @@ impl StromApp {
                     let _ = tx.send(AppMessage::FlowsLoaded(flows));
                 }
                 Err(e) => {
-                    tracing::error!("Failed to load flows: {}", e);
-                    let _ = tx.send(AppMessage::FlowsError(e.to_string()));
+                    if e.is_unauthorized() {
+                        let _ = tx.send(AppMessage::SessionExpired);
+                    } else {
+                        tracing::error!("Failed to load flows: {}", e);
+                        let _ = tx.send(AppMessage::FlowsError(e.to_string()));
+                    }
                 }
             }
             ctx.request_repaint();

--- a/frontend/src/app/probe_ui.rs
+++ b/frontend/src/app/probe_ui.rs
@@ -24,6 +24,7 @@ impl StromApp {
             {
                 let api = self.api.clone();
                 let eid = element_id.to_string();
+                let tx = self.channels.sender();
                 let ctx = ui.ctx().clone();
                 crate::app::spawn_task(async move {
                     match api.activate_probe(&flow_id, &eid, Some(1), Some(300)).await {
@@ -32,6 +33,10 @@ impl StromApp {
                         }
                         Err(e) => {
                             tracing::error!("Failed to activate probe on {}: {}", eid, e);
+                            let _ = tx.send(crate::state::AppMessage::FlowOperationError(format!(
+                                "Probe failed: {}",
+                                e
+                            )));
                         }
                     }
                     ctx.request_repaint();

--- a/frontend/src/app/rendering.rs
+++ b/frontend/src/app/rendering.rs
@@ -1185,7 +1185,7 @@ impl StromApp {
             .max_size(max_width)
             .resizable(true)
             .show_inside(ui, |ui| {
-            egui::ScrollArea::both().show(ui, |ui| {
+            egui::ScrollArea::both().id_salt("palette_properties_scroll").show(ui, |ui| {
                 // Check if an element is selected and trigger property loading if needed
                 // Do this BEFORE getting mutable reference to avoid borrow checker issues
                 if let Some((selected_element_type, active_tab)) = self

--- a/frontend/src/app/update.rs
+++ b/frontend/src/app/update.rs
@@ -30,6 +30,9 @@ impl eframe::App for StromApp {
             }
         }
 
+        // Apply deferred graph selection (avoids egui two-pass ID instability)
+        self.graph.apply_pending_selection();
+
         // Handle pending flow selection (deferred from previous frame to avoid accesskit panic)
         // This MUST happen before any UI is drawn to prevent "Focused ID not in node list" errors
         if let Some(flow_id) = self.pending_flow_selection.take() {
@@ -985,6 +988,28 @@ impl eframe::App for StromApp {
                     if !status.auth_required || status.authenticated {
                         self.setup_websocket_connection(ui.ctx().clone());
                         self.load_version(ui.ctx().clone());
+                    }
+                }
+                AppMessage::SessionExpired => {
+                    tracing::warn!("Session expired (401), triggering re-authentication");
+
+                    // Reload the page so the HTML login form can re-initialize
+                    #[cfg(target_arch = "wasm32")]
+                    {
+                        if let Some(window) = web_sys::window() {
+                            if let Err(e) = window.location().reload() {
+                                tracing::error!("Failed to reload page: {:?}", e);
+                            }
+                        }
+                    }
+
+                    // For native mode, reset state and recheck auth
+                    #[cfg(not(target_arch = "wasm32"))]
+                    {
+                        self.flows.clear();
+                        self.ws_client = None;
+                        self.connection_state = ConnectionState::Disconnected;
+                        self.check_auth_status(ui.ctx().clone());
                     }
                 }
                 AppMessage::LogoutComplete => {

--- a/frontend/src/graph/mod.rs
+++ b/frontend/src/graph/mod.rs
@@ -74,6 +74,15 @@ pub struct GraphEditor {
     runtime_dynamic_pads: HashMap<String, HashMap<String, String>>,
     /// Currently selected element ID
     pub selected: Option<ElementId>,
+    /// Deferred selection to apply at start of next frame (avoids egui two-pass ID instability).
+    /// Outer Option: None = no pending change. Inner Option: the new selection value.
+    pending_selected: Option<Option<ElementId>>,
+    /// Deferred link selection to apply at start of next frame.
+    pending_selected_link: Option<Option<usize>>,
+    /// Deferred property tab to apply at start of next frame.
+    pending_property_tab: Option<PropertyTab>,
+    /// Deferred focused pad to apply at start of next frame.
+    pending_focused_pad: Option<Option<String>>,
     /// Element being dragged
     dragging: Option<ElementId>,
     /// Offset for panning the canvas
@@ -163,6 +172,10 @@ impl Default for GraphEditor {
             block_content_map: HashMap::new(),
             runtime_dynamic_pads: HashMap::new(),
             selected: None,
+            pending_selected: None,
+            pending_selected_link: None,
+            pending_property_tab: None,
+            pending_focused_pad: None,
             dragging: None,
             pan_offset: Vec2::ZERO,
             zoom: DEFAULT_ZOOM,
@@ -188,6 +201,23 @@ impl GraphEditor {
     /// Create a new graph editor.
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Apply any deferred selection changes. Call at the start of each frame,
+    /// before any rendering, to keep selection state stable across egui's two passes.
+    pub fn apply_pending_selection(&mut self) {
+        if let Some(sel) = self.pending_selected.take() {
+            self.selected = sel;
+        }
+        if let Some(link) = self.pending_selected_link.take() {
+            self.selected_link = link;
+        }
+        if let Some(tab) = self.pending_property_tab.take() {
+            self.active_property_tab = tab;
+        }
+        if let Some(pad) = self.pending_focused_pad.take() {
+            self.focused_pad = pad;
+        }
     }
 
     /// Set the QoS health map for rendering indicators on nodes

--- a/frontend/src/graph/rendering.rs
+++ b/frontend/src/graph/rendering.rs
@@ -325,11 +325,12 @@ impl GraphEditor {
                 }
 
                 // Handle node selection - select on click OR when starting to drag
+                // Use deferred selection to avoid egui two-pass ID instability
                 if node_response.clicked() || (node_response.dragged() && self.dragging.is_none()) {
-                    self.selected = Some(element.id.clone());
-                    self.selected_link = None; // Deselect any link
-                    self.active_property_tab = PropertyTab::Element; // Switch to Element Properties tab
-                    self.focused_pad = None; // Clear pad focus
+                    self.pending_selected = Some(Some(element.id.clone()));
+                    self.pending_selected_link = Some(None);
+                    self.pending_property_tab = Some(PropertyTab::Element);
+                    self.pending_focused_pad = Some(None);
                 }
 
                 // Handle node dragging
@@ -447,10 +448,10 @@ impl GraphEditor {
                 };
 
                 if should_select {
-                    self.selected = Some(block.id.clone());
-                    self.selected_link = None;
-                    self.active_property_tab = PropertyTab::Element; // Switch to Element Properties tab
-                    self.focused_pad = None; // Clear pad focus
+                    self.pending_selected = Some(Some(block.id.clone()));
+                    self.pending_selected_link = Some(None);
+                    self.pending_property_tab = Some(PropertyTab::Element);
+                    self.pending_focused_pad = Some(None);
                 }
 
                 // Handle double-click to open compositor editor for compositor blocks
@@ -560,8 +561,8 @@ impl GraphEditor {
                     // Already deselected and not a double-click — signal to toggle right pane
                     self.request_toggle_right_pane.set(true);
                 }
-                self.selected = None;
-                self.selected_link = None;
+                self.pending_selected = Some(None);
+                self.pending_selected_link = Some(None);
             }
 
             // Ctrl+double-click on background: zoom to fit
@@ -652,8 +653,8 @@ impl GraphEditor {
 
             // Handle link selection on click
             if response.clicked() && self.hovered_link.is_some() {
-                self.selected_link = self.hovered_link;
-                self.selected = None; // Deselect any element
+                self.pending_selected_link = Some(self.hovered_link);
+                self.pending_selected = Some(None);
             }
 
             // Draw link being created (on top of everything)

--- a/frontend/src/properties.rs
+++ b/frontend/src/properties.rs
@@ -181,14 +181,13 @@ impl PropertyInspector {
         input_pads: Vec<String>,
         output_pads: Vec<String>,
     ) -> (PropertyTab, bool) {
-        let element_id = element.id.clone();
         let mut new_tab = active_tab;
         let delete_requested = false;
 
-        ui.push_id(&element_id, |ui| {
+        ui.push_id("selected_inspector", |ui| {
             // Outer scroll area for entire inspector
             ScrollArea::both()
-                .id_salt("property_inspector_outer_scroll")
+                .id_salt("inspector_scroll")
                 .auto_shrink([false, false])
                 .show(ui, |ui| {
                     // Element info in collapsible section
@@ -465,10 +464,10 @@ impl PropertyInspector {
         let block_id = block.id.clone();
         let mut result = BlockInspectorResult::default();
 
-        ui.push_id(&block_id, |ui| {
+        ui.push_id("selected_inspector", |ui| {
             // Outer scroll area for entire block inspector
             ScrollArea::both()
-                .id_salt("block_inspector_outer_scroll")
+                .id_salt("inspector_scroll")
                 .auto_shrink([false, false])
                 .show(ui, |ui| {
             // Block info in collapsible section

--- a/frontend/src/state.rs
+++ b/frontend/src/state.rs
@@ -51,6 +51,8 @@ pub enum AppMessage {
     AuthStatusLoaded(crate::api::AuthStatusResponse),
     /// Logout completed
     LogoutComplete,
+    /// Session expired (received 401 from API)
+    SessionExpired,
 
     /// WebRTC stats loaded for a flow
     WebRtcStatsLoaded {


### PR DESCRIPTION
## Summary
- **Session expiry handling**: Refresh session cookie on every request (`always_save`), detect 401 responses and trigger re-authentication (WASM reloads page, native resets state)
- **Movable flow properties window**: Replace fixed `anchor` with `pivot` + `default_pos` so the window can be repositioned
- **Deferred graph selection**: Avoid egui two-pass ID instability by applying selection changes at the start of each frame via `pending_*` fields
- **Probe error visibility**: Surface probe activation errors in the UI instead of silent log
- **Stable property inspector IDs**: Use fixed `push_id("selected_inspector")` instead of element-dependent IDs

## Test plan
- [ ] Open a flow and click elements/blocks/links — selection should work without flicker or panics
- [ ] Open flow properties window and drag it around
- [ ] Let the session expire (or simulate 401) — should show login form
- [ ] Activate a probe on a stopped flow — error should appear in UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)