### PR TITLE
chore(webrtc): lower client ICE gathering timeout from 2s to 1s

### DIFF
--- a/backend/static/whep/whep.js
+++ b/backend/static/whep/whep.js
@@ -276,7 +276,7 @@ class WhepConnection {
             this._logDebug('=== LOCAL SDP OFFER ===\n' + offer.sdp);
 
             // Wait for ICE gathering with detailed logging
-            this._log('Waiting for ICE gathering (timeout: 2s)...');
+            this._log('Waiting for ICE gathering (timeout: 1s)...');
             const gatheringStartTime = Date.now();
 
             await new Promise((resolve) => {
@@ -284,9 +284,9 @@ class WhepConnection {
                     resolve();
                 } else {
                     const timeout = setTimeout(() => {
-                        this._log('ICE gathering timeout after 2s', 'warning');
+                        this._log('ICE gathering timeout after 1s', 'warning');
                         resolve();
-                    }, 2000);
+                    }, 1000);
                     this.peerConnection.onicegatheringstatechange = () => {
                         if (this.peerConnection.iceGatheringState === 'complete') {
                             clearTimeout(timeout);

--- a/backend/static/whip/whip.js
+++ b/backend/static/whip/whip.js
@@ -283,7 +283,7 @@ class WhipClient {
             await this.peerConnection.setLocalDescription(offer);
 
             // Wait for ICE gathering to complete (or timeout)
-            this._log('Waiting for ICE gathering (timeout: 2s)...');
+            this._log('Waiting for ICE gathering (timeout: 1s)...');
             const gatheringStartTime = Date.now();
 
             await new Promise((resolve) => {
@@ -292,9 +292,9 @@ class WhipClient {
                     return;
                 }
                 const timeout = setTimeout(() => {
-                    this._log('ICE gathering timeout after 2s', 'warning');
+                    this._log('ICE gathering timeout after 1s', 'warning');
                     resolve();
-                }, 2000);
+                }, 1000);
                 this.peerConnection.onicegatheringstatechange = () => {
                     if (this.peerConnection.iceGatheringState === 'complete') {
                         clearTimeout(timeout);


### PR DESCRIPTION
## Summary
- Lower the client-side ICE gathering timeout from 2000 ms to 1000 ms in `whep.js` and `whip.js`.
- Affects the WHIP ingest page, the WHEP player page, and the vision mixer control UI (which reuses `whep.js` for its multiview connection).
- Soft timeout: when it fires, the SDP offer is still sent with whatever candidates have been gathered so far — now just 1 s sooner.

## Test plan
- [ ] Open the WHIP ingest page and confirm the "ICE gathering" log line reports 1 s timeout and the ingest connects.
- [ ] Open a WHEP player page and confirm playback starts.
- [ ] Open the vision mixer control UI and confirm the multiview preview comes up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)