### PR TITLE
vision-mixer: default gl_download to false

### DIFF
--- a/types/src/vision_mixer.rs
+++ b/types/src/vision_mixer.rs
@@ -52,7 +52,7 @@ pub const DEFAULT_PGM_FRAMERATE: &str = "30/1";
 pub const DEFAULT_MULTIVIEW_FRAMERATE: &str = "30/1";
 
 /// Whether to download GPU memory to system memory on output (GPU path only).
-pub const DEFAULT_GL_DOWNLOAD: bool = true;
+pub const DEFAULT_GL_DOWNLOAD: bool = false;
 
 // --- Z-order constants for compositor pads ---
 


### PR DESCRIPTION
## Summary
- Change `DEFAULT_GL_DOWNLOAD` in `strom-types` from `true` to `false`, so the vision mixer keeps frames in GL memory by default (no GPU→CPU readback).

## Test plan
- [ ] Verify a fresh vision-mixer block is created with `gl_download = false`
- [ ] Confirm PGM and multiview outputs still render correctly with the GL passthrough path
- [ ] Confirm downstream consumers that need system memory can still opt in by setting `gl_download = true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)