### PR TITLE
fix(buffer-age): show external pad label instead of internal "sink"

### DIFF
--- a/backend/src/api/probes.rs
+++ b/backend/src/api/probes.rs
@@ -44,9 +44,11 @@ pub async fn activate_probe(
     let timeout_secs = req.timeout_secs.unwrap_or(60);
 
     // Resolve block input pads BEFORE taking the pipeline lock.
-    // For blocks: look up external input pads -> internal element IDs to probe.
+    // For blocks: look up external input pads -> internal element IDs to probe,
+    // along with each external pad's display label (so events can distinguish
+    // inputs that share the same internal "sink" pad name).
     // For standalone elements: empty list (handled below with find_gst_element).
-    let block_input_element_ids: Vec<String> = {
+    let block_input_element_ids: Vec<(String, String)> = {
         let flows = state.get_flows().await;
         let block_def_id = flows
             .iter()
@@ -57,7 +59,12 @@ pub async fn activate_probe(
                 let inputs = b.computed_external_pads.as_ref().map(|p| {
                     p.inputs
                         .iter()
-                        .map(|pad| format!("{}:{}", req.element_id, pad.internal_element_id))
+                        .map(|pad| {
+                            let element_key =
+                                format!("{}:{}", req.element_id, pad.internal_element_id);
+                            let display = pad.label.clone().unwrap_or_else(|| pad.name.clone());
+                            (element_key, display)
+                        })
                         .collect::<Vec<_>>()
                 });
                 (b.block_definition_id.clone(), inputs)
@@ -73,7 +80,12 @@ pub async fn activate_probe(
                     d.external_pads
                         .inputs
                         .iter()
-                        .map(|pad| format!("{}:{}", req.element_id, pad.internal_element_id))
+                        .map(|pad| {
+                            let element_key =
+                                format!("{}:{}", req.element_id, pad.internal_element_id);
+                            let display = pad.label.clone().unwrap_or_else(|| pad.name.clone());
+                            (element_key, display)
+                        })
                         .collect()
                 })
                 .unwrap_or_default()
@@ -99,39 +111,49 @@ pub async fn activate_probe(
 
     let pipeline = manager.pipeline().clone();
 
-    // Collect GStreamer elements to probe (clone to release borrow on manager)
-    let elements_to_probe: Vec<gst::Element> = if block_input_element_ids.is_empty() {
-        // Standalone element
-        match manager.find_gst_element(&req.element_id) {
-            Some(el) => vec![el.clone()],
-            None => {
-                return (
-                    StatusCode::NOT_FOUND,
-                    Json(serde_json::json!(ErrorResponse::new(format!(
-                        "Element or block '{}' not found",
-                        req.element_id
-                    )))),
-                )
-                    .into_response();
+    // Collect (element, display_pad_name) pairs to probe (clone elements to
+    // release borrow on manager). For standalone the display name is None so
+    // each pad is labeled with its own GStreamer pad name; for blocks it is
+    // the external pad's label so the UI can tell sibling inputs apart.
+    let elements_to_probe: Vec<(gst::Element, Option<String>)> =
+        if block_input_element_ids.is_empty() {
+            // Standalone element
+            match manager.find_gst_element(&req.element_id) {
+                Some(el) => vec![(el.clone(), None)],
+                None => {
+                    return (
+                        StatusCode::NOT_FOUND,
+                        Json(serde_json::json!(ErrorResponse::new(format!(
+                            "Element or block '{}' not found",
+                            req.element_id
+                        )))),
+                    )
+                        .into_response();
+                }
             }
-        }
-    } else {
-        // Block: collect internal elements for each input port
-        block_input_element_ids
-            .iter()
-            .filter_map(|id| manager.find_gst_element(id).cloned())
-            .collect()
-    };
+        } else {
+            // Block: collect internal elements for each input port, paired
+            // with the external pad's display label.
+            block_input_element_ids
+                .iter()
+                .filter_map(|(id, label)| {
+                    manager
+                        .find_gst_element(id)
+                        .map(|el| (el.clone(), Some(label.clone())))
+                })
+                .collect()
+        };
 
     let probe_manager = manager.probe_manager();
     let mut all_probe_ids = Vec::new();
     let mut last_error = None;
 
-    for el in &elements_to_probe {
+    for (el, display_pad_name) in &elements_to_probe {
         match probe_manager.activate_all_sinks(
             &pipeline,
             el,
             req.element_id.clone(),
+            display_pad_name.clone(),
             sample_interval,
             timeout_secs,
         ) {

--- a/backend/src/gst/buffer_age_probe.rs
+++ b/backend/src/gst/buffer_age_probe.rs
@@ -160,6 +160,9 @@ struct ProbeState {
     probe_id: String,
     flow_id: FlowId,
     element_id: String,
+    /// Human-friendly pad label sent in events. For block-level probes this is
+    /// the external pad's label/name (e.g. "V0", "audio_in_0"). For probes on
+    /// standalone elements it falls back to the GStreamer pad name (e.g. "sink").
     pad_name: String,
     /// GStreamer pad probe ID (for removal)
     gst_probe_id: Option<gst::PadProbeId>,
@@ -273,22 +276,30 @@ impl ProbeManager {
     /// - `pipeline`: the GStreamer pipeline (to obtain clock/base_time)
     /// - `element`: the GStreamer element whose pad we probe
     /// - `element_id`: the strom element_id (for events)
-    /// - `pad_name`: name of the pad to probe
+    /// - `pad_name`: name of the GStreamer pad to attach to (used for resolution)
+    /// - `display_pad_name`: human-friendly pad label sent in events. Pass
+    ///   `None` to fall back to the resolved GStreamer pad name (typical for
+    ///   standalone elements). For block-level probes, pass the external pad's
+    ///   label or name so the UI can distinguish multiple inputs that share
+    ///   the same internal pad name (e.g. all "sink").
     /// - `sample_interval`: measure every Nth buffer (default 1)
     /// - `timeout_secs`: auto-remove after this many seconds (default 60)
+    #[allow(clippy::too_many_arguments)]
     pub fn activate(
         &self,
         pipeline: &gst::Pipeline,
         element: &gst::Element,
         element_id: String,
         pad_name: String,
+        display_pad_name: Option<String>,
         sample_interval: u32,
         timeout_secs: u32,
     ) -> Result<String, String> {
         let pad = resolve_pad(element, &pad_name)?;
 
-        // Use the actual pad name (may differ from requested name)
-        let pad_name = pad.name().to_string();
+        // For events: the caller-supplied display label, or the resolved
+        // GStreamer pad name as fallback.
+        let pad_name = display_pad_name.unwrap_or_else(|| pad.name().to_string());
 
         let probe_id = Uuid::new_v4().to_string();
         let sample_interval = sample_interval.max(1);
@@ -376,11 +387,18 @@ impl ProbeManager {
 
     /// Activate probes on all sink pads of an element.
     /// Returns the list of probe IDs created.
+    ///
+    /// `display_pad_name` provides a human-friendly label that is used in
+    /// events for every probe attached here. Pass `Some` for block-level
+    /// activations (so the UI can identify the external input by its label
+    /// rather than the internal "sink" pad name); pass `None` for standalone
+    /// elements to fall back to the GStreamer pad name per pad.
     pub fn activate_all_sinks(
         &self,
         pipeline: &gst::Pipeline,
         element: &gst::Element,
         element_id: String,
+        display_pad_name: Option<String>,
         sample_interval: u32,
         timeout_secs: u32,
     ) -> Result<Vec<String>, String> {
@@ -405,6 +423,7 @@ impl ProbeManager {
                 element,
                 element_id.clone(),
                 pad_name.clone(),
+                display_pad_name.clone(),
                 sample_interval,
                 timeout_secs,
             ) {
@@ -448,17 +467,19 @@ impl ProbeManager {
                 continue;
             }
             for pad in sink_pads {
+                let pad_name = pad.name().to_string();
                 match self.attach_automatic_probe(
                     pipeline,
                     element,
                     element_id.clone(),
-                    pad.name().to_string(),
+                    pad_name.clone(),
+                    None,
                 ) {
                     Ok(_) => count += 1,
                     Err(e) => {
                         debug!(
                             element = %element_id,
-                            pad = %pad.name(),
+                            pad = %pad_name,
                             error = %e,
                             "Skipping automatic probe"
                         );
@@ -502,12 +523,21 @@ impl ProbeManager {
                     }
                 };
 
-                // Probe the specific internal pad that receives external input
+                // Probe the specific internal pad that receives external
+                // input. The internal pad name (often "sink") is used to
+                // resolve the GStreamer pad; the external pad's label or name
+                // is what we display in events so the UI can distinguish
+                // multiple inputs that all share the same internal pad name.
+                let display_pad_name = input_pad
+                    .label
+                    .clone()
+                    .unwrap_or_else(|| input_pad.name.clone());
                 match self.attach_automatic_probe(
                     pipeline,
                     element,
                     block.id.clone(),
                     input_pad.internal_pad_name.clone(),
+                    Some(display_pad_name),
                 ) {
                     Ok(_) => count += 1,
                     Err(e) => {
@@ -529,16 +559,22 @@ impl ProbeManager {
     }
 
     /// Attach a single automatic probe to a pad.
+    ///
+    /// `display_pad_name` overrides the pad name reported in events. Pass
+    /// `None` to fall back to the resolved GStreamer pad name (used for
+    /// standalone elements); pass `Some(label)` for block-level probes so
+    /// the UI can identify the external input by its user-visible label.
     fn attach_automatic_probe(
         &self,
         pipeline: &gst::Pipeline,
         element: &gst::Element,
         element_id: String,
         pad_name: String,
+        display_pad_name: Option<String>,
     ) -> Result<String, String> {
         let pad = resolve_pad(element, &pad_name)?;
 
-        let pad_name = pad.name().to_string();
+        let pad_name = display_pad_name.unwrap_or_else(|| pad.name().to_string());
         let probe_id = format!("auto-{}", Uuid::new_v4());
 
         let slot = Arc::new(ProbeSlot::new());
@@ -766,6 +802,7 @@ mod tests {
             &sink,
             "sink".to_string(),
             "sink".to_string(),
+            None,
             1,
             60,
         );
@@ -803,6 +840,7 @@ mod tests {
             &sink,
             "s1".to_string(),
             "sink".to_string(),
+            None,
             1,
             60,
         )
@@ -812,6 +850,7 @@ mod tests {
             &sink,
             "s2".to_string(),
             "sink".to_string(),
+            None,
             1,
             60,
         )
@@ -841,6 +880,7 @@ mod tests {
             &sink,
             "manual".to_string(),
             "sink".to_string(),
+            None,
             1,
             60,
         )

--- a/frontend/src/app/probe_ui.rs
+++ b/frontend/src/app/probe_ui.rs
@@ -64,7 +64,7 @@ impl StromApp {
     /// Render per-pad probe values vertically. Call after the header separator.
     /// Returns true if any probes were rendered (so callers can add spacing).
     pub(crate) fn render_probe_details(&self, ui: &mut egui::Ui, element_id: &str) -> bool {
-        let probes: Vec<(String, u64, u64, u64)> = self
+        let mut probes: Vec<(String, u64, u64, u64)> = self
             .buffer_age_data
             .get_probes_for_element(element_id)
             .iter()
@@ -77,6 +77,11 @@ impl StromApp {
                 )
             })
             .collect();
+
+        // Probes come from a HashMap, so iteration order is undefined. Sort by
+        // pad name so labels render in a stable, intuitive grouping (A0..An,
+        // PGM*, V0..Vn).
+        probes.sort_by(|a, b| a.0.cmp(&b.0));
 
         if probes.is_empty() {
             return false;


### PR DESCRIPTION
## Summary
Buffer age probes attached to block input pads were reporting the internal GStreamer pad name (typically `"sink"`) in `BufferAgeProbe` and `BufferAgeWarning` events. With multiple inputs on the same block (e.g. a vision mixer with `V0..Vn` / `A0..An`), every row in the frontend's probe table read `sink`, making them indistinguishable.

| Before | After |
|--------|-------|
| `Pad: sink, Age: 0ms` | `Pad: V0, Age: 0ms` |
| `Pad: sink, Age: 0ms` | `Pad: A0, Age: 0ms` |
| `Pad: sink, Age: 70ms` | `Pad: PGM Audio, Age: 70ms` |

## Changes
**Backend (`gst/buffer_age_probe.rs`):**
- `ProbeManager::activate`, `activate_all_sinks`, and `attach_automatic_probe` take an optional `display_pad_name`.
  - `Some(label)` → used in events / `ProbeState`.
  - `None` → falls back to the resolved GStreamer pad name. Preserves today's behavior for standalone elements.

**Backend (`api/probes.rs`, manual path):**
- `block_input_element_ids` now carries the external pad's label alongside each internal element id and forwards it to `activate_all_sinks`.

**Backend (`gst/buffer_age_probe.rs::attach_automatic`, automatic path):**
- The block loop passes `Some(input_pad.label.unwrap_or(input_pad.name))`.
- The standalone-element loop passes `None`.

**Frontend (`probe_ui::render_probe_details`):**
- Sorts probe rows by pad name so the table renders in a stable order (A0..An, PGM*, V0..Vn) instead of the underlying HashMap iteration order. Fixes the random-looking row order users were seeing.

## What does NOT change
- No API / wire-format changes — the existing `pad_name` field on `BufferAgeProbe`, `BufferAgeProbeActivated`, and `BufferAgeWarning` events is just populated with a more useful value for block-level probes.
- Standalone-element probes (`pad_name = "sink"` / `"sink_0"` / etc.) keep their current labels.
- No frontend type changes; the existing renderer just gets a better string.

## Test plan
- [x] `cargo check` clean
- [x] `cargo test --package strom buffer_age` passes (3 tests, signatures updated)
- [x] `cargo clippy --features efp,nvidia --all-targets` clean (added `#[allow(clippy::too_many_arguments)]` on `activate` since it now takes 8 args)
- [ ] Manually verify on a vision-mixer flow: probe each block input, confirm rows show `V0`, `V1`, `A0`, `PGM Audio`, etc. in alphabetical order

🤖 Generated with [Claude Code](https://claude.com/claude-code)