### PR TITLE
ci: add manual workflow to trigger OSC fork sync

### DIFF
--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -1,0 +1,29 @@
+name: Sync OSC Fork
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Target environment"
+        required: true
+        default: "prod"
+        type: choice
+        options:
+          - prod
+          - dev
+          - stage
+
+jobs:
+  sync-fork:
+    name: Sync fork (${{ inputs.environment }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Install OSC CLI
+        run: npm install -g @osaas/cli
+
+      - name: Trigger sync fork
+        env:
+          OSC_ACCESS_TOKEN: unused
+          OSC_API_KEY: ${{ secrets.OSC_API_KEY }}
+        run: osc --env ${{ inputs.environment }} admin sync-fork eyevinn-strom


### PR DESCRIPTION
## Summary
- Adds a `workflow_dispatch` GitHub Action that triggers an OSC fork sync via `osc admin sync-fork eyevinn-strom`
- Supports targeting dev, stage, or prod environments
- Requires `OSC_API_KEY` secret to be set in repo settings

## Setup
Add `OSC_API_KEY` as a repository secret with the platform API key for the target environment.

🤖 Generated with [Claude Code](https://claude.ai/code)