### PR TITLE
fix: unblock preroll on mpegtssrt output (async=false)

### DIFF
--- a/backend/src/blocks/builtin/mpegtssrt.rs
+++ b/backend/src/blocks/builtin/mpegtssrt.rs
@@ -233,6 +233,10 @@ impl BlockBuilder for MpegTsSrtOutputBuilder {
         // Fixed: 2025-12-01
         srtsink.set_property("sync", sync);
         srtsink.set_property("qos", true);
+        // async=false: don't block pipeline preroll waiting for the first buffer.
+        // In listener mode without a connected client, the sink would otherwise
+        // hold PAUSED->PLAYING indefinitely. Matches WHEP/WHIP/AES67 sinks.
+        srtsink.set_property("async", false);
 
         if has_auto_reconnect {
             info!(

--- a/frontend/src/webrtc_stats.rs
+++ b/frontend/src/webrtc_stats.rs
@@ -122,9 +122,12 @@ pub fn show_compact(ui: &mut Ui, stats: &WebRtcStats) {
         0.0
     };
 
-    // Build compact status line (centered)
+    // Build compact status line. Offset from the left edge so the text
+    // clears the input port labels (V0/A0) that are drawn just inside
+    // the block rect.
     ui.with_layout(egui::Layout::top_down(egui::Align::Center), |ui| {
         ui.horizontal(|ui| {
+            ui.add_space(30.0);
             // Session count with color indicator
             let color = if connected_count == session_count && session_count > 0 {
                 Color32::from_rgb(0, 180, 0)


### PR DESCRIPTION
## Summary
- Set `async=false` on the `srtsink` in the `builtin.mpegtssrt_output` block
- In listener mode without a connected client, the default `async=true` holds PAUSED→PLAYING until the first buffer arrives, which can block the whole pipeline from reaching PLAYING
- Matches the pattern already used by WHEP/WHIP/AES67 sinks in this repo

## Why
A flow with an mpegtssrt output consistently failed to transition PAUSED→PLAYING, with downstream h264parse EOS errors appearing during state change. Root cause: the SRT sink was waiting for a buffer to complete preroll; before any client had connected, preroll never completed. With `async=false`, the sink no longer gates preroll.

## Test plan
- [x] Flow with `mpegtssrt_output` (listener mode, no client) reaches `Playing`
- [ ] Verify encoded MPEG-TS is delivered correctly once a caller connects
- [ ] Regression: WHEP/WHIP output flows still start cleanly

## Known follow-up (not in this PR)
On stop+restart, libsrt's internal socket state keeps the listener port busy for a few minutes ("Another socket is already listening on the same port"). That is a separate issue — libsrt-internal, outside our code — and will be addressed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)