### PR TITLE
fix: eliminate overlay lag in vision mixer multiview

### DIFF
--- a/backend/src/blocks/builtin/vision_mixer/builder.rs
+++ b/backend/src/blocks/builtin/vision_mixer/builder.rs
@@ -386,7 +386,7 @@ fn build_gpu_pipeline(
         .format(gst::Format::Time)
         .is_live(true)
         .automatic_eos(false)
-        .do_timestamp(true)
+        .do_timestamp(false)
         .max_buffers(2)
         .leaky_type(gst_app::AppLeakyType::Upstream)
         .build();
@@ -698,7 +698,7 @@ fn build_cpu_pipeline(
         .format(gst::Format::Time)
         .is_live(true)
         .automatic_eos(false)
-        .do_timestamp(true)
+        .do_timestamp(false)
         .max_buffers(2)
         .leaky_type(gst_app::AppLeakyType::Upstream)
         .build();

--- a/backend/src/blocks/builtin/vision_mixer/overlay.rs
+++ b/backend/src/blocks/builtin/vision_mixer/overlay.rs
@@ -464,6 +464,15 @@ impl OverlayRenderer {
 
             let t_copy = t0.elapsed();
 
+            // Set PTS=0 so the compositor renders the overlay immediately
+            // instead of waiting for the pipeline latency to elapse.
+            // The overlay is a static frame (borders/labels) that should
+            // reflect state changes instantly, not be synced to video time.
+            {
+                let buf_ref = buffer.get_mut()?;
+                buf_ref.set_pts(gst::ClockTime::ZERO);
+            }
+
             let sample = gst::Sample::builder()
                 .buffer(&buffer)
                 .caps(&self.caps)


### PR DESCRIPTION
## Summary
- The overlay appsrc used `do_timestamp(true)`, stamping buffers with the current pipeline running time
- The multiview compositor syncs all pads, so it held the overlay buffer until video caught up — delaying it by the full pipeline latency (~1s)
- PGM/PVW switches appeared instant in video but the border/label overlay lagged behind
- Fix: disable auto-timestamping and set PTS=0 on every overlay buffer so the compositor renders it immediately

## Test plan
- [ ] Start a vision mixer flow with latency > 0
- [ ] Switch PGM/PVW and verify overlay borders update instantly (no ~1s lag)
- [ ] Verify overlay clock still ticks correctly
- [ ] Verify overlay alpha toggle still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)