### PR TITLE
fix: filter vision mixer control UI events by both flow_id and block_id

### DIFF
--- a/backend/src/api/vision_mixer_page.rs
+++ b/backend/src/api/vision_mixer_page.rs
@@ -58,26 +58,50 @@ pub fn find_whep_endpoint_for_pad(flow: &Flow, block_id: &str, pad_name: &str) -
 
 const VISION_MIXER_HTML: &str = include_str!("../../static/vision-mixer.html");
 
-/// Serve the vision mixer control page.
+/// Serve the vision mixer control page (first vision mixer in the flow).
 /// GET /player/vision-mixer/{flow_id}
 pub async fn vision_mixer_page(
     State(state): State<AppState>,
     Path(flow_id): Path<FlowId>,
 ) -> Html<String> {
+    render_vision_mixer_page(&state, &flow_id, None).await
+}
+
+/// Serve the vision mixer control page for a specific block.
+/// GET /player/vision-mixer/{flow_id}/{block_id}
+pub async fn vision_mixer_page_for_block(
+    State(state): State<AppState>,
+    Path((flow_id, block_id)): Path<(FlowId, String)>,
+) -> Html<String> {
+    render_vision_mixer_page(&state, &flow_id, Some(&block_id)).await
+}
+
+async fn render_vision_mixer_page(
+    state: &AppState,
+    flow_id: &FlowId,
+    requested_block_id: Option<&str>,
+) -> Html<String> {
     let flows = state.get_flows().await;
 
-    let Some(flow) = flows.iter().find(|f| f.id == flow_id) else {
+    let Some(flow) = flows.iter().find(|f| f.id == *flow_id) else {
         return Html(format!(
             "<html><body>Flow {} not found</body></html>",
             flow_id
         ));
     };
 
-    let Some(vm_block) = flow
-        .blocks
-        .iter()
-        .find(|b| b.block_definition_id == "builtin.vision_mixer")
-    else {
+    let vm_block = match requested_block_id {
+        Some(bid) => flow
+            .blocks
+            .iter()
+            .find(|b| b.id == bid && b.block_definition_id == "builtin.vision_mixer"),
+        None => flow
+            .blocks
+            .iter()
+            .find(|b| b.block_definition_id == "builtin.vision_mixer"),
+    };
+
+    let Some(vm_block) = vm_block else {
         return Html(
             "<html><body>No vision mixer block found in this flow</body></html>".to_string(),
         );

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -339,6 +339,10 @@ pub async fn create_app_with_config(
             "/vision-mixer/{flow_id}",
             get(api::vision_mixer_page::vision_mixer_page),
         )
+        .route(
+            "/vision-mixer/{flow_id}/{block_id}",
+            get(api::vision_mixer_page::vision_mixer_page_for_block),
+        )
         .with_state(state.clone());
 
     // WHEP proxy routes - outside /api (acts as WHEP server endpoint)

--- a/backend/static/vision-mixer.html
+++ b/backend/static/vision-mixer.html
@@ -951,7 +951,7 @@
                     const event = JSON.parse(e.data);
                     if (event.type === 'VisionMixerStateChanged' && event.data) {
                         const d = event.data;
-                        if (d.block_id === BLOCK_ID) {
+                        if (d.flow_id === FLOW_ID && d.block_id === BLOCK_ID) {
                             currentPvwGroup = d.preview_inputs || [d.preview_input];
                             currentPgmGroup = d.program_inputs || [d.program_input];
                             updateButtons();
@@ -959,28 +959,28 @@
                     }
                     if (event.type === 'VisionMixerDskChanged' && event.data) {
                         const d = event.data;
-                        if (d.block_id === BLOCK_ID) {
+                        if (d.flow_id === FLOW_ID && d.block_id === BLOCK_ID) {
                             dskEnabled[d.dsk - 1] = d.enabled;
                             updateDskButtons();
                         }
                     }
                     if (event.type === 'VisionMixerFtbChanged' && event.data) {
                         const d = event.data;
-                        if (d.block_id === BLOCK_ID) {
+                        if (d.flow_id === FLOW_ID && d.block_id === BLOCK_ID) {
                             ftbActive = d.active;
                             updateFtbButton();
                         }
                     }
                     if (event.type === 'VisionMixerOverlayAlphaChanged' && event.data) {
                         const d = event.data;
-                        if (d.block_id === BLOCK_ID && !overlayAlphaDragging) {
+                        if (d.flow_id === FLOW_ID && d.block_id === BLOCK_ID && !overlayAlphaDragging) {
                             overlayAlpha = d.alpha;
                             updateOverlayAlphaUi();
                         }
                     }
                     if (event.type === 'VisionMixerBackgroundChanged' && event.data) {
                         const d = event.data;
-                        if (d.block_id === BLOCK_ID) {
+                        if (d.flow_id === FLOW_ID && d.block_id === BLOCK_ID) {
                             currentBackground = d.background_input;
                             updateButtons();
                         }

--- a/frontend/src/api/elements.rs
+++ b/frontend/src/api/elements.rs
@@ -165,10 +165,13 @@ impl ApiClient {
         )
     }
 
-    /// Get the vision mixer control page URL for a given flow ID.
-    pub fn get_vision_mixer_url(&self, flow_id: &strom_types::FlowId) -> String {
+    /// Get the vision mixer control page URL for a given flow ID and block ID.
+    pub fn get_vision_mixer_url(&self, flow_id: &strom_types::FlowId, block_id: &str) -> String {
         let server_base = self.base_url.trim_end_matches("/api");
-        format!("{}/player/vision-mixer/{}", server_base, flow_id)
+        format!(
+            "{}/player/vision-mixer/{}/{}",
+            server_base, flow_id, block_id
+        )
     }
 
     /// Get the WHIP ingest URL for a given endpoint ID.

--- a/frontend/src/app/rendering.rs
+++ b/frontend/src/app/rendering.rs
@@ -1519,8 +1519,8 @@ impl StromApp {
                         }
 
                         // Handle vision mixer control page request
-                        if let Some(flow_id) = result.vision_mixer_url {
-                            let url = self.api.get_vision_mixer_url(&flow_id);
+                        if let Some((flow_id, block_id)) = result.vision_mixer_url {
+                            let url = self.api.get_vision_mixer_url(&flow_id, &block_id);
                             ui.ctx().open_url(egui::OpenUrl::new_tab(&url));
                         }
 

--- a/frontend/src/app/update.rs
+++ b/frontend/src/app/update.rs
@@ -1436,11 +1436,11 @@ impl eframe::App for StromApp {
         }
 
         // Check for vision mixer control page open signal (double-click on Vision Mixer)
-        if let Some(_block_id) = get_local_storage("open_vision_mixer") {
+        if let Some(block_id) = get_local_storage("open_vision_mixer") {
             remove_local_storage("open_vision_mixer");
 
             if let Some(flow) = self.current_flow() {
-                let url = self.api.get_vision_mixer_url(&flow.id);
+                let url = self.api.get_vision_mixer_url(&flow.id, &block_id);
                 ui.ctx().open_url(egui::OpenUrl::new_tab(&url));
             }
         }

--- a/frontend/src/properties.rs
+++ b/frontend/src/properties.rs
@@ -127,8 +127,8 @@ pub struct BlockInspectorResult {
     pub recorder_split_requested: Option<(FlowId, String)>,
     /// Recorder file download requested - contains relative path
     pub recorder_download_requested: Option<String>,
-    /// Vision mixer control page requested - contains flow_id
-    pub vision_mixer_url: Option<FlowId>,
+    /// Vision mixer control page requested - contains (flow_id, block_id)
+    pub vision_mixer_url: Option<(FlowId, String)>,
     /// Live property updates to send to running pipeline elements
     pub live_property_updates: Vec<LivePropertyUpdate>,
 }
@@ -694,7 +694,7 @@ impl PropertyInspector {
                         .on_hover_text("Open vision mixer control page in browser")
                         .clicked()
                     {
-                        result.vision_mixer_url = Some(fid);
+                        result.vision_mixer_url = Some((fid, block.id.clone()));
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- The vision mixer control page WebSocket handler only filtered events by `block_id`, causing cross-talk when multiple vision mixers shared the same auto-generated block ID (e.g. `vision_mixer_1`) across different flows
- All five event handlers now also verify `flow_id`, preventing cross-coupling between control UIs
- Added a new route `/vision-mixer/{flow_id}/{block_id}` so individual vision mixers within the same flow can be addressed directly. The old `/vision-mixer/{flow_id}` route still works (picks the first mixer)
- The egui frontend now passes `block_id` through when opening the control page (both from the properties panel button and double-click)

## Test plan
- [ ] Start two flows, each with a vision mixer block
- [ ] Open the control page for each mixer in separate browser tabs
- [ ] Verify that switching PVW/PGM on one mixer does not affect the other tab
- [ ] Verify FTB, DSK, overlay alpha, and background changes are isolated per tab
- [ ] Test with two vision mixers in the same flow using the `/vision-mixer/{flow_id}/{block_id}` route

🤖 Generated with [Claude Code](https://claude.com/claude-code)