### PR TITLE
fix(whep): align encoder profile and SDP fmtp with WebRTC decoder expectations

### DIFF
--- a/backend/src/api/whep_player.rs
+++ b/backend/src/api/whep_player.rs
@@ -309,9 +309,7 @@ fn remove_fmtp_field(params: &str, key: &str) -> String {
     out.push_str(&params[..idx]);
     out.push_str(&params[idx + removed_total_len..]);
     // Clean up double `;;` or leading `;` artifacts left after removal.
-    out.replace(";;", ";")
-        .trim_start_matches(';')
-        .to_string()
+    out.replace(";;", ";").trim_start_matches(';').to_string()
 }
 
 /// Decide whether an H.264 profile-level-id (6 hex chars: profile_idc + iop +
@@ -338,14 +336,14 @@ fn is_supported_h264_profile_level_id(value: &str) -> bool {
     //   0x04 constraint_set5_flag  -> "progressive-high" / "constrained-high"
     let bad_high_constraints = (profile_iop & 0x1C) != 0;
     match profile_idc {
-        66 => true,                            // baseline / constrained-baseline
-        77 => (profile_iop & 0x10) == 0,       // main (not main-intra)
-        88 => false,                           // extended — not in webrtcsink whitelist
-        100 => !bad_high_constraints,          // high (block constrained/progressive/intra)
-        110 => !bad_high_constraints,          // high-10
-        122 => !bad_high_constraints,          // high-4:2:2
-        244 => !bad_high_constraints,          // high-4:4:4
-        _ => false,                            // scalable, multiview, stereo, etc.
+        66 => true,                      // baseline / constrained-baseline
+        77 => (profile_iop & 0x10) == 0, // main (not main-intra)
+        88 => false,                     // extended — not in webrtcsink whitelist
+        100 => !bad_high_constraints,    // high (block constrained/progressive/intra)
+        110 => !bad_high_constraints,    // high-10
+        122 => !bad_high_constraints,    // high-4:2:2
+        244 => !bad_high_constraints,    // high-4:4:4
+        _ => false,                      // scalable, multiview, stereo, etc.
     }
 }
 
@@ -545,10 +543,7 @@ pub async fn whep_endpoint_proxy(
             // which exceeds what most browser HW HEVC decoders support
             // (typically up to 5.1). With no level-id, browsers default to
             // a sane level that matches the actual stream the encoder emits.
-            let body_bytes = if body_bytes
-                .windows(5)
-                .any(|w| w == b"H265/")
-            {
+            let body_bytes = if body_bytes.windows(5).any(|w| w == b"H265/") {
                 let answer = String::from_utf8_lossy(&body_bytes).into_owned();
                 let rewritten = strip_h265_fmtp_level_id(&answer);
                 if rewritten != answer {

--- a/backend/src/api/whep_player.rs
+++ b/backend/src/api/whep_player.rs
@@ -180,7 +180,7 @@ fn renumber_low_h265_payload_types(sdp: &str, endpoint_id: &str) -> String {
             } else {
                 ""
             };
-            let core = rest.trim_end_matches(|c: char| c == '\r' || c == '\n');
+            let core = rest.trim_end_matches(['\r', '\n']);
             let parts: Vec<&str> = core.split(' ').collect();
             let mut rewritten: Vec<String> = Vec::with_capacity(parts.len());
             for (idx, p) in parts.iter().enumerate() {

--- a/backend/src/api/whep_player.rs
+++ b/backend/src/api/whep_player.rs
@@ -395,7 +395,7 @@ fn filter_unsupported_h264_profiles(sdp: &str, endpoint_id: &str) -> String {
             all_pts
         );
     } else {
-        tracing::info!(
+        tracing::debug!(
             "WHEP offer for endpoint '{}': all H264 profile-level-ids supported: {:?}",
             endpoint_id,
             all_pts
@@ -418,7 +418,7 @@ fn filter_unsupported_h264_profiles(sdp: &str, endpoint_id: &str) -> String {
                 })
             })
             .collect();
-        tracing::info!(
+        tracing::debug!(
             "WHEP offer for endpoint '{}': all rtpmap codecs: {:?}",
             endpoint_id,
             codecs
@@ -452,7 +452,7 @@ pub async fn whep_endpoint_proxy(
     // Log the raw SDP offer the browser sent, then the SDP after our
     // profile-level-id filter, and finally the SDP answer from webrtcsink.
     // Lets us trace exactly what each side advertises.
-    tracing::info!(
+    tracing::debug!(
         "WHEP SDP OFFER (raw) for '{}' [{} bytes]:\n{}",
         endpoint_id,
         body.len(),
@@ -472,7 +472,7 @@ pub async fn whep_endpoint_proxy(
     // strom process.
     let body = filter_unsupported_h264_profiles(&body, &endpoint_id);
 
-    tracing::info!(
+    tracing::debug!(
         "WHEP SDP OFFER (after strip) for '{}' [{} bytes]:\n{}",
         endpoint_id,
         body.len(),
@@ -532,7 +532,7 @@ pub async fn whep_endpoint_proxy(
 
             // DIAGNOSTIC: log the SDP answer webrtcsink returned (before our
             // post-processing).
-            tracing::info!(
+            tracing::debug!(
                 "WHEP SDP ANSWER (raw) for '{}' status={} [{} bytes]:\n{}",
                 endpoint_id,
                 status.as_u16(),
@@ -552,7 +552,7 @@ pub async fn whep_endpoint_proxy(
                 let answer = String::from_utf8_lossy(&body_bytes).into_owned();
                 let rewritten = strip_h265_fmtp_level_id(&answer);
                 if rewritten != answer {
-                    tracing::info!(
+                    tracing::debug!(
                         "WHEP SDP ANSWER (final) for '{}' [{} bytes]:\n{}",
                         endpoint_id,
                         rewritten.len(),

--- a/backend/src/api/whep_player.rs
+++ b/backend/src/api/whep_player.rs
@@ -61,6 +61,373 @@ pub async fn whep_streams_page() -> impl IntoResponse {
 // WHEP Proxy (endpoint_id-based routing via WhepRegistry)
 // ============================================================================
 
+/// Renumber any H.265 payload types that fall outside the dynamic RTP PT
+/// range [96, 127] so that GStreamer's `rtph265pay` element accepts them.
+///
+/// Chrome offers H.265 on low PTs (49, 51 in current builds) which fall
+/// outside `rtph265pay`'s src-pad template `payload=[96,127]`. webrtcsink's
+/// discovery pipeline then fails to link `rtph265pay → payload-chain-output-caps`
+/// (caps subset rejected on PT), `payloader-setup` never fires, the codec is
+/// dropped from negotiation, and the m=video line ends up `a=inactive`.
+///
+/// Walk the SDP, build a map `old_pt -> new_pt` for H.265 payloads and their
+/// RTX companions, and rewrite every reference (`m=video` PT list,
+/// `a=rtpmap`, `a=fmtp` including `apt=` back-references, `a=rtcp-fb`).
+fn renumber_low_h265_payload_types(sdp: &str, endpoint_id: &str) -> String {
+    use std::collections::{HashMap, HashSet};
+
+    // First pass: collect rtpmap entries and fmtp `apt=` mappings.
+    let mut used_pts: HashSet<u8> = HashSet::new();
+    let mut h265_pts: Vec<u8> = Vec::new(); // PTs whose rtpmap is H265
+    let mut rtx_for: HashMap<u8, u8> = HashMap::new(); // rtx_pt -> source_pt
+    for line in sdp.lines() {
+        if let Some(rest) = line.strip_prefix("a=rtpmap:") {
+            if let Some(sp) = rest.find(' ') {
+                if let Ok(pt) = rest[..sp].parse::<u8>() {
+                    used_pts.insert(pt);
+                    let codec = rest[sp + 1..].split('/').next().unwrap_or("");
+                    if codec.eq_ignore_ascii_case("H265") {
+                        h265_pts.push(pt);
+                    }
+                }
+            }
+        } else if let Some(rest) = line.strip_prefix("a=fmtp:") {
+            if let Some(sp) = rest.find(' ') {
+                if let Ok(pt) = rest[..sp].parse::<u8>() {
+                    if let Some(apt_idx) = rest[sp + 1..].find("apt=") {
+                        let after = &rest[sp + 1 + apt_idx + "apt=".len()..];
+                        let end = after
+                            .find(|c: char| c == ';' || c.is_whitespace())
+                            .unwrap_or(after.len());
+                        if let Ok(source) = after[..end].parse::<u8>() {
+                            rtx_for.insert(pt, source);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Identify the H.265 PTs that need renumbering (those below 96), plus
+    // their RTX partners (which inherit the move).
+    let mut to_renumber: Vec<u8> = Vec::new();
+    for &pt in &h265_pts {
+        if pt < 96 {
+            to_renumber.push(pt);
+        }
+    }
+    if to_renumber.is_empty() {
+        return sdp.to_string();
+    }
+    let mut rtx_to_renumber: Vec<u8> = Vec::new();
+    for (&rtx_pt, &source_pt) in &rtx_for {
+        if to_renumber.contains(&source_pt) && rtx_pt < 96 {
+            rtx_to_renumber.push(rtx_pt);
+        }
+    }
+
+    // Allocate fresh PTs in [96, 127] avoiding all currently-used PTs.
+    let mut pt_map: HashMap<u8, u8> = HashMap::new();
+    let mut next_free = || -> Option<u8> {
+        for candidate in 96..=127u8 {
+            if !used_pts.contains(&candidate) {
+                used_pts.insert(candidate);
+                return Some(candidate);
+            }
+        }
+        None
+    };
+    for &old in to_renumber.iter().chain(rtx_to_renumber.iter()) {
+        if let Some(new_pt) = next_free() {
+            pt_map.insert(old, new_pt);
+        }
+    }
+    if pt_map.is_empty() {
+        tracing::warn!(
+            "WHEP offer for endpoint '{}': H.265 PTs {:?} need renumbering but no free slots in [96,127]",
+            endpoint_id,
+            to_renumber
+        );
+        return sdp.to_string();
+    }
+
+    // Second pass: rewrite every reference. Lines we touch:
+    //   m=video <port> <proto> <pt1> <pt2> ...     → replace each pt
+    //   a=rtpmap:<pt> ...                          → replace prefix pt
+    //   a=fmtp:<pt> ... apt=<pt> ...               → replace prefix pt + apt= value
+    //   a=rtcp-fb:<pt> ...                         → replace prefix pt
+    let rewrite_pt = |s: &str| -> String {
+        // Helper: parse leading u8 and remainder.
+        if let Some(end) = s.find(|c: char| !c.is_ascii_digit()) {
+            if let Ok(pt) = s[..end].parse::<u8>() {
+                if let Some(&new_pt) = pt_map.get(&pt) {
+                    return format!("{}{}", new_pt, &s[end..]);
+                }
+            }
+        }
+        s.to_string()
+    };
+
+    let mut out = String::with_capacity(sdp.len() + 32);
+    for line in sdp.split_inclusive('\n') {
+        if let Some(rest) = line.strip_prefix("m=video ") {
+            // Rewrite each PT token in the m= line PT list (skip first 2
+            // tokens which are <port> and <proto>).
+            let trailing = if rest.ends_with("\r\n") {
+                "\r\n"
+            } else if rest.ends_with('\n') {
+                "\n"
+            } else {
+                ""
+            };
+            let core = rest.trim_end_matches(|c: char| c == '\r' || c == '\n');
+            let parts: Vec<&str> = core.split(' ').collect();
+            let mut rewritten: Vec<String> = Vec::with_capacity(parts.len());
+            for (idx, p) in parts.iter().enumerate() {
+                if idx < 2 {
+                    rewritten.push((*p).to_string());
+                    continue;
+                }
+                if let Ok(pt) = p.parse::<u8>() {
+                    if let Some(&new_pt) = pt_map.get(&pt) {
+                        rewritten.push(new_pt.to_string());
+                        continue;
+                    }
+                }
+                rewritten.push((*p).to_string());
+            }
+            out.push_str("m=video ");
+            out.push_str(&rewritten.join(" "));
+            out.push_str(trailing);
+        } else if let Some(rest) = line.strip_prefix("a=rtpmap:") {
+            out.push_str("a=rtpmap:");
+            out.push_str(&rewrite_pt(rest));
+        } else if let Some(rest) = line.strip_prefix("a=rtcp-fb:") {
+            out.push_str("a=rtcp-fb:");
+            out.push_str(&rewrite_pt(rest));
+        } else if let Some(rest) = line.strip_prefix("a=fmtp:") {
+            // Rewrite prefix PT, and also any `apt=N` reference inside.
+            let prefix_rewritten = rewrite_pt(rest);
+            // Replace `apt=<n>` if <n> is in the map.
+            let final_line = if let Some(idx) = prefix_rewritten.find("apt=") {
+                let head = &prefix_rewritten[..idx + "apt=".len()];
+                let tail = &prefix_rewritten[idx + "apt=".len()..];
+                let end = tail
+                    .find(|c: char| c == ';' || c.is_whitespace())
+                    .unwrap_or(tail.len());
+                let apt_str = &tail[..end];
+                let apt_rewritten = if let Ok(apt) = apt_str.parse::<u8>() {
+                    if let Some(&new_pt) = pt_map.get(&apt) {
+                        new_pt.to_string()
+                    } else {
+                        apt_str.to_string()
+                    }
+                } else {
+                    apt_str.to_string()
+                };
+                format!("{}{}{}", head, apt_rewritten, &tail[end..])
+            } else {
+                prefix_rewritten
+            };
+            out.push_str("a=fmtp:");
+            out.push_str(&final_line);
+        } else {
+            out.push_str(line);
+        }
+    }
+
+    let mut mapping: Vec<(u8, u8)> = pt_map.iter().map(|(a, b)| (*a, *b)).collect();
+    mapping.sort();
+    tracing::info!(
+        "WHEP offer for endpoint '{}': renumbered low H.265 PTs (old->new): {:?}",
+        endpoint_id,
+        mapping
+    );
+
+    out
+}
+
+/// Remove `level-id=<n>;` (or `level-id=<n>` if trailing) from any H.265
+/// `a=fmtp` line in an SDP. webrtcsink advertises level-id=180 (level 6.0)
+/// regardless of the actual stream level; Chrome desktop's HW HEVC decoder
+/// rejects level 6.0 because most platforms cap out at level 5.1 / 5.2. With
+/// no level-id present, browsers default to a level compatible with the
+/// actual encoded SPS.
+fn strip_h265_fmtp_level_id(sdp: &str) -> String {
+    // First pass: figure out which PTs are H.265 via rtpmap.
+    let mut h265_pts: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for line in sdp.lines() {
+        if let Some(rest) = line.strip_prefix("a=rtpmap:") {
+            if let Some(sp) = rest.find(' ') {
+                let pt = &rest[..sp];
+                let codec = rest[sp + 1..].split('/').next().unwrap_or("");
+                if codec.eq_ignore_ascii_case("H265") {
+                    h265_pts.insert(pt.to_string());
+                }
+            }
+        }
+    }
+    if h265_pts.is_empty() {
+        return sdp.to_string();
+    }
+
+    let mut out = String::with_capacity(sdp.len());
+    for line in sdp.split_inclusive('\n') {
+        if let Some(rest) = line.strip_prefix("a=fmtp:") {
+            // Find the PT prefix of the fmtp line and check if it's H.265.
+            if let Some(sp) = rest.find(' ') {
+                let pt = &rest[..sp];
+                if h265_pts.contains(pt) {
+                    // Drop `level-id=<digits>` plus an optional trailing `;`.
+                    let params = &rest[sp + 1..];
+                    let cleaned = remove_fmtp_field(params, "level-id");
+                    out.push_str("a=fmtp:");
+                    out.push_str(pt);
+                    out.push(' ');
+                    out.push_str(&cleaned);
+                    continue;
+                }
+            }
+        }
+        out.push_str(line);
+    }
+    out
+}
+
+/// Remove a `key=value` (with optional trailing `;`) from an fmtp parameter
+/// string. Preserves line endings.
+fn remove_fmtp_field(params: &str, key: &str) -> String {
+    let needle = format!("{}=", key);
+    let Some(idx) = params.find(&needle) else {
+        return params.to_string();
+    };
+    // Find end of value (next `;` or end of relevant portion).
+    let after = &params[idx + needle.len()..];
+    let end_rel = after.find(';').map(|i| i + 1).unwrap_or(after.len());
+    let removed_total_len = needle.len() + end_rel;
+    let mut out = String::with_capacity(params.len());
+    out.push_str(&params[..idx]);
+    out.push_str(&params[idx + removed_total_len..]);
+    // Clean up double `;;` or leading `;` artifacts left after removal.
+    out.replace(";;", ";")
+        .trim_start_matches(';')
+        .to_string()
+}
+
+/// Decide whether an H.264 profile-level-id (6 hex chars: profile_idc + iop +
+/// level_idc) is one that gst-plugin-webrtc's `compat_profiles()` accepts.
+/// That function panics outright on anything outside H264_PROFILES_COMPAT:
+/// constrained-baseline, baseline, main, high, high-10, high-4:2:2,
+/// high-4:4:4. So we have to filter at the SDP layer.
+fn is_supported_h264_profile_level_id(value: &str) -> bool {
+    if value.len() < 6 {
+        return false;
+    }
+    let Ok(profile_idc) = u8::from_str_radix(&value[0..2], 16) else {
+        return false;
+    };
+    let Ok(profile_iop) = u8::from_str_radix(&value[2..4], 16) else {
+        return false;
+    };
+    // Bits in profile_iop:
+    //   0x80 constraint_set0_flag
+    //   0x40 constraint_set1_flag
+    //   0x20 constraint_set2_flag
+    //   0x10 constraint_set3_flag  -> "*-intra" variants (not supported)
+    //   0x08 constraint_set4_flag  -> "progressive-high" / "constrained-high"
+    //   0x04 constraint_set5_flag  -> "progressive-high" / "constrained-high"
+    let bad_high_constraints = (profile_iop & 0x1C) != 0;
+    match profile_idc {
+        66 => true,                            // baseline / constrained-baseline
+        77 => (profile_iop & 0x10) == 0,       // main (not main-intra)
+        88 => false,                           // extended — not in webrtcsink whitelist
+        100 => !bad_high_constraints,          // high (block constrained/progressive/intra)
+        110 => !bad_high_constraints,          // high-10
+        122 => !bad_high_constraints,          // high-4:2:2
+        244 => !bad_high_constraints,          // high-4:4:4
+        _ => false,                            // scalable, multiview, stereo, etc.
+    }
+}
+
+/// Strip `a=fmtp:N profile-level-id=...` lines whose profile webrtcsink would
+/// panic on. Leaving the rtpmap intact lets webrtcsink still accept the
+/// payload type — it just won't have a profile constraint, so it picks its
+/// internal default (baseline) instead of crashing the whole process.
+fn filter_unsupported_h264_profiles(sdp: &str, endpoint_id: &str) -> String {
+    let mut out = String::with_capacity(sdp.len());
+    let mut removed_pts: Vec<String> = Vec::new();
+    let mut all_pts: Vec<(String, String)> = Vec::new();
+    for line in sdp.split_inclusive('\n') {
+        // Only inspect a=fmtp lines that look like H.264 profile-level-id
+        if !line.starts_with("a=fmtp:") {
+            out.push_str(line);
+            continue;
+        }
+        let Some(rest) = line.strip_prefix("a=fmtp:") else {
+            out.push_str(line);
+            continue;
+        };
+        let Some(sp) = rest.find(' ') else {
+            out.push_str(line);
+            continue;
+        };
+        let (pt, params) = rest.split_at(sp);
+        if let Some(idx) = params.find("profile-level-id=") {
+            let after = &params[idx + "profile-level-id=".len()..];
+            let end = after
+                .find(|c: char| c == ';' || c.is_whitespace())
+                .unwrap_or(after.len());
+            let pli = &after[..end];
+            all_pts.push((pt.to_string(), pli.to_string()));
+            if !is_supported_h264_profile_level_id(pli) {
+                removed_pts.push(format!("{}={}", pt, pli));
+                continue; // drop this line
+            }
+        }
+        out.push_str(line);
+    }
+    if !removed_pts.is_empty() {
+        tracing::info!(
+            "WHEP offer for endpoint '{}': stripped {} unsupported H264 fmtp(s) {:?}; all H264 PTs in offer: {:?}",
+            endpoint_id,
+            removed_pts.len(),
+            removed_pts,
+            all_pts
+        );
+    } else {
+        tracing::info!(
+            "WHEP offer for endpoint '{}': all H264 profile-level-ids supported: {:?}",
+            endpoint_id,
+            all_pts
+        );
+    }
+
+    // Diagnostic: list ALL video codecs the browser offered (from a=rtpmap
+    // lines). Useful for verifying whether H265/HEVC, VP8, VP9, AV1 are
+    // present in the offer — separate from H264-specific filtering above.
+    {
+        let codecs: Vec<String> = sdp
+            .lines()
+            .filter_map(|l| {
+                l.strip_prefix("a=rtpmap:").and_then(|rest| {
+                    rest.find(' ').map(|sp| {
+                        let (pt, codec) = rest.split_at(sp);
+                        let codec = codec.trim();
+                        format!("{}={}", pt, codec)
+                    })
+                })
+            })
+            .collect();
+        tracing::info!(
+            "WHEP offer for endpoint '{}': all rtpmap codecs: {:?}",
+            endpoint_id,
+            codecs
+        );
+    }
+
+    out
+}
+
 /// Proxy POST requests to /whep/{endpoint_id}
 /// Looks up the internal port from WhepRegistry and forwards to localhost:{port}/whep/endpoint
 #[utoipa::path(
@@ -82,6 +449,36 @@ pub async fn whep_endpoint_proxy(
     headers: HeaderMap,
     body: String,
 ) -> Response {
+    // Log the raw SDP offer the browser sent, then the SDP after our
+    // profile-level-id filter, and finally the SDP answer from webrtcsink.
+    // Lets us trace exactly what each side advertises.
+    tracing::info!(
+        "WHEP SDP OFFER (raw) for '{}' [{} bytes]:\n{}",
+        endpoint_id,
+        body.len(),
+        body
+    );
+
+    // Renumber low H.265 PTs (Chrome offers H265 on PT < 96, which
+    // rtph265pay's src-pad template rejects → discovery link fails → codec
+    // dropped → m=video goes inactive). Move them into [96, 127].
+    let body = renumber_low_h265_payload_types(&body, &endpoint_id);
+
+    // Filter out H264 fmtp lines with profile-level-ids that webrtcsink's
+    // compat_profiles() panics on (constrained-high, progressive-high,
+    // extended, scalable-*, etc — anything outside H264_PROFILES_COMPAT in
+    // gst-plugin-webrtc/src/utils.rs). Without this, mobile browsers (notably
+    // Safari/iOS) that advertise profile-level-id=640c1f abort the whole
+    // strom process.
+    let body = filter_unsupported_h264_profiles(&body, &endpoint_id);
+
+    tracing::info!(
+        "WHEP SDP OFFER (after strip) for '{}' [{} bytes]:\n{}",
+        endpoint_id,
+        body.len(),
+        body
+    );
+
     // Look up internal port from registry
     let port = match state.whep_registry().get_port(&endpoint_id).await {
         Some(p) => p,
@@ -132,6 +529,40 @@ pub async fn whep_endpoint_proxy(
                 .collect();
 
             let body_bytes = response.bytes().await.unwrap_or_default();
+
+            // DIAGNOSTIC: log the SDP answer webrtcsink returned (before our
+            // post-processing).
+            tracing::info!(
+                "WHEP SDP ANSWER (raw) for '{}' status={} [{} bytes]:\n{}",
+                endpoint_id,
+                status.as_u16(),
+                body_bytes.len(),
+                String::from_utf8_lossy(&body_bytes)
+            );
+
+            // Post-process the SDP answer: strip H.265 `level-id` from any
+            // `a=fmtp` line. webrtcsink hardcodes level-id=180 (level 6.0)
+            // which exceeds what most browser HW HEVC decoders support
+            // (typically up to 5.1). With no level-id, browsers default to
+            // a sane level that matches the actual stream the encoder emits.
+            let body_bytes = if body_bytes
+                .windows(5)
+                .any(|w| w == b"H265/")
+            {
+                let answer = String::from_utf8_lossy(&body_bytes).into_owned();
+                let rewritten = strip_h265_fmtp_level_id(&answer);
+                if rewritten != answer {
+                    tracing::info!(
+                        "WHEP SDP ANSWER (final) for '{}' [{} bytes]:\n{}",
+                        endpoint_id,
+                        rewritten.len(),
+                        rewritten
+                    );
+                }
+                rewritten.into_bytes().into()
+            } else {
+                body_bytes
+            };
 
             let mut builder = Response::builder()
                 .status(StatusCode::from_u16(status.as_u16()).unwrap_or(StatusCode::OK))

--- a/backend/src/blocks/builtin/videoenc.rs
+++ b/backend/src/blocks/builtin/videoenc.rs
@@ -731,7 +731,11 @@ fn map_quality_preset_vp9enc(quality_preset: &str) -> i32 {
 fn get_codec_caps_string(codec: Codec, profile: &str) -> String {
     match codec {
         Codec::H264 => {
-            let p = if profile == "auto" { "baseline" } else { profile };
+            let p = if profile == "auto" {
+                "baseline"
+            } else {
+                profile
+            };
             format!("video/x-h264,alignment=au,profile={}", p)
         }
         Codec::H265 => {

--- a/backend/src/blocks/builtin/videoenc.rs
+++ b/backend/src/blocks/builtin/videoenc.rs
@@ -109,6 +109,15 @@ impl BlockBuilder for VideoEncBuilder {
             })
             .unwrap_or(60);
 
+        let profile = properties
+            .get("profile")
+            .and_then(|v| match v {
+                PropertyValue::String(s) => Some(s.as_str()),
+                _ => None,
+            })
+            .unwrap_or("auto")
+            .to_string();
+
         // Create elements
         // Use detected video convert mode (autovideoconvert if GPU interop works, videoconvert otherwise)
         // Note: We always use "videoconvert" as the element ID for consistent external pad references,
@@ -156,7 +165,7 @@ impl BlockBuilder for VideoEncBuilder {
         info!("Added {} parser for proper stream formatting", parser_name);
 
         // Create capsfilter with codec-specific caps
-        let caps_str = get_codec_caps_string(codec);
+        let caps_str = get_codec_caps_string(codec, &profile);
         let caps = caps_str.parse::<gst::Caps>().map_err(|_| {
             BlockBuildError::InvalidConfiguration(format!("Invalid caps: {}", caps_str))
         })?;
@@ -533,6 +542,15 @@ fn set_encoder_properties(
             let realtime = matches!(quality_preset, "ultrafast" | "fast");
             encoder.set_property_from_str("realtime", if realtime { "true" } else { "false" });
         }
+        // VideoToolbox defaults to allow-frame-reordering=true, which emits
+        // B-frames. B-frames cause non-monotonic PTS in decode order —
+        // rtph264pay uses PTS for RTP timestamps, so the RTP stream becomes
+        // invalid and WebRTC clients (Chrome desktop especially) fail to
+        // decode. Disable unconditionally: VT HW produces good quality at
+        // streaming bitrates without B-frames.
+        if encoder.has_property("allow-frame-reordering") {
+            encoder.set_property("allow-frame-reordering", false);
+        }
     } else if encoder_name.starts_with("v4l2") {
         // V4L2 encoders (Raspberry Pi, embedded Linux)
         // V4L2 encoders use extra-controls structure for bitrate (bits per second)
@@ -702,11 +720,24 @@ fn map_quality_preset_vp9enc(quality_preset: &str) -> i32 {
     }
 }
 
-/// Get codec-specific caps string for capsfilter.
-fn get_codec_caps_string(codec: Codec) -> String {
+/// Get codec-specific caps string for capsfilter, given a profile selection.
+///
+/// `profile` is the user's chosen value or "auto". "auto" resolves to the
+/// most WebRTC-compatible profile for the codec: baseline for H.264 (matches
+/// webrtcsink's hardcoded SDP `profile-level-id=42001f`), main for H.265 (the
+/// 8-bit 4:2:0 profile every WebRTC H.265 decoder supports). For non-WebRTC
+/// downstreams (SRT, MPEG-TS, file output) users can pick a higher profile
+/// for better quality.
+fn get_codec_caps_string(codec: Codec, profile: &str) -> String {
     match codec {
-        Codec::H264 => "video/x-h264,alignment=au".to_string(),
-        Codec::H265 => "video/x-h265,alignment=au".to_string(),
+        Codec::H264 => {
+            let p = if profile == "auto" { "baseline" } else { profile };
+            format!("video/x-h264,alignment=au,profile={}", p)
+        }
+        Codec::H265 => {
+            let p = if profile == "auto" { "main" } else { profile };
+            format!("video/x-h265,alignment=au,profile={}", p)
+        }
         Codec::AV1 => "video/x-av1".to_string(),
         Codec::VP9 => "video/x-vp9".to_string(),
     }
@@ -741,6 +772,28 @@ fn videoenc_definition() -> BlockDefinition {
                 mapping: PropertyMapping {
                     element_id: "_block".to_string(),
                     property_name: "codec".to_string(),
+                    transform: None,
+                },
+                live: false,
+            },
+            ExposedProperty {
+                name: "profile".to_string(),
+                label: "Profile".to_string(),
+                description: "Codec profile to constrain encoder output. \"auto\" picks the most WebRTC-compatible profile (H.264=baseline, H.265=main) — required for WHEP output to Chrome desktop/iOS Safari. Override only for non-WebRTC pipelines (SRT/MPEG-TS/file) where higher profiles give better quality.".to_string(),
+                property_type: PropertyType::Enum {
+                    values: vec![
+                        EnumValue { value: "auto".to_string(), label: Some("Auto (WebRTC-compatible)".to_string()) },
+                        EnumValue { value: "baseline".to_string(), label: Some("Baseline (H.264)".to_string()) },
+                        EnumValue { value: "constrained-baseline".to_string(), label: Some("Constrained Baseline (H.264)".to_string()) },
+                        EnumValue { value: "main".to_string(), label: Some("Main (H.264 / H.265)".to_string()) },
+                        EnumValue { value: "high".to_string(), label: Some("High (H.264)".to_string()) },
+                        EnumValue { value: "high-10".to_string(), label: Some("High 10-bit (H.264 / H.265 Main 10)".to_string()) },
+                    ],
+                },
+                default_value: Some(PropertyValue::String("auto".to_string())),
+                mapping: PropertyMapping {
+                    element_id: "_block".to_string(),
+                    property_name: "profile".to_string(),
                     transform: None,
                 },
                 live: false,

--- a/backend/src/blocks/builtin/videoenc/tests.rs
+++ b/backend/src/blocks/builtin/videoenc/tests.rs
@@ -198,15 +198,23 @@ fn test_encoder_selection_software_only() {
 #[test]
 fn test_get_codec_caps_string() {
     assert_eq!(
-        get_codec_caps_string(Codec::H264),
-        "video/x-h264,alignment=au"
+        get_codec_caps_string(Codec::H264, "auto"),
+        "video/x-h264,alignment=au,profile=baseline"
     );
     assert_eq!(
-        get_codec_caps_string(Codec::H265),
-        "video/x-h265,alignment=au"
+        get_codec_caps_string(Codec::H264, "high"),
+        "video/x-h264,alignment=au,profile=high"
     );
-    assert_eq!(get_codec_caps_string(Codec::AV1), "video/x-av1");
-    assert_eq!(get_codec_caps_string(Codec::VP9), "video/x-vp9");
+    assert_eq!(
+        get_codec_caps_string(Codec::H265, "auto"),
+        "video/x-h265,alignment=au,profile=main"
+    );
+    assert_eq!(
+        get_codec_caps_string(Codec::H265, "main-10"),
+        "video/x-h265,alignment=au,profile=main-10"
+    );
+    assert_eq!(get_codec_caps_string(Codec::AV1, "auto"), "video/x-av1");
+    assert_eq!(get_codec_caps_string(Codec::VP9, "auto"), "video/x-vp9");
 }
 
 /// Test that we can create and configure available encoders without panicking

--- a/backend/src/blocks/builtin/whep.rs
+++ b/backend/src/blocks/builtin/whep.rs
@@ -1201,8 +1201,16 @@ fn build_whepserversink(
                     // Only add first occurrence of each codec type
                     if seen_codecs.insert(codec_name.to_string()) {
                         let mut new_structure = structure.to_owned();
+                        // H.264 / AV1
                         new_structure.remove_field("profile-level-id");
                         new_structure.remove_field("profile");
+                        new_structure.remove_field("level-idx");
+                        new_structure.remove_field("tier");
+                        // H.265
+                        new_structure.remove_field("profile-id");
+                        new_structure.remove_field("tier-flag");
+                        new_structure.remove_field("level-id");
+                        new_structure.remove_field("tx-mode");
                         new_caps.get_mut().unwrap().append_structure(new_structure);
                     }
                 }
@@ -1243,6 +1251,13 @@ fn build_whepserversink(
         let consumer_id = values[1].get::<String>().unwrap_or_default();
         let payloader = values[3].get::<gst::Element>().unwrap();
 
+        info!(
+            "WHEP Output: payloader-setup fired: consumer_id={}, payloader={} (factory={})",
+            consumer_id,
+            payloader.name(),
+            payloader.factory().map(|f| f.name().to_string()).unwrap_or_else(|| "unknown".to_string())
+        );
+
         // Helper: walk downstream capsfilters from a pad and strip profile fields
         fn strip_downstream_capsfilters(start_pad: &gst::Pad, consumer_id: &str) -> u32 {
             let mut count = 0u32;
@@ -1256,13 +1271,23 @@ fn build_whepserversink(
                     if is_capsfilter {
                         let caps: gst::Caps = element.property("caps");
                         if let Some(s) = caps.structure(0) {
-                            if s.has_field("profile-level-id") || s.has_field("profile") {
+                            if s.has_field("profile-level-id")
+                                || s.has_field("profile")
+                                || s.has_field("profile-id")
+                                || s.has_field("tier-flag")
+                                || s.has_field("level-id")
+                                || s.has_field("tx-mode")
+                            {
                                 let mut new_caps = gst::Caps::new_empty();
                                 for i in 0..caps.size() {
                                     if let Some(structure) = caps.structure(i) {
                                         let mut ns = structure.to_owned();
                                         ns.remove_field("profile-level-id");
                                         ns.remove_field("profile");
+                                        ns.remove_field("profile-id");
+                                        ns.remove_field("tier-flag");
+                                        ns.remove_field("level-id");
+                                        ns.remove_field("tx-mode");
                                         new_caps.merge_structure(ns);
                                     }
                                 }
@@ -1312,13 +1337,23 @@ fn build_whepserversink(
                         element.connect_notify(Some("caps"), move |el, _| {
                             let caps: gst::Caps = el.property("caps");
                             if let Some(s) = caps.structure(0) {
-                                if s.has_field("profile-level-id") || s.has_field("profile") {
+                                if s.has_field("profile-level-id")
+                                    || s.has_field("profile")
+                                    || s.has_field("profile-id")
+                                    || s.has_field("tier-flag")
+                                    || s.has_field("level-id")
+                                    || s.has_field("tx-mode")
+                                {
                                     let mut new_caps = gst::Caps::new_empty();
                                     for i in 0..caps.size() {
                                         if let Some(structure) = caps.structure(i) {
                                             let mut ns = structure.to_owned();
                                             ns.remove_field("profile-level-id");
                                             ns.remove_field("profile");
+                                            ns.remove_field("profile-id");
+                                            ns.remove_field("tier-flag");
+                                            ns.remove_field("level-id");
+                                            ns.remove_field("tx-mode");
                                             new_caps.merge_structure(ns);
                                         }
                                     }


### PR DESCRIPTION
## Summary
- webrtcsink in gst-plugin-webrtc 0.15.0 has several rough edges around H.264 and H.265 that broke WHEP playback on Chrome desktop and on iOS Safari. Three coordinated fixes restore mobile + Chrome desktop video.
- Adds a `profile` block property on **VideoEnc** (default `auto`): pins H.264 to baseline / H.265 to main so the bitstream matches what webrtcsink advertises (`profile-level-id=42001f` / `profile-id=1`) — Chrome desktop's HW decoder locks to the SDP-advertised profile at init.
- `vtenc*` encoders get `allow-frame-reordering=false` unconditionally — VideoToolbox emits B-frames by default which produces non-monotonic PTS and breaks `rtph264pay`'s RTP timestamps.
- **WHEP proxy** (`whep_player.rs`): renumber Chrome's low H.265 payload types (49/51/35) into the dynamic range [96,127] so `rtph265pay` accepts them; filter `a=fmtp profile-level-id=...` lines whose H.264 profile is outside `H264_PROFILES_COMPAT` (otherwise iOS Safari's `640c1f` triggers a `.expect()` panic in webrtcsink's `compat_profiles()`); strip H.265 `level-id` from the answer (webrtcsink hardcodes 6.0 which exceeds most browser HEVC HW decoders).
- **WHEP block** (`whep.rs`): extends the existing two profile-strip workarounds to remove H.265-specific fmtp fields (`profile-id`, `tier-flag`, `level-id`, `tx-mode`).
- Diagnostic SDP-body logs are at `debug` level; the two workaround-trigger logs (renumber, fmtp strip) stay at `info`.

## Verified
- H.264 x264enc + iOS Safari, Chrome desktop (macOS, Windows)
- H.264 vtenc  + iOS Safari, Chrome desktop (macOS)

## Known issue (parked)
- H.265 + Chrome desktop — DTLS handshake hangs even though the server-side pipeline is happy. Likely needs `sprop-vps/sprop-sps/sprop-pps` in the fmtp, which would require capturing the encoder's parameter sets and injecting them into the SDP answer.

## Test plan
- [x] `cargo test` (workspace) — all suites green
- [x] H.264 WebRTC playback verified on iOS Safari + Chrome desktop with both x264enc and vtenc
- [ ] Smoke-test that AV1 / VP9 WHEP paths are unaffected by the new `profile` property defaulting to `auto`
- [ ] Confirm SDP-body logs no longer appear at default log level in production config

🤖 Generated with [Claude Code](https://claude.com/claude-code)