### PR TITLE
fix(vision-mixer): enforce framerate on PGM/MV outputs in GL passthrough

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6683,7 +6683,7 @@ dependencies = [
 
 [[package]]
 name = "strom"
-version = "0.4.13-dev"
+version = "0.4.13-dev2"
 dependencies = [
  "agua-gst",
  "anyhow",
@@ -6758,7 +6758,7 @@ dependencies = [
 
 [[package]]
 name = "strom-frontend"
-version = "0.4.13-dev"
+version = "0.4.13-dev2"
 dependencies = [
  "base64",
  "chrono",
@@ -6794,7 +6794,7 @@ dependencies = [
 
 [[package]]
 name = "strom-mcp-server"
-version = "0.4.13-dev"
+version = "0.4.13-dev2"
 dependencies = [
  "anyhow",
  "reqwest 0.13.3",
@@ -6808,7 +6808,7 @@ dependencies = [
 
 [[package]]
 name = "strom-types"
-version = "0.4.13-dev"
+version = "0.4.13-dev2"
 dependencies = [
  "garde",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["types", "backend", "frontend", "mcp-server"]
 default-members = ["backend"]
 
 [workspace.package]
-version = "0.4.13-dev"
+version = "0.4.13-dev2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Per Enstedt <per.enstedt@eyevinn.se>"]

--- a/backend/src/blocks/builtin/vision_mixer/builder.rs
+++ b/backend/src/blocks/builtin/vision_mixer/builder.rs
@@ -233,6 +233,25 @@ impl<'a> PipelineParams<'a> {
         }
         builder.build()
     }
+
+    /// Build PGM output caps for the GL-memory passthrough path.
+    /// Constrains framerate/resolution without forcing a download to system memory.
+    fn pgm_caps_glmem(&self) -> gst::Caps {
+        let s = format!(
+            "video/x-raw(memory:GLMemory),width={},height={},framerate={}/{},pixel-aspect-ratio=1/1",
+            self.pgm_w, self.pgm_h, self.pgm_framerate.0, self.pgm_framerate.1
+        );
+        s.parse().expect("valid GL memory caps for PGM")
+    }
+
+    /// Build multiview output caps for the GL-memory passthrough path.
+    fn mv_caps_glmem(&self) -> gst::Caps {
+        let s = format!(
+            "video/x-raw(memory:GLMemory),width={},height={},framerate={}/{},pixel-aspect-ratio=1/1",
+            self.mv_w, self.mv_h, self.mv_framerate.0, self.mv_framerate.1
+        );
+        s.parse().expect("valid GL memory caps for MV")
+    }
 }
 
 // ============================================================================
@@ -264,7 +283,9 @@ fn build_gpu_pipeline(
     // --- Distribution output chain ---
     // queue_post_dist decouples the compositor from downstream processing.
     // With gl_download=true:  mixer → queue_post_dist → tee_pgm → gldownload → capsfilter → queue_dist_out
-    // With gl_download=false: mixer → queue_post_dist → tee_pgm → queue_dist_out (GL memory passthrough)
+    // With gl_download=false: mixer → queue_post_dist → tee_pgm → capsfilter(GLMemory) → queue_dist_out
+    // The capsfilter on the false path enforces pgm_framerate/resolution while
+    // keeping memory in GL — without it, the framerate property is silently ignored.
     let q_post_dist_id = p.id("queue_post_dist");
     let queue_post_dist = elements::make_queue(&q_post_dist_id)?;
     let tee_pgm_id = p.id("tee_pgm");
@@ -307,8 +328,22 @@ fn build_gpu_pipeline(
             ElementPadRef::pad(&q_dist_out_id, "sink"),
         ));
     } else {
+        // GL passthrough: insert capsfilter with GLMemory feature so pgm_framerate
+        // is enforced without a download. The compositor's src pad will negotiate
+        // to this rate via downstream caps propagation.
+        let cf_dist_id = p.id("capsfilter_dist");
+        let capsfilter_dist = gst::ElementFactory::make("capsfilter")
+            .name(&cf_dist_id)
+            .property("caps", p.pgm_caps_glmem())
+            .build()
+            .map_err(|e| BlockBuildError::ElementCreation(format!("capsfilter_dist: {}", e)))?;
+        elems.push((cf_dist_id.clone(), capsfilter_dist));
         links.push((
             ElementPadRef::pad(&tee_pgm_id, "src_0"),
+            ElementPadRef::pad(&cf_dist_id, "sink"),
+        ));
+        links.push((
+            ElementPadRef::pad(&cf_dist_id, "src"),
             ElementPadRef::pad(&q_dist_out_id, "sink"),
         ));
     }
@@ -347,7 +382,9 @@ fn build_gpu_pipeline(
     // --- Multiview output chain ---
     // queue_post_mv decouples the compositor from downstream processing.
     // With gl_download=true:  mv_comp → queue_post_mv → gldownload → capsfilter → tee_mv → queue_mv_out
-    // With gl_download=false: mv_comp → queue_post_mv → tee_mv → queue_mv_out (GL memory passthrough)
+    // With gl_download=false: mv_comp → queue_post_mv → capsfilter(GLMemory) → tee_mv → queue_mv_out
+    // The capsfilter on the false path enforces multiview_framerate/resolution while
+    // keeping memory in GL — without it, the framerate property is silently ignored.
     let q_post_mv_id = p.id("queue_post_mv");
     let queue_post_mv = elements::make_queue(&q_post_mv_id)?;
     let tee_mv_id = p.id("tee_mv");
@@ -388,8 +425,21 @@ fn build_gpu_pipeline(
             ElementPadRef::pad(&tee_mv_id, "sink"),
         ));
     } else {
+        // GL passthrough: insert capsfilter with GLMemory feature so mv_framerate
+        // is enforced without a download.
+        let cf_mv_id = p.id("capsfilter_mv");
+        let capsfilter_mv = gst::ElementFactory::make("capsfilter")
+            .name(&cf_mv_id)
+            .property("caps", p.mv_caps_glmem())
+            .build()
+            .map_err(|e| BlockBuildError::ElementCreation(format!("capsfilter_mv: {}", e)))?;
+        elems.push((cf_mv_id.clone(), capsfilter_mv));
         links.push((
             ElementPadRef::pad(&q_post_mv_id, "src"),
+            ElementPadRef::pad(&cf_mv_id, "sink"),
+        ));
+        links.push((
+            ElementPadRef::pad(&cf_mv_id, "src"),
             ElementPadRef::pad(&tee_mv_id, "sink"),
         ));
     }


### PR DESCRIPTION
## Summary
- The GPU pipeline path with `gl_download=false` (the default) had no capsfilter on either the PGM or multiview compositor output, so `pgm_framerate` and `multiview_framerate` properties were silently ignored
- PGM often appeared correct because downstream blocks (e.g. SDI/EFP outputs) propagated framerate caps back through negotiation, but the multiview output had no such downstream constraint and ran at the input rate
- Add a capsfilter with `video/x-raw(memory:GLMemory)` features in both `gl_download=false` branches so the configured framerate/resolution is enforced while keeping buffers in GL memory

## Root cause
In `vision_mixer/builder.rs`, the GPU pipeline conditionally added a `gldownload + capsfilter` chain when `gl_download=true`. The `gl_download=false` branch went straight from compositor → tee → output queue with no caps constraint at all. With the default `gl_download = false`, the `multiview_framerate` property had no observable effect.

## Test plan
- [x] `cargo check` clean
- [x] `cargo build` (debug) clean
- [x] `cargo build --release` clean
- [x] All 408 existing tests pass (`cargo test`), incl. `pipeline_lifecycle_test` and `openapi_test`
- [x] Pre-commit (fmt + clippy + secret check) passes
- [ ] Verify on frank: build runs, MV WHEP stream actually delivers configured framerate (e.g. 24fps when `multiview_framerate=24/1`) — observable in `chrome://webrtc-internals` `framesPerSecond` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)