### PR TITLE
feat(audio-mixer): smooth volume/mute via GstController (anti-zipper, anti-click)

### DIFF
--- a/backend/src/api/flows.rs
+++ b/backend/src/api/flows.rs
@@ -958,7 +958,13 @@ pub async fn update_element_property(
     ValidatedJson(req): ValidatedJson<UpdatePropertyRequest>,
 ) -> Result<Json<ElementPropertiesResponse>, (StatusCode, Json<ErrorResponse>)> {
     state
-        .update_element_property(&flow_id, &element_id, &req.property_name, req.value)
+        .update_element_property(
+            &flow_id,
+            &element_id,
+            &req.property_name,
+            req.value,
+            req.ramp_ms,
+        )
         .await
         .map_err(|e| {
             error!("Failed to update property: {}", e);

--- a/backend/src/gst/mod.rs
+++ b/backend/src/gst/mod.rs
@@ -10,6 +10,7 @@ pub mod thumbnail;
 pub mod thumbnail_tap;
 pub mod transitions;
 pub mod video_frame;
+pub mod volume_ramp;
 pub mod whep_probe;
 
 pub use discovery::ElementDiscovery;

--- a/backend/src/gst/pipeline/construction.rs
+++ b/backend/src/gst/pipeline/construction.rs
@@ -78,6 +78,7 @@ impl PipelineManager {
             probe_manager,
             blocks: flow.blocks.clone(),
             block_definitions: HashMap::new(),
+            volume_ramps: crate::gst::volume_ramp::VolumeRampManager::new(),
         };
 
         // Expand blocks into GStreamer elements
@@ -317,7 +318,10 @@ impl PipelineManager {
             );
         }
         for (prop_name, prop_value) in &element_def.properties {
-            self.set_property(&element, &element_def.id, prop_name, prop_value)?;
+            // Pipeline isn't running yet — no stream-time available — so any
+            // volume_ramp routing inside set_property falls back to a direct
+            // set. Pass None to make that explicit.
+            self.set_property(&element, &element_def.id, prop_name, prop_value, None)?;
         }
 
         // Store pad properties for later application (after pads are created)

--- a/backend/src/gst/pipeline/lifecycle.rs
+++ b/backend/src/gst/pipeline/lifecycle.rs
@@ -206,6 +206,10 @@ impl PipelineManager {
             task.abort();
         }
 
+        // Drop cached volume control sources. The bindings themselves are
+        // owned by the elements and released when the pipeline goes to NULL.
+        self.volume_ramps.clear();
+
         // Run set_state on a dedicated OS thread to avoid "Cannot start a runtime
         // from within a runtime" panics. Some GStreamer elements (e.g. whipserversrc)
         // internally call block_on() during state transitions, which is incompatible

--- a/backend/src/gst/pipeline/mod.rs
+++ b/backend/src/gst/pipeline/mod.rs
@@ -223,6 +223,10 @@ pub struct PipelineManager {
     blocks: Vec<BlockInstance>,
     /// Block definitions for blocks used in this flow (resolved at construction time)
     block_definitions: HashMap<String, BlockDefinition>,
+    /// Per-element control sources for smooth volume/mute transitions on
+    /// audio `volume` elements. Eliminates zipper noise on fader drags and
+    /// click artifacts on mute toggles.
+    volume_ramps: crate::gst::volume_ramp::VolumeRampManager,
 }
 
 impl Drop for PipelineManager {

--- a/backend/src/gst/pipeline/properties.rs
+++ b/backend/src/gst/pipeline/properties.rs
@@ -1,24 +1,63 @@
 use super::{PipelineError, PipelineManager};
+use crate::gst::volume_ramp::VolumeRampManager;
 use gstreamer as gst;
 use gstreamer::glib;
 use gstreamer::prelude::*;
 use std::collections::HashMap;
+use strom_types::mixer::{DEFAULT_VOLUME_RAMP_MS, MUTE_ANTICLICK_RAMP_MS};
 use strom_types::{PipelineState, PropertyValue};
 use tracing::{debug, info};
 
 impl PipelineManager {
     /// Set a property on an element.
+    ///
+    /// `ramp_ms` is consulted only for routes that support smooth interpolation
+    /// (currently audio `volume`-element `volume`/`mute`). Other properties are
+    /// set immediately regardless. `None` selects the per-route default ramp.
     pub(super) fn set_property(
         &self,
         element: &gst::Element,
         element_id: &str,
         prop_name: &str,
         prop_value: &PropertyValue,
+        ramp_ms: Option<u32>,
     ) -> Result<(), PipelineError> {
         debug!(
-            "Setting property: {}.{} = {:?}",
-            element_id, prop_name, prop_value
+            "Setting property: {}.{} = {:?} (ramp_ms={:?})",
+            element_id, prop_name, prop_value, ramp_ms
         );
+
+        // Audio volume element: route through the ramp manager to avoid
+        // zipper noise (volume) and click artifacts (mute). The match
+        // guards have side effects (they install a control source / schedule
+        // the mute toggle) and short-circuit when ramp setup succeeds; on
+        // failure (e.g. pipeline not yet running) we fall through to the
+        // direct `set_property` path below.
+        if VolumeRampManager::is_volume_element(element) {
+            match (prop_name, prop_value) {
+                ("volume", PropertyValue::Float(v))
+                    if self.volume_ramps.apply_volume_ramp(
+                        element,
+                        element_id,
+                        *v,
+                        ramp_ms.unwrap_or(DEFAULT_VOLUME_RAMP_MS),
+                    ) =>
+                {
+                    return Ok(());
+                }
+                ("mute", PropertyValue::Bool(v))
+                    if self.volume_ramps.apply_mute(
+                        element,
+                        element_id,
+                        *v,
+                        MUTE_ANTICLICK_RAMP_MS,
+                    ) =>
+                {
+                    return Ok(());
+                }
+                _ => {}
+            }
+        }
 
         // Set property based on type
         match prop_value {
@@ -142,15 +181,20 @@ impl PipelineManager {
 
     /// Update a property on a live element in the pipeline.
     /// Validates that the property can be changed in the current pipeline state.
+    ///
+    /// `ramp_ms` is consulted only for routes that support smooth interpolation
+    /// (currently audio `volume`-element `volume`). For other properties it is
+    /// silently ignored.
     pub fn update_element_property(
         &self,
         element_id: &str,
         property_name: &str,
         value: &PropertyValue,
+        ramp_ms: Option<u32>,
     ) -> Result<(), PipelineError> {
         debug!(
-            "Updating property {}.{} to {:?} on running pipeline",
-            element_id, property_name, value
+            "Updating property {}.{} to {:?} on running pipeline (ramp_ms={:?})",
+            element_id, property_name, value, ramp_ms
         );
 
         // Get element reference
@@ -181,7 +225,7 @@ impl PipelineManager {
         if translations.is_empty() {
             // No translation needed, use original property
             self.validate_property_mutability(element, element_id, property_name, state)?;
-            self.set_property(element, element_id, property_name, value)?;
+            self.set_property(element, element_id, property_name, value, ramp_ms)?;
         } else {
             for (translated_name, translated_value) in &translations {
                 debug!(
@@ -189,7 +233,13 @@ impl PipelineManager {
                     element_id, property_name, element_id, translated_name
                 );
                 self.validate_property_mutability(element, element_id, translated_name, state)?;
-                self.set_property(element, element_id, translated_name, translated_value)?;
+                self.set_property(
+                    element,
+                    element_id,
+                    translated_name,
+                    translated_value,
+                    ramp_ms,
+                )?;
             }
         }
 

--- a/backend/src/gst/volume_ramp.rs
+++ b/backend/src/gst/volume_ramp.rs
@@ -1,0 +1,370 @@
+//! Smooth volume transitions for audio `volume` elements.
+//!
+//! Sets up a `GstInterpolationControlSource` on the `volume` property so the
+//! GStreamer `volume` element samples the value per-sample (see
+//! `volume_transform_ip` in `gstvolume.c`), eliminating the zipper noise that
+//! a direct `set_property` step change produces.
+//!
+//! Also provides anti-click mute handling: a brief volume ramp toward zero is
+//! applied before the `mute` boolean is toggled, masking the click that would
+//! otherwise occur when a hard mute lands mid-waveform.
+//!
+//! Long ramps (> `LONG_RAMP_THRESHOLD_MS`) are laid out along a dB-linear
+//! curve. Linear amplitude interpolation sounds wrong over long durations
+//! (the last quarter contains barely-audible energy); dB-linear sounds even,
+//! matching how broadcast/DAW gear behaves.
+//!
+//! Lifecycle: bindings are owned by the `gst::Element` they attach to, so they
+//! are torn down with the element. `clear()` drops the cached control sources
+//! when the pipeline manager is shut down.
+
+use gstreamer as gst;
+use gstreamer::prelude::*;
+use gstreamer_controller::prelude::*;
+use gstreamer_controller::{DirectControlBinding, InterpolationControlSource, InterpolationMode};
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::time::Duration;
+use tracing::{debug, warn};
+
+/// Below this duration we use straight linear amplitude interpolation (2
+/// keyframes). The audible difference vs. dB-linear is negligible for
+/// short anti-zipper / anti-click ramps, and avoids overhead.
+const LONG_RAMP_THRESHOLD_MS: u32 = 50;
+
+/// Number of keyframes laid out along the dB-linear curve for long ramps.
+/// 12 gives smooth perceptual fades — the volume element still interpolates
+/// per-sample between them, so the curve is continuous, not stepped.
+const LOG_KEYFRAME_COUNT: usize = 12;
+
+/// dB floor for log conversion. Amplitudes below this are treated as zero.
+/// −60 dB ≈ 0.001 in amplitude — well below audible for a fade target.
+const LOG_DB_FLOOR: f64 = -60.0;
+
+/// Manages per-element volume control sources and pre-mute volume state.
+///
+/// One instance per `PipelineManager`. Element IDs are unique within a flow,
+/// so we don't need flow-scoped keys here.
+pub struct VolumeRampManager {
+    /// Active volume control sources keyed by element id. Kept alive while the
+    /// binding is attached to the element.
+    sources: Mutex<HashMap<String, InterpolationControlSource>>,
+    /// Pre-mute volume per element id, captured when entering mute so we can
+    /// restore it on unmute.
+    pre_mute: Mutex<HashMap<String, f64>>,
+}
+
+impl VolumeRampManager {
+    pub fn new() -> Self {
+        Self {
+            sources: Mutex::new(HashMap::new()),
+            pre_mute: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// True if `element` is a standalone `volume` element. Other elements may
+    /// expose a `volume` property (e.g. `audiomixer` sink pads), but this
+    /// module only handles the dedicated `volume` element used by the audio
+    /// mixer block.
+    pub fn is_volume_element(element: &gst::Element) -> bool {
+        element
+            .factory()
+            .map(|f| f.name() == "volume")
+            .unwrap_or(false)
+    }
+
+    /// Schedule a smooth interpolation of the `volume` property to `target`
+    /// over `ramp_ms` milliseconds. Starts from the current interpolated
+    /// value (or the property value on first call), so chained drag updates
+    /// don't produce hops. Returns `false` if the element does not yet have
+    /// a stream-time position — caller should fall back to a direct
+    /// `set_property`.
+    pub fn apply_volume_ramp(
+        &self,
+        element: &gst::Element,
+        element_id: &str,
+        target: f64,
+        ramp_ms: u32,
+    ) -> bool {
+        self.apply_volume_ramp_inner(element, element_id, None, target, ramp_ms)
+    }
+
+    /// Same as `apply_volume_ramp` but forces the ramp to start from
+    /// `start_value` regardless of the current control-source state. Used by
+    /// `apply_mute(false)` to force `0.0 → target` even when the control
+    /// source already has keyframes at `target` from a fader change made
+    /// while muted (which would otherwise produce a step-on instead of a
+    /// fade-in).
+    pub fn apply_volume_ramp_from(
+        &self,
+        element: &gst::Element,
+        element_id: &str,
+        start_value: f64,
+        target: f64,
+        ramp_ms: u32,
+    ) -> bool {
+        self.apply_volume_ramp_inner(element, element_id, Some(start_value), target, ramp_ms)
+    }
+
+    fn apply_volume_ramp_inner(
+        &self,
+        element: &gst::Element,
+        element_id: &str,
+        forced_start: Option<f64>,
+        target: f64,
+        ramp_ms: u32,
+    ) -> bool {
+        let Some(now) = element.query_position::<gst::ClockTime>() else {
+            debug!(
+                "volume_ramp[{}]: no stream-time position, falling back to direct set",
+                element_id
+            );
+            return false;
+        };
+        let duration = gst::ClockTime::from_mseconds(ramp_ms as u64);
+
+        let mut sources = self.sources.lock().unwrap();
+        let cs = sources.entry(element_id.to_string()).or_insert_with(|| {
+            let cs = InterpolationControlSource::new();
+            cs.set_mode(InterpolationMode::Linear);
+            // ABSOLUTE binding: keyframe values pass through directly as the
+            // property value. The non-absolute DirectControlBinding maps
+            // [0,1] → [min, max], which would silently scale our intended
+            // gain by the volume element's max (10.0 = +20 dB) and cause
+            // distortion. We're storing keyframes in property domain, so
+            // absolute is the correct mode.
+            let binding = DirectControlBinding::new_absolute(element, "volume", &cs);
+            if let Err(e) = element.add_control_binding(&binding) {
+                warn!(
+                    "volume_ramp[{}]: failed to attach control binding: {}",
+                    element_id, e
+                );
+            } else {
+                debug!(
+                    "volume_ramp[{}]: attached InterpolationControlSource on volume (absolute)",
+                    element_id
+                );
+            }
+            cs
+        });
+
+        // Resolve start value: explicit override (used by unmute), otherwise
+        // the interpolated control-source value at `now` (mid-ramp continuity),
+        // falling back to the property value on first attach.
+        let start = forced_start.unwrap_or_else(|| {
+            // Disambiguated via ControlSourceExt — `value` also lives on GstObjectExt.
+            gstreamer::prelude::ControlSourceExt::value(cs, now)
+                .unwrap_or_else(|| element.property::<f64>("volume"))
+        });
+
+        // Reset accumulated keyframes to keep memory bounded across drags.
+        cs.unset_all();
+        if !lay_out_keyframes(cs, now, duration, start, target, ramp_ms) {
+            warn!("volume_ramp[{}]: failed to set keyframes", element_id);
+            return false;
+        }
+
+        // Mirror the new target onto pre_mute when the element is currently
+        // muted, so a later unmute restores the value the user expected.
+        if element.property::<bool>("mute") && target > 0.0 {
+            self.pre_mute
+                .lock()
+                .unwrap()
+                .insert(element_id.to_string(), target);
+        }
+
+        debug!(
+            "volume_ramp[{}]: {:.4} -> {:.4} over {}ms ({})",
+            element_id,
+            start,
+            target,
+            ramp_ms,
+            if ramp_ms > LONG_RAMP_THRESHOLD_MS {
+                "log"
+            } else {
+                "linear"
+            }
+        );
+        true
+    }
+
+    /// Toggle `mute` with anti-click protection. Ramps `volume` toward zero
+    /// before `mute=true` is applied (masking the discontinuity click), and
+    /// restores the pre-mute volume on unmute.
+    ///
+    /// Falls back to a direct `set_property` if the pipeline doesn't have a
+    /// running stream-time yet.
+    pub fn apply_mute(
+        &self,
+        element: &gst::Element,
+        element_id: &str,
+        target_mute: bool,
+        anticlick_ms: u32,
+    ) -> bool {
+        if target_mute {
+            // Capture pre-mute volume only if not already muted (avoid
+            // overwriting on repeat-mute).
+            let already_muted = element.property::<bool>("mute");
+            if !already_muted {
+                let current = element.property::<f64>("volume");
+                if current > 0.0 {
+                    self.pre_mute
+                        .lock()
+                        .unwrap()
+                        .insert(element_id.to_string(), current);
+                }
+            }
+
+            // Ramp to silence first.
+            if !self.apply_volume_ramp(element, element_id, 0.0, anticlick_ms) {
+                element.set_property("mute", true);
+                return true;
+            }
+
+            // Schedule the boolean toggle to land just after the ramp ends.
+            // Using tokio because the API path runs inside the tokio runtime.
+            // A small extra margin (5ms) ensures the volume control source
+            // has reached zero before mute kicks in — otherwise the hard
+            // zeroing of the volume array would still produce a click.
+            let element_weak = element.downgrade();
+            let element_id_owned = element_id.to_string();
+            let delay = Duration::from_millis(anticlick_ms as u64 + 5);
+            tokio::spawn(async move {
+                tokio::time::sleep(delay).await;
+                if let Some(elem) = element_weak.upgrade() {
+                    elem.set_property("mute", true);
+                    debug!(
+                        "volume_ramp[{}]: mute=true applied after anti-click ramp",
+                        element_id_owned
+                    );
+                }
+            });
+        } else {
+            // Unmute: clear the boolean first so the controlled-volume path
+            // in volume_transform_ip is not bypassed by the muted shortcut.
+            element.set_property("mute", false);
+
+            let target = self
+                .pre_mute
+                .lock()
+                .unwrap()
+                .remove(element_id)
+                .unwrap_or(1.0);
+
+            // Force start from 0 — if the user changed volume during mute,
+            // the control source's keyframes may already point at `target`,
+            // and a normal apply_volume_ramp would produce a flat ramp
+            // (instant unmute = click). Forcing start=0 guarantees a real
+            // 0→target fade-in.
+            if !self.apply_volume_ramp_from(element, element_id, 0.0, target, anticlick_ms) {
+                element.set_property("volume", target);
+            }
+        }
+        true
+    }
+
+    /// Drop all cached control sources. Bindings are owned by the elements
+    /// and are released when the pipeline drops; this just releases our side.
+    pub fn clear(&self) {
+        self.sources.lock().unwrap().clear();
+        self.pre_mute.lock().unwrap().clear();
+    }
+}
+
+impl Default for VolumeRampManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Insert keyframes between `(now, start)` and `(now+duration, target)`.
+/// Short ramps get a straight linear pair; long ramps get a dB-linear curve
+/// with `LOG_KEYFRAME_COUNT` waypoints.
+fn lay_out_keyframes(
+    cs: &InterpolationControlSource,
+    now: gst::ClockTime,
+    duration: gst::ClockTime,
+    start: f64,
+    target: f64,
+    ramp_ms: u32,
+) -> bool {
+    let end = now + duration;
+
+    // Short ramp: just two keyframes. Linear amplitude is fine.
+    if ramp_ms <= LONG_RAMP_THRESHOLD_MS {
+        return cs.set(now, start) && cs.set(end, target);
+    }
+
+    // Long ramp: dB-linear curve with multiple keyframes. The volume element
+    // still interpolates per-sample between them (linearly in amplitude),
+    // but with enough keyframes the audible result follows the dB curve.
+    let start_db = amp_to_db(start);
+    let end_db = amp_to_db(target);
+    let target_is_zero = target <= 0.0;
+    let dur_ns = duration.nseconds() as f64;
+
+    for i in 0..=LOG_KEYFRAME_COUNT {
+        let t = i as f64 / LOG_KEYFRAME_COUNT as f64;
+
+        // Approach to true silence: a dB curve never reaches 0, so reserve
+        // the last 5% of the ramp for a linear segment from `db_to_amp(95%)`
+        // down to 0. Avoids a trailing inaudible tail.
+        let amp = if target_is_zero && t >= 0.95 {
+            let amp_at_95 = db_to_amp(start_db + 0.95 * (end_db - start_db));
+            let linear_t = (t - 0.95) / 0.05;
+            amp_at_95 * (1.0 - linear_t)
+        } else {
+            db_to_amp(start_db + t * (end_db - start_db))
+        };
+
+        let time = now + gst::ClockTime::from_nseconds((dur_ns * t) as u64);
+        if !cs.set(time, amp) {
+            return false;
+        }
+    }
+    true
+}
+
+fn amp_to_db(amp: f64) -> f64 {
+    if amp <= 0.0 {
+        LOG_DB_FLOOR
+    } else {
+        (20.0 * amp.log10()).max(LOG_DB_FLOOR)
+    }
+}
+
+fn db_to_amp(db: f64) -> f64 {
+    if db <= LOG_DB_FLOOR {
+        0.0
+    } else {
+        10f64.powf(db / 20.0)
+    }
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use super::*;
+
+    #[test]
+    fn db_amp_round_trip() {
+        for amp in [0.001, 0.01, 0.1, 0.5, 1.0, 2.0, 10.0] {
+            let db = amp_to_db(amp);
+            let back = db_to_amp(db);
+            assert!(
+                (back - amp).abs() / amp < 1e-9,
+                "round-trip failed: {} -> {} -> {}",
+                amp,
+                db,
+                back
+            );
+        }
+    }
+
+    #[test]
+    fn db_handles_zero_and_below_floor() {
+        assert_eq!(amp_to_db(0.0), LOG_DB_FLOOR);
+        assert_eq!(amp_to_db(-0.5), LOG_DB_FLOOR);
+        assert_eq!(db_to_amp(LOG_DB_FLOOR), 0.0);
+        assert_eq!(db_to_amp(-100.0), 0.0);
+    }
+}

--- a/backend/src/gst/volume_ramp.rs
+++ b/backend/src/gst/volume_ramp.rs
@@ -347,7 +347,9 @@ mod unit_tests {
 
     #[test]
     fn db_amp_round_trip() {
-        for amp in [0.001, 0.01, 0.1, 0.5, 1.0, 2.0, 10.0] {
+        // Values at or below LOG_DB_FLOOR map to silence by design and are
+        // not expected to round-trip — see `db_handles_zero_and_below_floor`.
+        for amp in [0.01, 0.1, 0.5, 1.0, 2.0, 10.0] {
             let db = amp_to_db(amp);
             let back = db_to_amp(db);
             assert!(

--- a/backend/src/mcp/handler.rs
+++ b/backend/src/mcp/handler.rs
@@ -546,7 +546,7 @@ impl McpHandler {
                 );
                 let flow_uuid: strom_types::FlowId = flow_id.parse()?;
                 state
-                    .update_element_property(&flow_uuid, element_id, property_name, value)
+                    .update_element_property(&flow_uuid, element_id, property_name, value, None)
                     .await?;
                 json!({
                     "success": true,

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -1429,16 +1429,20 @@ impl AppState {
     }
 
     /// Update a property on a running pipeline element.
+    ///
+    /// `ramp_ms` is honored for properties that support smooth interpolation
+    /// (currently audio `volume`-element `volume`); ignored for others.
     pub async fn update_element_property(
         &self,
         flow_id: &FlowId,
         element_id: &str,
         property_name: &str,
         value: PropertyValue,
+        ramp_ms: Option<u32>,
     ) -> Result<(), PipelineError> {
         info!(
-            "Updating property {}.{} in flow {}",
-            element_id, property_name, flow_id
+            "Updating property {}.{} in flow {} (ramp_ms={:?})",
+            element_id, property_name, flow_id, ramp_ms
         );
 
         let pipelines = self.inner.pipelines.read().await;
@@ -1447,7 +1451,7 @@ impl AppState {
             PipelineError::InvalidFlow(format!("Pipeline not running for flow: {}", flow_id))
         })?;
 
-        manager.update_element_property(element_id, property_name, &value)?;
+        manager.update_element_property(element_id, property_name, &value, ramp_ms)?;
 
         // Broadcast property change event
         self.inner.events.broadcast(StromEvent::PropertyChanged {

--- a/backend/tests/volume_ramp_test.rs
+++ b/backend/tests/volume_ramp_test.rs
@@ -1,0 +1,308 @@
+//! Integration tests for the `VolumeRampManager`.
+//!
+//! Each test builds a minimal `audiotestsrc ! volume ! fakesink` pipeline,
+//! exercises the manager directly, and asserts on the GObject `volume`
+//! property the way a real consumer would observe it.
+
+use gstreamer as gst;
+use gstreamer::prelude::*;
+use std::time::{Duration, Instant};
+use strom::gst::volume_ramp::VolumeRampManager;
+
+/// Block until `cond` returns true or `timeout` elapses. Tests pass as fast
+/// as the pipeline is ready instead of sleeping a fixed wall-clock.
+fn poll_until(cond: impl Fn() -> bool, timeout: Duration, msg: &str) {
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        if cond() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(5));
+    }
+    panic!("timed out after {:?}: {}", timeout, msg);
+}
+
+struct TestPipe {
+    pipeline: gst::Pipeline,
+    volume: gst::Element,
+}
+
+impl TestPipe {
+    fn new() -> Self {
+        gst::init().unwrap();
+        let pipeline = gst::Pipeline::new();
+        let src = gst::ElementFactory::make("audiotestsrc")
+            .property("is-live", true)
+            .property("samplesperbuffer", 480_i32) // 10ms @ 48k → frequent sync_values
+            .build()
+            .expect("audiotestsrc");
+        let volume = gst::ElementFactory::make("volume").build().expect("volume");
+        let sink = gst::ElementFactory::make("fakesink")
+            .property("sync", false)
+            .build()
+            .expect("fakesink");
+
+        pipeline.add_many([&src, &volume, &sink]).unwrap();
+        gst::Element::link_many([&src, &volume, &sink]).unwrap();
+
+        pipeline.set_state(gst::State::Playing).unwrap();
+
+        // Wait until the volume element has a stream-time position — required
+        // for the ramp manager to schedule keyframes. Buffers must be flowing.
+        poll_until(
+            || volume.query_position::<gst::ClockTime>().is_some(),
+            Duration::from_secs(3),
+            "pipeline never produced a stream-time position",
+        );
+
+        TestPipe { pipeline, volume }
+    }
+
+    fn vol(&self) -> f64 {
+        self.volume.property::<f64>("volume")
+    }
+
+    fn mute(&self) -> bool {
+        self.volume.property::<bool>("mute")
+    }
+}
+
+impl Drop for TestPipe {
+    fn drop(&mut self) {
+        let _ = self.pipeline.set_state(gst::State::Null);
+    }
+}
+
+/// Sleep just long enough for the volume element to process at least a few
+/// buffers (≥ 30ms, given our 10ms-buffer audiotestsrc). Allows the control
+/// source's sync_values to update `self->volume` to the latest interpolated
+/// keyframe value.
+async fn settle(extra_ms: u64) {
+    tokio::time::sleep(Duration::from_millis(30 + extra_ms)).await;
+}
+
+/// Regression test for the absolute-binding bug. With the default
+/// `DirectControlBinding` (non-absolute), a target of 0.5 would map through
+/// [min,max]=[0,10] and land at 5.0 — a +14 dB gain. This must never come
+/// back.
+#[tokio::test(flavor = "multi_thread")]
+async fn ramp_target_lands_in_property_domain_not_normalized() {
+    let p = TestPipe::new();
+    let mgr = VolumeRampManager::new();
+
+    assert!(mgr.apply_volume_ramp(&p.volume, "v", 0.5, 50));
+    settle(80).await;
+
+    let actual = p.vol();
+    assert!(
+        (actual - 0.5).abs() < 0.05,
+        "expected ~0.5, got {} (ABSOLUTE-BINDING REGRESSION if much higher)",
+        actual
+    );
+    assert!(
+        actual <= 1.5,
+        "volume {} > 1.5 — non-absolute binding regression (+14 dB+)",
+        actual
+    );
+}
+
+/// Mid-ramp updates: a second ramp starting before the first finishes should
+/// pick up the interpolated value, not snap back to the original property
+/// value. Verified by the start value logged in the second ramp.
+#[tokio::test(flavor = "multi_thread")]
+async fn mid_ramp_update_continues_smoothly() {
+    let p = TestPipe::new();
+    let mgr = VolumeRampManager::new();
+
+    assert!(mgr.apply_volume_ramp(&p.volume, "v", 0.0, 100));
+    // Halfway through the first ramp (volume should be ~0.5)
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert!(mgr.apply_volume_ramp(&p.volume, "v", 0.7, 100));
+    // Wait for the second ramp to settle.
+    settle(150).await;
+
+    let actual = p.vol();
+    assert!(
+        (actual - 0.7).abs() < 0.05,
+        "expected ~0.7 after second ramp, got {}",
+        actual
+    );
+}
+
+/// Mute then unmute restores the pre-mute volume.
+#[tokio::test(flavor = "multi_thread")]
+async fn mute_then_unmute_restores_volume() {
+    let p = TestPipe::new();
+    let mgr = VolumeRampManager::new();
+
+    // Set a non-default volume first.
+    assert!(mgr.apply_volume_ramp(&p.volume, "v", 0.4, 50));
+    settle(80).await;
+    assert!((p.vol() - 0.4).abs() < 0.05, "setup volume not at 0.4");
+
+    // Mute — anti-click ramps to 0, then mute=true scheduled.
+    assert!(mgr.apply_mute(&p.volume, "v", true, 10));
+    settle(50).await; // 10ms ramp + 5ms grace + slack for the tokio task
+    assert!(
+        p.mute(),
+        "mute property should be true after apply_mute(true)"
+    );
+    assert!(
+        p.vol() < 0.05,
+        "volume should be ~0 while muted, got {}",
+        p.vol()
+    );
+
+    // Unmute — should restore to 0.4.
+    assert!(mgr.apply_mute(&p.volume, "v", false, 10));
+    settle(40).await;
+    assert!(!p.mute(), "mute should be false");
+    assert!(
+        (p.vol() - 0.4).abs() < 0.05,
+        "expected ~0.4 after unmute, got {}",
+        p.vol()
+    );
+}
+
+/// P0 regression: when the user changes volume during mute, unmute must
+/// still produce a real fade-in from 0, not jump straight to the (mid-mute)
+/// target value.
+#[tokio::test(flavor = "multi_thread")]
+async fn unmute_after_mid_mute_fader_change_fades_in_from_zero() {
+    let p = TestPipe::new();
+    let mgr = VolumeRampManager::new();
+
+    // Initial volume.
+    assert!(mgr.apply_volume_ramp(&p.volume, "v", 0.6, 50));
+    settle(80).await;
+
+    // Mute.
+    assert!(mgr.apply_mute(&p.volume, "v", true, 10));
+    settle(50).await;
+    assert!(p.mute());
+
+    // Change "fader" while muted — pre_mute_volumes should be updated to
+    // this new target so unmute restores to 0.3, not 0.6.
+    assert!(mgr.apply_volume_ramp(&p.volume, "v", 0.3, 50));
+    settle(80).await;
+    assert!(p.mute(), "still muted (audio silent regardless of cs)");
+
+    // Unmute — must fade *up from 0* to 0.3.
+    assert!(mgr.apply_mute(&p.volume, "v", false, 30));
+
+    // Sample mid-fade: at 5ms, volume should still be small. If the fix is
+    // missing, the unmute would step straight to 0.3 with no fade.
+    tokio::time::sleep(Duration::from_millis(8)).await;
+    let mid = p.vol();
+    assert!(
+        mid < 0.25,
+        "unmute did NOT fade in (P0 regression): volume={} at +8ms (expected <0.25)",
+        mid
+    );
+
+    // Settled value lands at the new pre-mute target.
+    settle(60).await;
+    assert!(
+        (p.vol() - 0.3).abs() < 0.05,
+        "expected ~0.3 after fade-in, got {}",
+        p.vol()
+    );
+}
+
+/// Long ramp should follow a dB-linear curve. Sample at 1/4, 1/2, 3/4 along
+/// a 1.0 → 0.001 ramp and assert each waypoint is closer to dB-linear than
+/// to amplitude-linear.
+///
+/// Linear-amp would produce: 0.75, 0.5, 0.25 at the quarters.
+/// dB-linear (60 dB span over 1s) produces: ~0.18, ~0.032, ~0.0056.
+#[tokio::test(flavor = "multi_thread")]
+async fn long_ramp_is_db_linear_not_amp_linear() {
+    let p = TestPipe::new();
+    let mgr = VolumeRampManager::new();
+
+    // Start at full, fade to near-silence over 1000ms.
+    assert!(mgr.apply_volume_ramp(&p.volume, "v", 0.001, 1000));
+
+    // Sample at ~250ms.
+    tokio::time::sleep(Duration::from_millis(250)).await;
+    let q1 = p.vol();
+    // dB-linear at 25%: 10^((-60 * 0.25)/20) ≈ 0.178. Linear-amp would be 0.75.
+    assert!(
+        q1 < 0.45,
+        "at 25%: expected dB-linear (~0.18), got {} — linear-amp regression?",
+        q1
+    );
+
+    // Sample at ~500ms.
+    tokio::time::sleep(Duration::from_millis(250)).await;
+    let q2 = p.vol();
+    assert!(
+        q2 < 0.20,
+        "at 50%: expected dB-linear (~0.032), got {} — linear-amp regression?",
+        q2
+    );
+
+    // Settle.
+    tokio::time::sleep(Duration::from_millis(600)).await;
+    assert!(
+        p.vol() < 0.01,
+        "expected near-silence at end, got {}",
+        p.vol()
+    );
+}
+
+/// Ramp on a non-running pipeline (no stream-time position) returns false
+/// so the caller can fall back to a direct property set. This is the path
+/// taken during initial pipeline construction.
+#[tokio::test(flavor = "multi_thread")]
+async fn ramp_returns_false_when_no_stream_time() {
+    gst::init().unwrap();
+    let volume = gst::ElementFactory::make("volume").build().unwrap();
+    // Element exists but is not in any pipeline → query_position is None.
+
+    let mgr = VolumeRampManager::new();
+    let ok = mgr.apply_volume_ramp(&volume, "v", 0.5, 50);
+    assert!(!ok, "expected false when no stream-time available");
+}
+
+/// `clear()` drops cached control sources. The bindings remain attached to
+/// the elements until those elements are dropped — that's by design; the
+/// pipeline owns its elements and tears them down on Null. We verify the
+/// cache is empty after clear, and that subsequent ramps re-attach cleanly.
+#[tokio::test(flavor = "multi_thread")]
+async fn clear_drops_cache_and_subsequent_ramps_work() {
+    let p = TestPipe::new();
+    let mgr = VolumeRampManager::new();
+
+    assert!(mgr.apply_volume_ramp(&p.volume, "v", 0.7, 50));
+    settle(80).await;
+
+    mgr.clear();
+
+    // A new ramp on the same element id should still work — the manager
+    // re-attaches a fresh control source. (The existing binding from before
+    // clear() is still on the element, but we just keep going.)
+    assert!(mgr.apply_volume_ramp(&p.volume, "v", 0.2, 50));
+    settle(80).await;
+
+    let v = p.vol();
+    assert!(
+        (v - 0.2).abs() < 0.1,
+        "ramp after clear() did not reach target: got {}",
+        v
+    );
+}
+
+/// `is_volume_element` correctly distinguishes the volume element from
+/// other audio elements that happen to expose a `volume` property.
+#[tokio::test(flavor = "multi_thread")]
+async fn is_volume_element_only_matches_volume_factory() {
+    gst::init().unwrap();
+    let volume = gst::ElementFactory::make("volume").build().unwrap();
+    let testsrc = gst::ElementFactory::make("audiotestsrc").build().unwrap();
+    assert!(VolumeRampManager::is_volume_element(&volume));
+    assert!(
+        !VolumeRampManager::is_volume_element(&testsrc),
+        "audiotestsrc has a volume property but is not the volume element"
+    );
+}

--- a/frontend/src/api/elements.rs
+++ b/frontend/src/api/elements.rs
@@ -101,12 +101,18 @@ impl ApiClient {
     }
 
     /// Update a property on a live element in a running flow.
+    ///
+    /// `ramp_ms` is honored by the backend only for properties that support
+    /// smooth interpolation (currently audio `volume`-element `volume`).
+    /// Other properties ignore it; callers can safely pass `None` or always
+    /// pass their preferred fade duration.
     pub async fn update_element_property(
         &self,
         flow_id: &FlowId,
         element_id: &str,
         property_name: &str,
         value: strom_types::PropertyValue,
+        ramp_ms: Option<u32>,
     ) -> ApiResult<()> {
         use strom_types::api::UpdatePropertyRequest;
         use tracing::info;
@@ -116,13 +122,14 @@ impl ApiClient {
             self.base_url, flow_id, element_id
         );
         info!(
-            "Updating element property: {} on {} in flow {}",
-            property_name, element_id, flow_id
+            "Updating element property: {} on {} in flow {} (ramp_ms={:?})",
+            property_name, element_id, flow_id, ramp_ms
         );
 
         let request = UpdatePropertyRequest {
             property_name: property_name.to_string(),
             value,
+            ramp_ms,
         };
 
         let response = self

--- a/frontend/src/app/rendering.rs
+++ b/frontend/src/app/rendering.rs
@@ -1638,6 +1638,7 @@ impl StromApp {
                                         &update.element_id,
                                         &update.property_name,
                                         update.value,
+                                        None,
                                     )
                                     .await
                                 {

--- a/frontend/src/mixer/api.rs
+++ b/frontend/src/mixer/api.rs
@@ -99,6 +99,7 @@ impl MixerEditor {
             _ => return,
         };
 
+        let ramp_ms = Some(self.fade_ms);
         let api = self.api.clone();
         let flow_id = self.flow_id;
         let element_id = format!("{}:{}", self.block_id, element_suffix);
@@ -106,7 +107,7 @@ impl MixerEditor {
 
         crate::app::spawn_task(async move {
             if let Err(e) = api
-                .update_element_property(&flow_id, &element_id, &gst_prop, value)
+                .update_element_property(&flow_id, &element_id, &gst_prop, value, ramp_ms)
                 .await
             {
                 tracing::warn!("Mixer API update failed: {}", e);
@@ -146,6 +147,7 @@ impl MixerEditor {
             _ => return,
         };
 
+        let ramp_ms = Some(self.fade_ms);
         let api = self.api.clone();
         let flow_id = self.flow_id;
         let element_id = format!("{}:eq_{}", self.block_id, index);
@@ -153,7 +155,7 @@ impl MixerEditor {
 
         crate::app::spawn_task(async move {
             if let Err(e) = api
-                .update_element_property(&flow_id, &element_id, &gst_prop, value)
+                .update_element_property(&flow_id, &element_id, &gst_prop, value, ramp_ms)
                 .await
             {
                 tracing::warn!("Mixer API update failed: {}", e);
@@ -235,6 +237,7 @@ impl MixerEditor {
             _ => return,
         };
 
+        let ramp_ms = Some(self.fade_ms);
         let api = self.api.clone();
         let flow_id = self.flow_id;
         let element_id = format!("{}:{}", self.block_id, element_suffix);
@@ -242,7 +245,7 @@ impl MixerEditor {
 
         crate::app::spawn_task(async move {
             if let Err(e) = api
-                .update_element_property(&flow_id, &element_id, &gst_prop, value)
+                .update_element_property(&flow_id, &element_id, &gst_prop, value, ramp_ms)
                 .await
             {
                 tracing::warn!("Mixer API update failed: {}", e);
@@ -275,6 +278,7 @@ impl MixerEditor {
             _ => return,
         };
 
+        let ramp_ms = Some(self.fade_ms);
         let api = self.api.clone();
         let flow_id = self.flow_id;
         let element_id = format!("{}:main_eq", self.block_id);
@@ -282,7 +286,7 @@ impl MixerEditor {
 
         crate::app::spawn_task(async move {
             if let Err(e) = api
-                .update_element_property(&flow_id, &element_id, &gst_prop, value)
+                .update_element_property(&flow_id, &element_id, &gst_prop, value, ramp_ms)
                 .await
             {
                 tracing::warn!("Mixer API update failed: {}", e);
@@ -367,6 +371,7 @@ impl MixerEditor {
             _ => return,
         };
 
+        let ramp_ms = Some(self.fade_ms);
         let api = self.api.clone();
         let flow_id = self.flow_id;
         let element_id = format!("{}:{}", self.block_id, element_suffix);
@@ -375,7 +380,7 @@ impl MixerEditor {
 
         crate::app::spawn_task(async move {
             if let Err(e) = api
-                .update_element_property(&flow_id, &element_id, &gst_prop, value)
+                .update_element_property(&flow_id, &element_id, &gst_prop, value, ramp_ms)
                 .await
             {
                 tracing::warn!("Mixer API update failed: {}", e);
@@ -403,6 +408,7 @@ impl MixerEditor {
             self.main_fader as f64
         };
 
+        let ramp_ms = Some(self.fade_ms);
         let api = self.api.clone();
         let flow_id = self.flow_id;
         let element_id = format!("{}:main_volume", self.block_id);
@@ -411,7 +417,7 @@ impl MixerEditor {
 
         crate::app::spawn_task(async move {
             if let Err(e) = api
-                .update_element_property(&flow_id, &element_id, "volume", value)
+                .update_element_property(&flow_id, &element_id, "volume", value, ramp_ms)
                 .await
             {
                 tracing::warn!("Mixer API update failed: {}", e);
@@ -433,6 +439,7 @@ impl MixerEditor {
             self.main_fader as f64
         };
 
+        let ramp_ms = Some(self.fade_ms);
         let api = self.api.clone();
         let flow_id = self.flow_id;
         let element_id = format!("{}:main_volume", self.block_id);
@@ -441,7 +448,7 @@ impl MixerEditor {
 
         crate::app::spawn_task(async move {
             if let Err(e) = api
-                .update_element_property(&flow_id, &element_id, "volume", value)
+                .update_element_property(&flow_id, &element_id, "volume", value, ramp_ms)
                 .await
             {
                 tracing::warn!("Mixer API update failed: {}", e);
@@ -464,6 +471,7 @@ impl MixerEditor {
 
         let level = self.channels[ch_idx].aux_sends[aux_idx] as f64;
 
+        let ramp_ms = Some(self.fade_ms);
         let api = self.api.clone();
         let flow_id = self.flow_id;
         let element_id = format!("{}:aux_send_{}_{}", self.block_id, ch_idx, aux_idx);
@@ -472,7 +480,7 @@ impl MixerEditor {
 
         crate::app::spawn_task(async move {
             if let Err(e) = api
-                .update_element_property(&flow_id, &element_id, "volume", value)
+                .update_element_property(&flow_id, &element_id, "volume", value, ramp_ms)
                 .await
             {
                 tracing::warn!("Mixer API update failed: {}", e);
@@ -493,6 +501,7 @@ impl MixerEditor {
         let to_grp = self.channels[ch_idx].to_grp;
         let num_groups = self.num_groups;
 
+        let ramp_ms = Some(self.fade_ms);
         let api = self.api.clone();
         let flow_id = self.flow_id;
         let block_id = self.block_id.clone();
@@ -511,6 +520,7 @@ impl MixerEditor {
                     &to_main_id,
                     "volume",
                     PropertyValue::Float(to_main_vol),
+                    ramp_ms,
                 )
                 .await
             {
@@ -534,6 +544,7 @@ impl MixerEditor {
                         &to_grp_id,
                         "volume",
                         PropertyValue::Float(route_sg_vol),
+                        ramp_ms,
                     )
                     .await
                 {
@@ -580,6 +591,7 @@ impl MixerEditor {
             self.groups[sg_idx].fader as f64
         };
 
+        let ramp_ms = Some(self.fade_ms);
         let api = self.api.clone();
         let flow_id = self.flow_id;
         let element_id = format!("{}:group{}_volume", self.block_id, sg_idx);
@@ -588,7 +600,7 @@ impl MixerEditor {
 
         crate::app::spawn_task(async move {
             if let Err(e) = api
-                .update_element_property(&flow_id, &element_id, "volume", value)
+                .update_element_property(&flow_id, &element_id, "volume", value, ramp_ms)
                 .await
             {
                 tracing::warn!("Mixer API update failed: {}", e);
@@ -610,6 +622,7 @@ impl MixerEditor {
             self.groups[sg_idx].fader as f64
         };
 
+        let ramp_ms = Some(self.fade_ms);
         let api = self.api.clone();
         let flow_id = self.flow_id;
         let element_id = format!("{}:group{}_volume", self.block_id, sg_idx);
@@ -618,7 +631,7 @@ impl MixerEditor {
 
         crate::app::spawn_task(async move {
             if let Err(e) = api
-                .update_element_property(&flow_id, &element_id, "volume", value)
+                .update_element_property(&flow_id, &element_id, "volume", value, ramp_ms)
                 .await
             {
                 tracing::warn!("Mixer API update failed: {}", e);
@@ -646,6 +659,7 @@ impl MixerEditor {
             self.aux_masters[aux_idx].fader as f64
         };
 
+        let ramp_ms = Some(self.fade_ms);
         let api = self.api.clone();
         let flow_id = self.flow_id;
         let element_id = format!("{}:aux{}_volume", self.block_id, aux_idx);
@@ -654,7 +668,7 @@ impl MixerEditor {
 
         crate::app::spawn_task(async move {
             if let Err(e) = api
-                .update_element_property(&flow_id, &element_id, "volume", value)
+                .update_element_property(&flow_id, &element_id, "volume", value, ramp_ms)
                 .await
             {
                 tracing::warn!("Mixer API update failed: {}", e);
@@ -676,6 +690,7 @@ impl MixerEditor {
             self.aux_masters[aux_idx].fader as f64
         };
 
+        let ramp_ms = Some(self.fade_ms);
         let api = self.api.clone();
         let flow_id = self.flow_id;
         let element_id = format!("{}:aux{}_volume", self.block_id, aux_idx);
@@ -684,7 +699,7 @@ impl MixerEditor {
 
         crate::app::spawn_task(async move {
             if let Err(e) = api
-                .update_element_property(&flow_id, &element_id, "volume", value)
+                .update_element_property(&flow_id, &element_id, "volume", value, ramp_ms)
                 .await
             {
                 tracing::warn!("Mixer API update failed: {}", e);

--- a/frontend/src/mixer/mod.rs
+++ b/frontend/src/mixer/mod.rs
@@ -267,6 +267,11 @@ pub struct MixerEditor {
 
     /// Live updates enabled
     live_updates: bool,
+    /// Fade duration in milliseconds applied to volume/mute updates.
+    /// Sent as `ramp_ms` in PATCH requests; backend ignores it for
+    /// non-volume properties. Higher values produce slower fades —
+    /// useful when matching an auto-transition duration.
+    fade_ms: u32,
     /// Last update time (for throttling)
     last_update: instant::Instant,
     /// Save requested (checked by app to persist properties)

--- a/frontend/src/mixer/rendering.rs
+++ b/frontend/src/mixer/rendering.rs
@@ -134,6 +134,28 @@ impl MixerEditor {
                                 None => {}
                             }
                             ui.checkbox(&mut self.live_updates, "Live");
+                            // Fade duration applied to volume/mute updates.
+                            // Sent as ramp_ms in PATCH; eliminates zipper noise on
+                            // fader drag and matches auto-transition durations on
+                            // explicit fades. 20ms is the safe default; > 50ms
+                            // switches the backend to a dB-linear curve.
+                            ui.add(
+                                egui::DragValue::new(&mut self.fade_ms)
+                                    .range(0..=5000)
+                                    .suffix(" ms")
+                                    .speed(1.0),
+                            )
+                            .on_hover_text(
+                                "Fade duration applied to volume and mute changes.\n\
+                                 20 ms (default): zipper-free fader drag.\n\
+                                 > 50 ms: switches to a dB-linear curve.\n\
+                                 Up to 5000 ms for explicit fades / auto-transition match.",
+                            );
+                            ui.label(
+                                egui::RichText::new("Fade")
+                                    .small()
+                                    .color(Color32::from_gray(120)),
+                            );
                             if ui.button(format!("{} Save", egui_phosphor::regular::FLOPPY_DISK)).clicked() {
                                 self.save_requested = true;
                                 self.status = "Saving mixer state...".to_string();

--- a/frontend/src/mixer/state.rs
+++ b/frontend/src/mixer/state.rs
@@ -33,6 +33,7 @@ impl MixerEditor {
             status: String::new(),
             error: None,
             live_updates: true,
+            fade_ms: strom_types::mixer::DEFAULT_VOLUME_RAMP_MS,
             last_update: instant::Instant::now(),
             save_requested: false,
             is_reset: false,

--- a/mcp-server/src/client.rs
+++ b/mcp-server/src/client.rs
@@ -194,6 +194,7 @@ impl StromClient {
         let request = UpdatePropertyRequest {
             property_name: property_name.to_string(),
             value,
+            ramp_ms: None,
         };
         let response: ElementPropertiesResponse = self
             .with_auth(self.client.patch(&url))

--- a/openapi.json
+++ b/openapi.json
@@ -9879,6 +9879,15 @@
             "type": "string",
             "description": "The name of the property to update"
           },
+          "ramp_ms": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "description": "Optional ramp duration in milliseconds. Currently only honored for\naudio `volume`-element `volume` updates — when set, the value is\ninterpolated per-sample over the given duration to avoid zipper\nnoise on fader drags or to match an auto-transition duration.\nWhen omitted, a short default ramp is used for `volume`; other\nproperties are set immediately.",
+            "minimum": 0
+          },
           "value": {
             "$ref": "#/components/schemas/PropertyValue",
             "description": "The new value for the property"

--- a/types/src/api.rs
+++ b/types/src/api.rs
@@ -83,6 +83,15 @@ pub struct UpdatePropertyRequest {
     /// The new value for the property
     #[cfg_attr(feature = "validation", garde(skip))]
     pub value: PropertyValue,
+    /// Optional ramp duration in milliseconds. Currently only honored for
+    /// audio `volume`-element `volume` updates — when set, the value is
+    /// interpolated per-sample over the given duration to avoid zipper
+    /// noise on fader drags or to match an auto-transition duration.
+    /// When omitted, a short default ramp is used for `volume`; other
+    /// properties are set immediately.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "validation", garde(range(max = 60000)))]
+    pub ramp_ms: Option<u32>,
 }
 
 /// Request to trigger a transition on a compositor block.

--- a/types/src/mixer.rs
+++ b/types/src/mixer.rs
@@ -50,3 +50,14 @@ pub const MIN_KNEE_LINEAR: f64 = 0.0631;
 // ── Latency / live defaults ─────────────────────────────────────────
 pub const DEFAULT_LATENCY_MS: u64 = 30;
 pub const DEFAULT_MIN_UPSTREAM_LATENCY_MS: u64 = 30;
+
+// ── Volume ramp / anti-zipper defaults ──────────────────────────────
+/// Default ramp duration applied to `volume`-element `volume` updates
+/// when no explicit `ramp_ms` is provided. Eliminates zipper noise from
+/// fader-drag updates without making the fader feel laggy.
+pub const DEFAULT_VOLUME_RAMP_MS: u32 = 20;
+
+/// Anti-click ramp applied automatically when `mute` is toggled. Not
+/// user-configurable — short enough to feel instant, long enough to
+/// prevent the discontinuity click of a hard mute.
+pub const MUTE_ANTICLICK_RAMP_MS: u32 = 10;


### PR DESCRIPTION
## Summary

Wires the GStreamer controller subsystem onto the audio mixer's `volume` elements so the volume parameter is interpolated per-sample. Eliminates zipper noise on fader drag and click artifacts on mute toggles.

- **Default 20 ms ramp** on every volume update — applied without API change, frontend gets it for free.
- **10 ms anti-click ramp** when toggling `mute`; pre-mute volume is captured and restored on unmute.
- **Long ramps (`ramp_ms > 50`)** lay out a 12-point dB-linear curve (−60 dB floor + linear-to-zero last 5 %) so explicit fades sound even, not front-loaded.
- **API**: `UpdatePropertyRequest` gains optional `ramp_ms`. Backend honors it for `volume`-element `volume`, silently ignores elsewhere.
- **Frontend**: new `Fade` DragValue (0–5000 ms) in the audio mixer status bar; sent on every volume/mute PATCH from the mixer.
- **Lifecycle**: per-`PipelineManager` `VolumeRampManager`, cleared on `stop()`. `pipeline_lifecycle_test` still passes (no leaked refs).

Verified against the actual `volume_transform_ip` in `gst-plugins-base`: when a control binding is attached, `gst_control_binding_get_value_array` is invoked with `interval = 1/rate`, producing one volume value per audio sample — true per-sample interpolation.

## Testing

`cargo test --test volume_ramp_test` adds 8 integration tests against a real `audiotestsrc ! volume ! fakesink` pipeline:

| Test | Catches |
|------|---------|
| `ramp_target_lands_in_property_domain_not_normalized` | absolute-vs-normalized binding (+20 dB scaling bug) |
| `mid_ramp_update_continues_smoothly` | chained drag updates without hops |
| `mute_then_unmute_restores_volume` | pre-mute capture/restore round-trip |
| `unmute_after_mid_mute_fader_change_fades_in_from_zero` | P0 click on unmute after mid-mute fader change |
| `long_ramp_is_db_linear_not_amp_linear` | dB-linear curve shape on long ramps |
| `ramp_returns_false_when_no_stream_time` | construction-time fallback to direct set |
| `clear_drops_cache_and_subsequent_ramps_work` | lifecycle cleanup |
| `is_volume_element_only_matches_volume_factory` | factory discrimination |

Plus 2 unit tests for dB conversion round-trip. `pipeline_lifecycle_test` (3/3) and `openapi_test` still green.

## Live verified

```
PATCH volume=0.001, ramp_ms=800   → log curve, sample at 50/200/400ms
  +50 ms : 0.194  (~−14 dB)         linear-amp would be ~0.94
  +200 ms: 0.031  (~−30 dB)
  +400 ms: 0.004  (~−47 dB)

PATCH mute=true                    → ramp 0.5→0 → mute=true scheduled
  reads volume=0.0, mute=True
PATCH mute=false                   → fade-in from 0 to 0.5
  reads volume=0.5, mute=False
```

## Test plan

- [ ] Pull, build, run a flow with the audio mixer block.
- [ ] Drag a fader fast — no zipper noise on continuous changes.
- [ ] Toggle mute on a channel — no audible click in the output.
- [ ] In the mixer status bar (lower right), find the `Fade` field. Set to e.g. `1000`. Drag fader from full to silence — should hear an even, smooth dB fade rather than a front-loaded amplitude fade.
- [ ] Stop and restart the flow — bindings re-attach cleanly on first volume change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)