### PR TITLE
fix: change vision mixer num_inputs from enum to uint

### DIFF
--- a/backend/src/blocks/builtin/vision_mixer/definition.rs
+++ b/backend/src/blocks/builtin/vision_mixer/definition.rs
@@ -50,31 +50,8 @@ fn vision_mixer_definition() -> BlockDefinition {
             name: "num_inputs".to_string(),
             label: "Number of Inputs".to_string(),
             description: "Number of video inputs (2-10)".to_string(),
-            property_type: PropertyType::Enum {
-                values: vec![
-                    EnumValue {
-                        value: "2".to_string(),
-                        label: Some("2".to_string()),
-                    },
-                    EnumValue {
-                        value: "4".to_string(),
-                        label: Some("4".to_string()),
-                    },
-                    EnumValue {
-                        value: "6".to_string(),
-                        label: Some("6".to_string()),
-                    },
-                    EnumValue {
-                        value: "8".to_string(),
-                        label: Some("8".to_string()),
-                    },
-                    EnumValue {
-                        value: "10".to_string(),
-                        label: Some("10".to_string()),
-                    },
-                ],
-            },
-            default_value: Some(PropertyValue::String(DEFAULT_NUM_INPUTS.to_string())),
+            property_type: PropertyType::UInt,
+            default_value: Some(PropertyValue::UInt(DEFAULT_NUM_INPUTS as u64)),
             mapping: PropertyMapping {
                 element_id: "_block".to_string(),
                 property_name: "num_inputs".to_string(),


### PR DESCRIPTION
## Summary
- Changed vision mixer `num_inputs` property from `Enum` (restricted to 2,4,6,8,10) to `UInt` allowing any value 2-10
- Backend already clamps to valid range and layout code handles arbitrary input counts
- Removes artificial even-number restriction from the UI

## Test plan
- [ ] Create a vision mixer block with odd input counts (3, 5, 7, 9) and verify pipeline builds correctly
- [ ] Verify multiview layout renders correctly with odd input counts
- [ ] Verify existing even input counts still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)