### PR TITLE
chore: bump version to 0.4.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6683,7 +6683,7 @@ dependencies = [
 
 [[package]]
 name = "strom"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "agua-gst",
  "anyhow",
@@ -6758,7 +6758,7 @@ dependencies = [
 
 [[package]]
 name = "strom-frontend"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "base64",
  "chrono",
@@ -6794,7 +6794,7 @@ dependencies = [
 
 [[package]]
 name = "strom-mcp-server"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "anyhow",
  "reqwest 0.13.2",
@@ -6808,7 +6808,7 @@ dependencies = [
 
 [[package]]
 name = "strom-types"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "garde",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["types", "backend", "frontend", "mcp-server"]
 default-members = ["backend"]
 
 [workspace.package]
-version = "0.4.10"
+version = "0.4.11"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Per Enstedt <per.enstedt@eyevinn.se>"]


### PR DESCRIPTION
## Summary
- Bump workspace version from 0.4.10 to 0.4.11

## Test plan
- [x] `cargo check` (via pre-commit clippy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)