### PR TITLE
chore(cef): bump to CEF 144.0.21 and align strom-full version

### DIFF
--- a/.github/workflows/build-gstcefsrc.yml
+++ b/.github/workflows/build-gstcefsrc.yml
@@ -7,9 +7,9 @@ on:
   workflow_dispatch:
     inputs:
       cef_version:
-        description: 'CEF version (e.g., 144.0.11+ge135be2+chromium-144.0.7559.97)'
+        description: 'CEF version (e.g., 144.0.21+g4f5b28c+chromium-144.0.7559.248)'
         required: true
-        default: '144.0.11+ge135be2+chromium-144.0.7559.97'
+        default: '144.0.21+g4f5b28c+chromium-144.0.7559.248'
         type: string
       gstcefsrc_ref:
         description: 'gstcefsrc git ref (full 40-char commit SHA, tag, or branch). Must be a full SHA — GitHub uploadpack does not resolve short SHAs.'

--- a/docker/gstcefsrc/Dockerfile
+++ b/docker/gstcefsrc/Dockerfile
@@ -21,7 +21,7 @@ ARG TARGETARCH
 # docs/CEF_SIGILL_CRASH.md). The shim interposes glibc's legacy int-based
 # mallinfo(), whose fields overflow when the CEF process arena > 2 GiB and
 # trigger a Chromium CHECK() on a failed checked_cast<size_t>.
-ARG CEF_VERSION=144.0.11+ge135be2+chromium-144.0.7559.97
+ARG CEF_VERSION=144.0.21+g4f5b28c+chromium-144.0.7559.248
 
 # Current gstcefsrc master (pinned to a full SHA for reproducibility).
 ARG GSTCEFSRC_REF=b63340852fc93b0ab67b07200e1ff44f59ba6769

--- a/docker/strom-full/Dockerfile
+++ b/docker/strom-full/Dockerfile
@@ -13,7 +13,7 @@ ARG VERSION=latest
 FROM eyevinntechnology/strom:${VERSION}
 
 # gstcefsrc version (pinned to known-good version)
-ARG GSTCEFSRC_VERSION=144.0.12
+ARG GSTCEFSRC_VERSION=144.0.21
 ARG TARGETARCH
 
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
## Summary
- Bump CEF from 144.0.11 (Chromium 144.0.7559.97) to 144.0.21 (Chromium 144.0.7559.248). Patch-level within the 144 series; no ABI break.
- Align `docker/strom-full/Dockerfile` `GSTCEFSRC_VERSION` from 144.0.12 -> 144.0.21. The 144.0.12 value pre-dated recent work and pointed at an artifact that was never built; 144.0.21 matches what the new workflow run will produce.
- Picks up ~5 months of Chromium security fixes.

## Test plan
- [ ] `build-gstcefsrc.yml` succeeds for both archs
- [ ] Release artifact `gstcefsrc-144.0.21-linux-*.tar.gz` contains `lib/cef/libmallinfo_shim.so`
- [ ] `strom-full` build can resolve the new artifact