### PR TITLE
fix(audio): bump default mute anti-click ramp 10ms -> 30ms

### DIFF
--- a/types/src/mixer.rs
+++ b/types/src/mixer.rs
@@ -60,4 +60,4 @@ pub const DEFAULT_VOLUME_RAMP_MS: u32 = 20;
 /// Anti-click ramp applied automatically when `mute` is toggled. Not
 /// user-configurable — short enough to feel instant, long enough to
 /// prevent the discontinuity click of a hard mute.
-pub const MUTE_ANTICLICK_RAMP_MS: u32 = 10;
+pub const MUTE_ANTICLICK_RAMP_MS: u32 = 30;


### PR DESCRIPTION
## Summary

- Bumps `MUTE_ANTICLICK_RAMP_MS` from 10 → 30 in `types/src/mixer.rs`.
- Default fade applied when `mute` is toggled without an explicit `ramp_ms`. Explicit callers (e.g. `to_main_vol_*` with `ramp_ms: 200`) are unaffected.

## Why

Field report: audible clicks on a deployed main bus when an external automation client toggled `main_volume.mute` rapidly. Debug logs confirmed the code is doing exactly what it was designed to (`0.97 -> 0.00 over 10 ms (linear)` then `mute=true` 16 ms later) — no fallback path, no race. The 10 ms default itself is the problem:

- 10 ms = 1 full cycle at 100 Hz, 0.5 cycle at 50 Hz → the amplitude envelope still has an audible discontinuity for bass/tonal material, which a main mix typically contains.
- 30 ms covers several cycles of low-frequency content and stays well below "feels like a fade" territory.

## Industry references checked

| Source | Time | Notes |
|---|---|---|
| Web Audio (`setTargetAtTime`, alemangui) | 15 ms exp | "Impression of being immediate" |
| TI TAS5424 amplifier | 20 ms | Hardware mute clamp |
| JFET soft-mute circuits (sound-au.com) | ~10 ms | Analog domain only |
| `exponentialRampToValueAtTime` total | 30 ms | Smooth + still snappy |
| DAW clip-edge crossfades | 50–100 ms | Different use case |

30 ms linear ≈ 15 ms exponential in perceived speed — the consensus sweet spot for "instant but clean".

## Curve note

Stays under `LONG_RAMP_THRESHOLD_MS = 50`, so `lay_out_keyframes` still uses two linear-amplitude keyframes. Important: dB-linear never truly reaches zero, so fade-to-silence stays on the linear branch.

## Test plan

- [x] `cargo check` clean (workspace).
- [x] `cargo clippy` clean (pre-commit hook).
- [ ] Manual: trigger mute/unmute on the deployed `main_volume` element and confirm the click is gone on bass-heavy program audio.
- [ ] Verify `volume_ramp_test.rs` still passes — tests pass explicit `ramp_ms` values, so they're not coupled to the constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)