### PR TITLE
fix: add peer address to connection logs and fix audiogain f32 type

### DIFF
--- a/backend/src/api/websocket.rs
+++ b/backend/src/api/websocket.rs
@@ -1,14 +1,15 @@
 //! WebSocket endpoint for real-time bidirectional updates.
 
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
-use axum::extract::State;
+use axum::extract::{ConnectInfo, State};
 use axum::response::Response;
 use futures::{sink::SinkExt, stream::StreamExt};
+use std::net::SocketAddr;
 use std::time::Duration;
 use strom_types::StromEvent;
 use tokio::select;
 use tokio::time::interval;
-use tracing::{debug, error, info, trace};
+use tracing::{debug, error, info, trace, Instrument};
 
 use crate::state::AppState;
 
@@ -38,16 +39,26 @@ use crate::state::AppState;
         (status = 401, description = "Authentication required (use auth_token query param)")
     )
 )]
-pub async fn websocket_handler(ws: WebSocketUpgrade, State(state): State<AppState>) -> Response {
+pub async fn websocket_handler(
+    ws: WebSocketUpgrade,
+    State(state): State<AppState>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+) -> Response {
     info!(
-        "New WebSocket client connecting (total subscribers: {})",
+        peer = %peer,
+        "WebSocket client connecting (total subscribers: {})",
         state.events().subscriber_count() + 1
     );
-    ws.on_upgrade(move |socket| handle_socket(socket, state))
+    ws.on_upgrade(move |socket| handle_socket(socket, state, peer))
 }
 
 /// Handle an individual WebSocket connection.
-async fn handle_socket(socket: WebSocket, state: AppState) {
+async fn handle_socket(socket: WebSocket, state: AppState, peer: SocketAddr) {
+    let span = tracing::info_span!("ws", %peer);
+    handle_socket_inner(socket, state).instrument(span).await;
+}
+
+async fn handle_socket_inner(socket: WebSocket, state: AppState) {
     let (mut sender, mut receiver) = socket.split();
 
     // Subscribe to the event broadcaster

--- a/backend/src/blocks/builtin/audiogain.rs
+++ b/backend/src/blocks/builtin/audiogain.rs
@@ -95,7 +95,7 @@ impl BlockBuilder for AudioGainBuilder {
                 _ => None,
             })
             .unwrap_or(false);
-        let amplification: f64 = if inverted { -1.0 } else { 1.0 };
+        let amplification: f32 = if inverted { -1.0 } else { 1.0 };
 
         info!(
             "AudioGain properties: gain_db={}, gain_linear={}, mute={}, inverted={}",

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! This module exposes the application builder for use in tests.
 
-use axum::extract::DefaultBodyLimit;
+use axum::extract::{ConnectInfo, DefaultBodyLimit};
 use axum::http::HeaderValue;
 use axum::http::{header, HeaderName, Method};
 use axum::{
@@ -10,8 +10,10 @@ use axum::{
     routing::{delete, get, patch, post, put},
     Extension, Router,
 };
+use std::net::SocketAddr;
 use std::sync::Arc;
 use tower_http::cors::{Any, CorsLayer};
+use tower_http::trace::TraceLayer;
 use tower_sessions::{cookie::time::Duration, Expiry, MemoryStore, SessionManagerLayer};
 use utoipa_swagger_ui::SwaggerUi;
 
@@ -472,6 +474,20 @@ pub async fn create_app_with_config(
                 cors.allow_origin(origins).allow_credentials(true)
             }
         })
+        .layer(
+            TraceLayer::new_for_http().make_span_with(|req: &axum::http::Request<_>| {
+                let peer = req
+                    .extensions()
+                    .get::<ConnectInfo<SocketAddr>>()
+                    .map(|ci| ci.0);
+                tracing::info_span!(
+                    "http",
+                    method = %req.method(),
+                    path = %req.uri().path(),
+                    peer = %peer.map_or_else(|| "unknown".to_string(), |a| a.to_string()),
+                )
+            }),
+        )
         .with_state(state)
         // Serve embedded frontend for all other routes
         .fallback(assets::serve_static)

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -650,13 +650,13 @@ async fn serve_with_tls(
         info!("Server listening on https://{}", addr);
         axum_server::bind_rustls(addr, tls_config)
             .handle(handle)
-            .serve(app.into_make_service())
+            .serve(app.into_make_service_with_connect_info::<SocketAddr>())
             .await?;
     } else {
         info!("Server listening on http://{}", addr);
         axum_server::bind(addr)
             .handle(handle)
-            .serve(app.into_make_service())
+            .serve(app.into_make_service_with_connect_info::<SocketAddr>())
             .await?;
     }
     Ok(())


### PR DESCRIPTION
## Summary
- **HTTP request logging**: Add `TraceLayer` with `ConnectInfo<SocketAddr>` so all REST API requests log `method`, `path`, and `peer` address automatically
- **WebSocket peer logging**: Add `ConnectInfo` extractor and tracing span per connection — all WS log lines include `peer=ip:port`
- **AudioGain panic fix**: `audioamplify` element expects `gfloat` (f32) for the `amplification` property but was given `f64`, causing a panic on block creation

## Test plan
- [ ] Start server and verify HTTP requests show peer address in logs
- [ ] Connect WebSocket client and verify connect/disconnect logs show peer
- [ ] Create an AudioGain block and verify it no longer panics

🤖 Generated with [Claude Code](https://claude.com/claude-code)