### PR TITLE
fix(audio-mixer): use UInt type for channel/aux/group count properties

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6683,7 +6683,7 @@ dependencies = [
 
 [[package]]
 name = "strom"
-version = "0.4.12"
+version = "0.4.13-dev"
 dependencies = [
  "agua-gst",
  "anyhow",
@@ -6758,7 +6758,7 @@ dependencies = [
 
 [[package]]
 name = "strom-frontend"
-version = "0.4.12"
+version = "0.4.13-dev"
 dependencies = [
  "base64",
  "chrono",
@@ -6794,7 +6794,7 @@ dependencies = [
 
 [[package]]
 name = "strom-mcp-server"
-version = "0.4.12"
+version = "0.4.13-dev"
 dependencies = [
  "anyhow",
  "reqwest 0.13.3",
@@ -6808,7 +6808,7 @@ dependencies = [
 
 [[package]]
 name = "strom-types"
-version = "0.4.12"
+version = "0.4.13-dev"
 dependencies = [
  "garde",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["types", "backend", "frontend", "mcp-server"]
 default-members = ["backend"]
 
 [workspace.package]
-version = "0.4.12"
+version = "0.4.13-dev"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Per Enstedt <per.enstedt@eyevinn.se>"]

--- a/backend/src/blocks/builtin/mixer/definition.rs
+++ b/backend/src/blocks/builtin/mixer/definition.rs
@@ -10,44 +10,13 @@ pub fn get_blocks() -> Vec<BlockDefinition> {
 pub(super) fn mixer_definition() -> BlockDefinition {
     // Generate channel properties
     let mut exposed_properties = vec![
-        // Global: number of channels
+        // Global: number of channels (1..=MAX_CHANNELS, clamped on parse)
         ExposedProperty {
             name: "num_channels".to_string(),
             label: "Channels".to_string(),
-            description: "Number of input channels".to_string(),
-            property_type: PropertyType::Enum {
-                values: vec![
-                    EnumValue {
-                        value: "2".to_string(),
-                        label: Some("2".to_string()),
-                    },
-                    EnumValue {
-                        value: "4".to_string(),
-                        label: Some("4".to_string()),
-                    },
-                    EnumValue {
-                        value: "8".to_string(),
-                        label: Some("8".to_string()),
-                    },
-                    EnumValue {
-                        value: "12".to_string(),
-                        label: Some("12".to_string()),
-                    },
-                    EnumValue {
-                        value: "16".to_string(),
-                        label: Some("16".to_string()),
-                    },
-                    EnumValue {
-                        value: "24".to_string(),
-                        label: Some("24".to_string()),
-                    },
-                    EnumValue {
-                        value: "32".to_string(),
-                        label: Some("32".to_string()),
-                    },
-                ],
-            },
-            default_value: Some(PropertyValue::String("8".to_string())),
+            description: format!("Number of input channels (1 to {})", MAX_CHANNELS),
+            property_type: PropertyType::UInt,
+            default_value: Some(PropertyValue::UInt(DEFAULT_CHANNELS as u64)),
             mapping: PropertyMapping {
                 element_id: "_block".to_string(),
                 property_name: "num_channels".to_string(),
@@ -95,36 +64,13 @@ pub(super) fn mixer_definition() -> BlockDefinition {
             },
             live: false,
         },
-        // Number of aux buses
+        // Number of aux buses (0..=MAX_AUX_BUSES, clamped on parse)
         ExposedProperty {
             name: "num_aux_buses".to_string(),
             label: "Aux Buses".to_string(),
-            description: "Number of aux send buses (0-4)".to_string(),
-            property_type: PropertyType::Enum {
-                values: vec![
-                    EnumValue {
-                        value: "0".to_string(),
-                        label: Some("None".to_string()),
-                    },
-                    EnumValue {
-                        value: "1".to_string(),
-                        label: Some("1".to_string()),
-                    },
-                    EnumValue {
-                        value: "2".to_string(),
-                        label: Some("2".to_string()),
-                    },
-                    EnumValue {
-                        value: "3".to_string(),
-                        label: Some("3".to_string()),
-                    },
-                    EnumValue {
-                        value: "4".to_string(),
-                        label: Some("4".to_string()),
-                    },
-                ],
-            },
-            default_value: Some(PropertyValue::String("0".to_string())),
+            description: format!("Number of aux send buses (0 to {})", MAX_AUX_BUSES),
+            property_type: PropertyType::UInt,
+            default_value: Some(PropertyValue::UInt(0)),
             mapping: PropertyMapping {
                 element_id: "_block".to_string(),
                 property_name: "num_aux_buses".to_string(),
@@ -132,36 +78,13 @@ pub(super) fn mixer_definition() -> BlockDefinition {
             },
             live: false,
         },
-        // Number of groups
+        // Number of groups (0..=MAX_GROUPS, clamped on parse)
         ExposedProperty {
             name: "num_groups".to_string(),
             label: "Groups".to_string(),
-            description: "Number of group buses (0-4)".to_string(),
-            property_type: PropertyType::Enum {
-                values: vec![
-                    EnumValue {
-                        value: "0".to_string(),
-                        label: Some("None".to_string()),
-                    },
-                    EnumValue {
-                        value: "1".to_string(),
-                        label: Some("1".to_string()),
-                    },
-                    EnumValue {
-                        value: "2".to_string(),
-                        label: Some("2".to_string()),
-                    },
-                    EnumValue {
-                        value: "3".to_string(),
-                        label: Some("3".to_string()),
-                    },
-                    EnumValue {
-                        value: "4".to_string(),
-                        label: Some("4".to_string()),
-                    },
-                ],
-            },
-            default_value: Some(PropertyValue::String("0".to_string())),
+            description: format!("Number of group buses (0 to {})", MAX_GROUPS),
+            property_type: PropertyType::UInt,
+            default_value: Some(PropertyValue::UInt(0)),
             mapping: PropertyMapping {
                 element_id: "_block".to_string(),
                 property_name: "num_groups".to_string(),


### PR DESCRIPTION
## Summary

- Three properties on the audio mixer block — `num_channels`, `num_aux_buses`, `num_groups` — were declared as `PropertyType::Enum` with string values (`"0"`, `"2"`, `"4"`, ...). Integer counts ended up described as strings in the OpenAPI schema even though the frontend wrote them as `PropertyValue::Int`.
- Switch all three to `PropertyType::UInt` with integer defaults. Descriptions now reference the existing `MAX_CHANNELS` / `MAX_AUX_BUSES` / `MAX_GROUPS` constants for ranges.
- The `parse_num_channels` / `parse_num_aux_buses` / `parse_num_groups` helpers already accept `Int`, `UInt` and `String`, so existing saved flows keep working without migration.
- Bumps the workspace version to `0.4.13-dev`.

## Test plan

- [x] `cargo check` passes
- [x] `cargo test --lib mixer::` — all 67 mixer tests pass
- [x] `cargo test --test openapi_test` — snapshot unchanged (block definitions are runtime data, not in the static schema)
- [x] Verified via `GET /api/blocks` that the running backend returns `{"type":"uint","default":8}` for `num_channels` (was string enum before)
- [ ] Smoke test in UI: create a mixer block, change channel count, save, reload — should round-trip cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)