### PR TITLE
fix(videoenc): replace "auto" profile with "none" default and expand codec profile enum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6684,7 +6684,7 @@ dependencies = [
 
 [[package]]
 name = "strom"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "agua-gst",
  "anyhow",
@@ -6760,7 +6760,7 @@ dependencies = [
 
 [[package]]
 name = "strom-frontend"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "base64",
  "chrono",
@@ -6796,7 +6796,7 @@ dependencies = [
 
 [[package]]
 name = "strom-mcp-server"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "reqwest 0.13.3",
@@ -6810,7 +6810,7 @@ dependencies = [
 
 [[package]]
 name = "strom-types"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "garde",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["types", "backend", "frontend", "mcp-server"]
 default-members = ["backend"]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Per Enstedt <per.enstedt@eyevinn.se>"]

--- a/backend/src/blocks/builtin/videoenc.rs
+++ b/backend/src/blocks/builtin/videoenc.rs
@@ -745,25 +745,23 @@ fn map_quality_preset_vp9enc(quality_preset: &str) -> i32 {
 
 /// Get codec-specific caps string for capsfilter, given a profile selection.
 ///
-/// `profile` is the user's chosen value or "auto". "auto" resolves to the
-/// most WebRTC-compatible profile for the codec: baseline for H.264 (matches
-/// webrtcsink's hardcoded SDP `profile-level-id=42001f`), main for H.265 (the
-/// 8-bit 4:2:0 profile every WebRTC H.265 decoder supports). For non-WebRTC
-/// downstreams (SRT, MPEG-TS, file output) users can pick a higher profile
-/// for better quality.
+/// `profile` is either `"none"` — omit the profile field so the encoder
+/// negotiates freely with downstream — or an explicit codec profile name
+/// (`"baseline"`, `"constrained-baseline"`, `"main"`, `"high"`, `"high-10"`,
+/// `"main-10"`, `"main-422-10"`, …) that gets pinned on the capsfilter.
 fn get_codec_caps_string(codec: Codec, profile: &str) -> String {
     match codec {
         Codec::H264 => {
-            let p = if profile == "auto" {
-                "baseline"
-            } else {
-                profile
-            };
-            format!("video/x-h264,alignment=au,profile={}", p)
+            if profile == "none" {
+                return "video/x-h264,alignment=au".to_string();
+            }
+            format!("video/x-h264,alignment=au,profile={}", profile)
         }
         Codec::H265 => {
-            let p = if profile == "auto" { "main" } else { profile };
-            format!("video/x-h265,alignment=au,profile={}", p)
+            if profile == "none" {
+                return "video/x-h265,alignment=au".to_string();
+            }
+            format!("video/x-h265,alignment=au,profile={}", profile)
         }
         Codec::AV1 => "video/x-av1".to_string(),
         Codec::VP9 => "video/x-vp9".to_string(),
@@ -806,18 +804,28 @@ fn videoenc_definition() -> BlockDefinition {
             ExposedProperty {
                 name: "profile".to_string(),
                 label: "Profile".to_string(),
-                description: "Codec profile to constrain encoder output. \"auto\" picks the most WebRTC-compatible profile (H.264=baseline, H.265=main) — required for WHEP output to Chrome desktop/iOS Safari. Override only for non-WebRTC pipelines (SRT/MPEG-TS/file) where higher profiles give better quality.".to_string(),
+                description: "Codec profile pinned on the encoder's output capsfilter. \"none\" (default) omits the profile field, letting the encoder negotiate freely with downstream — works with any downstream and is the right choice unless something specifically requires a pinned profile. Pick an explicit profile only when the downstream needs it. H.264 profiles begin with baseline/main/high; H.265 profiles begin with main.".to_string(),
                 property_type: PropertyType::Enum {
                     values: vec![
-                        EnumValue { value: "auto".to_string(), label: Some("Auto (WebRTC-compatible)".to_string()) },
-                        EnumValue { value: "baseline".to_string(), label: Some("Baseline (H.264)".to_string()) },
+                        EnumValue { value: "none".to_string(), label: Some("None (no constraint)".to_string()) },
                         EnumValue { value: "constrained-baseline".to_string(), label: Some("Constrained Baseline (H.264)".to_string()) },
+                        EnumValue { value: "baseline".to_string(), label: Some("Baseline (H.264)".to_string()) },
                         EnumValue { value: "main".to_string(), label: Some("Main (H.264 / H.265)".to_string()) },
                         EnumValue { value: "high".to_string(), label: Some("High (H.264)".to_string()) },
-                        EnumValue { value: "high-10".to_string(), label: Some("High 10-bit (H.264 / H.265 Main 10)".to_string()) },
+                        EnumValue { value: "high-10".to_string(), label: Some("High 10-bit (H.264)".to_string()) },
+                        EnumValue { value: "high-4:2:2".to_string(), label: Some("High 4:2:2 (H.264, 8/10-bit)".to_string()) },
+                        EnumValue { value: "high-4:4:4".to_string(), label: Some("High 4:4:4 (H.264)".to_string()) },
+                        EnumValue { value: "main-10".to_string(), label: Some("Main 10 (H.265, 10-bit 4:2:0)".to_string()) },
+                        EnumValue { value: "main-12".to_string(), label: Some("Main 12 (H.265, 12-bit 4:2:0)".to_string()) },
+                        EnumValue { value: "main-422-10".to_string(), label: Some("Main 4:2:2 10 (H.265)".to_string()) },
+                        EnumValue { value: "main-422-12".to_string(), label: Some("Main 4:2:2 12 (H.265)".to_string()) },
+                        EnumValue { value: "main-444".to_string(), label: Some("Main 4:4:4 (H.265)".to_string()) },
+                        EnumValue { value: "main-444-10".to_string(), label: Some("Main 4:4:4 10 (H.265)".to_string()) },
+                        EnumValue { value: "main-444-12".to_string(), label: Some("Main 4:4:4 12 (H.265)".to_string()) },
+                        EnumValue { value: "main-still-picture".to_string(), label: Some("Main Still Picture (H.265)".to_string()) },
                     ],
                 },
-                default_value: Some(PropertyValue::String("auto".to_string())),
+                default_value: Some(PropertyValue::String("none".to_string())),
                 mapping: PropertyMapping {
                     element_id: "_block".to_string(),
                     property_name: "profile".to_string(),

--- a/backend/src/blocks/builtin/videoenc.rs
+++ b/backend/src/blocks/builtin/videoenc.rs
@@ -21,7 +21,9 @@ use crate::gpu::video_convert_mode;
 use gstreamer as gst;
 use gstreamer::prelude::*;
 use std::collections::HashMap;
-use strom_types::{block::*, element::ElementPadRef, EnumValue, PropertyValue, *};
+use strom_types::{
+    block::*, element::ElementPadRef, videoenc::Profile, EnumValue, PropertyValue, *,
+};
 use tracing::{info, warn};
 
 /// Video Encoder block builder.
@@ -109,14 +111,7 @@ impl BlockBuilder for VideoEncBuilder {
             })
             .unwrap_or(60);
 
-        let profile = properties
-            .get("profile")
-            .and_then(|v| match v {
-                PropertyValue::String(s) => Some(s.as_str()),
-                _ => None,
-            })
-            .unwrap_or("auto")
-            .to_string();
+        let profile = parse_profile(properties);
 
         // Create elements
         // Use detected video convert mode (autovideoconvert if GPU interop works, videoconvert otherwise)
@@ -165,7 +160,7 @@ impl BlockBuilder for VideoEncBuilder {
         info!("Added {} parser for proper stream formatting", parser_name);
 
         // Create capsfilter with codec-specific caps
-        let caps_str = get_codec_caps_string(codec, &profile);
+        let caps_str = get_codec_caps_string(codec, profile);
         let caps = caps_str.parse::<gst::Caps>().map_err(|_| {
             BlockBuildError::InvalidConfiguration(format!("Invalid caps: {}", caps_str))
         })?;
@@ -745,27 +740,44 @@ fn map_quality_preset_vp9enc(quality_preset: &str) -> i32 {
 
 /// Get codec-specific caps string for capsfilter, given a profile selection.
 ///
-/// `profile` is either `"none"` — omit the profile field so the encoder
-/// negotiates freely with downstream — or an explicit codec profile name
-/// (`"baseline"`, `"constrained-baseline"`, `"main"`, `"high"`, `"high-10"`,
-/// `"main-10"`, `"main-422-10"`, …) that gets pinned on the capsfilter.
-fn get_codec_caps_string(codec: Codec, profile: &str) -> String {
+/// For H.264/H.265: pins `profile=<name>` on the capsfilter unless `profile`
+/// is [`Profile::None`], in which case no profile field is added and the
+/// encoder negotiates freely with downstream.
+/// For AV1/VP9: profile is ignored — caps only contain the codec media type.
+fn get_codec_caps_string(codec: Codec, profile: Profile) -> String {
     match codec {
-        Codec::H264 => {
-            if profile == "none" {
-                return "video/x-h264,alignment=au".to_string();
-            }
-            format!("video/x-h264,alignment=au,profile={}", profile)
-        }
-        Codec::H265 => {
-            if profile == "none" {
-                return "video/x-h265,alignment=au".to_string();
-            }
-            format!("video/x-h265,alignment=au,profile={}", profile)
-        }
+        Codec::H264 => match profile.as_caps_str() {
+            None => "video/x-h264,alignment=au".to_string(),
+            Some(p) => format!("video/x-h264,alignment=au,profile={}", p),
+        },
+        Codec::H265 => match profile.as_caps_str() {
+            None => "video/x-h265,alignment=au".to_string(),
+            Some(p) => format!("video/x-h265,alignment=au,profile={}", p),
+        },
         Codec::AV1 => "video/x-av1".to_string(),
         Codec::VP9 => "video/x-vp9".to_string(),
     }
+}
+
+/// Parse the `profile` property. Unknown / missing values fall back to the
+/// enum's `Default` (no profile constraint).
+fn parse_profile(properties: &HashMap<String, PropertyValue>) -> Profile {
+    properties
+        .get("profile")
+        .and_then(|v| match v {
+            PropertyValue::String(s) => {
+                let parsed = Profile::from_property_str(s);
+                if parsed.is_none() {
+                    warn!(
+                        "videoenc: invalid profile value '{}', falling back to default",
+                        s
+                    );
+                }
+                parsed
+            }
+            _ => None,
+        })
+        .unwrap_or_default()
 }
 
 /// Get metadata for VideoEncoder block (for UI/API).
@@ -806,26 +818,11 @@ fn videoenc_definition() -> BlockDefinition {
                 label: "Profile".to_string(),
                 description: "Codec profile pinned on the encoder's output capsfilter. \"none\" (default) omits the profile field, letting the encoder negotiate freely with downstream — works with any downstream and is the right choice unless something specifically requires a pinned profile. Pick an explicit profile only when the downstream needs it. H.264 profiles begin with baseline/main/high; H.265 profiles begin with main.".to_string(),
                 property_type: PropertyType::Enum {
-                    values: vec![
-                        EnumValue { value: "none".to_string(), label: Some("None (no constraint)".to_string()) },
-                        EnumValue { value: "constrained-baseline".to_string(), label: Some("Constrained Baseline (H.264)".to_string()) },
-                        EnumValue { value: "baseline".to_string(), label: Some("Baseline (H.264)".to_string()) },
-                        EnumValue { value: "main".to_string(), label: Some("Main (H.264 / H.265)".to_string()) },
-                        EnumValue { value: "high".to_string(), label: Some("High (H.264)".to_string()) },
-                        EnumValue { value: "high-10".to_string(), label: Some("High 10-bit (H.264)".to_string()) },
-                        EnumValue { value: "high-4:2:2".to_string(), label: Some("High 4:2:2 (H.264, 8/10-bit)".to_string()) },
-                        EnumValue { value: "high-4:4:4".to_string(), label: Some("High 4:4:4 (H.264)".to_string()) },
-                        EnumValue { value: "main-10".to_string(), label: Some("Main 10 (H.265, 10-bit 4:2:0)".to_string()) },
-                        EnumValue { value: "main-12".to_string(), label: Some("Main 12 (H.265, 12-bit 4:2:0)".to_string()) },
-                        EnumValue { value: "main-422-10".to_string(), label: Some("Main 4:2:2 10 (H.265)".to_string()) },
-                        EnumValue { value: "main-422-12".to_string(), label: Some("Main 4:2:2 12 (H.265)".to_string()) },
-                        EnumValue { value: "main-444".to_string(), label: Some("Main 4:4:4 (H.265)".to_string()) },
-                        EnumValue { value: "main-444-10".to_string(), label: Some("Main 4:4:4 10 (H.265)".to_string()) },
-                        EnumValue { value: "main-444-12".to_string(), label: Some("Main 4:4:4 12 (H.265)".to_string()) },
-                        EnumValue { value: "main-still-picture".to_string(), label: Some("Main Still Picture (H.265)".to_string()) },
-                    ],
+                    values: Profile::block_enum_values(),
                 },
-                default_value: Some(PropertyValue::String("none".to_string())),
+                default_value: Some(PropertyValue::String(
+                    Profile::default().as_property_str().to_string(),
+                )),
                 mapping: PropertyMapping {
                     element_id: "_block".to_string(),
                     property_name: "profile".to_string(),

--- a/backend/src/blocks/builtin/videoenc/tests.rs
+++ b/backend/src/blocks/builtin/videoenc/tests.rs
@@ -198,39 +198,77 @@ fn test_encoder_selection_software_only() {
 #[test]
 fn test_get_codec_caps_string() {
     assert_eq!(
-        get_codec_caps_string(Codec::H264, "none"),
+        get_codec_caps_string(Codec::H264, Profile::None),
         "video/x-h264,alignment=au"
     );
     assert_eq!(
-        get_codec_caps_string(Codec::H264, "baseline"),
+        get_codec_caps_string(Codec::H264, Profile::Baseline),
         "video/x-h264,alignment=au,profile=baseline"
     );
     assert_eq!(
-        get_codec_caps_string(Codec::H264, "high"),
+        get_codec_caps_string(Codec::H264, Profile::High),
         "video/x-h264,alignment=au,profile=high"
     );
     assert_eq!(
-        get_codec_caps_string(Codec::H264, "high-4:4:4"),
+        get_codec_caps_string(Codec::H264, Profile::High444),
         "video/x-h264,alignment=au,profile=high-4:4:4"
     );
     assert_eq!(
-        get_codec_caps_string(Codec::H265, "main-422-10"),
+        get_codec_caps_string(Codec::H265, Profile::Main422_10),
         "video/x-h265,alignment=au,profile=main-422-10"
     );
     assert_eq!(
-        get_codec_caps_string(Codec::H265, "none"),
+        get_codec_caps_string(Codec::H265, Profile::None),
         "video/x-h265,alignment=au"
     );
     assert_eq!(
-        get_codec_caps_string(Codec::H265, "main"),
+        get_codec_caps_string(Codec::H265, Profile::Main),
         "video/x-h265,alignment=au,profile=main"
     );
     assert_eq!(
-        get_codec_caps_string(Codec::H265, "main-10"),
+        get_codec_caps_string(Codec::H265, Profile::Main10),
         "video/x-h265,alignment=au,profile=main-10"
     );
-    assert_eq!(get_codec_caps_string(Codec::AV1, "none"), "video/x-av1");
-    assert_eq!(get_codec_caps_string(Codec::VP9, "none"), "video/x-vp9");
+    assert_eq!(
+        get_codec_caps_string(Codec::AV1, Profile::None),
+        "video/x-av1"
+    );
+    assert_eq!(
+        get_codec_caps_string(Codec::VP9, Profile::None),
+        "video/x-vp9"
+    );
+}
+
+#[test]
+fn test_parse_profile_invalid_value_falls_back_to_default() {
+    let mut props = HashMap::new();
+    props.insert(
+        "profile".to_string(),
+        PropertyValue::String("auto".to_string()),
+    );
+    assert_eq!(parse_profile(&props), Profile::default());
+
+    props.insert(
+        "profile".to_string(),
+        PropertyValue::String("garbage".to_string()),
+    );
+    assert_eq!(parse_profile(&props), Profile::default());
+}
+
+#[test]
+fn test_parse_profile_missing_falls_back_to_default() {
+    let props = HashMap::new();
+    assert_eq!(parse_profile(&props), Profile::default());
+}
+
+#[test]
+fn test_parse_profile_valid_value() {
+    let mut props = HashMap::new();
+    props.insert(
+        "profile".to_string(),
+        PropertyValue::String("main-422-10".to_string()),
+    );
+    assert_eq!(parse_profile(&props), Profile::Main422_10);
 }
 
 /// Test that we can create and configure available encoders without panicking

--- a/backend/src/blocks/builtin/videoenc/tests.rs
+++ b/backend/src/blocks/builtin/videoenc/tests.rs
@@ -198,7 +198,11 @@ fn test_encoder_selection_software_only() {
 #[test]
 fn test_get_codec_caps_string() {
     assert_eq!(
-        get_codec_caps_string(Codec::H264, "auto"),
+        get_codec_caps_string(Codec::H264, "none"),
+        "video/x-h264,alignment=au"
+    );
+    assert_eq!(
+        get_codec_caps_string(Codec::H264, "baseline"),
         "video/x-h264,alignment=au,profile=baseline"
     );
     assert_eq!(
@@ -206,15 +210,27 @@ fn test_get_codec_caps_string() {
         "video/x-h264,alignment=au,profile=high"
     );
     assert_eq!(
-        get_codec_caps_string(Codec::H265, "auto"),
+        get_codec_caps_string(Codec::H264, "high-4:4:4"),
+        "video/x-h264,alignment=au,profile=high-4:4:4"
+    );
+    assert_eq!(
+        get_codec_caps_string(Codec::H265, "main-422-10"),
+        "video/x-h265,alignment=au,profile=main-422-10"
+    );
+    assert_eq!(
+        get_codec_caps_string(Codec::H265, "none"),
+        "video/x-h265,alignment=au"
+    );
+    assert_eq!(
+        get_codec_caps_string(Codec::H265, "main"),
         "video/x-h265,alignment=au,profile=main"
     );
     assert_eq!(
         get_codec_caps_string(Codec::H265, "main-10"),
         "video/x-h265,alignment=au,profile=main-10"
     );
-    assert_eq!(get_codec_caps_string(Codec::AV1, "auto"), "video/x-av1");
-    assert_eq!(get_codec_caps_string(Codec::VP9, "auto"), "video/x-vp9");
+    assert_eq!(get_codec_caps_string(Codec::AV1, "none"), "video/x-av1");
+    assert_eq!(get_codec_caps_string(Codec::VP9, "none"), "video/x-vp9");
 }
 
 /// Test that we can create and configure available encoders without panicking

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -24,6 +24,7 @@ pub mod state;
 pub mod stats;
 pub mod system_monitor;
 pub mod thread_stats;
+pub mod videoenc;
 pub mod vision_mixer;
 pub mod whep;
 pub mod whip;

--- a/types/src/videoenc.rs
+++ b/types/src/videoenc.rs
@@ -1,0 +1,125 @@
+//! Shared types for the Video Encoder block.
+
+use crate::block::EnumValue;
+
+/// Codec profile constraint on the video encoder's output.
+///
+/// Values map 1:1 to the GStreamer `profile` caps field for H.264 / H.265
+/// (except `None`, which means "no profile field" — let the encoder negotiate
+/// freely with downstream).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[allow(non_camel_case_types)]
+pub enum Profile {
+    /// No profile constraint — encoder negotiates freely with downstream.
+    #[default]
+    None,
+    ConstrainedBaseline,
+    Baseline,
+    Main,
+    High,
+    High10,
+    High422,
+    High444,
+    Main10,
+    Main12,
+    Main422_10,
+    Main422_12,
+    Main444,
+    Main444_10,
+    Main444_12,
+    MainStillPicture,
+}
+
+impl Profile {
+    /// All variants in canonical display order.
+    pub const ALL: &'static [Profile] = &[
+        Self::None,
+        Self::ConstrainedBaseline,
+        Self::Baseline,
+        Self::Main,
+        Self::High,
+        Self::High10,
+        Self::High422,
+        Self::High444,
+        Self::Main10,
+        Self::Main12,
+        Self::Main422_10,
+        Self::Main422_12,
+        Self::Main444,
+        Self::Main444_10,
+        Self::Main444_12,
+        Self::MainStillPicture,
+    ];
+
+    /// Property-value string used in the block's `properties` map and over the API.
+    /// For non-`None` variants this is also the GStreamer caps profile name.
+    pub fn as_property_str(self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::ConstrainedBaseline => "constrained-baseline",
+            Self::Baseline => "baseline",
+            Self::Main => "main",
+            Self::High => "high",
+            Self::High10 => "high-10",
+            Self::High422 => "high-4:2:2",
+            Self::High444 => "high-4:4:4",
+            Self::Main10 => "main-10",
+            Self::Main12 => "main-12",
+            Self::Main422_10 => "main-422-10",
+            Self::Main422_12 => "main-422-12",
+            Self::Main444 => "main-444",
+            Self::Main444_10 => "main-444-10",
+            Self::Main444_12 => "main-444-12",
+            Self::MainStillPicture => "main-still-picture",
+        }
+    }
+
+    /// GStreamer caps profile string, or `None` if no `profile=` field should
+    /// be set on the capsfilter.
+    pub fn as_caps_str(self) -> Option<&'static str> {
+        match self {
+            Self::None => None,
+            other => Some(other.as_property_str()),
+        }
+    }
+
+    /// Human-readable UI label for property dropdowns.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::None => "None (no constraint)",
+            Self::ConstrainedBaseline => "Constrained Baseline (H.264)",
+            Self::Baseline => "Baseline (H.264)",
+            Self::Main => "Main (H.264 / H.265)",
+            Self::High => "High (H.264)",
+            Self::High10 => "High 10-bit (H.264)",
+            Self::High422 => "High 4:2:2 (H.264, 8/10-bit)",
+            Self::High444 => "High 4:4:4 (H.264)",
+            Self::Main10 => "Main 10 (H.265, 10-bit 4:2:0)",
+            Self::Main12 => "Main 12 (H.265, 12-bit 4:2:0)",
+            Self::Main422_10 => "Main 4:2:2 10 (H.265)",
+            Self::Main422_12 => "Main 4:2:2 12 (H.265)",
+            Self::Main444 => "Main 4:4:4 (H.265)",
+            Self::Main444_10 => "Main 4:4:4 10 (H.265)",
+            Self::Main444_12 => "Main 4:4:4 12 (H.265)",
+            Self::MainStillPicture => "Main Still Picture (H.265)",
+        }
+    }
+
+    /// Parse a property string. Returns `None` for unknown values so callers
+    /// can decide whether to fall back to default and/or log.
+    pub fn from_property_str(s: &str) -> Option<Self> {
+        Self::ALL.iter().copied().find(|p| p.as_property_str() == s)
+    }
+
+    /// `EnumValue` list for `BlockDefinition` — keeps the API enum surface and
+    /// the Rust enum in lock-step.
+    pub fn block_enum_values() -> Vec<EnumValue> {
+        Self::ALL
+            .iter()
+            .map(|p| EnumValue {
+                value: p.as_property_str().to_string(),
+                label: Some(p.label().to_string()),
+            })
+            .collect()
+    }
+}


### PR DESCRIPTION
## Summary

- Replaces the `profile` property's `"auto"` value (a hidden WebRTC-compatibility mapping baked into a codec property) with `"none"` as the new default. `"none"` omits the `profile=` field from the encoder's output capsfilter so the encoder negotiates freely with downstream — the right behavior for SRT/MPEG-TS muxers and for hardware encoders (NVENC, VA-API) that won't reconfigure to match a pinned profile.
- Expands the enum to cover the codec profiles GStreamer encoders actually produce: H.264 adds `high-4:2:2` and `high-4:4:4`; H.265 adds `main-10`, `main-12`, `main-422-10/12`, `main-444/-10/-12`, `main-still-picture`.
- Property values verified against `gst-inspect-1.0` for `x264enc`, `x265enc`, `nvh264enc`, `nvh265enc`.
- WHEP/WebRTC pipelines now need to explicitly pick `baseline` (H.264) or `main` (H.265) — both are still in the enum.

## Test plan

- [x] `cargo test --lib blocks::builtin::videoenc::tests::test_get_codec_caps_string`
- [x] `cargo test --test openapi_test`
- [ ] Verify in UI that the `Profile` dropdown shows the new options and that `none` is the pre-selected default for new VideoEncoder blocks
- [ ] Run a SRT/MPEG-TS output pipeline with default settings (profile=none) and confirm encoder negotiates correctly
- [ ] Run a WHEP output pipeline with profile=baseline (H.264) and profile=main (H.265) and confirm the SDP/decoder still works on Chrome/Safari

🤖 Generated with [Claude Code](https://claude.com/claude-code)