### PR TITLE
feat(cef): opt-in GPU rendering via STROM_CEF_GPU=1

### DIFF
--- a/docker/strom-full/entrypoint.sh
+++ b/docker/strom-full/entrypoint.sh
@@ -9,6 +9,16 @@
 # strom-full uses Xvfb (X11) for CEF, so we need to adjust GL settings:
 # - With GPU: Keep egl-device for GStreamer GL (CUDA-GL interop), fully isolate CEF from GPU
 # - Without GPU: Override to x11/glx so GStreamer GL falls back via Xvfb/Mesa
+#
+# CEF GPU mode (opt-in via STROM_CEF_GPU=1):
+# Default is software rendering — safe, portable, near-zero CPU for idle/static
+# pages. Set STROM_CEF_GPU=1 to route CEF through ANGLE/Vulkan on the NVIDIA GPU.
+# GPU mode has a ~50% CPU floor per 1080p30 cefsrc regardless of page content
+# but greatly reduces renderer CPU for heavy canvas/WebGL work (e.g. 95% → 57%
+# on a 1080p30 canvas-heavy page). Recommended only for such workloads.
+# Requires host + docker run:
+#   --gpus all -e NVIDIA_DRIVER_CAPABILITIES=all
+#   -v /usr/share/vulkan/icd.d/nvidia_icd.json:/usr/share/vulkan/icd.d/nvidia_icd.json:ro
 
 # Start dbus and avahi-daemon for NDI network discovery
 # NDI uses mDNS (Avahi) to discover streams on the local network.
@@ -25,26 +35,33 @@ rm -f /tmp/.X99-lock /tmp/.X11-unix/X99 2>/dev/null
 Xvfb :99 -screen 0 1920x1080x24 &
 export DISPLAY=:99
 
-# Detect GPU availability and configure GL accordingly
-if nvidia-smi > /dev/null 2>&1; then
-    echo "GPU detected - GStreamer will use egl-device, CEF uses software rendering"
-    # Keep GST_GL_WINDOW=egl-device and GST_GL_PLATFORM=egl from base image
-    # GStreamer GL elements (glvideomixer, glupload, etc.) use NVIDIA EGL directly
+# Detect GPU availability (container must be launched with --gpus all)
+HAS_GPU=no
+if nvidia-smi > /dev/null 2>&1; then HAS_GPU=yes; fi
 
+# Opt-in CEF GPU path via ANGLE/Vulkan.
+# ANGLE-over-Vulkan bypasses X11/DRI3 (which Xvfb lacks); it needs NVIDIA's
+# Vulkan ICD visible in the container (see header comment for the bind-mount).
+if [ "${STROM_CEF_GPU:-0}" = "1" ] && [ "$HAS_GPU" = "yes" ]; then
+    echo "CEF GPU mode enabled (STROM_CEF_GPU=1) - ANGLE/Vulkan on NVIDIA"
+    export GST_CEF_GPU_ENABLED=set
+    export GST_CEF_CHROME_EXTRA_FLAGS="no-sandbox,use-gl=angle,use-angle=vulkan,enable-gpu-rasterization,ignore-gpu-blocklist,enable-zero-copy,disable-features=BackgroundTracing,no-periodic-tasks,force-fieldtrials=,disable-field-trial-config,disable-breakpad,disable-crash-reporter,disable-dev-shm-usage,disable-background-networking,disable-component-update,enable-logging=stderr"
+elif [ "$HAS_GPU" = "yes" ]; then
+    if [ "${STROM_CEF_GPU:-0}" = "1" ]; then
+        echo "WARNING: STROM_CEF_GPU=1 but nvidia-smi unavailable - falling back to software"
+    else
+        echo "GPU detected - GStreamer uses egl-device; CEF in software (set STROM_CEF_GPU=1 to enable)"
+    fi
     # Fully isolate CEF from GPU to prevent SharedImageManager crashes.
     # disable-gpu alone is not enough - Chromium still starts a GPU subprocess that
     # probes the NVIDIA driver and initializes SharedImage mailboxes.
-    #
-    # MemoryInfra/PartitionAlloc SIGILL (exit code 132):
-    # The root cause is an mallinfo() int overflow when the CEF process arena
-    # exceeds 2 GiB — fixed at runtime by LD_PRELOADing libmallinfo_shim.so
-    # (see the LD_PRELOAD block below and docs/CEF_SIGILL_CRASH.md).
-    # The Chrome-runtime-specific flags below (disable-features=BackgroundTracing,
-    # no-periodic-tasks, etc.) are defense-in-depth — they reduce how often
-    # MemoryInfra runs but do not by themselves prevent the overflow CHECK.
     export GST_CEF_CHROME_EXTRA_FLAGS="no-sandbox,disable-gpu,disable-gpu-compositing,use-gl=disabled,disable-features=BackgroundTracing,no-periodic-tasks,force-fieldtrials=,disable-field-trial-config,disable-breakpad,disable-crash-reporter,disable-dev-shm-usage,disable-background-networking,disable-component-update,enable-logging=stderr"
 else
-    echo "No GPU detected - using software rendering for both GStreamer and CEF"
+    if [ "${STROM_CEF_GPU:-0}" = "1" ]; then
+        echo "WARNING: STROM_CEF_GPU=1 but no GPU visible in container (pass --gpus all) - falling back to software"
+    else
+        echo "No GPU detected - using software rendering for both GStreamer and CEF"
+    fi
     # Override base image GL settings to use Xvfb (X11/Mesa software renderer)
     # Without GPU, egl-device will fail since there's no EGL device available
     export GST_GL_WINDOW=x11

--- a/docs/HTML_RENDER.md
+++ b/docs/HTML_RENDER.md
@@ -133,10 +133,49 @@ The entrypoint script automatically:
 
 - Starts Xvfb on display `:99`
 - Disables CEF sandbox (required for Docker root user)
-- Disables GPU (Xvfb is software-only)
+- Uses software rendering for CEF by default (see GPU mode below for opt-in)
 - Configures CEF cache and logging
 
 No manual configuration is needed - just run the container and use `cefsrc` in your pipelines.
+
+### GPU mode (opt-in, experimental)
+
+CEF can be routed through the host NVIDIA GPU via ANGLE/Vulkan by setting
+`STROM_CEF_GPU=1`. The software default is kept because:
+
+- GPU mode has a roughly 50% CPU floor per `cefsrc` at 1080p30, independent of
+  page content (continuous Vulkan command-buffer submits and compositor work).
+- Software mode is near-zero-cost for idle or static pages — Chromium elides
+  paint when nothing changes, and `cefsrc` emits duplicate buffers cheaply.
+
+GPU mode pays off when the renderer is the bottleneck: canvas-heavy animations,
+WebGL/3D scenes, or very high resolutions. For example, a 1080p30 wind-map
+(canvas + continuous simulation) drops from ~95% CPU to ~57% CPU with GPU mode
+on an RTX 3090; the same simple static page goes from ~1% CPU to ~53%.
+
+**Enabling GPU mode:**
+
+```bash
+docker run --gpus all \
+  -e STROM_CEF_GPU=1 \
+  -e NVIDIA_DRIVER_CAPABILITIES=all \
+  -v /usr/share/vulkan/icd.d/nvidia_icd.json:/usr/share/vulkan/icd.d/nvidia_icd.json:ro \
+  --network host \
+  eyevinntechnology/strom-full:latest
+```
+
+Requirements:
+
+- NVIDIA driver on the host and `nvidia-container-toolkit` installed
+- `--gpus all` to pass the device into the container
+- `NVIDIA_DRIVER_CAPABILITIES=all` so the toolkit mounts the full lib set
+  (including `libGLX_nvidia.so.0`)
+- Bind-mount of the host's `nvidia_icd.json` — the container toolkit does not
+  mount the Vulkan ICD JSON automatically on all setups
+
+The entrypoint prints `CEF GPU mode enabled (STROM_CEF_GPU=1) - ANGLE/Vulkan
+on NVIDIA` when the GPU path activates, and warns if `STROM_CEF_GPU=1` is set
+but no GPU is visible in the container.
 
 ## Troubleshooting
 
@@ -168,10 +207,18 @@ Messages like "Failed to connect to the bus" are benign warnings - DBus is not a
 
 ### High CPU usage
 
-CEF renders pages continuously. For static content, consider:
-- Using simpler HTML/CSS
-- Reducing resolution if full HD isn't needed
-- Setting appropriate framerate in your pipeline
+CEF renders pages continuously. For software mode the biggest levers are:
+- **Resolution** — rendering at the target output size instead of 1080p is the
+  single biggest win for software mode. 640x360 uses roughly 3x less CPU than
+  1920x1080 because paint, compositor and BGRA transport all scale with pixel
+  count. Pass width/height via `cefsrc` or a downstream capsfilter.
+- **Framerate** — dropping from 30 to 15 fps roughly halves compositor and
+  transport cost, but page-internal JS loops continue at the browser's own
+  cadence unless the page is strictly `requestAnimationFrame`-driven.
+- **Content complexity** — simpler HTML/CSS. Canvas simulations and heavy
+  WebGL are CPU-bound in software mode.
+
+For genuinely canvas/WebGL-heavy pages, consider GPU mode (see above) instead.
 
 ## Building gstcefsrc
 
@@ -191,7 +238,7 @@ The build uses Ubuntu Questing to match the strom base image's glibc version.
 ## Limitations
 
 - **Docker only**: CEF requires X11, which the strom-full image provides via Xvfb
-- **Software rendering**: GPU acceleration is disabled in Docker; rendering is CPU-based
+- **Software rendering by default**: CEF uses CPU rendering; opt in to GPU with `STROM_CEF_GPU=1` (see above)
 - **Memory usage**: CEF spawns multiple processes (browser, renderer, GPU process)
 - **No audio by default**: Use `cefbin` or `cefdemux` if you need audio from web content
 


### PR DESCRIPTION
## Summary

- Add `STROM_CEF_GPU=1` env-var toggle to route CEF through ANGLE/Vulkan on NVIDIA GPUs. Default remains software rendering.
- Document when GPU mode pays off vs. hurts, plus the runtime requirements (`--gpus all`, `NVIDIA_DRIVER_CAPABILITIES=all`, bind-mount of `nvidia_icd.json`).
- Refresh the *High CPU usage* troubleshooting notes to reflect measured behaviour (resolution is the biggest software-mode lever).

## Why not default-on

Measured on an RTX 3090 (`cefsrc → fakesink sync=true` @ 1080p30):

| Page | Software CPU | GPU CPU |
|---|---|---|
| Static HTML (`<h1>Hello</h1>`) | ~1 % | ~53 % |
| Canvas-heavy wind map (earth.nullschool.net) | ~95 % | ~57 % |

GPU mode has a roughly 50 % CPU floor per stream at 1080p30 (continuous Vulkan command-buffer submits + compositor work) independent of page content. Software mode is near-zero-cost for idle/static pages because Chromium elides paint and `cefsrc` emits duplicate buffers cheaply. So GPU mode only wins when the renderer is the bottleneck (canvas/WebGL, 3D, very high resolutions).

## Why ANGLE/Vulkan specifically

Other Chromium GL backends don't work in this setup:

- `use-gl=egl` direct — rejected by CEF 144's allowed-implementations list
- `use-angle=gl-egl` — requires DRI3 which Xvfb lacks; falls back to Mesa llvmpipe software Vulkan and burns >1000 % CPU
- ANGLE/Vulkan — bypasses X11 entirely, talks to the NVIDIA driver via the Vulkan ICD

## Test plan

- [ ] `docker run strom-full` (no env, no `--gpus`) — logs `No GPU detected - using software rendering for both GStreamer and CEF`
- [ ] `docker run -e STROM_CEF_GPU=1 strom-full` (no `--gpus`) — logs `WARNING: STROM_CEF_GPU=1 but no GPU visible in container (pass --gpus all) - falling back to software`
- [ ] `docker run --gpus all -e STROM_CEF_GPU=1 -e NVIDIA_DRIVER_CAPABILITIES=all -v /usr/share/vulkan/icd.d/nvidia_icd.json:/usr/share/vulkan/icd.d/nvidia_icd.json:ro strom-full` — logs `CEF GPU mode enabled (STROM_CEF_GPU=1) - ANGLE/Vulkan on NVIDIA`; `nvidia-smi` shows `gstcefsubprocess --type=gpu-process` with non-zero VRAM
- [ ] `docker run --gpus all` (GPU passthrough but no `STROM_CEF_GPU`) — logs `GPU detected - GStreamer uses egl-device; CEF in software (set STROM_CEF_GPU=1 to enable)`, GStreamer side still has egl-device for existing CUDA-GL flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)