### PR TITLE
fix(cef): use full SHA for gstcefsrc pin so git fetch works

### DIFF
--- a/.github/workflows/build-gstcefsrc.yml
+++ b/.github/workflows/build-gstcefsrc.yml
@@ -12,9 +12,9 @@ on:
         default: '126.2.18+g3647d39+chromium-126.0.6478.183'
         type: string
       gstcefsrc_ref:
-        description: 'gstcefsrc git ref (commit SHA, tag, or branch). Default pins to the last master commit that defaulted to CEF 122, compatible with CEF 126 (Alloy runtime).'
+        description: 'gstcefsrc git ref (full 40-char commit SHA, tag, or branch). Default pins to the last master commit that defaulted to CEF 122, compatible with CEF 126 (Alloy runtime). Must be a full SHA — GitHub uploadpack does not resolve short SHAs.'
         required: true
-        default: '0e470f51fd'
+        default: '0e470f51fdb8afdd9e31ef0b3d75b26536b180e5'
         type: string
       upload_to_release:
         description: 'Upload artifacts to GitHub release'

--- a/docker/gstcefsrc/Dockerfile
+++ b/docker/gstcefsrc/Dockerfile
@@ -23,7 +23,7 @@ ARG CEF_VERSION=126.2.18+g3647d39+chromium-126.0.6478.183
 # Pinned gstcefsrc commit — last upstream master commit that defaulted to
 # CEF 122 (parent of the CEF 130 bump `be42330b4a`). Later gstcefsrc masters
 # target Chrome-runtime-era CEF and require newer CEF ABI than 126 ships.
-ARG GSTCEFSRC_REF=0e470f51fd
+ARG GSTCEFSRC_REF=0e470f51fdb8afdd9e31ef0b3d75b26536b180e5
 
 FROM ubuntu:questing AS builder
 

--- a/docs/CEF_SIGILL_CRASH.md
+++ b/docs/CEF_SIGILL_CRASH.md
@@ -65,7 +65,7 @@ We pin the build to:
 
 - **CEF `126.2.18+g3647d39+chromium-126.0.6478.183`** — latest stable CEF 126,
   Alloy runtime default.
-- **gstcefsrc commit `0e470f51fd`** — last master commit that defaulted to
+- **gstcefsrc commit `0e470f51fdb8afdd9e31ef0b3d75b26536b180e5`** — last master commit that defaulted to
   CEF 122, the parent of the CEF 130 bump (`be42330b4a`, 2024-10-02). Later
   gstcefsrc masters track Chrome-runtime-era CEF and require a newer CEF ABI
   than 126 ships.


### PR DESCRIPTION
GitHub's uploadpack.allowAnySHA1InWant only resolves full 40-char SHAs, not the short form. `git fetch --depth 1 origin 0e470f51fd` fails with "couldn't find remote ref 0e470f51fd", breaking the gstcefsrc build.

Replace all references to the short SHA with the full commit ID 0e470f51fdb8afdd9e31ef0b3d75b26536b180e5.

## Description

Brief description of the changes.

## Related Issue

Fixes #(issue number)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have run `cargo fmt --all`
- [ ] I have run `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] I have run `cargo test --workspace`
- [ ] I have updated documentation as needed
- [ ] I have added tests for new functionality
