### PR TITLE
fix(nvidia-setup): cgroupfs + dev-char workarounds for NVML cgroup-reload bug

### DIFF
--- a/scripts/setup/nvidia/README.md
+++ b/scripts/setup/nvidia/README.md
@@ -232,6 +232,32 @@ docker: Error response from daemon: could not select device driver "" with capab
 ./install-nvidia-container-toolkit.sh
 ```
 
+### Container loses GPU after `systemctl daemon-reload`
+
+**Symptom:** A container that was running fine suddenly fails with:
+```
+nvidia-smi: Failed to initialize NVML: Unknown Error
+```
+or GStreamer pipelines fail with `Could not initialize supporting library` /
+`Failed to open encoder` on `nvh264enc` / `nvh265enc`. The host's
+`nvidia-smi` still works fine.
+
+**Cause:** Docker's default systemd cgroup driver lets systemd revoke device
+cgroup permissions on `daemon-reload` (or any unit reload involving GPU
+references). The container keeps running but its `/dev/nvidia*` access is
+gone. Tracked in
+[NVIDIA/nvidia-container-toolkit#48](https://github.com/NVIDIA/nvidia-container-toolkit/issues/48).
+
+**Solution:** `install-nvidia-container-toolkit.sh` applies both NVIDIA-recommended
+mitigations automatically:
+1. Sets `"exec-opts": ["native.cgroupdriver=cgroupfs"]` in `/etc/docker/daemon.json`
+   so device cgroups are managed by Docker directly, not via systemd
+2. Installs `/etc/udev/rules.d/71-nvidia-dev-char.rules` which keeps
+   `/dev/char/<major>:<minor>` symlinks present for `runc` device injection
+
+**Recovery if you hit this on an unfixed host:** `docker restart <container>`
+restores GPU access immediately. Then run the install script for a permanent fix.
+
 ### GStreamer GL plugins not found
 
 **Symptom:** `glupload`, `gldownload` elements not available.

--- a/scripts/setup/nvidia/install-nvidia-container-toolkit.sh
+++ b/scripts/setup/nvidia/install-nvidia-container-toolkit.sh
@@ -15,13 +15,47 @@ curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-contai
   sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
 
 # Update and install
-echo "Installing nvidia-container-toolkit..."
+echo "Installing nvidia-container-toolkit and jq..."
 sudo apt update
-sudo apt install -y nvidia-container-toolkit
+sudo apt install -y nvidia-container-toolkit jq
 
 # Configure Docker runtime
 echo "Configuring Docker runtime..."
 sudo nvidia-ctk runtime configure --runtime=docker
+
+# Apply NVML cgroup-reload workaround.
+#
+# Without this, containers lose GPU access ("Failed to initialize NVML:
+# Unknown Error") after any `systemctl daemon-reload` on the host because
+# Docker's default systemd cgroup driver lets systemd revoke the device
+# cgroup permissions that the container was started with.
+#
+# Switching Docker to the cgroupfs driver is NVIDIA's primary recommended
+# workaround. See: https://github.com/NVIDIA/nvidia-container-toolkit/issues/48
+echo "Applying cgroupdriver=cgroupfs to /etc/docker/daemon.json..."
+DAEMON_JSON="/etc/docker/daemon.json"
+if [ ! -f "$DAEMON_JSON" ]; then
+  echo "{}" | sudo tee "$DAEMON_JSON" >/dev/null
+fi
+sudo cp -a "$DAEMON_JSON" "${DAEMON_JSON}.bak.$(date +%Y%m%d-%H%M%S)"
+TMP=$(mktemp)
+sudo jq '."exec-opts" = (((."exec-opts" // []) | map(select(startswith("native.cgroupdriver=") | not))) + ["native.cgroupdriver=cgroupfs"])' \
+  "$DAEMON_JSON" > "$TMP"
+sudo mv "$TMP" "$DAEMON_JSON"
+sudo chmod 0644 "$DAEMON_JSON"
+
+# Install udev rule for /dev/char NVIDIA symlinks. Newer runc versions
+# require these symlinks to inject device nodes into containers correctly;
+# the NVIDIA driver does not create them itself. The rule re-runs nvidia-ctk
+# every time the nvidia driver binds to a PCI device (boot, module reload).
+echo "Installing /dev/char symlink udev rule..."
+sudo tee /etc/udev/rules.d/71-nvidia-dev-char.rules >/dev/null <<'RULE'
+# Create /dev/char symlinks for NVIDIA devices so runc can inject them
+# into containers correctly.
+ACTION=="add", DEVPATH=="/bus/pci/drivers/nvidia", RUN+="/usr/bin/nvidia-ctk system create-dev-char-symlinks --create-all"
+RULE
+sudo udevadm control --reload-rules
+sudo /usr/bin/nvidia-ctk system create-dev-char-symlinks --create-all
 
 # Restart Docker
 echo "Restarting Docker..."
@@ -29,8 +63,10 @@ sudo systemctl restart docker
 
 # Verify installation
 echo "=== Verifying installation ==="
+echo "Cgroup driver:"
+docker info 2>/dev/null | grep -E "Cgroup Driver|Cgroup Version"
+echo
 echo "Testing nvidia-smi in Docker..."
-#docker run --rm --gpus all nvidia/cuda:12.0.0-base-ubuntu22.04 nvidia-smi
 docker run --rm --gpus all ubuntu nvidia-smi
 
 echo "=== Done! ==="


### PR DESCRIPTION
## Summary

- Containers using `--gpus all` lose GPU access after `systemctl daemon-reload` because Docker's default systemd cgroup driver lets systemd revoke the device cgroup permissions. Surfaces as `Failed to initialize NVML: Unknown Error` inside the container and as `Could not initialize supporting library` / `Failed to open encoder` on `nvh264enc` in strom flows.
- `scripts/setup/nvidia/install-nvidia-container-toolkit.sh` now applies both NVIDIA-recommended mitigations: switches Docker to the cgroupfs cgroup driver and installs a udev rule that keeps `/dev/char` NVIDIA symlinks in sync. Tracked upstream in [NVIDIA/nvidia-container-toolkit#48](https://github.com/NVIDIA/nvidia-container-toolkit/issues/48); no fix exists in any released toolkit version (1.19.0 is latest).
- README gets a troubleshooting entry describing the symptom and the `docker restart` recovery for hosts that haven't been re-installed yet.

## Test plan

- [x] On affected host (frank): observed the bug — `nvidia-smi` inside `strom` / `strom8082` returned `Failed to initialize NVML: Unknown Error`, host `nvidia-smi` was fine, no GPU processes blocking.
- [x] Applied `cgroupdriver=cgroupfs` to `/etc/docker/daemon.json` and restarted Docker — verified `docker info` reports `Cgroup Driver: cgroupfs`, all containers came back up healthy.
- [x] Triggered `sudo systemctl daemon-reload` to reproduce the bug post-fix — both containers retained NVML access (passes the test that previously failed).
- [x] Verified udev rule recreates `/dev/char/<major>:<minor>` symlinks on driver bind.
- [x] `bash -n` syntax check on updated install script.
- [ ] Run the updated `install-nvidia-container-toolkit.sh` end-to-end on a fresh host to confirm the full flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)