### PR TITLE
chore: bump version to 0.4.12 and gst-plugin-efp to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1671,16 +1671,16 @@ dependencies = [
 
 [[package]]
 name = "efp"
-version = "0.2.6"
-source = "git+https://github.com/Eyevinn/efp?tag=v0.2.6#10c4d839c9e7db73f13ba5183d3c34eeafbea9bc"
+version = "0.3.0"
+source = "git+https://github.com/Eyevinn/efp?tag=v0.3.0#fbb24bbfe3d05463d9f8ccec9fb8949e40b96812"
 dependencies = [
  "efp-sys",
 ]
 
 [[package]]
 name = "efp-sys"
-version = "0.2.6"
-source = "git+https://github.com/Eyevinn/efp?tag=v0.2.6#10c4d839c9e7db73f13ba5183d3c34eeafbea9bc"
+version = "0.3.0"
+source = "git+https://github.com/Eyevinn/efp?tag=v0.3.0#fbb24bbfe3d05463d9f8ccec9fb8949e40b96812"
 dependencies = [
  "bindgen",
  "cmake",
@@ -2672,8 +2672,8 @@ dependencies = [
 
 [[package]]
 name = "gst-plugin-efp"
-version = "0.2.6"
-source = "git+https://github.com/Eyevinn/efp?tag=v0.2.6#10c4d839c9e7db73f13ba5183d3c34eeafbea9bc"
+version = "0.3.0"
+source = "git+https://github.com/Eyevinn/efp?tag=v0.3.0#fbb24bbfe3d05463d9f8ccec9fb8949e40b96812"
 dependencies = [
  "efp",
  "glib",
@@ -6683,7 +6683,7 @@ dependencies = [
 
 [[package]]
 name = "strom"
-version = "0.4.11"
+version = "0.4.12"
 dependencies = [
  "agua-gst",
  "anyhow",
@@ -6758,7 +6758,7 @@ dependencies = [
 
 [[package]]
 name = "strom-frontend"
-version = "0.4.11"
+version = "0.4.12"
 dependencies = [
  "base64",
  "chrono",
@@ -6794,7 +6794,7 @@ dependencies = [
 
 [[package]]
 name = "strom-mcp-server"
-version = "0.4.11"
+version = "0.4.12"
 dependencies = [
  "anyhow",
  "reqwest 0.13.2",
@@ -6808,7 +6808,7 @@ dependencies = [
 
 [[package]]
 name = "strom-types"
-version = "0.4.11"
+version = "0.4.12"
 dependencies = [
  "garde",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["types", "backend", "frontend", "mcp-server"]
 default-members = ["backend"]
 
 [workspace.package]
-version = "0.4.11"
+version = "0.4.12"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Per Enstedt <per.enstedt@eyevinn.se>"]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -60,7 +60,7 @@ gst-plugin-inter.workspace = true
 gst-plugin-rtp.workspace = true
 gst-plugins-lsp = { git = "https://github.com/srperens/lsp-plugins-rs", tag = "v1.3.1", package = "gst-plugins-lsp" }
 agua-gst = { git = "https://github.com/srperens/agua", tag = "v0.2.4", package = "agua-gst" }
-gst-plugin-efp = { git = "https://github.com/Eyevinn/efp", tag = "v0.2.6", package = "gst-plugin-efp", optional = true }
+gst-plugin-efp = { git = "https://github.com/Eyevinn/efp", tag = "v0.3.0", package = "gst-plugin-efp", optional = true }
 
 # Encoding
 base64 = "0.22"


### PR DESCRIPTION
## Summary

- Bump workspace version `0.4.11` → `0.4.12`
- Upgrade `gst-plugin-efp` dependency from `v0.2.6` to `v0.3.0`

## Test plan

- [ ] `cargo build` passes at workspace root
- [ ] `cargo check` shows `Building version: 0.4.12`
- [ ] Existing EFP-using flows continue to play without regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)