### PR TITLE
chore: bump rustls-webpki to 0.103.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5941,9 +5941,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## Summary
- Bump `rustls-webpki` from 0.103.10 → 0.103.12 (lockfile only)
- Resolves two RustSec advisories dated 2026-04-14:
  - [RUSTSEC-2026-0098](https://rustsec.org/advisories/RUSTSEC-2026-0098) — name constraints incorrectly accepted for URI names
  - [RUSTSEC-2026-0099](https://rustsec.org/advisories/RUSTSEC-2026-0099) — name constraints accepted for wildcard certs

## Test plan
- [x] `cargo audit` — both advisories cleared (remaining `rsa`/sqlx-mysql has no upstream fix and is build-macro transitive only)
- [x] `cargo check` (via pre-commit clippy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)