### PR TITLE
fix: align static external_pads with computed defaults

### DIFF
--- a/backend/src/blocks/builder.rs
+++ b/backend/src/blocks/builder.rs
@@ -60,9 +60,9 @@ pub enum WhepStreamMode {
     /// Audio only
     Audio,
     /// Video only
-    #[default]
     Video,
     /// Both audio and video
+    #[default]
     AudioVideo,
 }
 

--- a/backend/src/blocks/builder.rs
+++ b/backend/src/blocks/builder.rs
@@ -60,9 +60,9 @@ pub enum WhepStreamMode {
     /// Audio only
     Audio,
     /// Video only
+    #[default]
     Video,
     /// Both audio and video
-    #[default]
     AudioVideo,
 }
 

--- a/backend/src/blocks/builtin/mpegtssrt.rs
+++ b/backend/src/blocks/builtin/mpegtssrt.rs
@@ -945,6 +945,13 @@ fn mpegtssrt_output_definition() -> BlockDefinition {
                     internal_element_id: "video_input".to_string(),
                     internal_pad_name: "sink".to_string(),
                 },
+                ExternalPad {
+                    label: Some("A0".to_string()),
+                    name: "audio_in_0".to_string(),
+                    media_type: MediaType::Audio,
+                    internal_element_id: "audio_input_0".to_string(),
+                    internal_pad_name: "sink".to_string(),
+                },
             ],
             outputs: vec![],
         },

--- a/backend/src/blocks/builtin/mpegtssrt_input.rs
+++ b/backend/src/blocks/builtin/mpegtssrt_input.rs
@@ -597,13 +597,22 @@ fn mpegtssrt_input_definition() -> BlockDefinition {
         ],
         external_pads: ExternalPads {
             inputs: vec![],
-            outputs: vec![ExternalPad {
-                label: Some("V0".to_string()),
-                name: "video_out".to_string(),
-                media_type: MediaType::Video,
-                internal_element_id: "video_output".to_string(),
-                internal_pad_name: "src".to_string(),
-            }],
+            outputs: vec![
+                ExternalPad {
+                    label: Some("V0".to_string()),
+                    name: "video_out".to_string(),
+                    media_type: MediaType::Video,
+                    internal_element_id: "video_output".to_string(),
+                    internal_pad_name: "src".to_string(),
+                },
+                ExternalPad {
+                    label: Some("A0".to_string()),
+                    name: "audio_out_0".to_string(),
+                    media_type: MediaType::Audio,
+                    internal_element_id: "audio_output_0".to_string(),
+                    internal_pad_name: "src".to_string(),
+                },
+            ],
         },
         built_in: true,
         ui_metadata: Some(BlockUIMetadata {

--- a/backend/src/blocks/builtin/vision_mixer/definition.rs
+++ b/backend/src/blocks/builtin/vision_mixer/definition.rs
@@ -292,30 +292,17 @@ fn vision_mixer_definition() -> BlockDefinition {
         category: "Production".to_string(),
         exposed_properties,
         external_pads: ExternalPads {
-            inputs: {
-                let mut pads: Vec<ExternalPad> = (0..MAX_NUM_INPUTS)
-                    .map(|i| {
-                        ExternalPad::with_label(
-                            format!("video_in_{}", i),
-                            format!("V{}", i),
-                            MediaType::Video,
-                            format!("queue_{}", i),
-                            "sink".to_string(),
-                        )
-                    })
-                    .collect();
-                // DSK input pads
-                for i in 0..MAX_DSK_INPUTS {
-                    pads.push(ExternalPad::with_label(
-                        format!("dsk_in_{}", i),
-                        format!("DSK{}", i + 1),
+            inputs: (0..DEFAULT_NUM_INPUTS)
+                .map(|i| {
+                    ExternalPad::with_label(
+                        format!("video_in_{}", i),
+                        format!("V{}", i),
                         MediaType::Video,
-                        format!("queue_dsk_{}", i),
+                        format!("queue_{}", i),
                         "sink".to_string(),
-                    ));
-                }
-                pads
-            },
+                    )
+                })
+                .collect(),
             outputs: vec![
                 ExternalPad::with_label(
                     "pgm_out",

--- a/backend/src/blocks/builtin/whep.rs
+++ b/backend/src/blocks/builtin/whep.rs
@@ -2009,22 +2009,15 @@ fn whep_output_definition() -> BlockDefinition {
                 live: false,
             },
         ],
-        // Note: external_pads here are the static defaults for audio_video mode.
+        // Note: external_pads here are the static defaults for video-only mode (the default).
         // The actual pads are determined dynamically by WHEPOutputBuilder::get_external_pads() based on mode.
         external_pads: ExternalPads {
             inputs: vec![
                 ExternalPad {
-                    label: Some("V0".to_string()),
+                    label: None,
                     name: "video_in".to_string(),
                     media_type: MediaType::Video,
                     internal_element_id: "video_queue".to_string(),
-                    internal_pad_name: "sink".to_string(),
-                },
-                ExternalPad {
-                    label: Some("A0".to_string()),
-                    name: "audio_in".to_string(),
-                    media_type: MediaType::Audio,
-                    internal_element_id: "audio_queue".to_string(),
                     internal_pad_name: "sink".to_string(),
                 },
             ],

--- a/backend/src/blocks/builtin/whep.rs
+++ b/backend/src/blocks/builtin/whep.rs
@@ -1987,7 +1987,7 @@ fn whep_output_definition() -> BlockDefinition {
                         },
                     ],
                 },
-                default_value: Some(PropertyValue::String("audio_video".to_string())),
+                default_value: Some(PropertyValue::String("video".to_string())),
                 mapping: PropertyMapping {
                     element_id: "_block".to_string(),
                     property_name: "mode".to_string(),
@@ -2009,22 +2009,15 @@ fn whep_output_definition() -> BlockDefinition {
                 live: false,
             },
         ],
-        // Note: external_pads here are the static defaults for audio_video mode (the default).
+        // Note: external_pads here are the static defaults for video-only mode (the default).
         // The actual pads are determined dynamically by WHEPOutputBuilder::get_external_pads() based on mode.
         external_pads: ExternalPads {
             inputs: vec![
                 ExternalPad {
-                    label: Some("V0".to_string()),
+                    label: None,
                     name: "video_in".to_string(),
                     media_type: MediaType::Video,
                     internal_element_id: "video_queue".to_string(),
-                    internal_pad_name: "sink".to_string(),
-                },
-                ExternalPad {
-                    label: Some("A0".to_string()),
-                    name: "audio_in".to_string(),
-                    media_type: MediaType::Audio,
-                    internal_element_id: "audio_queue".to_string(),
                     internal_pad_name: "sink".to_string(),
                 },
             ],

--- a/backend/src/blocks/builtin/whep.rs
+++ b/backend/src/blocks/builtin/whep.rs
@@ -1987,7 +1987,7 @@ fn whep_output_definition() -> BlockDefinition {
                         },
                     ],
                 },
-                default_value: Some(PropertyValue::String("video".to_string())),
+                default_value: Some(PropertyValue::String("audio_video".to_string())),
                 mapping: PropertyMapping {
                     element_id: "_block".to_string(),
                     property_name: "mode".to_string(),
@@ -2009,15 +2009,22 @@ fn whep_output_definition() -> BlockDefinition {
                 live: false,
             },
         ],
-        // Note: external_pads here are the static defaults for video-only mode (the default).
+        // Note: external_pads here are the static defaults for audio_video mode (the default).
         // The actual pads are determined dynamically by WHEPOutputBuilder::get_external_pads() based on mode.
         external_pads: ExternalPads {
             inputs: vec![
                 ExternalPad {
-                    label: None,
+                    label: Some("V0".to_string()),
                     name: "video_in".to_string(),
                     media_type: MediaType::Video,
                     internal_element_id: "video_queue".to_string(),
+                    internal_pad_name: "sink".to_string(),
+                },
+                ExternalPad {
+                    label: Some("A0".to_string()),
+                    name: "audio_in".to_string(),
+                    media_type: MediaType::Audio,
+                    internal_element_id: "audio_queue".to_string(),
                     internal_pad_name: "sink".to_string(),
                 },
             ],


### PR DESCRIPTION
## Summary
- **MPEG-TS/SRT Input**: static pads showed only video, but default config includes 1 audio track — audio port appeared after save
- **MPEG-TS/SRT Output**: same issue, audio input port appeared after save
- **WHEP Output**: static pads showed audio+video, but default mode is video-only — audio port disappeared after save
- **Vision Mixer**: static pads showed MAX inputs (10 video + 4 DSK), but defaults are 4 video + 0 DSK — ports collapsed after save

Static `external_pads` in each block definition now match what `get_external_pads()` produces with default property values, so blocks look correct immediately when dragged into the editor.

## Test plan
- [ ] Drag each of the 4 blocks into the editor, verify ports match expectations
- [ ] Save the flow, verify no ports appear or disappear
- [ ] Change properties (e.g. add audio tracks), save, verify ports update correctly
- [ ] `cargo test --test openapi_test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)