### PR TITLE
feat: add debug logging for flow API request bodies

### DIFF
--- a/backend/src/api/flows.rs
+++ b/backend/src/api/flows.rs
@@ -306,6 +306,7 @@ pub async fn create_flow(
     }
 
     info!("Received create flow request: name='{}'", flow.name);
+    debug!("Create flow request body: {:?}", flow);
 
     // Assign a new ID to avoid collisions with imported flows
     flow.id = FlowId::new_v4();
@@ -375,6 +376,7 @@ pub async fn update_flow(
     ))?;
 
     info!("Updating flow: {} ({})", flow.name, flow.id);
+    debug!("Update flow request body: {:?}", flow);
 
     prepare_flow(&mut flow);
 
@@ -1143,6 +1145,7 @@ pub async fn update_flow_properties(
     JsonBody(req): JsonBody<UpdateFlowPropertiesRequest>,
 ) -> Result<Json<FlowResponse>, (StatusCode, Json<ErrorResponse>)> {
     info!("Updating properties for flow {}", id);
+    debug!("Update flow properties request body: {:?}", req);
 
     // Get the flow
     let mut flow = state.get_flow(&id).await.ok_or_else(|| {


### PR DESCRIPTION
## Summary
- Adds `debug!` logging of the full request body for `create_flow`, `update_flow`, and `update_flow_properties` endpoints
- Silent at the default info level — enable with e.g. `RUST_LOG=info,strom::api=debug`

## Test plan
- [ ] Start server with `RUST_LOG=info,strom::api=debug`
- [ ] Create a flow, verify full request body appears in log at DEBUG level
- [ ] Save/update a flow, verify full request body appears in log at DEBUG level
- [ ] Start server without the flag, verify no debug output

🤖 Generated with [Claude Code](https://claude.com/claude-code)