### PR TITLE
feat(cef): LD_PRELOAD mallinfo shim to fix MemoryInfra SIGILL

### DIFF
--- a/.github/workflows/build-gstcefsrc.yml
+++ b/.github/workflows/build-gstcefsrc.yml
@@ -7,14 +7,14 @@ on:
   workflow_dispatch:
     inputs:
       cef_version:
-        description: 'CEF version (e.g., 122.1.13+gde5b724+chromium-122.0.6261.130)'
+        description: 'CEF version (e.g., 144.0.11+ge135be2+chromium-144.0.7559.97)'
         required: true
-        default: '122.1.13+gde5b724+chromium-122.0.6261.130'
+        default: '144.0.11+ge135be2+chromium-144.0.7559.97'
         type: string
       gstcefsrc_ref:
-        description: 'gstcefsrc git ref (full 40-char commit SHA, tag, or branch). Default pins to the last master commit that defaulted to CEF 122 (Alloy runtime). Must be a full SHA — GitHub uploadpack does not resolve short SHAs.'
+        description: 'gstcefsrc git ref (full 40-char commit SHA, tag, or branch). Must be a full SHA — GitHub uploadpack does not resolve short SHAs.'
         required: true
-        default: '0e470f51fdb8afdd9e31ef0b3d75b26536b180e5'
+        default: 'b63340852fc93b0ab67b07200e1ff44f59ba6769'
         type: string
       upload_to_release:
         description: 'Upload artifacts to GitHub release'

--- a/docker/gstcefsrc/Dockerfile
+++ b/docker/gstcefsrc/Dockerfile
@@ -15,18 +15,16 @@
 
 ARG TARGETARCH
 
-# CEF 122 (Alloy runtime) — intentionally downgraded from 144 to avoid the
-# MemoryInfra SIGILL crash introduced when Chrome runtime became default in
-# CEF 127. We use 122 (not 126) because the pinned gstcefsrc commit was
-# tested against exactly this version; CEF 126 introduced an ABI change in
-# OnRenderProcessTerminated that breaks the build.
-# See docs/CEF_SIGILL_CRASH.md.
-ARG CEF_VERSION=122.1.13+gde5b724+chromium-122.0.6261.130
+# CEF 144 (Chrome runtime). The MemoryInfra SIGILL that could otherwise crash
+# libcef in long-running processes is handled at runtime by LD_PRELOADing
+# libmallinfo_shim.so (see docker/strom-full/entrypoint.sh and
+# docs/CEF_SIGILL_CRASH.md). The shim interposes glibc's legacy int-based
+# mallinfo(), whose fields overflow when the CEF process arena > 2 GiB and
+# trigger a Chromium CHECK() on a failed checked_cast<size_t>.
+ARG CEF_VERSION=144.0.11+ge135be2+chromium-144.0.7559.97
 
-# Pinned gstcefsrc commit — last upstream master commit that defaulted to
-# CEF 122 (parent of the CEF 130 bump `be42330b4a`). Upstream jumped straight
-# from 122 to 130, so no gstcefsrc commit was ever tested against 123-129.
-ARG GSTCEFSRC_REF=0e470f51fdb8afdd9e31ef0b3d75b26536b180e5
+# Current gstcefsrc master (pinned to a full SHA for reproducibility).
+ARG GSTCEFSRC_REF=b63340852fc93b0ab67b07200e1ff44f59ba6769
 
 FROM ubuntu:questing AS builder
 
@@ -72,6 +70,11 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build
+
+# Copy and compile the mallinfo LD_PRELOAD shim (fixes CEF MemoryInfra SIGILL
+# when arena > 2 GiB; see mallinfo_shim.c and docs/CEF_SIGILL_CRASH.md).
+COPY mallinfo_shim.c /build/mallinfo_shim.c
+RUN gcc -shared -fPIC -O2 -o /build/libmallinfo_shim.so /build/mallinfo_shim.c
 
 # Clone gstcefsrc from Centricular at the pinned ref.
 # We can't shallow-clone an arbitrary SHA directly, so we init an empty repo,
@@ -129,6 +132,8 @@ RUN mkdir -p /output/lib/gstreamer-1.0 && \
     cp /build/gstcefsrc/build/Release/libvk_swiftshader.so /output/lib/cef/ 2>/dev/null || true && \
     cp /build/gstcefsrc/build/Release/libvulkan.so.1 /output/lib/cef/ 2>/dev/null || true && \
     cp /build/gstcefsrc/build/Release/vk_swiftshader_icd.json /output/lib/cef/ 2>/dev/null || true && \
+    # Copy the mallinfo LD_PRELOAD shim
+    cp /build/libmallinfo_shim.so /output/lib/cef/ && \
     # Create version info file
     echo "CEF_VERSION=${CEF_VERSION}" > /output/version.txt && \
     echo "TARGETARCH=${TARGETARCH}" >> /output/version.txt && \

--- a/docker/gstcefsrc/mallinfo_shim.c
+++ b/docker/gstcefsrc/mallinfo_shim.c
@@ -1,0 +1,30 @@
+/*
+ * mallinfo_shim — LD_PRELOAD interposer for glibc `mallinfo()`.
+ *
+ * Chromium's MallocDumpProvider::OnMemoryDump calls the legacy int-based
+ * mallinfo() from libcef.so (built against an old sysroot without mallinfo2).
+ * When the process arena grows beyond 2 GiB, the int fields overflow to
+ * negative values. Chromium then checked_cast<size_t> them, fails the
+ * narrowing check, and CHECK()s — producing a SIGILL on the MemoryInfra
+ * thread that kills the whole CEF process.
+ *
+ * This shim replaces mallinfo() with a zero-filled result. The memory dump
+ * just records zero bytes (we don't use memory profiling in production),
+ * no overflow, no CHECK() failure, no crash.
+ *
+ * Workaround reference:
+ *   https://github.com/chromiumembedded/cef/issues/3963
+ *   https://issues.chromium.org/issues/401168177
+ *
+ * Build:  gcc -shared -fPIC -o libmallinfo_shim.so mallinfo_shim.c
+ * Use:    LD_PRELOAD=/path/to/libmallinfo_shim.so <cef-process>
+ */
+
+#include <malloc.h>
+#include <string.h>
+
+struct mallinfo mallinfo(void) {
+    struct mallinfo mi;
+    memset(&mi, 0, sizeof(mi));
+    return mi;
+}

--- a/docker/strom-full/entrypoint.sh
+++ b/docker/strom-full/entrypoint.sh
@@ -36,11 +36,12 @@ if nvidia-smi > /dev/null 2>&1; then
     # probes the NVIDIA driver and initializes SharedImage mailboxes.
     #
     # MemoryInfra/PartitionAlloc SIGILL (exit code 132):
-    # This crash is a Chrome-runtime regression (CEF 127+). We currently build
-    # against CEF 122 (Alloy runtime) specifically to avoid it, so the
-    # "disable-features=BackgroundTracing,no-periodic-tasks,force-fieldtrials="
-    # flags below are no-ops on Alloy but are kept as defense-in-depth in case
-    # we ever move forward to a Chrome-runtime CEF. See docs/CEF_SIGILL_CRASH.md.
+    # The root cause is an mallinfo() int overflow when the CEF process arena
+    # exceeds 2 GiB — fixed at runtime by LD_PRELOADing libmallinfo_shim.so
+    # (see the LD_PRELOAD block below and docs/CEF_SIGILL_CRASH.md).
+    # The Chrome-runtime-specific flags below (disable-features=BackgroundTracing,
+    # no-periodic-tasks, etc.) are defense-in-depth — they reduce how often
+    # MemoryInfra runs but do not by themselves prevent the overflow CHECK.
     export GST_CEF_CHROME_EXTRA_FLAGS="no-sandbox,disable-gpu,disable-gpu-compositing,use-gl=disabled,disable-features=BackgroundTracing,no-periodic-tasks,force-fieldtrials=,disable-field-trial-config,disable-breakpad,disable-crash-reporter,disable-dev-shm-usage,disable-background-networking,disable-component-update,enable-logging=stderr"
 else
     echo "No GPU detected - using software rendering for both GStreamer and CEF"
@@ -59,6 +60,16 @@ mkdir -p /tmp/cef-cache
 
 # Enable CEF debug logging
 export GST_CEF_LOG_SEVERITY="verbose"
+
+# LD_PRELOAD the mallinfo shim to neutralise the MemoryInfra SIGILL crash.
+# libcef.so was built against an old sysroot and calls glibc's int-based
+# mallinfo(); when the CEF process arena exceeds 2 GiB, the ints overflow to
+# negative values, Chromium checked_casts them to size_t, and CHECK()s -> SIGILL.
+# The shim returns zeroed values so the cast succeeds harmlessly.
+# Reference: https://github.com/chromiumembedded/cef/issues/3963
+if [ -f /usr/local/lib/cef/libmallinfo_shim.so ]; then
+    export LD_PRELOAD="/usr/local/lib/cef/libmallinfo_shim.so${LD_PRELOAD:+:$LD_PRELOAD}"
+fi
 
 # Wait briefly for Xvfb to initialize
 sleep 0.5

--- a/docs/CEF_SIGILL_CRASH.md
+++ b/docs/CEF_SIGILL_CRASH.md
@@ -21,14 +21,23 @@ SIGILL, Illegal instruction
 #2  ContinueAsyncProcessDump() at memory_dump_manager.cc:377
 ```
 
-MemoryInfra periodically collects memory statistics from **PartitionAlloc**
-(Chromium's memory allocator since ~M116, replacing tcmalloc).
-`MallocDumpProvider::OnMemoryDump()` walks PartitionAlloc's internal metadata
-to gather allocation stats. In long-running, high-throughput rendering processes
-(like gstcefsrc), the metadata can end up in an inconsistent state. When the
-dump provider encounters this, the CHECK fails and Chromium crashes.
+### The actual bug (identified 2025-10, CEF issue [#3963](https://github.com/chromiumembedded/cef/issues/3963))
+
+`MallocDumpProvider::OnMemoryDump()` calls glibc's **legacy `mallinfo()`**,
+not `mallinfo2()`. Spotify's official CEF builds compile against a Debian
+bullseye sysroot (glibc 2.31) which lacks `mallinfo2`, so the int-based
+API is what ends up baked into `libcef.so` regardless of the host's glibc.
+
+Once the CEF process's arena exceeds **2 GiB** (INT_MAX ≈ 2.147 GB), the
+int fields overflow to negative values. Chromium narrows them via
+`checked_cast<size_t>(int)`, the narrowing check fails, and Chromium
+CHECKs — executing `ud2` → SIGILL.
 
 Core dump files are named `core.MemoryInfra.*`, confirming the crashing thread.
+
+This is not truly a Chrome-runtime regression, even though Chrome runtime
+(CEF 127+) made it much more visible by running more long-lived allocations.
+Both Alloy- and Chrome-runtime builds can hit it given enough memory.
 
 ## Previous symptoms
 
@@ -47,52 +56,58 @@ pci id for fd 9: 10de:2204, driver (null)
 
 ## Known issue
 
-Reported on the CEF Forum for CEF 127+ (which introduced the Chrome runtime by
-default, changing threading and process models). No upstream fix exists as of
-2026-03.
+Tracked in CEF issue [#3963](https://github.com/chromiumembedded/cef/issues/3963)
+(closed 2025-10 as "not planned") and upstream Chromium bug
+[401168177](https://issues.chromium.org/issues/401168177) (open, no progress
+as of 2026-04).
 
-References:
-- CEF Forum: "Process hangs after switching to chrome runtime" (MemoryInfra SIGILL)
-- SharedImageManager::ProduceMemory errors reported around Chromium 124
+## Fix: LD_PRELOAD mallinfo shim
 
-## Fix: Downgrade to CEF 122 (Alloy runtime)
+Since the bug is an int overflow of `mallinfo()`'s return fields, the simplest
+fix is to interpose `mallinfo()` and return zeroed values. Chromium then
+narrows 0 to size_t without any CHECK() failure, and the memory dump records
+zero bytes for the CEF process (we don't use MemoryInfra profiling in
+production).
 
-The root cause is the Chrome runtime, which became the default in CEF 127 and
-is mandatory from CEF 128 onwards (the Alloy bootstrap was removed). CEF 126
-and earlier, under Alloy, do not exhibit the MemoryInfra SIGILL.
+The shim source is `docker/gstcefsrc/mallinfo_shim.c`. It is compiled to
+`libmallinfo_shim.so` during the gstcefsrc build and shipped alongside the
+CEF binaries in the release tarball. `docker/strom-full/entrypoint.sh`
+injects it via `LD_PRELOAD` before `exec`ing the strom binary.
 
-We pin the build to:
+### Why this is safe for the rest of the stack
 
-- **CEF `122.1.13+gde5b724+chromium-122.0.6261.130`** — latest stable CEF 122,
-  Alloy runtime default. This is the exact version the pinned gstcefsrc commit
-  was tested against. CEF 123-126 are also pre-Chrome-runtime but introduced
-  ABI changes (notably `OnRenderProcessTerminated` gaining `error_code` and
-  `error_string` parameters in CEF 126) that break this gstcefsrc commit.
-- **gstcefsrc commit `0e470f51fdb8afdd9e31ef0b3d75b26536b180e5`** — last master
-  commit that defaulted to CEF 122, the parent of the CEF 130 bump
-  (`be42330b4a`, 2024-10-02). Upstream gstcefsrc jumped straight from 122 to
-  130, so no commit was ever tested against CEF 123-129.
+`LD_PRELOAD` only replaces the specific symbol `mallinfo()`; all other
+allocator entry points (malloc/free/calloc/realloc) are untouched. GStreamer,
+GLib, Rust's allocator interface, and our own code do not call `mallinfo()`.
+The only consumer in our process tree is Chromium's MemoryInfra thread —
+which is exactly what we want to silence.
 
-Pinning lives in:
+### This was confirmed by another CEF user
 
-- `docker/gstcefsrc/Dockerfile` — `ARG CEF_VERSION` and `ARG GSTCEFSRC_REF`.
-- `.github/workflows/build-gstcefsrc.yml` — `cef_version` and `gstcefsrc_ref`
-  inputs.
-- `docker/strom-full/Dockerfile` — `ARG GSTCEFSRC_VERSION` must match the
-  short CEF version string (`122.1.13`) produced by the workflow.
+From CEF [#3963](https://github.com/chromiumembedded/cef/issues/3963#issuecomment-3677232632):
+> "We are working around it for now by LD_PRELOADing a small lib which
+> interposes mallinfo and basically does pad the reported values, working
+> fine for now."
 
-**Trade-off**: Chromium 122 is ~26 months old (released 2024-02-20). More than
-sufficient for HTML overlay rendering (CSS, WebGL, WebCodecs, View Transitions
-are all supported), but lacks security patches and bleeding-edge web platform
-features from 2024-2026. Acceptable for an internal overlay renderer running
-trusted content.
+### Why not downgrade to an older CEF?
 
-## Legacy fix: Disable MemoryInfra periodic dumps (Chrome runtime only)
+Earlier attempts downgraded to CEF 122 / 126 (pre-Chrome-runtime), believing
+this was a Chrome-runtime regression. That does avoid the crash, but:
 
-If the project ever moves back to a Chrome-runtime CEF (127+), the following
-flags reduce — but do not eliminate — the crash rate. They are no-ops on the
-Alloy runtime we currently use, but are kept in `entrypoint.sh` as
-defense-in-depth.
+- Gives up ~20 Chromium versions of security patches and web platform features.
+- Pins to an old gstcefsrc commit (`0e470f51fd`, 2024-10); no bugfixes.
+- CEF 123–126 introduced ABI changes (e.g. `OnRenderProcessTerminated` added
+  `error_code`/`error_string` params in CEF 126) that break that gstcefsrc
+  pin, forcing CEF 122 specifically.
+
+The shim targets the real bug at a lower level and keeps us on modern CEF.
+
+### Defense-in-depth flags
+
+The Chromium flags in `entrypoint.sh` reduce how often MemoryInfra runs,
+which lowers the probability of hitting the overflow path even without the
+shim. They are retained because they're harmless and provide a second line
+of defense:
 
 ### Important: `disable-background-tracing` does not exist
 


### PR DESCRIPTION
## Summary
- Root cause identified via CEF issue [#3963](https://github.com/chromiumembedded/cef/issues/3963): libcef.so calls glibc's legacy int-based `mallinfo()`; when the CEF arena exceeds 2 GiB the int fields overflow, Chromium `checked_cast<size_t>` fails, and Chromium CHECKs → SIGILL.
- Fix: LD_PRELOAD a ~30-line shim that replaces `mallinfo()` with a zero-filled struct. No overflow, no crash, and zero impact on GStreamer/GLib/Rust (nothing in our stack calls `mallinfo`).
- Restores CEF to 144.0.11 (latest) and gstcefsrc to current master — the earlier downgrade to CEF 122 is no longer needed.

## Test plan
- [ ] `build-gstcefsrc.yml` succeeds for both linux-amd64 and linux-arm64
- [ ] Release artifact `gstcefsrc-144.0.11-linux-*.tar.gz` contains `lib/cef/libmallinfo_shim.so`
- [ ] `strom-full` runs with `LD_PRELOAD` set; cefsrc flows run without SIGILL beyond 2 GiB arena usage