### PR TITLE
fix(cef): downgrade gstcefsrc to CEF 126 (Alloy runtime) to avoid Mem…

### DIFF
--- a/.github/workflows/build-gstcefsrc.yml
+++ b/.github/workflows/build-gstcefsrc.yml
@@ -7,9 +7,14 @@ on:
   workflow_dispatch:
     inputs:
       cef_version:
-        description: 'CEF version (e.g., 144.0.11+ge135be2+chromium-144.0.7559.97)'
+        description: 'CEF version (e.g., 126.2.18+g3647d39+chromium-126.0.6478.183)'
         required: true
-        default: '144.0.11+ge135be2+chromium-144.0.7559.97'
+        default: '126.2.18+g3647d39+chromium-126.0.6478.183'
+        type: string
+      gstcefsrc_ref:
+        description: 'gstcefsrc git ref (commit SHA, tag, or branch). Default pins to the last master commit that defaulted to CEF 122, compatible with CEF 126 (Alloy runtime).'
+        required: true
+        default: '0e470f51fd'
         type: string
       upload_to_release:
         description: 'Upload artifacts to GitHub release'
@@ -62,6 +67,7 @@ jobs:
           docker build \
             --platform ${{ matrix.docker_platform }} \
             --build-arg CEF_VERSION="${{ inputs.cef_version }}" \
+            --build-arg GSTCEFSRC_REF="${{ inputs.gstcefsrc_ref }}" \
             -t gstcefsrc-builder:${{ matrix.arch }} \
             -f docker/gstcefsrc/Dockerfile \
             docker/gstcefsrc/
@@ -117,6 +123,7 @@ jobs:
           echo "## gstcefsrc Build Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**CEF Version:** \`${{ inputs.cef_version }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**gstcefsrc ref:** \`${{ inputs.gstcefsrc_ref }}\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Platform | Status |" >> $GITHUB_STEP_SUMMARY
           echo "|----------|--------|" >> $GITHUB_STEP_SUMMARY

--- a/docker/gstcefsrc/Dockerfile
+++ b/docker/gstcefsrc/Dockerfile
@@ -15,13 +15,21 @@
 
 ARG TARGETARCH
 
-# Latest stable CEF version (as of 2026-01)
-ARG CEF_VERSION=144.0.11+ge135be2+chromium-144.0.7559.97
+# CEF 126 (Alloy runtime) — intentionally downgraded from 144 to avoid the
+# MemoryInfra SIGILL crash introduced when Chrome runtime became default in
+# CEF 127. See docs/CEF_SIGILL_CRASH.md.
+ARG CEF_VERSION=126.2.18+g3647d39+chromium-126.0.6478.183
+
+# Pinned gstcefsrc commit — last upstream master commit that defaulted to
+# CEF 122 (parent of the CEF 130 bump `be42330b4a`). Later gstcefsrc masters
+# target Chrome-runtime-era CEF and require newer CEF ABI than 126 ships.
+ARG GSTCEFSRC_REF=0e470f51fd
 
 FROM ubuntu:questing AS builder
 
 ARG TARGETARCH
 ARG CEF_VERSION
+ARG GSTCEFSRC_REF
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -62,8 +70,15 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /build
 
-# Clone gstcefsrc from Centricular
-RUN git clone --depth 1 https://github.com/centricular/gstcefsrc.git
+# Clone gstcefsrc from Centricular at the pinned ref.
+# We can't shallow-clone an arbitrary SHA directly, so we init an empty repo,
+# fetch the specific commit, and check it out. This works against GitHub which
+# enables `uploadpack.allowAnySHA1InWant` by default.
+RUN git init gstcefsrc && \
+    cd gstcefsrc && \
+    git remote add origin https://github.com/centricular/gstcefsrc.git && \
+    git fetch --depth 1 origin "${GSTCEFSRC_REF}" && \
+    git checkout FETCH_HEAD
 
 WORKDIR /build/gstcefsrc
 

--- a/docker/strom-full/entrypoint.sh
+++ b/docker/strom-full/entrypoint.sh
@@ -35,19 +35,12 @@ if nvidia-smi > /dev/null 2>&1; then
     # disable-gpu alone is not enough - Chromium still starts a GPU subprocess that
     # probes the NVIDIA driver and initializes SharedImage mailboxes.
     #
-    # Prevent MemoryInfra SIGILL crashes (exit code 132):
-    # Chromium's MemoryInfra thread periodically dumps PartitionAlloc stats;
-    # in long-running processes the allocator metadata can become inconsistent,
-    # causing a CHECK() failure (ud2/SIGILL).
-    #
-    # NOTE: "disable-background-tracing" does NOT exist as a Chromium switch
-    # (verified in Chromium 144 source and libcef.so binary). The correct
-    # approach is to disable the BackgroundTracing feature flag and prevent
-    # periodic tasks from scheduling memory dumps:
-    #   disable-features=BackgroundTracing  - disables the feature entirely
-    #   no-periodic-tasks                   - prevents periodic dump scheduling
-    #   force-fieldtrials=                  - clears all field trial configs
-    # See docs/CEF_SIGILL_CRASH.md for full investigation.
+    # MemoryInfra/PartitionAlloc SIGILL (exit code 132):
+    # This crash is a Chrome-runtime regression (CEF 127+). We currently build
+    # against CEF 126 (Alloy runtime) specifically to avoid it, so the
+    # "disable-features=BackgroundTracing,no-periodic-tasks,force-fieldtrials="
+    # flags below are no-ops on Alloy but are kept as defense-in-depth in case
+    # we ever move forward to a Chrome-runtime CEF. See docs/CEF_SIGILL_CRASH.md.
     export GST_CEF_CHROME_EXTRA_FLAGS="no-sandbox,disable-gpu,disable-gpu-compositing,use-gl=disabled,disable-features=BackgroundTracing,no-periodic-tasks,force-fieldtrials=,disable-field-trial-config,disable-breakpad,disable-crash-reporter,disable-dev-shm-usage,disable-background-networking,disable-component-update,enable-logging=stderr"
 else
     echo "No GPU detected - using software rendering for both GStreamer and CEF"

--- a/docs/CEF_SIGILL_CRASH.md
+++ b/docs/CEF_SIGILL_CRASH.md
@@ -55,10 +55,41 @@ References:
 - CEF Forum: "Process hangs after switching to chrome runtime" (MemoryInfra SIGILL)
 - SharedImageManager::ProduceMemory errors reported around Chromium 124
 
-## Fix: Disable MemoryInfra periodic dumps
+## Fix: Downgrade to CEF 126 (Alloy runtime)
 
-Since the MemoryInfra dump is not needed for production rendering, the fix is to
-prevent the periodic memory dump system from running.
+The root cause is the Chrome runtime, which became the default in CEF 127 and
+is mandatory from CEF 128 onwards (the Alloy bootstrap was removed). CEF 124
+and earlier, and CEF 125/126 under Alloy, do not exhibit the MemoryInfra SIGILL.
+
+We pin the build to:
+
+- **CEF `126.2.18+g3647d39+chromium-126.0.6478.183`** — latest stable CEF 126,
+  Alloy runtime default.
+- **gstcefsrc commit `0e470f51fd`** — last master commit that defaulted to
+  CEF 122, the parent of the CEF 130 bump (`be42330b4a`, 2024-10-02). Later
+  gstcefsrc masters track Chrome-runtime-era CEF and require a newer CEF ABI
+  than 126 ships.
+
+Pinning lives in:
+
+- `docker/gstcefsrc/Dockerfile` — `ARG CEF_VERSION` and `ARG GSTCEFSRC_REF`.
+- `.github/workflows/build-gstcefsrc.yml` — `cef_version` and `gstcefsrc_ref`
+  inputs.
+- `docker/strom-full/Dockerfile` — `ARG GSTCEFSRC_VERSION` must match the
+  short CEF version string (`126.2.18`) produced by the workflow.
+
+**Trade-off**: Chromium 126 is ~22 months old (released 2024-06-11). More than
+sufficient for HTML overlay rendering (CSS, WebGL, WebCodecs, View Transitions
+are all supported), but lacks security patches and bleeding-edge web platform
+features from 2024-2026. Acceptable for an internal overlay renderer running
+trusted content.
+
+## Legacy fix: Disable MemoryInfra periodic dumps (Chrome runtime only)
+
+If the project ever moves back to a Chrome-runtime CEF (127+), the following
+flags reduce — but do not eliminate — the crash rate. They are no-ops on the
+Alloy runtime we currently use, but are kept in `entrypoint.sh` as
+defense-in-depth.
 
 ### Important: `disable-background-tracing` does not exist
 


### PR DESCRIPTION
…oryInfra SIGILL

CEF 127+ switched to Chrome runtime by default, introducing a MemoryInfra / PartitionAlloc CHECK() failure (SIGILL, exit 132) that crashes long-running cefsrc processes intermittently. No upstream fix exists. CEF 128 removed the Alloy bootstrap entirely.

Pin the build to:
- CEF 126.2.18+g3647d39+chromium-126.0.6478.183 (last stable Alloy-default)
- gstcefsrc 0e470f51fd (last master commit defaulting to CEF 122, compatible with the CEF 126 ABI)

Changes:
- docker/gstcefsrc/Dockerfile: bump default CEF_VERSION, add GSTCEFSRC_REF arg, switch clone from --depth 1 to init/fetch/checkout to support arbitrary SHAs.
- .github/workflows/build-gstcefsrc.yml: update defaults, add gstcefsrc_ref workflow_dispatch input, wire through as --build-arg.
- docker/strom-full/entrypoint.sh: update comment — Chrome-runtime-specific flags are no-ops on Alloy but kept as defense-in-depth.
- docs/CEF_SIGILL_CRASH.md: new "Downgrade to CEF 126" section documenting rationale and pinning locations; old flag-based fix retained as legacy.

Note: docker/strom-full/Dockerfile GSTCEFSRC_VERSION is intentionally NOT bumped in this commit — it must stay at 144.0.12 until the workflow has produced and released the 126.2.18 artifact. Follow-up commit after the release upload.

## Description

Brief description of the changes.

## Related Issue

Fixes #(issue number)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have run `cargo fmt --all`
- [ ] I have run `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] I have run `cargo test --workspace`
- [ ] I have updated documentation as needed
- [ ] I have added tests for new functionality
