### PR TITLE
feat(efp): cross-source sync via normalize_segment + preroll fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1671,16 +1671,16 @@ dependencies = [
 
 [[package]]
 name = "efp"
-version = "0.2.5"
-source = "git+https://github.com/Eyevinn/efp?tag=v0.2.5#f6791367b094ae506dae0561931ea74dd76df2b2"
+version = "0.2.6"
+source = "git+https://github.com/Eyevinn/efp?tag=v0.2.6#10c4d839c9e7db73f13ba5183d3c34eeafbea9bc"
 dependencies = [
  "efp-sys",
 ]
 
 [[package]]
 name = "efp-sys"
-version = "0.2.5"
-source = "git+https://github.com/Eyevinn/efp?tag=v0.2.5#f6791367b094ae506dae0561931ea74dd76df2b2"
+version = "0.2.6"
+source = "git+https://github.com/Eyevinn/efp?tag=v0.2.6#10c4d839c9e7db73f13ba5183d3c34eeafbea9bc"
 dependencies = [
  "bindgen",
  "cmake",
@@ -1969,7 +1969,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2417,7 +2417,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2672,8 +2672,8 @@ dependencies = [
 
 [[package]]
 name = "gst-plugin-efp"
-version = "0.2.5"
-source = "git+https://github.com/Eyevinn/efp?tag=v0.2.5#f6791367b094ae506dae0561931ea74dd76df2b2"
+version = "0.2.6"
+source = "git+https://github.com/Eyevinn/efp?tag=v0.2.6#10c4d839c9e7db73f13ba5183d3c34eeafbea9bc"
 dependencies = [
  "efp",
  "glib",
@@ -3510,7 +3510,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -5871,7 +5871,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5930,7 +5930,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6929,7 +6929,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -60,7 +60,7 @@ gst-plugin-inter.workspace = true
 gst-plugin-rtp.workspace = true
 gst-plugins-lsp = { git = "https://github.com/srperens/lsp-plugins-rs", tag = "v1.3.1", package = "gst-plugins-lsp" }
 agua-gst = { git = "https://github.com/srperens/agua", tag = "v0.2.4", package = "agua-gst" }
-gst-plugin-efp = { git = "https://github.com/Eyevinn/efp", tag = "v0.2.5", package = "gst-plugin-efp", optional = true }
+gst-plugin-efp = { git = "https://github.com/Eyevinn/efp", tag = "v0.2.6", package = "gst-plugin-efp", optional = true }
 
 # Encoding
 base64 = "0.22"

--- a/backend/src/blocks/builtin/efpsrt.rs
+++ b/backend/src/blocks/builtin/efpsrt.rs
@@ -201,6 +201,10 @@ impl BlockBuilder for EfpSrtOutputBuilder {
 
         srtsink.set_property("sync", sync);
         srtsink.set_property("qos", true);
+        // async=false: don't block pipeline preroll waiting for the first buffer.
+        // In listener mode without a connected client, the sink would otherwise
+        // hold PAUSED->PLAYING indefinitely. Matches mpegtssrt and WHEP/WHIP/AES67 sinks.
+        srtsink.set_property("async", false);
 
         if has_auto_reconnect {
             info!(

--- a/backend/src/blocks/builtin/efpsrt_input.rs
+++ b/backend/src/blocks/builtin/efpsrt_input.rs
@@ -23,12 +23,13 @@
 //! (e.g. CUDAMemory from nvh264dec) for downstream elements.
 
 use crate::blocks::{BlockBuildContext, BlockBuildError, BlockBuildResult, BlockBuilder};
+use crate::events::EventBroadcaster;
 use gstreamer as gst;
 use gstreamer::prelude::*;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use strom_types::{block::*, element::ElementPadRef, PropertyValue, *};
+use strom_types::{block::*, element::ElementPadRef, FlowId, PropertyValue, *};
 use tracing::{debug, error, warn};
 
 /// EFP/SRT Input block builder.
@@ -147,6 +148,20 @@ impl BlockBuilder for EfpSrtInputBuilder {
             })
             .unwrap_or(DEFAULT_EFP_HOL_TIMEOUT);
 
+        let normalize_segment = properties
+            .get("normalize_segment")
+            .and_then(|v| match v {
+                PropertyValue::String(s) => Some(s.clone()),
+                _ => None,
+            })
+            .unwrap_or_else(|| "auto".to_string());
+        if !matches!(normalize_segment.as_str(), "auto" | "always" | "never") {
+            return Err(BlockBuildError::InvalidProperty(format!(
+                "normalize_segment must be one of 'auto', 'always', 'never' (got '{}')",
+                normalize_segment
+            )));
+        }
+
         let num_video_tracks = properties
             .get("num_video_tracks")
             .and_then(|v| match v {
@@ -201,10 +216,19 @@ impl BlockBuilder for EfpSrtInputBuilder {
             .map_err(|e| BlockBuildError::ElementCreation(format!("efpdemux: {}", e)))?;
         demux_element.set_property("bucket-timeout", bucket_timeout);
         demux_element.set_property("hol-timeout", hol_timeout);
+        if demux_element.has_property("normalize-segment") {
+            demux_element.set_property_from_str("normalize-segment", &normalize_segment);
+        } else {
+            warn!(
+                "EFP demuxer does not expose 'normalize-segment' (requires gst-plugin-efp >= 0.2.6); \
+                 ignoring normalize_segment={}",
+                normalize_segment
+            );
+        }
 
         debug!(
-            "EFP demuxer configured: bucket-timeout={}, hol-timeout={}",
-            bucket_timeout, hol_timeout
+            "EFP demuxer configured: bucket-timeout={}, hol-timeout={}, normalize-segment={}",
+            bucket_timeout, hol_timeout, normalize_segment
         );
 
         let mut elements = vec![
@@ -399,10 +423,26 @@ impl BlockBuilder for EfpSrtInputBuilder {
             mode_label, num_video_tracks, num_audio_tracks
         );
 
+        // If the operator asked for `never`, absolute PTS must survive as running-time.
+        // That only works when the pipeline clock is globally meaningful (realtime/TAI
+        // or a network clock). Monotonic pipeline clock + normalize=never = nonsense
+        // timestamps — warn the operator at pipeline-start.
+        let bus_message_handler = if normalize_segment == "never" {
+            let instance_id_for_handler = instance_id.to_string();
+            let demux_weak = demux_element.downgrade();
+            Some(Box::new(
+                move |bus: &gst::Bus, _flow_id: FlowId, _events: EventBroadcaster| {
+                    connect_clock_check_handler(bus, instance_id_for_handler, demux_weak)
+                },
+            ) as crate::blocks::BusMessageConnectFn)
+        } else {
+            None
+        };
+
         Ok(BlockBuildResult {
             elements,
             internal_links,
-            bus_message_handler: None,
+            bus_message_handler,
             pad_properties: HashMap::new(),
         })
     }
@@ -612,6 +652,69 @@ fn link_passthrough_video(
     Ok(())
 }
 
+/// Connect a handler that inspects the pipeline clock once the pipeline enters
+/// Playing, and warns if the operator chose `normalize_segment=never` while
+/// running on a monotonic clock. That combination produces running-times
+/// anchored to a sender-local wallclock with a receiver-local monotonic base
+/// — i.e. nonsense — and is almost always a configuration error.
+fn connect_clock_check_handler(
+    bus: &gst::Bus,
+    instance_id: String,
+    demux: gst::glib::WeakRef<gst::Element>,
+) -> gst::glib::SignalHandlerId {
+    use gst::MessageView;
+    let already_checked = Arc::new(AtomicBool::new(false));
+    bus.connect_message(Some("state-changed"), move |_bus, msg| {
+        if already_checked.load(Ordering::SeqCst) {
+            return;
+        }
+        let state_changed = match msg.view() {
+            MessageView::StateChanged(sc) => sc,
+            _ => return,
+        };
+        if state_changed.current() != gst::State::Playing {
+            return;
+        }
+        // Only care about the pipeline's state change, not individual elements.
+        let src = match msg.src() {
+            Some(s) => s,
+            None => return,
+        };
+        if src.downcast_ref::<gst::Pipeline>().is_none() {
+            return;
+        }
+        let Some(demux) = demux.upgrade() else {
+            return;
+        };
+        let Some(clock) = demux.clock() else {
+            return;
+        };
+        let type_name = clock.type_().name();
+        let is_monotonic = match type_name {
+            "GstPtpClock" | "GstNtpClock" | "GstNetClientClock" => false,
+            "GstSystemClock" => matches!(
+                clock.property::<gst::ClockType>("clock-type"),
+                gst::ClockType::Monotonic
+            ),
+            _ => false,
+        };
+        already_checked.store(true, Ordering::SeqCst);
+        if is_monotonic {
+            warn!(
+                "EFPSRT Input {}: normalize_segment=never but pipeline clock is monotonic ({}). \
+                 Absolute PTS won't map to a meaningful running-time. Configure the pipeline \
+                 with a realtime/NTP/PTP clock, or set normalize_segment=auto.",
+                instance_id, type_name
+            );
+        } else {
+            debug!(
+                "EFPSRT Input {}: normalize_segment=never running on clock '{}' — OK",
+                instance_id, type_name
+            );
+        }
+    })
+}
+
 /// Get metadata for EFP/SRT input blocks (for UI/API).
 pub fn get_blocks() -> Vec<BlockDefinition> {
     vec![efpsrt_input_definition()]
@@ -693,6 +796,38 @@ fn efpsrt_input_definition() -> BlockDefinition {
                 live: false,
             },
             ExposedProperty {
+                name: "normalize_segment".to_string(),
+                label: "Normalize Segment".to_string(),
+                description: "How to set segment.start on outgoing pads. 'auto' (default) \
+                    picks based on the pipeline clock: monotonic → normalize, \
+                    realtime/TAI/NTP/PTP → pass absolute PTS through. 'always' forces \
+                    normalization (legacy). 'never' preserves absolute PTS — required \
+                    for cross-source synchronization.".to_string(),
+                property_type: PropertyType::Enum {
+                    values: vec![
+                        EnumValue {
+                            value: "auto".to_string(),
+                            label: Some("Auto (based on pipeline clock)".to_string()),
+                        },
+                        EnumValue {
+                            value: "always".to_string(),
+                            label: Some("Always normalize".to_string()),
+                        },
+                        EnumValue {
+                            value: "never".to_string(),
+                            label: Some("Never (preserve absolute PTS)".to_string()),
+                        },
+                    ],
+                },
+                default_value: Some(PropertyValue::String("auto".to_string())),
+                mapping: PropertyMapping {
+                    element_id: "_block".to_string(),
+                    property_name: "normalize_segment".to_string(),
+                    transform: None,
+                },
+                live: false,
+            },
+            ExposedProperty {
                 name: "keep_listening".to_string(),
                 label: "Keep Listening".to_string(),
                 description: "Keep SRT source alive after disconnect, allowing reconnection (default: true)".to_string(),
@@ -758,5 +893,100 @@ fn efpsrt_input_definition() -> BlockDefinition {
             height: Some(2.0),
             ..Default::default()
         }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gstreamer as gst;
+
+    fn init_gst() {
+        let _ = gst::init();
+    }
+
+    fn efpdemux_available() -> bool {
+        let registry = gst::Registry::get();
+        registry
+            .find_feature("efpdemux", gst::ElementFactory::static_type())
+            .is_some()
+    }
+
+    fn build_with_normalize_segment(value: &str) -> Result<BlockBuildResult, BlockBuildError> {
+        let mut properties = HashMap::new();
+        properties.insert(
+            "normalize_segment".to_string(),
+            PropertyValue::String(value.to_string()),
+        );
+        let ctx = BlockBuildContext::new(vec![], "all".to_string());
+        EfpSrtInputBuilder.build("test_instance", &properties, &ctx)
+    }
+
+    fn find_demux(result: &BlockBuildResult) -> gst::Element {
+        result
+            .elements
+            .iter()
+            .find(|(id, _)| id.ends_with(":efpdemux"))
+            .map(|(_, e)| e.clone())
+            .expect("block result must contain an efpdemux element")
+    }
+
+    #[test]
+    fn normalize_segment_never_is_applied_to_demux() {
+        init_gst();
+        if !efpdemux_available() {
+            eprintln!("efpdemux plugin not available — skipping");
+            return;
+        }
+        let result = build_with_normalize_segment("never").expect("build should succeed");
+        let demux = find_demux(&result);
+        let mode: i32 = demux
+            .property_value("normalize-segment")
+            .get()
+            .unwrap_or(-1);
+        // Matches the enum ordering in gst-plugin-efp: Auto=0, Always=1, Never=2.
+        assert_eq!(
+            mode, 2,
+            "normalize_segment=never must set demux property to Never"
+        );
+    }
+
+    #[test]
+    fn normalize_segment_auto_is_default() {
+        init_gst();
+        if !efpdemux_available() {
+            eprintln!("efpdemux plugin not available — skipping");
+            return;
+        }
+        let ctx = BlockBuildContext::new(vec![], "all".to_string());
+        let result = EfpSrtInputBuilder
+            .build("test_instance", &HashMap::new(), &ctx)
+            .expect("build should succeed with no properties");
+        let demux = find_demux(&result);
+        let mode: i32 = demux
+            .property_value("normalize-segment")
+            .get()
+            .unwrap_or(-1);
+        assert_eq!(mode, 0, "default normalize_segment must be Auto");
+    }
+
+    #[test]
+    fn normalize_segment_invalid_value_errors() {
+        init_gst();
+        let result = build_with_normalize_segment("sometimes");
+        let err = match result {
+            Err(e) => e,
+            Ok(_) => panic!("invalid value should produce InvalidProperty, got Ok"),
+        };
+        match err {
+            BlockBuildError::InvalidProperty(msg) => {
+                assert!(
+                    msg.contains("normalize_segment"),
+                    "error should mention the offending property, got: {}",
+                    msg
+                );
+            }
+            other => panic!("expected InvalidProperty, got {:?}", other),
+        }
     }
 }

--- a/docs/STREAM_SYNCHRONIZATION.md
+++ b/docs/STREAM_SYNCHRONIZATION.md
@@ -1,0 +1,125 @@
+# Stream Synchronization
+
+How to align multiple input streams on a shared timeline so that buffers with
+the same source-wallclock PTS line up at the mixer/compositor input, regardless
+of independent network paths, jitter, or receiver latency.
+
+This document is the reference for anyone configuring EFP/SRT inputs (and
+eventually other protocols) for synchronized playout.
+
+## Concept
+
+Synchronization in a GStreamer pipeline happens in three places:
+
+1. **At the sender.** Each buffer gets a PTS that is interpreted on the
+   sender's clock. If that clock is globally meaningful (NTP/PTP/wallclock),
+   the PTS encodes "absolute time of this frame".
+2. **In transport.** EFP preserves PTS exactly. If the sender wrote "20.040 s
+   since epoch", the receiver reads "20.040 s since epoch".
+3. **At the receiver.** The pipeline's running-time is what downstream elements
+   (mixers, compositors) sync on. Running-time is derived from buffer PTS via
+   `running_time = PTS - segment.start + segment.base`. To make running-time
+   across two demux instances comparable, `segment.start` must be identical
+   (typically 0) on both.
+
+If any of these three links is broken, synchronization fails.
+
+## Pipeline clock
+
+The pipeline clock determines what "now" means in a running-time domain. Pick
+one *globally meaningful* clock when you care about cross-source alignment:
+
+| Clock | When to use | `normalize_segment=never` works? |
+|---|---|---|
+| `GstSystemClock` — realtime | Single machine, all peers share the same OS wallclock (NTP-synced OS). | Yes |
+| `GstSystemClock` — TAI | Same as realtime, leap-seconds-free. | Yes |
+| `GstNetClientClock` | Receiver slaves to a sender's clock over UDP. | Yes |
+| `GstNtpClock` | NTP-synced clock without OS-level NTP required. | Yes |
+| `GstPtpClock` | Broadcast-grade sub-microsecond sync via PTP (IEEE 1588). | Yes |
+| `GstSystemClock` — monotonic (default) | Playout / transcode where only frame cadence matters. | **No — config error** |
+
+Monotonic clock is the default; GStreamer picks it silently if you don't
+override. It cannot be used for cross-source sync, because its zero is
+"receiver boot time" — incommensurable with any sender's timeline.
+
+### Setting a non-default clock
+
+You can set the clock on the pipeline before it reaches PLAYING. Example (in
+code):
+
+```rust
+use gstreamer::prelude::*;
+
+let clock: gst::SystemClock = glib::Object::builder()
+    .property("clock-type", gst::ClockType::Realtime)
+    .build();
+pipeline.use_clock(Some(&clock));
+```
+
+For PTP, replace with `gst::PtpClock::new(Some("eth0"), 0)`. For NTP, use
+`gst::NtpClock::new(None, "ntp.server.example", 123, gst::ClockTime::ZERO)`.
+
+Strom does not currently expose a per-flow clock selector in the UI. If you
+need one, the pipeline is built in `backend/src/gst/pipeline`; the clock must
+be installed after the pipeline is constructed but before `set_state(Playing)`.
+
+## `normalize_segment` on EFP inputs
+
+The EFP demuxer has a `normalize_segment` property with three values:
+
+- **`auto`** (default). The demuxer inspects the pipeline clock: a monotonic
+  `GstSystemClock` means normalize (legacy behaviour), any realtime/TAI/NTP/PTP
+  clock means pass absolute PTS through. This is the right choice for almost
+  all users.
+- **`always`**. Force normalization. Segment start is rewritten to match the
+  first large PTS seen on each pad; running-time starts near 0 per pad. Use
+  this only for legacy pipelines that assumed this behaviour.
+- **`never`**. Never rewrite the segment. Running-time equals absolute PTS.
+  Required for cross-source synchronization. Only valid when the pipeline
+  clock is globally meaningful — if you set `never` with a monotonic clock,
+  strom logs a warning at pipeline start.
+
+### Choosing a value
+
+| Scenario | `normalize_segment` | Clock |
+|---|---|---|
+| Single stream playout / transcode (no sync needed) | `auto` | any |
+| Multiple EFP inputs mixed/composited by real-world time | `never` | realtime / NTP / PTP |
+| Legacy pipeline expecting running-time-from-zero per pad | `always` | any |
+| "I'm not sure" | `auto` | Match what you actually want: monotonic for simplicity, realtime/NTP/PTP for sync |
+
+## Sender side
+
+`efpmux` copies `buffer.pts()` from each input buffer directly into the EFP
+frame; it does not rewrite timestamps. For the sender's PTS to be globally
+meaningful, the upstream pipeline must have been timestamping in the
+wallclock/NTP/PTP domain — typically because the pipeline clock was chosen
+that way and the source element populates PTS from `clock.time() - base_time`.
+
+If your sender clock is monotonic, you can still force wallclock stamping by
+inserting a `clocksync` with `sync=true` just before `efpmux` while running
+the sender's pipeline clock as realtime/NTP/PTP.
+
+## Verifying sync works
+
+1. Confirm the sender pipeline clock is realtime / NTP / PTP.
+2. Confirm the receiver pipeline clock is the same family (realtime, NTP, or
+   PTP).
+3. Set `normalize_segment=never` on each receiving EFP input block.
+4. Start the flow. Look for `EFPSRT Input {id}: normalize_segment=never
+   running on clock 'GstSystemClock' — OK` in the log (or equivalent for
+   NTP/PTP). If you see a warning about monotonic clock, fix the config.
+5. Compare running-times on the receiving side using a mixer latency probe
+   or `gst_debug_bin_to_dot_file` to confirm the two streams align within
+   expected jitter.
+
+## Reference: tests
+
+- `gst-plugin-efp/tests/pipeline.rs`:
+  `pts_preservation_roundtrip_with_normalize_never` — end-to-end proof that
+  absolute PTS survives `efpmux → efpdemux` when `normalize-segment=never`.
+- `gst-plugin-efp/tests/pipeline.rs`:
+  `normalize_segment_auto_{monotonic,realtime}_clock_*` — auto-mode clock
+  detection.
+- `backend/src/blocks/builtin/efpsrt_input.rs::tests::normalize_segment_*` —
+  strom block wiring tests.


### PR DESCRIPTION
## Summary

Two related changes on the EFP/SRT input and output paths:

1. **`fix(efpsrt)`** — add `async=false` to the srtsink in the EFP/SRT Output block, matching the recent mpegtssrt fix (#504). Without it, listener-mode srtsink blocks the pipeline preroll waiting for data that only arrives after PLAYING is reached.

2. **`feat(efpsrt_input)`** — expose `normalize_segment` (auto/always/never, default auto) on the EFP/SRT Input block, bumping `gst-plugin-efp` to v0.2.6. The new property controls whether the demuxer rewrites `segment.start` to normalize per-pad running-time (legacy behaviour) or preserves absolute PTS so running-time is comparable across multiple demux instances — a prerequisite for synchronizing several EFP inputs in a mixer/compositor.

   - `auto` decides based on the pipeline clock: monotonic → normalize, realtime/TAI/NTP/PTP → passthrough. Safe default that doesn't change existing behaviour.
   - `never` is the sync mode; when combined with a monotonic pipeline clock a bus-message handler logs a warning at pipeline start (config error).
   - `always` is available for legacy pipelines that expected the old behaviour explicitly.

The plugin-side change is published as [Eyevinn/efp v0.2.6](https://github.com/Eyevinn/efp/releases/tag/v0.2.6) with its own end-to-end tests (PTS preservation through `efpmux → efpdemux`, plus auto-mode clock detection).

New docs: `docs/STREAM_SYNCHRONIZATION.md` covers pipeline clock selection, the `normalize_segment` options, and verification steps.

## Test plan

- [x] `cargo test --lib --features efp` — all 370 lib tests pass, including 3 new `blocks::builtin::efpsrt_input::tests::normalize_segment_*`
- [x] `cargo test --test openapi_test --features efp` — schema snapshot unchanged
- [x] `cargo clippy`, `cargo fmt` — pre-commit hooks pass
- [ ] Manual: spin up two senders on NTP-synced machines, configure receiver pipeline clock as NTP/realtime, set `normalize_segment=never` on both inputs, verify running-times align at the mixer
- [ ] Manual: `normalize_segment=never` on a default (monotonic) pipeline → confirm the warn log appears at Playing

🤖 Generated with [Claude Code](https://claude.com/claude-code)