### PR TITLE
chore: bump version to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6684,7 +6684,7 @@ dependencies = [
 
 [[package]]
 name = "strom"
-version = "0.4.13-dev4"
+version = "0.5.0"
 dependencies = [
  "agua-gst",
  "anyhow",
@@ -6760,7 +6760,7 @@ dependencies = [
 
 [[package]]
 name = "strom-frontend"
-version = "0.4.13-dev4"
+version = "0.5.0"
 dependencies = [
  "base64",
  "chrono",
@@ -6796,7 +6796,7 @@ dependencies = [
 
 [[package]]
 name = "strom-mcp-server"
-version = "0.4.13-dev4"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "reqwest 0.13.3",
@@ -6810,7 +6810,7 @@ dependencies = [
 
 [[package]]
 name = "strom-types"
-version = "0.4.13-dev4"
+version = "0.5.0"
 dependencies = [
  "garde",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["types", "backend", "frontend", "mcp-server"]
 default-members = ["backend"]
 
 [workspace.package]
-version = "0.4.13-dev4"
+version = "0.5.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Per Enstedt <per.enstedt@eyevinn.se>"]


### PR DESCRIPTION
## Summary
- Bump workspace version from 0.4.13-dev4 to 0.5.0

## Test plan
- [x] cargo check passes
- [x] pre-commit (fmt + clippy) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)