### PR TITLE
feat(whep): multi-audio + multi-video on WHEP Output; replace mode with track counts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6683,7 +6683,7 @@ dependencies = [
 
 [[package]]
 name = "strom"
-version = "0.4.13-dev2"
+version = "0.4.13-dev4"
 dependencies = [
  "agua-gst",
  "anyhow",
@@ -6758,7 +6758,7 @@ dependencies = [
 
 [[package]]
 name = "strom-frontend"
-version = "0.4.13-dev2"
+version = "0.4.13-dev4"
 dependencies = [
  "base64",
  "chrono",
@@ -6794,7 +6794,7 @@ dependencies = [
 
 [[package]]
 name = "strom-mcp-server"
-version = "0.4.13-dev2"
+version = "0.4.13-dev4"
 dependencies = [
  "anyhow",
  "reqwest 0.13.3",
@@ -6808,7 +6808,7 @@ dependencies = [
 
 [[package]]
 name = "strom-types"
-version = "0.4.13-dev2"
+version = "0.4.13-dev4"
 dependencies = [
  "garde",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["types", "backend", "frontend", "mcp-server"]
 default-members = ["backend"]
 
 [workspace.package]
-version = "0.4.13-dev2"
+version = "0.4.13-dev4"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Per Enstedt <per.enstedt@eyevinn.se>"]

--- a/backend/src/api/whep_player.rs
+++ b/backend/src/api/whep_player.rs
@@ -361,9 +361,8 @@ pub async fn list_whep_streams(State(state): State<AppState>) -> axum::Json<Whep
         .into_iter()
         .map(|(endpoint_id, entry)| WhepStreamInfo {
             endpoint_id,
-            mode: entry.mode.as_str().to_string(),
-            has_audio: entry.mode.has_audio(),
-            has_video: entry.mode.has_video(),
+            num_audio_tracks: entry.num_audio_tracks,
+            num_video_tracks: entry.num_video_tracks,
         })
         .collect();
 

--- a/backend/src/blocks/builder.rs
+++ b/backend/src/blocks/builder.rs
@@ -81,8 +81,10 @@ pub struct WhepEndpointInfo {
     pub endpoint_id: String,
     /// The internal localhost port where whepserversink is listening
     pub internal_port: u16,
-    /// Stream mode (audio, video, or both)
-    pub mode: StreamMode,
+    /// Number of independent audio tracks exposed by this endpoint (0 = no audio)
+    pub num_audio_tracks: usize,
+    /// Number of independent video tracks exposed by this endpoint (0 = no video)
+    pub num_video_tracks: usize,
 }
 
 /// Context provided to block builders during build.
@@ -240,13 +242,15 @@ impl BlockBuildContext {
         block_id: &str,
         endpoint_id: &str,
         port: u16,
-        mode: StreamMode,
+        num_audio_tracks: usize,
+        num_video_tracks: usize,
     ) {
         self.whep_endpoints.borrow_mut().push(WhepEndpointInfo {
             block_id: block_id.to_string(),
             endpoint_id: endpoint_id.to_string(),
             internal_port: port,
-            mode,
+            num_audio_tracks,
+            num_video_tracks,
         });
     }
 

--- a/backend/src/blocks/builtin/whep.rs
+++ b/backend/src/blocks/builtin/whep.rs
@@ -43,41 +43,65 @@ impl BlockBuilder for WHEPOutputBuilder {
         &self,
         properties: &HashMap<String, PropertyValue>,
     ) -> Option<ExternalPads> {
-        // Get mode from properties
-        let mode = properties
-            .get("mode")
-            .and_then(|v| match v {
-                PropertyValue::String(s) => Some(StreamMode::parse(s)),
-                _ => None,
-            })
-            .unwrap_or_default();
+        let (num_audio_tracks, num_video_tracks) = resolve_track_counts(properties);
+        let has_video = num_video_tracks > 0;
+        let has_audio = num_audio_tracks > 0;
 
         let mut inputs = Vec::new();
 
-        if mode.has_video() {
+        for slot in 0..num_video_tracks {
+            // Slot 0 keeps the unsuffixed names (video_in / video_queue) so
+            // existing flows continue to link without modification when
+            // num_video_tracks grows past 1.
+            let (pad_name, queue_id) = if slot == 0 {
+                ("video_in".to_string(), "video_queue".to_string())
+            } else {
+                (
+                    format!("video_in_{}", slot),
+                    format!("video_queue_{}", slot),
+                )
+            };
+
+            let label = if has_audio || num_video_tracks > 1 {
+                Some(format!("V{}", slot))
+            } else {
+                None
+            };
+
             inputs.push(ExternalPad {
-                label: if mode.has_audio() {
-                    Some("V0".to_string())
-                } else {
-                    None
-                },
-                name: "video_in".to_string(),
+                label,
+                name: pad_name,
                 media_type: MediaType::Video,
-                internal_element_id: "video_queue".to_string(),
+                internal_element_id: queue_id,
                 internal_pad_name: "sink".to_string(),
             });
         }
 
-        if mode.has_audio() {
+        for slot in 0..num_audio_tracks {
+            // Slot 0 keeps the unsuffixed names (audio_in / audio_queue) so
+            // existing flows continue to link without modification when
+            // num_audio_tracks grows past 1. Other blocks use audio_in_0 for
+            // slot 0; this asymmetry is deliberate for backwards compat.
+            let (pad_name, queue_id) = if slot == 0 {
+                ("audio_in".to_string(), "audio_queue".to_string())
+            } else {
+                (
+                    format!("audio_in_{}", slot),
+                    format!("audio_queue_{}", slot),
+                )
+            };
+
+            let label = if has_video || num_audio_tracks > 1 {
+                Some(format!("A{}", slot))
+            } else {
+                None
+            };
+
             inputs.push(ExternalPad {
-                label: if mode.has_video() {
-                    Some("A0".to_string())
-                } else {
-                    None
-                },
-                name: "audio_in".to_string(),
+                label,
+                name: pad_name,
                 media_type: MediaType::Audio,
-                internal_element_id: "audio_queue".to_string(),
+                internal_element_id: queue_id,
                 internal_pad_name: "sink".to_string(),
             });
         }
@@ -87,6 +111,60 @@ impl BlockBuilder for WHEPOutputBuilder {
             outputs: vec![],
         })
     }
+}
+
+/// Resolve audio and video track counts from block properties.
+///
+/// Returns `(num_audio_tracks, num_video_tracks)`. 0 means the media type is
+/// disabled on this endpoint; 1..=8 produces that many request pads.
+///
+/// Resolution order per media type:
+/// 1. Explicit `num_audio_tracks` / `num_video_tracks` property (clamped to 0..=8).
+/// 2. Legacy `mode` enum (`"audio"` / `"video"` / `"audio_video"`): translated
+///    to 0 or 1 based on which media types it enabled. Allows old flows saved
+///    before the count-based API to keep working.
+/// 3. Default `1` when no property is present, matching the previous behaviour
+///    where a missing `mode` was treated as audio+video.
+fn resolve_track_counts(properties: &HashMap<String, PropertyValue>) -> (usize, usize) {
+    let explicit_audio = explicit_track_count(properties, "num_audio_tracks");
+    let explicit_video = explicit_track_count(properties, "num_video_tracks");
+    let legacy_mode = properties.get("mode").and_then(|v| match v {
+        PropertyValue::String(s) => Some(StreamMode::parse(s)),
+        _ => None,
+    });
+
+    let num_audio = match (explicit_audio, &legacy_mode) {
+        (Some(n), _) => n,
+        (None, Some(m)) => {
+            if m.has_audio() {
+                1
+            } else {
+                0
+            }
+        }
+        (None, None) => 1,
+    };
+    let num_video = match (explicit_video, &legacy_mode) {
+        (Some(n), _) => n,
+        (None, Some(m)) => {
+            if m.has_video() {
+                1
+            } else {
+                0
+            }
+        }
+        (None, None) => 1,
+    };
+
+    (num_audio, num_video)
+}
+
+fn explicit_track_count(properties: &HashMap<String, PropertyValue>, name: &str) -> Option<usize> {
+    properties.get(name).and_then(|v| match v {
+        PropertyValue::UInt(u) => Some((*u as usize).min(8)),
+        PropertyValue::Int(i) => Some((*i).clamp(0, 8) as usize),
+        _ => None,
+    })
 }
 
 impl BlockBuilder for WHEPInputBuilder {
@@ -823,16 +901,18 @@ fn build_whepserversink(
 ) -> Result<BlockBuildResult, BlockBuildError> {
     info!("Building WHEP Output using whepserversink (server mode)");
 
-    // Get mode (audio, video, or audio_video)
-    let mode = properties
-        .get("mode")
-        .and_then(|v| match v {
-            PropertyValue::String(s) => Some(StreamMode::parse(s)),
-            _ => None,
-        })
-        .unwrap_or_default();
+    // Number of audio/video tracks to expose. Each track gets its own
+    // audio_in / video_in pad, queue and request pad on whepserversink
+    // (audio_0, audio_1, ..., video_0, video_1, ...). 0 disables the media
+    // type on this endpoint.
+    let (num_audio_tracks, num_video_tracks) = resolve_track_counts(properties);
+    let has_audio = num_audio_tracks > 0;
+    let has_video = num_video_tracks > 0;
 
-    info!("WHEP Output mode: {:?}", mode);
+    info!(
+        "WHEP Output: num_audio_tracks={}, num_video_tracks={}",
+        num_audio_tracks, num_video_tracks
+    );
 
     // Timestamp offset in milliseconds. A negative value shifts playout earlier,
     // reducing end-to-end latency for this output while maintaining A/V sync.
@@ -982,12 +1062,12 @@ fn build_whepserversink(
         );
     }
 
-    // Configure audio/video caps based on mode.
+    // Configure audio/video caps based on which media types are enabled.
     // Video caps will be set dynamically when we detect the input codec.
-    if !mode.has_audio() {
+    if !has_audio {
         whepserversink.set_property("audio-caps", gst::Caps::new_empty());
     }
-    if !mode.has_video() {
+    if !has_video {
         whepserversink.set_property("video-caps", gst::Caps::new_empty());
     }
 
@@ -1290,239 +1370,302 @@ fn build_whepserversink(
     let mut internal_links: Vec<(ElementPadRef, ElementPadRef)> = Vec::new();
 
     // Create audio processing elements if mode includes audio.
-    // Uses a queue as entry point (same pattern as video) linked directly to
-    // whepserversink. A caps probe detects the audio format and sets audio-caps:
-    // - Encoded audio (opus etc.): whepserversink passes through directly
-    // - Raw audio: whepserversink runs codec discovery and encodes internally
-    if mode.has_audio() {
-        let audio_queue_id = format!("{}:audio_queue", instance_id);
-        let audio_queue = gst::ElementFactory::make("queue")
-            .name(&audio_queue_id)
-            .build()
-            .map_err(|e| BlockBuildError::ElementCreation(format!("audio_queue: {}", e)))?;
-
-        // Dynamic audio caps detection (same pattern as video caps probe)
-        let whepserversink_weak = whepserversink.downgrade();
+    // For num_audio_tracks > 1 we expose multiple audio_in pads, each with its own
+    // queue wired to a distinct request pad (audio_0, audio_1, ...) on
+    // whepserversink. The audio-caps property on whepserversink is global, so only
+    // the first queue's caps probe drives it — all audio inputs must share the
+    // same format (all Opus or all raw). Mixed formats are not supported.
+    if has_audio {
+        // Shared latch: only the first input that sees a caps event sets audio-caps.
         let audio_caps_set = Arc::new(AtomicBool::new(false));
-        let audio_caps_set_clone = audio_caps_set.clone();
-        let instance_id_owned = instance_id.to_string();
 
-        let audio_queue_sink = audio_queue.static_pad("sink").expect("queue has sink pad");
-        audio_queue_sink.add_probe(
-            gst::PadProbeType::EVENT_DOWNSTREAM,
-            move |_pad, info| {
-                if audio_caps_set_clone.load(Ordering::SeqCst) {
-                    return gst::PadProbeReturn::Pass;
-                }
+        for slot in 0..num_audio_tracks {
+            // Slot 0 keeps the unsuffixed element id for backwards compatibility
+            // with existing flows (matches get_external_pads above).
+            let audio_queue_id = if slot == 0 {
+                format!("{}:audio_queue", instance_id)
+            } else {
+                format!("{}:audio_queue_{}", instance_id, slot)
+            };
+            let audio_queue = gst::ElementFactory::make("queue")
+                .name(&audio_queue_id)
+                .build()
+                .map_err(|e| {
+                    BlockBuildError::ElementCreation(format!("audio_queue (slot {}): {}", slot, e))
+                })?;
 
+            let whepserversink_weak = whepserversink.downgrade();
+            let audio_caps_set_clone = audio_caps_set.clone();
+            let instance_id_owned = instance_id.to_string();
+
+            let audio_queue_sink = audio_queue.static_pad("sink").expect("queue has sink pad");
+            audio_queue_sink.add_probe(
+                gst::PadProbeType::EVENT_DOWNSTREAM,
+                move |_pad, info| {
+                    if let Some(gst::PadProbeData::Event(ref event)) = info.data {
+                        if event.type_() == gst::EventType::Caps {
+                            // Atomically claim the latch — only one probe wins
+                            // and proceeds to set audio-caps; the rest pass.
+                            if audio_caps_set_clone
+                                .compare_exchange(
+                                    false,
+                                    true,
+                                    Ordering::SeqCst,
+                                    Ordering::SeqCst,
+                                )
+                                .is_err()
+                            {
+                                return gst::PadProbeReturn::Pass;
+                            }
+
+                            if let gst::EventView::Caps(caps_event) = event.view() {
+                                let caps = caps_event.caps();
+                                if let Some(structure) = caps.structure(0) {
+                                    let caps_name = structure.name().as_str();
+
+                                    let audio_caps: Option<gst::Caps> = match caps_name {
+                                        "audio/x-opus" => {
+                                            debug!(
+                                                "WHEP Output {} (slot {}): Detected Opus input, setting audio-caps",
+                                                instance_id_owned, slot
+                                            );
+                                            Some(gst::Caps::builder("audio/x-opus").build())
+                                        }
+                                        "audio/x-raw" => {
+                                            debug!(
+                                                "WHEP Output {} (slot {}): Detected raw audio, using default audio-caps",
+                                                instance_id_owned, slot
+                                            );
+                                            None
+                                        }
+                                        _ => {
+                                            warn!(
+                                                "WHEP Output {} (slot {}): Unknown audio format '{}', using default",
+                                                instance_id_owned, slot, caps_name
+                                            );
+                                            None
+                                        }
+                                    };
+
+                                    if let Some(caps) = audio_caps {
+                                        if let Some(whepserversink) = whepserversink_weak.upgrade()
+                                        {
+                                            whepserversink.set_property("audio-caps", &caps);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    gst::PadProbeReturn::Pass
+                },
+            );
+
+            // Audio link: queue -> whepserversink (audio_<slot> request pad)
+            internal_links.push((
+                ElementPadRef::pad(&audio_queue_id, "src"),
+                ElementPadRef::pad(&whepserversink_id, format!("audio_{}", slot)),
+            ));
+
+            elements.push((audio_queue_id, audio_queue));
+        }
+
+        info!(
+            "WHEP Output {}: configured {} audio track(s)",
+            instance_id, num_audio_tracks
+        );
+    }
+
+    // Create video processing elements if mode includes video.
+    // For num_video_tracks > 1 we expose multiple video_in pads, each with its own
+    // queue wired to a distinct request pad (video_0, video_1, ...) on
+    // whepserversink. The video-caps property on whepserversink is global, so only
+    // the first queue's caps probe drives it — all video inputs must share the
+    // same codec.
+    if has_video {
+        // Shared latch: only the first input that sees a caps event sets video-caps.
+        let video_caps_set = Arc::new(AtomicBool::new(false));
+
+        for slot in 0..num_video_tracks {
+            // Slot 0 keeps the unsuffixed element id for backwards compatibility
+            // with existing flows (matches get_external_pads above).
+            let video_queue_id = if slot == 0 {
+                format!("{}:video_queue", instance_id)
+            } else {
+                format!("{}:video_queue_{}", instance_id, slot)
+            };
+            let video_queue = gst::ElementFactory::make("queue")
+                .name(&video_queue_id)
+                .build()
+                .map_err(|e| {
+                    BlockBuildError::ElementCreation(format!("video_queue (slot {}): {}", slot, e))
+                })?;
+
+            // Dynamic video codec detection: detect input codec and set video-caps
+            // on whepserversink before discovery runs. Works with any codec
+            // (H264, H265, VP9, AV1, raw). Only the first slot to see a caps
+            // event sets the global video-caps property — the rest pass through.
+            let whepserversink_weak = whepserversink.downgrade();
+            let video_caps_set_clone = video_caps_set.clone();
+            let instance_id_owned = instance_id.to_string();
+
+            let video_queue_sink = video_queue.static_pad("sink").expect("queue has sink pad");
+            video_queue_sink.add_probe(gst::PadProbeType::EVENT_DOWNSTREAM, move |_pad, info| {
                 if let Some(gst::PadProbeData::Event(ref event)) = info.data {
                     if event.type_() == gst::EventType::Caps {
+                        // Atomically claim the latch — only one probe wins
+                        // and proceeds to set video-caps; the rest pass.
+                        if video_caps_set_clone
+                            .compare_exchange(
+                                false,
+                                true,
+                                Ordering::SeqCst,
+                                Ordering::SeqCst,
+                            )
+                            .is_err()
+                        {
+                            return gst::PadProbeReturn::Pass;
+                        }
+
                         if let gst::EventView::Caps(caps_event) = event.view() {
                             let caps = caps_event.caps();
                             if let Some(structure) = caps.structure(0) {
-                                let caps_name = structure.name().as_str();
+                                let codec_name = structure.name().as_str();
 
-                                let audio_caps: Option<gst::Caps> = match caps_name {
-                                    "audio/x-opus" => {
-                                        debug!(
-                                            "WHEP Output {}: Detected Opus input, setting audio-caps",
-                                            instance_id_owned
+                                // Map input caps to webrtc-compatible caps.
+                                // For pre-encoded video, restrict to that codec only.
+                                // For raw video, offer modern codecs (exclude VP8).
+                                let video_caps: Option<gst::Caps> = match codec_name {
+                                    "video/x-h264" => {
+                                        info!(
+                                            "WHEP Output {} (slot {}): Detected H.264 input, setting video-caps",
+                                            instance_id_owned, slot
                                         );
-                                        Some(gst::Caps::builder("audio/x-opus").build())
+                                        Some(gst::Caps::builder("video/x-h264").build())
                                     }
-                                    "audio/x-raw" => {
-                                        debug!(
-                                            "WHEP Output {}: Detected raw audio, using default audio-caps",
-                                            instance_id_owned
+                                    "video/x-h265" => {
+                                        info!(
+                                            "WHEP Output {} (slot {}): Detected H.265 input, setting video-caps",
+                                            instance_id_owned, slot
                                         );
-                                        None
+                                        Some(gst::Caps::builder("video/x-h265").build())
+                                    }
+                                    "video/x-vp9" => {
+                                        info!(
+                                            "WHEP Output {} (slot {}): Detected VP9 input, setting video-caps",
+                                            instance_id_owned, slot
+                                        );
+                                        Some(gst::Caps::builder("video/x-vp9").build())
+                                    }
+                                    "video/x-av1" => {
+                                        info!(
+                                            "WHEP Output {} (slot {}): Detected AV1 input, setting video-caps",
+                                            instance_id_owned, slot
+                                        );
+                                        Some(gst::Caps::builder("video/x-av1").build())
+                                    }
+                                    "video/x-raw" => {
+                                        info!(
+                                            "WHEP Output {} (slot {}): Detected raw video input, setting video-caps to H.264/H.265/VP9/AV1",
+                                            instance_id_owned, slot
+                                        );
+                                        let mut caps = gst::Caps::new_empty();
+                                        {
+                                            let caps_mut = caps.get_mut().unwrap();
+                                            caps_mut.append(gst::Caps::builder("video/x-h264").build());
+                                            caps_mut.append(gst::Caps::builder("video/x-h265").build());
+                                            caps_mut.append(gst::Caps::builder("video/x-vp9").build());
+                                            caps_mut.append(gst::Caps::builder("video/x-av1").build());
+                                        }
+                                        Some(caps)
                                     }
                                     _ => {
                                         warn!(
-                                            "WHEP Output {}: Unknown audio format '{}', using default",
-                                            instance_id_owned, caps_name
+                                            "WHEP Output {} (slot {}): Unknown video codec '{}', using default",
+                                            instance_id_owned, slot, codec_name
                                         );
                                         None
                                     }
                                 };
 
-                                if let Some(caps) = audio_caps {
+                                if let Some(caps) = video_caps {
                                     if let Some(whepserversink) = whepserversink_weak.upgrade() {
-                                        whepserversink.set_property("audio-caps", &caps);
+                                        whepserversink.set_property("video-caps", &caps);
                                     }
                                 }
-                                audio_caps_set_clone.store(true, Ordering::SeqCst);
                             }
                         }
                     }
                 }
                 gst::PadProbeReturn::Pass
-            },
-        );
+            });
 
-        // Audio link: queue -> whepserversink (audio_0 request pad)
-        // whepserversink handles both raw audio (encodes internally) and
-        // pre-encoded audio (passes through) based on audio-caps.
-        internal_links.push((
-            ElementPadRef::pad(&audio_queue_id, "src"),
-            ElementPadRef::pad(&whepserversink_id, "audio_0"),
-        ));
-
-        elements.push((audio_queue_id, audio_queue));
-    }
-
-    // Create video queue and link to whepserversink if mode includes video
-    if mode.has_video() {
-        let video_queue_id = format!("{}:video_queue", instance_id);
-
-        let video_queue = gst::ElementFactory::make("queue")
-            .name(&video_queue_id)
-            .build()
-            .map_err(|e| BlockBuildError::ElementCreation(format!("video_queue: {}", e)))?;
-
-        // Dynamic video codec detection: Add a pad probe to detect input codec
-        // and set video-caps on whepserversink before discovery runs.
-        // This allows the WHEP block to work with any codec (H264, H265, VP9, AV1, raw).
-        let whepserversink_weak = whepserversink.downgrade();
-        let caps_set = Arc::new(AtomicBool::new(false));
-        let caps_set_clone = caps_set.clone();
-
-        let video_queue_sink = video_queue.static_pad("sink").expect("queue has sink pad");
-        video_queue_sink.add_probe(gst::PadProbeType::EVENT_DOWNSTREAM, move |_pad, info| {
-            // Only process CAPS events, and only once
-            if caps_set_clone.load(Ordering::SeqCst) {
-                return gst::PadProbeReturn::Pass;
-            }
-
-            if let Some(gst::PadProbeData::Event(ref event)) = info.data {
-                if event.type_() == gst::EventType::Caps {
-                    if let gst::EventView::Caps(caps_event) = event.view() {
-                        let caps = caps_event.caps();
-                        if let Some(structure) = caps.structure(0) {
-                            let codec_name = structure.name().as_str();
-
-                            // Map input caps to webrtc-compatible caps
-                            // For pre-encoded video, restrict to that codec only
-                            // For raw video, don't set video-caps (let webrtcsink use defaults)
-                            let video_caps: Option<gst::Caps> = match codec_name {
-                                "video/x-h264" => {
-                                    info!("WHEP Output: Detected H.264 input, setting video-caps");
-                                    Some(gst::Caps::builder("video/x-h264").build())
-                                }
-                                "video/x-h265" => {
-                                    info!("WHEP Output: Detected H.265 input, setting video-caps");
-                                    Some(gst::Caps::builder("video/x-h265").build())
-                                }
-                                "video/x-vp9" => {
-                                    info!("WHEP Output: Detected VP9 input, setting video-caps");
-                                    Some(gst::Caps::builder("video/x-vp9").build())
-                                }
-                                "video/x-av1" => {
-                                    info!("WHEP Output: Detected AV1 input, setting video-caps");
-                                    Some(gst::Caps::builder("video/x-av1").build())
-                                }
-                                "video/x-raw" => {
-                                    // Raw video - offer modern codecs (H.264 preferred), exclude VP8
-                                    info!(
-                                        "WHEP Output: Detected raw video input, setting video-caps to H.264/H.265/VP9/AV1"
-                                    );
-                                    let mut caps = gst::Caps::new_empty();
-                                    {
-                                        let caps_mut = caps.get_mut().unwrap();
-                                        caps_mut.append(gst::Caps::builder("video/x-h264").build());
-                                        caps_mut.append(gst::Caps::builder("video/x-h265").build());
-                                        caps_mut.append(gst::Caps::builder("video/x-vp9").build());
-                                        caps_mut.append(gst::Caps::builder("video/x-av1").build());
+            // Normalize H.264/H.265 caps before they reach webrtcsink.
+            // h264parse progressively adds fields (coded-picture-structure, chroma-format,
+            // bit-depth-luma, bit-depth-chroma) as it parses the stream. webrtcsink's
+            // input_caps_change_allowed() doesn't account for these and rejects them as
+            // "renegotiation". This probe removes those fields from CAPS events to
+            // prevent false renegotiation errors. Applied per-slot.
+            let queue_src_pad = video_queue.static_pad("src").expect("queue has src pad");
+            queue_src_pad.add_probe(gst::PadProbeType::EVENT_DOWNSTREAM, move |_pad, info| {
+                if let Some(gst::PadProbeData::Event(ref event)) = info.data {
+                    if event.type_() == gst::EventType::Caps {
+                        if let gst::EventView::Caps(caps_event) = event.view() {
+                            let caps = caps_event.caps();
+                            if let Some(structure) = caps.structure(0) {
+                                if structure.name() == "video/x-h264"
+                                    || structure.name() == "video/x-h265"
+                                {
+                                    let mut new_caps = caps.copy();
+                                    if let Some(s) = new_caps.make_mut().structure_mut(0) {
+                                        s.remove_fields([
+                                            "coded-picture-structure",
+                                            "chroma-format",
+                                            "bit-depth-luma",
+                                            "bit-depth-chroma",
+                                        ]);
                                     }
-                                    Some(caps)
+                                    let new_event = gst::event::Caps::new(&new_caps);
+                                    info.data = Some(gst::PadProbeData::Event(new_event));
                                 }
-                                _ => {
-                                    warn!(
-                                        "WHEP Output: Unknown video codec '{}', using default",
-                                        codec_name
-                                    );
-                                    None
-                                }
-                            };
-
-                            if let Some(caps) = video_caps {
-                                if let Some(whepserversink) = whepserversink_weak.upgrade() {
-                                    whepserversink.set_property("video-caps", &caps);
-                                }
-                            }
-                            caps_set_clone.store(true, Ordering::SeqCst);
-                        }
-                    }
-                }
-            }
-            gst::PadProbeReturn::Pass
-        });
-
-        // Skip additional parsing - feed directly to whepserversink.
-        // webrtcsink handles codec discovery internally. Adding our own parser
-        // caused issues because webrtcsink's internal discovery pipeline creates
-        // its own parser that converts stream format, losing codec_data.
-        //
-        // For pre-encoded video, we rely on:
-        // 1. Upstream parser (in VideoEncoder block) with config-interval=1 for H.264
-        // 2. Dynamic video-caps detection (probe above sets caps based on input codec)
-        info!("WHEP Output: Passing video directly to whepserversink (no additional parsing)");
-
-        // Add a pad probe to normalize H.264 caps before they reach webrtcsink.
-        // h264parse progressively adds fields (coded-picture-structure, chroma-format,
-        // bit-depth-luma, bit-depth-chroma) as it parses the stream. webrtcsink's
-        // input_caps_change_allowed() doesn't account for these and rejects them as "renegotiation".
-        // This probe removes those fields from CAPS events to prevent false renegotiation errors.
-        let queue_src_pad = video_queue.static_pad("src").expect("queue has src pad");
-        queue_src_pad.add_probe(gst::PadProbeType::EVENT_DOWNSTREAM, move |_pad, info| {
-            if let Some(gst::PadProbeData::Event(ref event)) = info.data {
-                if event.type_() == gst::EventType::Caps {
-                    if let gst::EventView::Caps(caps_event) = event.view() {
-                        let caps = caps_event.caps();
-                        if let Some(structure) = caps.structure(0) {
-                            if structure.name() == "video/x-h264"
-                                || structure.name() == "video/x-h265"
-                            {
-                                // Create new caps without h264parse/h265parse-specific fields
-                                let mut new_caps = caps.copy();
-                                if let Some(s) = new_caps.make_mut().structure_mut(0) {
-                                    s.remove_fields([
-                                        "coded-picture-structure",
-                                        "chroma-format",
-                                        "bit-depth-luma",
-                                        "bit-depth-chroma",
-                                    ]);
-                                }
-                                // Replace the event with one containing cleaned caps
-                                let new_event = gst::event::Caps::new(&new_caps);
-                                info.data = Some(gst::PadProbeData::Event(new_event));
                             }
                         }
                     }
                 }
-            }
-            gst::PadProbeReturn::Ok
-        });
+                gst::PadProbeReturn::Ok
+            });
 
-        // Video link: queue -> whepserversink (video_0 request pad)
-        internal_links.push((
-            ElementPadRef::pad(&video_queue_id, "src"),
-            ElementPadRef::pad(&whepserversink_id, "video_0"),
-        ));
+            // Video link: queue -> whepserversink (video_<slot> request pad)
+            internal_links.push((
+                ElementPadRef::pad(&video_queue_id, "src"),
+                ElementPadRef::pad(&whepserversink_id, format!("video_{}", slot)),
+            ));
 
-        elements.push((video_queue_id, video_queue));
+            elements.push((video_queue_id, video_queue));
+        }
+
+        info!(
+            "WHEP Output {}: configured {} video track(s)",
+            instance_id, num_video_tracks
+        );
     }
 
     // Add whepserversink last (after audio/video processing elements)
     elements.push((whepserversink_id.clone(), whepserversink));
 
     info!(
-        "WHEP Output configured: endpoint_id='{}', internal_host={}, stun={:?}, turn={:?}, mode={:?}",
-        endpoint_id, host_addr, stun_server, turn_server, mode
+        "WHEP Output configured: endpoint_id='{}', internal_host={}, stun={:?}, turn={:?}, audio_tracks={}, video_tracks={}",
+        endpoint_id, host_addr, stun_server, turn_server, num_audio_tracks, num_video_tracks
     );
 
     // Register WHEP endpoint with the build context
-    ctx.register_whep_endpoint(instance_id, &endpoint_id, internal_port, mode);
+    ctx.register_whep_endpoint(
+        instance_id,
+        &endpoint_id,
+        internal_port,
+        num_audio_tracks,
+        num_video_tracks,
+    );
 
     Ok(BlockBuildResult {
         elements,
@@ -2059,33 +2202,31 @@ fn whep_output_definition() -> BlockDefinition {
     BlockDefinition {
         id: "builtin.whep_output".to_string(),
         name: "WHEP Output".to_string(),
-        description: "Hosts a WHEP server endpoint. Clients can connect via WHEP to receive the WebRTC stream. Access at /api/whep/{endpoint_id}".to_string(),
+        description: "Hosts a WHEP server endpoint. Clients can connect via WHEP to receive the WebRTC stream. Access at /api/whep/{endpoint_id}. Set Number of Video/Audio Tracks to 0 to disable that media type.".to_string(),
         category: "Outputs".to_string(),
         exposed_properties: vec![
             ExposedProperty {
-                name: "mode".to_string(),
-                label: "Stream Mode".to_string(),
-                description: "What media to stream: audio only, video only, or both".to_string(),
-                property_type: PropertyType::Enum {
-                    values: vec![
-                        EnumValue {
-                            value: "audio".to_string(),
-                            label: Some("Audio Only".to_string()),
-                        },
-                        EnumValue {
-                            value: "video".to_string(),
-                            label: Some("Video Only".to_string()),
-                        },
-                        EnumValue {
-                            value: "audio_video".to_string(),
-                            label: Some("Audio + Video".to_string()),
-                        },
-                    ],
-                },
-                default_value: Some(PropertyValue::String("audio_video".to_string())),
+                name: "num_video_tracks".to_string(),
+                label: "Number of Video Tracks".to_string(),
+                description: "Number of video input tracks (0 disables video on this endpoint).".to_string(),
+                property_type: PropertyType::UInt,
+                default_value: Some(PropertyValue::UInt(1)),
                 mapping: PropertyMapping {
                     element_id: "_block".to_string(),
-                    property_name: "mode".to_string(),
+                    property_name: "num_video_tracks".to_string(),
+                    transform: None,
+                },
+                live: false,
+            },
+            ExposedProperty {
+                name: "num_audio_tracks".to_string(),
+                label: "Number of Audio Tracks".to_string(),
+                description: "Number of audio input tracks (0 disables audio on this endpoint).".to_string(),
+                property_type: PropertyType::UInt,
+                default_value: Some(PropertyValue::UInt(1)),
+                mapping: PropertyMapping {
+                    element_id: "_block".to_string(),
+                    property_name: "num_audio_tracks".to_string(),
                     transform: None,
                 },
                 live: false,
@@ -2117,8 +2258,9 @@ fn whep_output_definition() -> BlockDefinition {
                 live: false,
             },
         ],
-        // Note: external_pads here are the static defaults for audio_video mode (the default).
-        // The actual pads are determined dynamically by WHEPOutputBuilder::get_external_pads() based on mode.
+        // Note: external_pads here are the static defaults (1 video + 1 audio).
+        // The actual pads are determined dynamically by WHEPOutputBuilder::get_external_pads()
+        // based on num_audio_tracks / num_video_tracks (and the legacy mode property if present).
         external_pads: ExternalPads {
             inputs: vec![
                 ExternalPad {
@@ -2145,5 +2287,169 @@ fn whep_output_definition() -> BlockDefinition {
             height: Some(1.5),
             ..Default::default()
         }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a property map. `legacy_mode` populates the old "mode" enum
+    /// (`Some("audio")` etc.) to exercise the migration path; pass `None` for
+    /// new flows. Count values pass through `num_audio_tracks` /
+    /// `num_video_tracks`.
+    fn props(
+        legacy_mode: Option<&str>,
+        num_audio_tracks: Option<i64>,
+        num_video_tracks: Option<i64>,
+    ) -> HashMap<String, PropertyValue> {
+        let mut p = HashMap::new();
+        if let Some(m) = legacy_mode {
+            p.insert("mode".to_string(), PropertyValue::String(m.to_string()));
+        }
+        if let Some(c) = num_audio_tracks {
+            p.insert("num_audio_tracks".to_string(), PropertyValue::Int(c));
+        }
+        if let Some(c) = num_video_tracks {
+            p.insert("num_video_tracks".to_string(), PropertyValue::Int(c));
+        }
+        p
+    }
+
+    fn audio_pad_names(pads: &ExternalPads) -> Vec<String> {
+        pads.inputs
+            .iter()
+            .filter(|p| matches!(p.media_type, MediaType::Audio))
+            .map(|p| p.name.clone())
+            .collect()
+    }
+
+    fn video_pad_names(pads: &ExternalPads) -> Vec<String> {
+        pads.inputs
+            .iter()
+            .filter(|p| matches!(p.media_type, MediaType::Video))
+            .map(|p| p.name.clone())
+            .collect()
+    }
+
+    #[test]
+    fn external_pads_default_is_one_video_and_one_audio() {
+        let pads = WHEPOutputBuilder
+            .get_external_pads(&props(None, None, None))
+            .expect("expected pads");
+        assert_eq!(audio_pad_names(&pads), vec!["audio_in"]);
+        assert_eq!(video_pad_names(&pads), vec!["video_in"]);
+    }
+
+    #[test]
+    fn external_pads_zero_audio_disables_audio() {
+        let pads = WHEPOutputBuilder
+            .get_external_pads(&props(None, Some(0), None))
+            .expect("expected pads");
+        assert!(audio_pad_names(&pads).is_empty());
+        assert_eq!(video_pad_names(&pads), vec!["video_in"]);
+    }
+
+    #[test]
+    fn external_pads_zero_video_disables_video() {
+        let pads = WHEPOutputBuilder
+            .get_external_pads(&props(None, None, Some(0)))
+            .expect("expected pads");
+        assert!(video_pad_names(&pads).is_empty());
+        assert_eq!(audio_pad_names(&pads), vec!["audio_in"]);
+    }
+
+    #[test]
+    fn external_pads_count_clamped_to_max_eight() {
+        let pads = WHEPOutputBuilder
+            .get_external_pads(&props(None, Some(99), Some(99)))
+            .expect("expected pads");
+        assert_eq!(audio_pad_names(&pads).len(), 8);
+        assert_eq!(video_pad_names(&pads).len(), 8);
+    }
+
+    #[test]
+    fn external_pads_count_clamped_to_min_zero() {
+        let pads = WHEPOutputBuilder
+            .get_external_pads(&props(None, Some(-5), Some(-1)))
+            .expect("expected pads");
+        assert!(audio_pad_names(&pads).is_empty());
+        assert!(video_pad_names(&pads).is_empty());
+    }
+
+    #[test]
+    fn external_pads_audio_count_four() {
+        let pads = WHEPOutputBuilder
+            .get_external_pads(&props(None, Some(4), Some(0)))
+            .expect("expected pads");
+        // Slot 0 keeps the unsuffixed name; subsequent slots are suffixed.
+        assert_eq!(
+            audio_pad_names(&pads),
+            vec!["audio_in", "audio_in_1", "audio_in_2", "audio_in_3"],
+        );
+        assert!(video_pad_names(&pads).is_empty());
+    }
+
+    #[test]
+    fn external_pads_video_count_four() {
+        let pads = WHEPOutputBuilder
+            .get_external_pads(&props(None, Some(0), Some(4)))
+            .expect("expected pads");
+        assert_eq!(
+            video_pad_names(&pads),
+            vec!["video_in", "video_in_1", "video_in_2", "video_in_3"],
+        );
+        assert!(audio_pad_names(&pads).is_empty());
+    }
+
+    #[test]
+    fn external_pads_video_three_with_audio_one() {
+        let pads = WHEPOutputBuilder
+            .get_external_pads(&props(None, Some(1), Some(3)))
+            .expect("expected pads");
+        assert_eq!(
+            video_pad_names(&pads),
+            vec!["video_in", "video_in_1", "video_in_2"],
+        );
+        assert_eq!(audio_pad_names(&pads), vec!["audio_in"]);
+    }
+
+    // --- Legacy mode migration ---
+
+    #[test]
+    fn legacy_mode_audio_video_with_no_counts_yields_one_plus_one() {
+        let pads = WHEPOutputBuilder
+            .get_external_pads(&props(Some("audio_video"), None, None))
+            .expect("expected pads");
+        assert_eq!(audio_pad_names(&pads), vec!["audio_in"]);
+        assert_eq!(video_pad_names(&pads), vec!["video_in"]);
+    }
+
+    #[test]
+    fn legacy_mode_audio_only_with_no_counts_disables_video() {
+        let pads = WHEPOutputBuilder
+            .get_external_pads(&props(Some("audio"), None, None))
+            .expect("expected pads");
+        assert_eq!(audio_pad_names(&pads), vec!["audio_in"]);
+        assert!(video_pad_names(&pads).is_empty());
+    }
+
+    #[test]
+    fn legacy_mode_video_only_with_no_counts_disables_audio() {
+        let pads = WHEPOutputBuilder
+            .get_external_pads(&props(Some("video"), None, None))
+            .expect("expected pads");
+        assert_eq!(video_pad_names(&pads), vec!["video_in"]);
+        assert!(audio_pad_names(&pads).is_empty());
+    }
+
+    #[test]
+    fn explicit_counts_override_legacy_mode() {
+        // Counts are authoritative when present; legacy mode is ignored.
+        let pads = WHEPOutputBuilder
+            .get_external_pads(&props(Some("audio"), Some(2), Some(3)))
+            .expect("expected pads");
+        assert_eq!(audio_pad_names(&pads).len(), 2);
+        assert_eq!(video_pad_names(&pads).len(), 3);
     }
 }

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -852,11 +852,12 @@ impl AppState {
             let mut endpoints: Vec<(String, String)> = Vec::new();
             for whep_info in manager.whep_endpoints() {
                 info!(
-                    "Registering WHEP endpoint '{}' (block {}) on port {} mode={:?}",
+                    "Registering WHEP endpoint '{}' (block {}) on port {} audio_tracks={} video_tracks={}",
                     whep_info.endpoint_id,
                     whep_info.block_id,
                     whep_info.internal_port,
-                    whep_info.mode
+                    whep_info.num_audio_tracks,
+                    whep_info.num_video_tracks,
                 );
                 if let Err(e) = self
                     .inner
@@ -864,7 +865,8 @@ impl AppState {
                     .register(
                         whep_info.endpoint_id.clone(),
                         whep_info.internal_port,
-                        whep_info.mode,
+                        whep_info.num_audio_tracks,
+                        whep_info.num_video_tracks,
                     )
                     .await
                 {

--- a/backend/src/whep_registry.rs
+++ b/backend/src/whep_registry.rs
@@ -5,7 +5,6 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
-use strom_types::block::StreamMode;
 use tokio::sync::RwLock;
 
 /// Information about a registered WHEP endpoint.
@@ -13,8 +12,10 @@ use tokio::sync::RwLock;
 pub struct WhepEndpointEntry {
     /// Internal localhost port where whepserversink is listening
     pub port: u16,
-    /// Stream mode (audio, video, or both)
-    pub mode: StreamMode,
+    /// Number of audio tracks exposed by this endpoint (0 = no audio)
+    pub num_audio_tracks: usize,
+    /// Number of video tracks exposed by this endpoint (0 = no video)
+    pub num_video_tracks: usize,
 }
 
 /// Registry mapping endpoint IDs to internal ports.
@@ -31,14 +32,15 @@ impl WhepRegistry {
         }
     }
 
-    /// Register an endpoint with its internal port and stream mode.
+    /// Register an endpoint with its internal port and track counts.
     ///
     /// Returns an error if an endpoint with the same ID is already registered.
     pub async fn register(
         &self,
         endpoint_id: String,
         port: u16,
-        mode: StreamMode,
+        num_audio_tracks: usize,
+        num_video_tracks: usize,
     ) -> Result<(), String> {
         let mut map = self.inner.write().await;
         if map.contains_key(&endpoint_id) {
@@ -47,7 +49,14 @@ impl WhepRegistry {
                 endpoint_id
             ));
         }
-        map.insert(endpoint_id, WhepEndpointEntry { port, mode });
+        map.insert(
+            endpoint_id,
+            WhepEndpointEntry {
+                port,
+                num_audio_tracks,
+                num_video_tracks,
+            },
+        );
         Ok(())
     }
 

--- a/backend/static/whep/player.html
+++ b/backend/static/whep/player.html
@@ -10,7 +10,7 @@
 <body style="display: flex; flex-direction: column; align-items: center;">
     <div class="container">
         <div style="position: relative; margin-bottom: 8px;">
-            <span style="position: absolute; left: 0; top: 50%; transform: translateY(-50%); color: #666; font-size: 0.7em;">v11</span>
+            <span style="position: absolute; left: 0; top: 50%; transform: translateY(-50%); color: #666; font-size: 0.7em;">v15</span>
             <h1 style="text-align: center; margin: 0;">WHEP Player at <span id="hostAddress"></span></h1>
             <a href="/player/whep-streams" style="color: #888; font-size: 0.9em; position: absolute; right: 0; top: 50%; transform: translateY(-50%);">All streams</a>
         </div>
@@ -32,6 +32,11 @@
             <div class="video-container" id="videoContainer" style="max-width: 720px;">
                 <video id="video" autoplay muted playsinline controls></video>
             </div>
+            <div id="videoTrackGroup" style="display: none; width: 100%; max-width: 400px;">
+                <label style="color: #888; font-size: 12px;">Video track:
+                    <select id="videoTrackSelect" style="width: auto; padding: 4px 8px;" onchange="onVideoTrackChange()"></select>
+                </label>
+            </div>
             <div class="audio-indicator" id="audioIndicator">
                 <div class="meter-bar"><div class="meter-fill" id="meterFill"></div></div>
             </div>
@@ -39,6 +44,11 @@
                 <button class="mute-btn muted" id="muteBtn" onclick="toggleMute()" title="Toggle mute">&#128263;</button>
                 <input type="range" class="volume-slider" id="volumeSlider" min="0" max="100" value="100" oninput="setVolume(this.value)">
                 <span class="volume-label" id="volumeLabel">100%</span>
+            </div>
+            <div id="audioTrackGroup" style="display: none; width: 100%; max-width: 400px;">
+                <label style="color: #888; font-size: 12px;">Audio track:
+                    <select id="audioTrackSelect" style="width: auto; padding: 4px 8px;" onchange="onAudioTrackChange()"></select>
+                </label>
             </div>
             <div id="audioOutputGroup" style="display: none; width: 100%; max-width: 400px;">
                 <label style="color: #888; font-size: 12px;">Output:
@@ -102,6 +112,10 @@
         let hasAudioStream = false;
         let audioTrack = null;   // Stored for adding to video stream in A+V mode
         let audioMeter = null;   // Audio level meter (AnalyserNode + animation)
+        let availableAudioTracks = []; // Multi-audio: tracks received so far
+        let selectedAudioIndex = 0;    // Which track index is currently routed to the audio element
+        let availableVideoTracks = []; // Multi-video: tracks received so far
+        let selectedVideoIndex = 0;    // Which track index is currently routed to the video element
         const MAX_RECONNECT_ATTEMPTS = 15;
         const RECONNECT_DELAY = 10000;
 
@@ -126,6 +140,126 @@
             const video = document.getElementById('video');
             const ok = await deviceManager.setAudioOutput(deviceId, audio, video);
             if (ok) log('Switched audio output');
+        }
+
+        // Look up num_audio_tracks / num_video_tracks for the given endpoint URL
+        // by querying the streams API. The endpoint URL has the form
+        // /whep/{endpoint_id}. Returns { numAudioTracks, numVideoTracks }.
+        async function fetchTrackCounts(endpointUrl) {
+            try {
+                const id = endpointUrl.replace(/^.*\/whep\//, '').replace(/\/$/, '');
+                if (!id) return { numAudioTracks: 1, numVideoTracks: 1 };
+                const res = await fetch('/api/whep-streams');
+                if (!res.ok) return { numAudioTracks: 1, numVideoTracks: 1 };
+                const data = await res.json();
+                const match = (data.streams || []).find(s => s.endpoint_id === id);
+                if (match) {
+                    const a = typeof match.num_audio_tracks === 'number' && match.num_audio_tracks > 0
+                        ? match.num_audio_tracks : 1;
+                    const v = typeof match.num_video_tracks === 'number' && match.num_video_tracks > 0
+                        ? match.num_video_tracks : 1;
+                    return { numAudioTracks: a, numVideoTracks: v };
+                }
+            } catch (e) {
+                log('Failed to fetch track counts: ' + e.message, 'warning');
+            }
+            return { numAudioTracks: 1, numVideoTracks: 1 };
+        }
+
+        function refreshAudioTrackDropdown() {
+            const group = document.getElementById('audioTrackGroup');
+            const select = document.getElementById('audioTrackSelect');
+            // Slot-indexed array — null slots have not yet received a track.
+            const filledCount = availableAudioTracks.filter(t => t != null).length;
+            if (filledCount <= 1) {
+                group.style.display = 'none';
+                return;
+            }
+            // Preserve selection if the slot is still populated.
+            const previous = select.value;
+            select.innerHTML = '';
+            availableAudioTracks.forEach((track, slot) => {
+                if (!track) return;
+                const opt = document.createElement('option');
+                opt.value = String(slot);
+                opt.textContent = 'A' + slot + (track.label ? ' (' + track.label + ')' : '');
+                select.appendChild(opt);
+            });
+            if (previous && availableAudioTracks[Number(previous)]) {
+                select.value = previous;
+            } else {
+                select.value = String(selectedAudioIndex);
+            }
+            group.style.display = 'block';
+        }
+
+        function applySelectedAudioTrack() {
+            const track = availableAudioTracks[selectedAudioIndex];
+            if (!track) return;
+            const audio = document.getElementById('audio');
+            const stream = new MediaStream([track]);
+            audio.srcObject = stream;
+            audio.play().catch(() => {});
+            // Restart the meter on the new track.
+            startAudioMeter(track);
+        }
+
+        function onAudioTrackChange() {
+            const select = document.getElementById('audioTrackSelect');
+            const idx = Number(select.value);
+            if (Number.isNaN(idx) || idx < 0 || idx >= availableAudioTracks.length) return;
+            if (!availableAudioTracks[idx]) return;
+            selectedAudioIndex = idx;
+            applySelectedAudioTrack();
+            log('Switched to audio track A' + idx);
+        }
+
+        function refreshVideoTrackDropdown() {
+            const group = document.getElementById('videoTrackGroup');
+            const select = document.getElementById('videoTrackSelect');
+            const filledCount = availableVideoTracks.filter(t => t != null).length;
+            if (filledCount <= 1) {
+                group.style.display = 'none';
+                return;
+            }
+            const previous = select.value;
+            select.innerHTML = '';
+            availableVideoTracks.forEach((track, slot) => {
+                if (!track) return;
+                const opt = document.createElement('option');
+                opt.value = String(slot);
+                opt.textContent = 'V' + slot + (track.label ? ' (' + track.label + ')' : '');
+                select.appendChild(opt);
+            });
+            if (previous && availableVideoTracks[Number(previous)]) {
+                select.value = previous;
+            } else {
+                select.value = String(selectedVideoIndex);
+            }
+            group.style.display = 'block';
+        }
+
+        function applySelectedVideoTrack() {
+            const track = availableVideoTracks[selectedVideoIndex];
+            if (!track) return;
+            const video = document.getElementById('video');
+            // In multi-video mode the dropdown owns the video element source.
+            // Build a video-only stream (audio routing is handled separately by
+            // the audio element / audio-track dropdown).
+            video.srcObject = new MediaStream([track]);
+            setElementClass('videoContainer', 'active', true);
+            video.muted = true;
+            video.play().catch(() => {});
+        }
+
+        function onVideoTrackChange() {
+            const select = document.getElementById('videoTrackSelect');
+            const idx = Number(select.value);
+            if (Number.isNaN(idx) || idx < 0 || idx >= availableVideoTracks.length) return;
+            if (!availableVideoTracks[idx]) return;
+            selectedVideoIndex = idx;
+            applySelectedVideoTrack();
+            log('Switched to video track V' + idx);
         }
 
         function scheduleReconnect(reason) {
@@ -162,7 +296,7 @@
             }
         }
 
-        function doConnect(isReconnect = false) {
+        async function doConnect(isReconnect = false) {
             const endpoint = document.getElementById('endpoint').value.trim();
             if (!endpoint) {
                 log('Please enter a WHEP endpoint URL', 'error');
@@ -184,14 +318,35 @@
                 connection = null;
             }
 
+            // Reset multi-track state for the new connection.
+            availableAudioTracks = [];
+            selectedAudioIndex = 0;
+            availableVideoTracks = [];
+            selectedVideoIndex = 0;
+            document.getElementById('audioTrackGroup').style.display = 'none';
+            document.getElementById('videoTrackGroup').style.display = 'none';
+
             document.getElementById('connectBtn').disabled = true;
             document.getElementById('disconnectBtn').disabled = false;
             setStatus('status', isReconnect ? 'Reconnecting...' : 'Connecting...', 'connecting');
             log(isReconnect ? 'Reconnecting to ' + endpoint : 'Connecting to ' + endpoint);
 
+            // Look up how many audio/video tracks this endpoint exposes.
+            const { numAudioTracks, numVideoTracks } = await fetchTrackCounts(endpoint);
+            if (myConnectionId !== connectionId) return; // User started a new connect while we awaited
+            const multiAudio = numAudioTracks > 1;
+            const multiVideo = numVideoTracks > 1;
+            if (multiAudio) {
+                log('Endpoint exposes ' + numAudioTracks + ' audio tracks');
+            }
+            if (multiVideo) {
+                log('Endpoint exposes ' + numVideoTracks + ' video tracks');
+            }
+
             connection = new WhepConnection(endpoint, {
                 onAudioTrack: (stream) => {
                     if (myConnectionId !== connectionId) return; // Stale
+                    if (multiAudio) return; // Multi-audio path handled by onAudioTracks
                     audioTrack = stream.getAudioTracks()[0];
                     startAudioMeter(audioTrack);
                     // Set on audio element for now; if video arrives,
@@ -200,20 +355,59 @@
                     audio.srcObject = stream;
                     audio.play().catch(() => {});
                 },
+                onAudioTracks: (tracks) => {
+                    if (myConnectionId !== connectionId) return; // Stale
+                    availableAudioTracks = tracks;
+                    if (!multiAudio) return;
+                    refreshAudioTrackDropdown();
+                    // Route the currently-selected track to the audio element.
+                    // If the selected slot is empty (e.g. tracks arriving in
+                    // a different order), fall back to the first filled slot.
+                    if (selectedAudioIndex >= availableAudioTracks.length ||
+                        !availableAudioTracks[selectedAudioIndex]) {
+                        const firstFilled = availableAudioTracks.findIndex(t => t != null);
+                        selectedAudioIndex = firstFilled >= 0 ? firstFilled : 0;
+                    }
+                    applySelectedAudioTrack();
+                },
                 onVideoTrack: (stream) => {
                     if (myConnectionId !== connectionId) return; // Stale
-                    // Add audio track to video stream so built-in controls
-                    // handle both audio and video
-                    if (audioTrack) {
-                        stream.addTrack(audioTrack);
-                    }
+                    if (multiVideo) return; // Multi-video path handled by onVideoTracks
                     const video = document.getElementById('video');
-                    video.srcObject = stream;
+                    // In multi-audio mode the dropdown is the only audio source,
+                    // so build a video-only stream to keep audio off the video
+                    // element entirely (defends against same-MSID delivery and
+                    // accidental unmute via the controls UI).
+                    let videoStream;
+                    if (multiAudio) {
+                        videoStream = new MediaStream(stream.getVideoTracks());
+                    } else {
+                        videoStream = stream;
+                        if (audioTrack) {
+                            videoStream.addTrack(audioTrack);
+                        }
+                    }
+                    video.srcObject = videoStream;
                     setElementClass('videoContainer', 'active', true);
                     video.muted = true;
                     video.play().catch(e => {
                         log('Autoplay blocked: ' + e.message, 'warning');
                     });
+                },
+                onVideoTracks: (tracks) => {
+                    if (myConnectionId !== connectionId) return; // Stale
+                    availableVideoTracks = tracks;
+                    if (!multiVideo) return;
+                    refreshVideoTrackDropdown();
+                    // Route the currently-selected track to the video element.
+                    // Fall back to the first filled slot if the selected one
+                    // hasn't arrived yet.
+                    if (selectedVideoIndex >= availableVideoTracks.length ||
+                        !availableVideoTracks[selectedVideoIndex]) {
+                        const firstFilled = availableVideoTracks.findIndex(t => t != null);
+                        selectedVideoIndex = firstFilled >= 0 ? firstFilled : 0;
+                    }
+                    applySelectedVideoTrack();
                 },
                 onStats: (stats) => {
                     if (myConnectionId !== connectionId) return;
@@ -253,9 +447,11 @@
                     if (myConnectionId !== connectionId) return; // Stale
                     const isAudioOnly = hasAudio && !hasVideo;
                     setElementClass('audioIndicator', 'active', hasAudio);
-                    setElementClass('audioControls', 'active', isAudioOnly);
+                    // In multi-audio we always need the mute/volume controls
+                    // for the selected track, even when video is also present.
+                    setElementClass('audioControls', 'active', isAudioOnly || multiAudio);
                     hasAudioStream = hasAudio;
-                    if (hasVideo) {
+                    if (hasVideo && !multiAudio) {
                         // Audio is on the video element now, clear the
                         // separate audio element
                         document.getElementById('audio').srcObject = null;
@@ -284,6 +480,12 @@
                     setElementClass('videoContainer', 'active', false);
                     hasAudioStream = false;
                     audioTrack = null;
+                    availableAudioTracks = [];
+                    selectedAudioIndex = 0;
+                    availableVideoTracks = [];
+                    selectedVideoIndex = 0;
+                    document.getElementById('audioTrackGroup').style.display = 'none';
+                    document.getElementById('videoTrackGroup').style.display = 'none';
                     stopAudioMeter();
                     updateAudioOutputDropdown();
                     document.getElementById('audio').srcObject = null;
@@ -309,7 +511,7 @@
                     if (myConnectionId !== connectionId) return; // Stale
                     log(msg, type || '');
                 }
-            });
+            }, { numAudioTracks, numVideoTracks });
 
             connection.connect();
         }
@@ -330,6 +532,12 @@
             setElementClass('videoContainer', 'active', false);
             hasAudioStream = false;
             audioTrack = null;
+            availableAudioTracks = [];
+            selectedAudioIndex = 0;
+            availableVideoTracks = [];
+            selectedVideoIndex = 0;
+            document.getElementById('audioTrackGroup').style.display = 'none';
+            document.getElementById('videoTrackGroup').style.display = 'none';
             stopAudioMeter();
             updateAudioOutputDropdown();
             document.getElementById('audio').srcObject = null;

--- a/backend/static/whep/streams.html
+++ b/backend/static/whep/streams.html
@@ -129,8 +129,15 @@
             card.className = 'stream-card';
             card.id = 'card-' + stream.endpoint_id;
 
-            const modeLabel = stream.mode === 'audio_video' ? 'Audio + Video' :
-                             stream.mode === 'video' ? 'Video' : 'Audio';
+            const numAudio = typeof stream.num_audio_tracks === 'number' ? stream.num_audio_tracks : 0;
+            const numVideo = typeof stream.num_video_tracks === 'number' ? stream.num_video_tracks : 0;
+            const audioLabel = numAudio === 0 ? null
+                : numAudio === 1 ? 'Audio'
+                : numAudio + 'x Audio';
+            const videoLabel = numVideo === 0 ? null
+                : numVideo === 1 ? 'Video'
+                : numVideo + 'x Video';
+            const modeLabel = [videoLabel, audioLabel].filter(Boolean).join(' + ') || 'None';
 
             const fullWhepUrl = window.location.protocol + '//' + window.location.host + '/whep/' + encodeURIComponent(stream.endpoint_id);
 

--- a/backend/static/whep/whep.js
+++ b/backend/static/whep/whep.js
@@ -76,13 +76,27 @@ function parseIceCandidate(candidateStr) {
 }
 
 class WhepConnection {
-    constructor(endpoint, callbacks = {}) {
+    constructor(endpoint, callbacks = {}, options = {}) {
         this.endpoint = endpoint;
         this.callbacks = callbacks;
+        // Number of recvonly audio/video transceivers to add in the offer. The
+        // server can answer with up to this many m= sections of each kind.
+        this.numAudioTracks = Math.max(1, options.numAudioTracks || 1);
+        this.numVideoTracks = Math.max(1, options.numVideoTracks || 1);
         this.peerConnection = null;
         this.resourceUrl = null;
         this.hasAudio = false;
         this.hasVideo = false;
+        // Slot-indexed audio/video tracks: index N corresponds to transceiver N
+        // (and therefore audio_in / audio_in_N on the backend pad). Slots that
+        // have not yet received a track contain null. This is more robust than
+        // arrival order, which relies on SDP m-line ordering being preserved.
+        this.audioTracks = [];
+        this.videoTracks = [];
+        // Transceivers we created for audio/video, kept so we can map an
+        // incoming ontrack event back to the slot we asked for.
+        this.audioTransceivers = [];
+        this.videoTransceivers = [];
         this.localCandidates = [];
         this.remoteCandidates = [];
         this.iceConfig = null;
@@ -131,6 +145,10 @@ class WhepConnection {
     async connect() {
         this.hasAudio = false;
         this.hasVideo = false;
+        this.audioTracks = new Array(this.numAudioTracks).fill(null);
+        this.videoTracks = new Array(this.numVideoTracks).fill(null);
+        this.audioTransceivers = [];
+        this.videoTransceivers = [];
         this.localCandidates = [];
         this.remoteCandidates = [];
 
@@ -216,13 +234,68 @@ class WhepConnection {
                 this._log('Track received: kind=' + event.track.kind + ' id=' + event.track.id);
                 if (event.track.kind === 'audio') {
                     this.hasAudio = true;
-                    if (this.callbacks.onAudioTrack) {
+                    // Map back to the slot we asked for via the transceiver
+                    // identity, so UI labels A0/A1/... line up with backend pads
+                    // even if the answer SDP reorders m-sections.
+                    let slot = this.audioTransceivers.indexOf(event.transceiver);
+                    let isFirst;
+                    if (slot >= 0 && slot < this.audioTracks.length) {
+                        isFirst = this.audioTracks.every(t => t == null);
+                        this.audioTracks[slot] = event.track;
+                    } else {
+                        // Fallback: transceiver not in our list — fill the first
+                        // empty slot, otherwise append. Should not happen with
+                        // a spec-compliant server.
+                        this._log('Audio track from unknown transceiver, falling back to first empty slot', 'warning');
+                        const firstEmpty = this.audioTracks.indexOf(null);
+                        isFirst = this.audioTracks.every(t => t == null);
+                        if (firstEmpty >= 0) {
+                            this.audioTracks[firstEmpty] = event.track;
+                        } else {
+                            this.audioTracks.push(event.track);
+                        }
+                    }
+                    // First audio track is delivered via onAudioTrack for backwards
+                    // compatibility with single-audio UIs (stream cards).
+                    if (isFirst && this.callbacks.onAudioTrack) {
                         this.callbacks.onAudioTrack(event.streams[0]);
+                    }
+                    // Notify on every audio track so multi-audio UIs can populate
+                    // their selectors as tracks arrive. Array is slot-indexed and
+                    // may contain null entries for slots not yet delivered.
+                    if (this.callbacks.onAudioTracks) {
+                        this.callbacks.onAudioTracks(this.audioTracks.slice());
                     }
                 } else if (event.track.kind === 'video') {
                     this.hasVideo = true;
-                    if (this.callbacks.onVideoTrack) {
+                    // Map back to the slot we asked for via the transceiver
+                    // identity, so UI labels V0/V1/... line up with backend pads
+                    // even if the answer SDP reorders m-sections.
+                    let slot = this.videoTransceivers.indexOf(event.transceiver);
+                    let isFirst;
+                    if (slot >= 0 && slot < this.videoTracks.length) {
+                        isFirst = this.videoTracks.every(t => t == null);
+                        this.videoTracks[slot] = event.track;
+                    } else {
+                        this._log('Video track from unknown transceiver, falling back to first empty slot', 'warning');
+                        const firstEmpty = this.videoTracks.indexOf(null);
+                        isFirst = this.videoTracks.every(t => t == null);
+                        if (firstEmpty >= 0) {
+                            this.videoTracks[firstEmpty] = event.track;
+                        } else {
+                            this.videoTracks.push(event.track);
+                        }
+                    }
+                    // First video track is delivered via onVideoTrack for
+                    // backwards compatibility with single-video UIs.
+                    if (isFirst && this.callbacks.onVideoTrack) {
                         this.callbacks.onVideoTrack(event.streams[0]);
+                    }
+                    // Notify on every video track so multi-video UIs can populate
+                    // their selectors as tracks arrive. Array is slot-indexed and
+                    // may contain null entries for slots not yet delivered.
+                    if (this.callbacks.onVideoTracks) {
+                        this.callbacks.onVideoTracks(this.videoTracks.slice());
                     }
                 }
                 this._updateStatus();
@@ -262,10 +335,25 @@ class WhepConnection {
                 }
             };
 
-            // Create both audio and video transceivers - server decides what to send
-            this._log('Adding transceivers (audio + video, recvonly)');
-            this.peerConnection.addTransceiver('audio', { direction: 'recvonly' });
-            this.peerConnection.addTransceiver('video', { direction: 'recvonly' });
+            // Create transceivers - server decides what to send. Add
+            // numAudioTracks + numVideoTracks recvonly transceivers so the
+            // server can answer with that many m= sections of each kind. Keep
+            // references so ontrack can map an incoming track to the slot we
+            // asked for.
+            this._log('Adding transceivers (audio x' + this.numAudioTracks +
+                ' + video x' + this.numVideoTracks + ', recvonly)');
+            this.audioTransceivers = [];
+            for (let i = 0; i < this.numAudioTracks; i++) {
+                this.audioTransceivers.push(
+                    this.peerConnection.addTransceiver('audio', { direction: 'recvonly' })
+                );
+            }
+            this.videoTransceivers = [];
+            for (let i = 0; i < this.numVideoTracks; i++) {
+                this.videoTransceivers.push(
+                    this.peerConnection.addTransceiver('video', { direction: 'recvonly' })
+                );
+            }
 
             const offer = await this.peerConnection.createOffer();
             // Enable Opus stereo - Chrome defaults to mono which breaks stereo audio
@@ -838,6 +926,10 @@ class WhepConnection {
         this.resourceUrl = null;
         this.hasAudio = false;
         this.hasVideo = false;
+        this.audioTracks = [];
+        this.videoTracks = [];
+        this.audioTransceivers = [];
+        this.videoTransceivers = [];
     }
 
     isConnected() {

--- a/openapi.json
+++ b/openapi.json
@@ -10,7 +10,7 @@
     "license": {
       "name": "MIT OR Apache-2.0"
     },
-    "version": "0.4.13-dev"
+    "version": "0.4.13-dev4"
   },
   "paths": {
     "/api/auth/status": {
@@ -10046,26 +10046,23 @@
         "description": "Response structure for a WHEP stream.",
         "required": [
           "endpoint_id",
-          "mode",
-          "has_audio",
-          "has_video"
+          "num_audio_tracks",
+          "num_video_tracks"
         ],
         "properties": {
           "endpoint_id": {
             "type": "string",
             "description": "Unique identifier for the WHEP endpoint"
           },
-          "has_audio": {
-            "type": "boolean",
-            "description": "Whether the stream includes audio"
+          "num_audio_tracks": {
+            "type": "integer",
+            "description": "Number of independent audio tracks exposed by this endpoint (0 = audio\ndisabled). Clients should add this many recvonly audio transceivers in\ntheir offer.",
+            "minimum": 0
           },
-          "has_video": {
-            "type": "boolean",
-            "description": "Whether the stream includes video"
-          },
-          "mode": {
-            "type": "string",
-            "description": "Stream mode (e.g., \"video\", \"audio\", \"video+audio\")"
+          "num_video_tracks": {
+            "type": "integer",
+            "description": "Number of independent video tracks exposed by this endpoint (0 = video\ndisabled). Clients should add this many recvonly video transceivers in\ntheir offer.",
+            "minimum": 0
           }
         }
       },

--- a/types/src/whep.rs
+++ b/types/src/whep.rs
@@ -11,12 +11,14 @@ use utoipa::ToSchema;
 pub struct WhepStreamInfo {
     /// Unique identifier for the WHEP endpoint
     pub endpoint_id: String,
-    /// Stream mode (e.g., "video", "audio", "video+audio")
-    pub mode: String,
-    /// Whether the stream includes audio
-    pub has_audio: bool,
-    /// Whether the stream includes video
-    pub has_video: bool,
+    /// Number of independent audio tracks exposed by this endpoint (0 = audio
+    /// disabled). Clients should add this many recvonly audio transceivers in
+    /// their offer.
+    pub num_audio_tracks: usize,
+    /// Number of independent video tracks exposed by this endpoint (0 = video
+    /// disabled). Clients should add this many recvonly video transceivers in
+    /// their offer.
+    pub num_video_tracks: usize,
 }
 
 /// Response structure for the streams list endpoint.


### PR DESCRIPTION
> ⚠️ **Breaking API change** in `GET /api/whep-streams`: `mode`, `has_audio`, `has_video` removed from `WhepStreamInfo`; replaced by `num_audio_tracks` and `num_video_tracks`. See the **API breaking changes** section below — external consumers of `/api/whep-streams` need to update.

## Summary

Generalizes WHEP Output to support multiple **audio _and_ video** tracks, and phases out the legacy `mode` enum in favour of two track-count properties.

### Multi-track pipeline
- `num_audio_tracks` and `num_video_tracks` (0..=8) added to the WHEP Output block. Each track gets its own `audio_in_N` / `video_in_N` pad wired to a distinct request pad on `whepserversink`, producing one `m=audio` / `m=video` section per track in the SDP.
- Caps detection drives the global `audio-caps` / `video-caps` once from the first input via a shared per-block latch — all audio inputs must share the same format (Opus or raw); all video inputs must share the same codec.
- Slot 0 keeps the unsuffixed pad names (`audio_in` / `video_in`) and element ids for backwards compatibility with existing flows.

### `mode` enum removed from WHEP Output
- The `mode` property (audio / video / audio_video) is gone from the block definition — it no longer appears in the UI.
- Track counts now control which media types are exposed: `0 = disabled`, `1..=8 = N tracks`.
- Legacy flows that stored `mode` keep working: explicit counts win when present; otherwise the legacy mode is translated to `1+0` / `0+1` / `1+1` at load time.

### Embedded WHEP player
- Mirrors the audio track selector with a new video track selector. Both selectors hide when there is ≤1 track of that kind, so single-audio + single-video flows look exactly like before.
- Adds N recvonly transceivers per media type and maps incoming tracks back to slots via transceiver identity, so V0/V1/A0/A1 labels stay stable even if the answer SDP reorders m-sections.
- `/player/whep-streams` derives the mode label client-side from the counts (`1x Video + 3x Audio`, `Video`, `Audio`, `None`).

### Property reordering
- `Number of Video Tracks` and `Number of Audio Tracks` now appear at the top of the WHEP Output properties, matching the convention used by EFP/SRT, Recorder and MPEG-TS/SRT.

## API breaking changes

These are visible in `openapi.json` (snapshot updated). **External consumers of these APIs must be updated when this lands.**

`WhepStreamInfo` (`GET /api/whep-streams`):
- ❌ **Removed**: `mode`, `has_audio`, `has_video`
- ➕ **Added**: `num_audio_tracks`, `num_video_tracks` (both `usize`; 0 means that media type is disabled)
- Clients deriving `has_audio` / `has_video` should now check `num_*_tracks > 0`. The streams page label can be built from the two counts.

Block configuration (saved flows):
- ❌ **Removed**: the `mode` property is no longer exposed on WHEP Output. Saved flows that still carry it are migrated transparently on load (see above); new saves use `num_*_tracks` only.
- 🆕 **Added**: `num_video_tracks`, `num_audio_tracks`. Range `0..=8`; default `1`.

Workspace version bumped to `0.4.13-dev4`.

## Test plan
- [x] `cargo check` and `cargo build` clean from workspace root
- [x] `cargo test --lib` green (387 tests)
- [x] `cargo test --test openapi_test` green
- [x] WHEP block unit tests green (12 tests — 4 new for legacy mode migration + 0-disable)
- [ ] Manual: `audio_video` WHEP Output with `num_audio_tracks=2`, `num_video_tracks=2`; verify four distinct request pads on `whepserversink` and four matching `m=` lines in the SDP
- [ ] Manual: load an existing pre-branch flow (with `mode = "audio"` / `"video"` / `"audio_video"`) and verify it still builds + serves the same media (migration path)
- [ ] Manual: open `/player/whep?endpoint=…` against a 2A+2V endpoint; verify both selectors appear and switching changes the displayed/audible track
- [ ] Manual: single-track flow shows neither selector (unchanged UI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
