### PR TITLE
fix(frontend): avoid Instant underflow panic on WASM startup

### DIFF
--- a/frontend/src/app/constructors.rs
+++ b/frontend/src/app/constructors.rs
@@ -153,7 +153,7 @@ impl StromApp {
             last_rtp_stats_fetch: instant::Instant::now(),
             system_clock_info: None,
             system_clock_unsupported: false,
-            last_system_clock_fetch: instant::Instant::now() - std::time::Duration::from_secs(10),
+            last_system_clock_fetch: None,
 
             compositor_editor: None,
             mixer_editor: None,
@@ -327,7 +327,7 @@ impl StromApp {
             last_rtp_stats_fetch: instant::Instant::now(),
             system_clock_info: None,
             system_clock_unsupported: false,
-            last_system_clock_fetch: instant::Instant::now() - std::time::Duration::from_secs(10),
+            last_system_clock_fetch: None,
 
             compositor_editor: None,
             mixer_editor: None,

--- a/frontend/src/app/mod.rs
+++ b/frontend/src/app/mod.rs
@@ -693,8 +693,9 @@ pub struct StromApp {
     /// True if the backend reported the system clock endpoint is unsupported on
     /// this platform (non-Linux). Drives the "not available" message.
     system_clock_unsupported: bool,
-    /// Last time system clock was fetched (for periodic refresh while Clocks page is open)
-    last_system_clock_fetch: instant::Instant,
+    /// Last time system clock was fetched (for periodic refresh while Clocks page is open).
+    /// `None` means never fetched — triggers an immediate fetch on first Clocks page visit.
+    last_system_clock_fetch: Option<instant::Instant>,
     /// Compositor layout editor (if open)
     compositor_editor: Option<CompositorEditor>,
     /// Mixer editor (if open)

--- a/frontend/src/app/update.rs
+++ b/frontend/src/app/update.rs
@@ -1347,9 +1347,11 @@ impl eframe::App for StromApp {
         // Skip polling if we've already learned the backend doesn't support it.
         if matches!(self.current_page, AppPage::Clocks)
             && !self.system_clock_unsupported
-            && self.last_system_clock_fetch.elapsed() > std::time::Duration::from_secs(2)
+            && self
+                .last_system_clock_fetch
+                .is_none_or(|t| t.elapsed() > std::time::Duration::from_secs(2))
         {
-            self.last_system_clock_fetch = instant::Instant::now();
+            self.last_system_clock_fetch = Some(instant::Instant::now());
             self.fetch_system_clock_info(ui.ctx());
         }
 


### PR DESCRIPTION
## Summary
- WASM GUI crashed on load with `overflow when subtracting durations`. Root cause: `instant::Instant::now() - Duration::from_secs(10)` in the app constructor underflows because `performance.now()` is still under 10s at app-init time on every page load.
- Native uses `CLOCK_MONOTONIC` which is typically well past 10s by the time the GUI starts, so the bug never surfaced there — but the same code path would also panic if the process started within 10s of boot.
- Fix: switch `last_system_clock_fetch` to `Option<instant::Instant>`. `None` preserves the original intent (fetch immediately on the first Clocks page visit) without any startup-time subtraction.

## Test plan
- [x] `cargo check --target wasm32-unknown-unknown` in `frontend/` passes
- [x] Pre-commit clippy check passes
- [ ] Load the WASM GUI in a browser and confirm it no longer panics at startup
- [ ] Open the Clocks page and confirm system clock info fetches on first visit and refreshes periodically

🤖 Generated with [Claude Code](https://claude.com/claude-code)