### PR TITLE
fix: unique session cookie name per port

### DIFF
--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -67,17 +67,20 @@ pub async fn create_app_with_state_and_auth(
     state: AppState,
     auth_config: auth::AuthConfig,
 ) -> Router {
-    create_app_with_config(state, auth_config, Vec::new()).await
+    create_app_with_config(state, auth_config, Vec::new(), 0).await
 }
 
 /// Create the Axum application router with a given state, auth configuration, and CORS origins.
 ///
 /// If `cors_allowed_origins` is empty, any origin is allowed.
 /// Otherwise, only the specified origins are allowed.
+/// The `port` is embedded in the session cookie name (`strom_session_{port}`) so that
+/// multiple instances on the same host with different ports do not overwrite each other's cookies.
 pub async fn create_app_with_config(
     state: AppState,
     auth_config: auth::AuthConfig,
     cors_allowed_origins: Vec<String>,
+    port: u16,
 ) -> Router {
     // Note: GStreamer is already initialized in main.rs before this is called.
     // DO NOT call gst::init() here - it can corrupt internal state if pipelines
@@ -98,8 +101,10 @@ pub async fn create_app_with_config(
     }
 
     // Create session store (in-memory, sessions lost on restart)
+    // Cookie name includes the port so multiple instances on the same host don't collide
     let session_store = MemoryStore::default();
     let session_layer = SessionManagerLayer::new(session_store)
+        .with_name(format!("strom_session_{}", port))
         .with_expiry(Expiry::OnInactivity(Duration::hours(24)))
         .with_secure(false)
         .with_always_save(true);

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -443,6 +443,7 @@ fn run_with_gui(config: Config, no_auto_restart: bool) -> anyhow::Result<()> {
             state.clone(),
             auth_config,
             config.cors_allowed_origins.clone(),
+            config.port,
         )
         .await;
 
@@ -581,6 +582,7 @@ async fn run_headless(config: Config, no_auto_restart: bool) -> anyhow::Result<(
         state.clone(),
         auth::AuthConfig::from_env(),
         config.cors_allowed_origins.clone(),
+        config.port,
     )
     .await;
 


### PR DESCRIPTION
## Summary
- Session cookie name now includes the port (`strom_session_{port}`) so multiple Strom instances on the same host with different ports don't overwrite each other's login sessions
- Previously all instances used the default `tower_sessions` cookie name, causing login on one instance to invalidate the session on another

## Test plan
- [ ] Run two instances on different ports, log in to both, verify sessions are independent
- [ ] Verify single-instance login still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)