### PR TITLE
fix: add buffer limits to appsrc elements

### DIFF
--- a/backend/src/blocks/builtin/mediaplayer/builder.rs
+++ b/backend/src/blocks/builtin/mediaplayer/builder.rs
@@ -5,6 +5,7 @@ use super::normalize_uri;
 use super::state::{MediaPlayerKey, MediaPlayerState, MEDIA_PLAYER_REGISTRY};
 use crate::blocks::{
     BlockBuildContext, BlockBuildError, BlockBuildResult, BlockBuilder, BusMessageConnectFn,
+    APPSRC_MAX_BYTES_AUDIO, APPSRC_MAX_BYTES_VIDEO, APPSRC_MAX_TIME,
 };
 use crate::events::EventBroadcaster;
 use gstreamer as gst;
@@ -149,6 +150,9 @@ fn build_media_player(
         .format(gst::Format::Time)
         .is_live(true)
         .automatic_eos(false)
+        .max_bytes(APPSRC_MAX_BYTES_VIDEO)
+        .max_time(APPSRC_MAX_TIME)
+        .leaky_type(gst_app::AppLeakyType::Upstream)
         .build();
 
     let appsrc_audio = gst_app::AppSrc::builder()
@@ -156,6 +160,9 @@ fn build_media_player(
         .format(gst::Format::Time)
         .is_live(true)
         .automatic_eos(false)
+        .max_bytes(APPSRC_MAX_BYTES_AUDIO)
+        .max_time(APPSRC_MAX_TIME)
+        .leaky_type(gst_app::AppLeakyType::Upstream)
         .build();
 
     let video_out = gst::ElementFactory::make("identity")

--- a/backend/src/blocks/builtin/whip.rs
+++ b/backend/src/blocks/builtin/whip.rs
@@ -12,6 +12,7 @@
 
 use crate::blocks::{
     BlockBuildContext, BlockBuildError, BlockBuildResult, BlockBuilder, WhepStreamMode,
+    APPSRC_MAX_BYTES_AUDIO, APPSRC_MAX_BYTES_VIDEO, APPSRC_MAX_TIME,
 };
 use crate::whip_session_manager::{SessionCleanupRequest, WhipEndpointConfig};
 use gstreamer as gst;
@@ -225,6 +226,8 @@ fn build_whipserversrc(
                 .format(gst::Format::Time)
                 .is_live(true)
                 .handle_segment_change(true)
+                .max_bytes(APPSRC_MAX_BYTES_AUDIO)
+                .max_time(APPSRC_MAX_TIME)
                 .leaky_type(gst_app::AppLeakyType::Downstream)
                 .automatic_eos(false)
                 .build();
@@ -326,6 +329,8 @@ fn build_whipserversrc(
                 .format(gst::Format::Time)
                 .is_live(true)
                 .handle_segment_change(true)
+                .max_bytes(APPSRC_MAX_BYTES_VIDEO)
+                .max_time(APPSRC_MAX_TIME)
                 .leaky_type(gst_app::AppLeakyType::Downstream)
                 .automatic_eos(false)
                 .build();

--- a/backend/src/blocks/mod.rs
+++ b/backend/src/blocks/mod.rs
@@ -11,3 +11,12 @@ pub use builder::{
     DynamicWebrtcbinStore, ElementSetupFn, WhepEndpointInfo, WhepStreamMode, WhipEndpointInfo,
 };
 pub use registry::BlockRegistry;
+
+use gstreamer as gst;
+
+/// Maximum bytes allowed in a video appsrc queue before dropping old buffers.
+pub const APPSRC_MAX_BYTES_VIDEO: u64 = 20 * 1024 * 1024;
+/// Maximum bytes allowed in an audio appsrc queue before dropping old buffers.
+pub const APPSRC_MAX_BYTES_AUDIO: u64 = 2 * 1024 * 1024;
+/// Maximum time buffered in an appsrc queue before dropping old buffers.
+pub const APPSRC_MAX_TIME: gst::ClockTime = gst::ClockTime::from_seconds(10);


### PR DESCRIPTION
## Summary
- Adds `max_bytes`, `max_time`, and `leaky_type` to media player and WHIP appsrc elements to prevent unbounded memory growth when downstream is not consuming
- Shared constants in `blocks/mod.rs`: video 20 MB, audio 2 MB, time 10 s
- Observed 55 MB / 285 seconds accumulated in a single media player appsrc when downstream was unlinked

## Test plan
- [ ] Start a media player flow with no downstream link, verify appsrc levels stay within limits
- [ ] Normal media player playback still works without drops
- [ ] WHIP ingest sessions still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)