### PR TITLE
fix(vision-mixer): use gpu-aware videoconvert in CPU pipeline

### DIFF
--- a/backend/src/blocks/builtin/vision_mixer/builder.rs
+++ b/backend/src/blocks/builtin/vision_mixer/builder.rs
@@ -6,6 +6,7 @@ use super::overlay::{self, OverlayRenderer, VisionMixerOverlayState};
 use super::properties;
 use crate::blocks::{BlockBuildContext, BlockBuildError, BlockBuildResult, BlockBuilder};
 use crate::events::EventBroadcaster;
+use crate::gpu;
 use gstreamer as gst;
 use gstreamer::prelude::*;
 use gstreamer_app as gst_app;
@@ -647,12 +648,17 @@ fn build_cpu_pipeline(
     elems.push((cf_pgm_mv_id.clone(), capsfilter_pgm_mv));
 
     // DSK input element chains (links to mixer added later after video inputs)
+    let vc_factory = gpu::video_convert_mode().element_name();
     for i in 0..p.num_dsk_inputs {
         let q_id = p.id(&format!("queue_dsk_{}", i));
         let vc_id_dsk = p.id(&format!("videoconvert_dsk_{}", i));
 
         let queue = elements::make_queue(&q_id)?;
-        let videoconvert = elements::make_element("videoconvert", &vc_id_dsk)?;
+        // Uses autovideoconvert on hosts with working CUDA-GL interop, plain
+        // videoconvert elsewhere — same pattern as videoenc/videoformat. Needed
+        // so that upstream GPU-memory sources (e.g. nvh264dec from efpsrt_input)
+        // negotiate correctly against the CPU compositor backend.
+        let videoconvert = elements::make_element(vc_factory, &vc_id_dsk)?;
 
         elems.push((q_id.clone(), queue));
         elems.push((vc_id_dsk.clone(), videoconvert));
@@ -738,7 +744,7 @@ fn build_cpu_pipeline(
     let q_overlay_id = p.id("queue_overlay");
     let queue_overlay = elements::make_queue(&q_overlay_id)?;
     let vc_overlay_id = p.id("videoconvert_overlay");
-    let videoconvert_overlay = elements::make_element("videoconvert", &vc_overlay_id)?;
+    let videoconvert_overlay = elements::make_element(vc_factory, &vc_overlay_id)?;
 
     elems.push((appsrc_overlay_id.clone(), appsrc_overlay.clone().upcast()));
     elems.push((q_overlay_id.clone(), queue_overlay));
@@ -792,7 +798,7 @@ fn build_cpu_pipeline(
         let tee_id = p.id(&format!("tee_{}", i));
 
         let queue = elements::make_queue(&q_id)?;
-        let videoconvert = elements::make_element("videoconvert", &vc_in_id)?;
+        let videoconvert = elements::make_element(vc_factory, &vc_in_id)?;
         let tee = elements::make_tee(&tee_id)?;
 
         elems.push((q_id.clone(), queue));

--- a/openapi.json
+++ b/openapi.json
@@ -10,7 +10,7 @@
     "license": {
       "name": "MIT OR Apache-2.0"
     },
-    "version": "0.4.11"
+    "version": "0.4.12"
   },
   "paths": {
     "/api/auth/status": {
@@ -295,8 +295,8 @@
         "tags": [
           "whip"
         ],
-        "summary": "Receive client-side log messages from the WHIP ingest page.",
-        "description": "Accepts a JSON array of log entries and writes them to the server log\nprefixed with `[WHIP-CLIENT]` so they can be correlated with server-side events.",
+        "summary": "Receive client-side log messages from any browser page (WHIP, WHEP, clocks, …).",
+        "description": "Accepts a JSON array of log entries and writes them to the server log\nprefixed with `[CLIENT]` so they can be correlated with server-side events.",
         "operationId": "client_log",
         "responses": {
           "204": {


### PR DESCRIPTION
## Summary
The CPU compositor path in the vision mixer hardcoded plain `videoconvert` for the DSK, overlay, and video-input chains. When an upstream source produces GPU memory (e.g. `nvh264dec` fed from `efpsrt_input`), plain `videoconvert` cannot negotiate against the CPU compositor backend and the pipeline fails to link.

This PR switches all three chains in `build_cpu_pipeline` to `gpu::video_convert_mode().element_name()`, matching the pattern already used by the videoenc, videoformat, decklink and ndi blocks — `autovideoconvert` on hosts with working CUDA-GL interop, plain `videoconvert` everywhere else.

The selection is computed once at startup in `backend/src/gpu.rs:42` based on WSL detection, GL renderer probing, and CUDA capability checks.

## Why this is safe
- **CPU-only hosts behave identically** — `video_convert_mode()` returns `Software`, which maps back to plain `videoconvert`.
- **Consistent with existing convention** — `videoformat.rs:107`, `decklink.rs:55,255`, `ndi.rs:209` already use the exact same helper. Vision mixer was the only hold-out.
- **No tests reference `"videoconvert"` by string**, so the rename does not break the existing `vision_mixer/tests.rs` assertions.
- **Only the CPU pipeline branch is touched** (`build_cpu_pipeline`, line 581+). The GPU pipeline (`build_gpu_pipeline`, line 242+) is untouched.
- **No code sets properties on these specific converter elements after construction**, so the fact that `autovideoconvert` (a bin) does not expose the same properties as plain `videoconvert` does not matter.

## Risks worth watching
- On a NVIDIA + working-interop host, sanity-check that `autovideoconvert` correctly inserts `cudadownload` when downstream is the CPU compositor (it is designed to, but worth a quick eyeball during the first run).
- `autovideoconvert` is a bin and adds a small amount of probing at element creation; negligible for typical input counts.

## Test plan
- [ ] `cargo build --release --features efp,nvidia` clean
- [ ] On a CPU-only host: build a vision-mixer flow with multiple inputs, start it, verify no CAPS negotiation errors in the log
- [ ] On a NVIDIA host with `nvh264dec` upstream (e.g. via `efpsrt_input`): same flow, verify the pipeline links and runs without errors
- [ ] Verify existing `vision_mixer/tests.rs` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)