### PR TITLE
fix(cef): use CEF 122 instead of 126 to match pinned gstcefsrc ABI

### DIFF
--- a/.github/workflows/build-gstcefsrc.yml
+++ b/.github/workflows/build-gstcefsrc.yml
@@ -7,12 +7,12 @@ on:
   workflow_dispatch:
     inputs:
       cef_version:
-        description: 'CEF version (e.g., 126.2.18+g3647d39+chromium-126.0.6478.183)'
+        description: 'CEF version (e.g., 122.1.13+gde5b724+chromium-122.0.6261.130)'
         required: true
-        default: '126.2.18+g3647d39+chromium-126.0.6478.183'
+        default: '122.1.13+gde5b724+chromium-122.0.6261.130'
         type: string
       gstcefsrc_ref:
-        description: 'gstcefsrc git ref (full 40-char commit SHA, tag, or branch). Default pins to the last master commit that defaulted to CEF 122, compatible with CEF 126 (Alloy runtime). Must be a full SHA — GitHub uploadpack does not resolve short SHAs.'
+        description: 'gstcefsrc git ref (full 40-char commit SHA, tag, or branch). Default pins to the last master commit that defaulted to CEF 122 (Alloy runtime). Must be a full SHA — GitHub uploadpack does not resolve short SHAs.'
         required: true
         default: '0e470f51fdb8afdd9e31ef0b3d75b26536b180e5'
         type: string

--- a/docker/gstcefsrc/Dockerfile
+++ b/docker/gstcefsrc/Dockerfile
@@ -15,14 +15,17 @@
 
 ARG TARGETARCH
 
-# CEF 126 (Alloy runtime) — intentionally downgraded from 144 to avoid the
+# CEF 122 (Alloy runtime) — intentionally downgraded from 144 to avoid the
 # MemoryInfra SIGILL crash introduced when Chrome runtime became default in
-# CEF 127. See docs/CEF_SIGILL_CRASH.md.
-ARG CEF_VERSION=126.2.18+g3647d39+chromium-126.0.6478.183
+# CEF 127. We use 122 (not 126) because the pinned gstcefsrc commit was
+# tested against exactly this version; CEF 126 introduced an ABI change in
+# OnRenderProcessTerminated that breaks the build.
+# See docs/CEF_SIGILL_CRASH.md.
+ARG CEF_VERSION=122.1.13+gde5b724+chromium-122.0.6261.130
 
 # Pinned gstcefsrc commit — last upstream master commit that defaulted to
-# CEF 122 (parent of the CEF 130 bump `be42330b4a`). Later gstcefsrc masters
-# target Chrome-runtime-era CEF and require newer CEF ABI than 126 ships.
+# CEF 122 (parent of the CEF 130 bump `be42330b4a`). Upstream jumped straight
+# from 122 to 130, so no gstcefsrc commit was ever tested against 123-129.
 ARG GSTCEFSRC_REF=0e470f51fdb8afdd9e31ef0b3d75b26536b180e5
 
 FROM ubuntu:questing AS builder

--- a/docker/strom-full/entrypoint.sh
+++ b/docker/strom-full/entrypoint.sh
@@ -37,7 +37,7 @@ if nvidia-smi > /dev/null 2>&1; then
     #
     # MemoryInfra/PartitionAlloc SIGILL (exit code 132):
     # This crash is a Chrome-runtime regression (CEF 127+). We currently build
-    # against CEF 126 (Alloy runtime) specifically to avoid it, so the
+    # against CEF 122 (Alloy runtime) specifically to avoid it, so the
     # "disable-features=BackgroundTracing,no-periodic-tasks,force-fieldtrials="
     # flags below are no-ops on Alloy but are kept as defense-in-depth in case
     # we ever move forward to a Chrome-runtime CEF. See docs/CEF_SIGILL_CRASH.md.

--- a/docs/CEF_SIGILL_CRASH.md
+++ b/docs/CEF_SIGILL_CRASH.md
@@ -55,20 +55,23 @@ References:
 - CEF Forum: "Process hangs after switching to chrome runtime" (MemoryInfra SIGILL)
 - SharedImageManager::ProduceMemory errors reported around Chromium 124
 
-## Fix: Downgrade to CEF 126 (Alloy runtime)
+## Fix: Downgrade to CEF 122 (Alloy runtime)
 
 The root cause is the Chrome runtime, which became the default in CEF 127 and
-is mandatory from CEF 128 onwards (the Alloy bootstrap was removed). CEF 124
-and earlier, and CEF 125/126 under Alloy, do not exhibit the MemoryInfra SIGILL.
+is mandatory from CEF 128 onwards (the Alloy bootstrap was removed). CEF 126
+and earlier, under Alloy, do not exhibit the MemoryInfra SIGILL.
 
 We pin the build to:
 
-- **CEF `126.2.18+g3647d39+chromium-126.0.6478.183`** — latest stable CEF 126,
-  Alloy runtime default.
-- **gstcefsrc commit `0e470f51fdb8afdd9e31ef0b3d75b26536b180e5`** — last master commit that defaulted to
-  CEF 122, the parent of the CEF 130 bump (`be42330b4a`, 2024-10-02). Later
-  gstcefsrc masters track Chrome-runtime-era CEF and require a newer CEF ABI
-  than 126 ships.
+- **CEF `122.1.13+gde5b724+chromium-122.0.6261.130`** — latest stable CEF 122,
+  Alloy runtime default. This is the exact version the pinned gstcefsrc commit
+  was tested against. CEF 123-126 are also pre-Chrome-runtime but introduced
+  ABI changes (notably `OnRenderProcessTerminated` gaining `error_code` and
+  `error_string` parameters in CEF 126) that break this gstcefsrc commit.
+- **gstcefsrc commit `0e470f51fdb8afdd9e31ef0b3d75b26536b180e5`** — last master
+  commit that defaulted to CEF 122, the parent of the CEF 130 bump
+  (`be42330b4a`, 2024-10-02). Upstream gstcefsrc jumped straight from 122 to
+  130, so no commit was ever tested against CEF 123-129.
 
 Pinning lives in:
 
@@ -76,9 +79,9 @@ Pinning lives in:
 - `.github/workflows/build-gstcefsrc.yml` — `cef_version` and `gstcefsrc_ref`
   inputs.
 - `docker/strom-full/Dockerfile` — `ARG GSTCEFSRC_VERSION` must match the
-  short CEF version string (`126.2.18`) produced by the workflow.
+  short CEF version string (`122.1.13`) produced by the workflow.
 
-**Trade-off**: Chromium 126 is ~22 months old (released 2024-06-11). More than
+**Trade-off**: Chromium 122 is ~26 months old (released 2024-02-20). More than
 sufficient for HTML overlay rendering (CSS, WebGL, WebCodecs, View Transitions
 are all supported), but lacks security patches and bleeding-edge web platform
 features from 2024-2026. Acceptable for an internal overlay renderer running


### PR DESCRIPTION
## Summary
- CEF 126 added `error_code`/`error_string` params to `OnRenderProcessTerminated`, which breaks gstcefsrc commit `0e470f51fd` (uses the 2-arg CEF 122 signature).
- Upstream gstcefsrc jumped 122→130, so no commit was ever tested against 123–129.
- Switch pin to CEF 122.1.13+gde5b724+chromium-122.0.6261.130 (Alloy runtime, the exact version the gstcefsrc pin was tested against).
- Goal is unchanged: avoid the Chrome-runtime MemoryInfra SIGILL. 122 vs 126 makes no difference for that.

## Test plan
- [ ] `build-gstcefsrc.yml` succeeds for both linux-amd64 and linux-arm64
- [ ] `gstcefsrc-122.1.13-linux-*.tar.gz` artifacts appear in `gstcefsrc-deps` release