### PR TITLE
Mixer: Monitor bus, parallel PFL/AFL, collapsing property panel, scaled max counts

### DIFF
--- a/backend/build.rs
+++ b/backend/build.rs
@@ -14,6 +14,7 @@ fn main() {
     embed_windows_resources();
 
     let frontend_dir = PathBuf::from("../frontend");
+    let types_dir = PathBuf::from("../types");
     let dist_dir = PathBuf::from("dist");
     let hash_file = PathBuf::from(".frontend-build-hash");
 
@@ -22,6 +23,9 @@ fn main() {
     println!("cargo:rerun-if-changed=../frontend/Cargo.toml");
     println!("cargo:rerun-if-changed=../frontend/index.html");
     println!("cargo:rerun-if-changed=../frontend/Trunk.toml");
+    // Frontend depends on strom-types — rebuild WASM if shared types change.
+    println!("cargo:rerun-if-changed=../types/src");
+    println!("cargo:rerun-if-changed=../types/Cargo.toml");
     // Also rerun if dist directory changes (manual builds)
     println!("cargo:rerun-if-changed=dist");
     // Rerun if static assets change (WHEP player, etc.)
@@ -34,8 +38,8 @@ fn main() {
     // Rerun if Windows icon changes
     println!("cargo:rerun-if-changed=strom.ico");
 
-    // Compute current hash of frontend sources
-    let current_hash = compute_frontend_hash(&frontend_dir);
+    // Compute current hash of frontend sources (including shared types crate)
+    let current_hash = compute_frontend_hash(&frontend_dir, &types_dir);
 
     // Check if rebuild is needed
     let needs_rebuild = !dist_dir.exists()
@@ -138,7 +142,7 @@ fn set_version_info() {
 }
 
 /// Compute a hash of all frontend source files
-fn compute_frontend_hash(frontend_dir: &Path) -> u64 {
+fn compute_frontend_hash(frontend_dir: &Path, types_dir: &Path) -> u64 {
     let mut hasher = DefaultHasher::new();
 
     // Hash all .rs files in src/
@@ -151,6 +155,14 @@ fn compute_frontend_hash(frontend_dir: &Path) -> u64 {
     hash_file(&frontend_dir.join("Cargo.toml"), &mut hasher);
     hash_file(&frontend_dir.join("index.html"), &mut hasher);
     hash_file(&frontend_dir.join("Trunk.toml"), &mut hasher);
+
+    // Frontend depends on strom-types — hash its sources so changes there
+    // (e.g. shared constants or schema types) trigger a WASM rebuild.
+    let types_src = types_dir.join("src");
+    if types_src.exists() {
+        hash_directory(&types_src, &mut hasher);
+    }
+    hash_file(&types_dir.join("Cargo.toml"), &mut hasher);
 
     hasher.finish()
 }

--- a/backend/src/blocks/builtin/mixer/builder.rs
+++ b/backend/src/blocks/builtin/mixer/builder.rs
@@ -848,7 +848,7 @@ impl BlockBuilder for MixerBuilder {
                 let aux_pre = get_bool_prop(
                     properties,
                     &format!("ch{}_aux{}_pre", ch_num, aux + 1),
-                    aux < 2, // Default: aux 1-2 pre-fader (monitor/IEM), rest post-fader (FX)
+                    false, // All aux sends default post-fader (matches definition.rs)
                 );
 
                 let aux_send_id = format!("{}:aux_send_{}_{}", instance_id, ch, aux);

--- a/backend/src/blocks/builtin/mixer/builder.rs
+++ b/backend/src/blocks/builtin/mixer/builder.rs
@@ -23,13 +23,6 @@ impl BlockBuilder for MixerBuilder {
         let num_channels = parse_num_channels(properties);
         let num_aux_buses = parse_num_aux_buses(properties);
         let num_groups = parse_num_groups(properties);
-        // Label the solo output port "PFL" or "AFL" based on solo_mode so the
-        // graph view matches what the user sees in the mixer strip header.
-        let solo_label = if get_string_prop(properties, "solo_mode", "pfl") == "afl" {
-            "AFL"
-        } else {
-            "PFL"
-        };
         // Create input pads dynamically
         let inputs = (0..num_channels)
             .map(|i| ExternalPad {
@@ -52,12 +45,13 @@ impl BlockBuilder for MixerBuilder {
                 internal_element_id: "main_out_tee".to_string(),
                 internal_pad_name: "src_%u".to_string(),
             },
-            // Solo output (PFL or AFL depending on solo_mode; always present)
+            // Monitor output: follows Main when no PFL/AFL is active anywhere,
+            // and the solo mix the moment any channel engages PFL or AFL.
             ExternalPad {
-                name: "pfl_out".to_string(),
-                label: Some(solo_label.to_string()),
+                name: "monitor_out".to_string(),
+                label: Some("Monitor".to_string()),
                 media_type: MediaType::Audio,
-                internal_element_id: "pfl_out_tee".to_string(),
+                internal_element_id: "monitor_out_tee".to_string(),
                 internal_pad_name: "src_%u".to_string(),
             },
         ];
@@ -110,14 +104,9 @@ impl BlockBuilder for MixerBuilder {
         } else {
             "rust"
         };
-        let solo_mode_afl = get_string_prop(properties, "solo_mode", "pfl") == "afl";
         info!(
-            "Mixer config: {} channels, {} aux buses, {} groups, solo={}, dsp={}",
-            num_channels,
-            num_aux_buses,
-            num_groups,
-            if solo_mode_afl { "afl" } else { "pfl" },
-            dsp_backend,
+            "Mixer config: {} channels, {} aux buses, {} groups, dsp={}",
+            num_channels, num_aux_buses, num_groups, dsp_backend,
         );
 
         let mut elements = Vec::new();
@@ -276,57 +265,137 @@ impl BlockBuilder for MixerBuilder {
         ));
 
         // ========================================================================
-        // Create PFL (Pre-Fader Listen) bus with master level
+        // Create solo bus (sums PFL pre-fader + AFL post-fader sends from every
+        // channel) and the Monitor bus that listens to either Main or solo.
+        //
+        // Routing rule (driven by frontend gate updates, never by pad probes):
+        //   - no PFL/AFL active anywhere → main_to_mon=1, solo_to_mon=0
+        //   - any PFL/AFL active        → main_to_mon=0, solo_to_mon=1
+        // The frontend computes "any solo active" whenever a ch{N}_pfl /
+        // ch{N}_afl toggles and ramps both gate volumes via the standard
+        // volume-element ramp.
         // ========================================================================
-        let pfl_mixer_id = format!("{}:pfl_mixer", instance_id);
-        let pfl_mixer = make_audiomixer(
-            &pfl_mixer_id,
+        let solo_mixer_id = format!("{}:solo_mixer", instance_id);
+        let solo_mixer = make_audiomixer(
+            &solo_mixer_id,
             force_live,
             latency_ms,
             min_upstream_latency_ms,
         )?;
-        elements.push((pfl_mixer_id.clone(), pfl_mixer));
+        elements.push((solo_mixer_id.clone(), solo_mixer));
 
-        // PFL master volume
-        let pfl_master_vol_id = format!("{}:pfl_master_vol", instance_id);
-        let pfl_master_level = get_float_prop(properties, "pfl_level", 1.0);
-        let pfl_master_vol = gst::ElementFactory::make("volume")
-            .name(&pfl_master_vol_id)
-            .property("volume", pfl_master_level)
+        // Gates feeding monitor_mixer
+        let solo_to_mon_id = format!("{}:solo_to_mon", instance_id);
+        let solo_to_mon = gst::ElementFactory::make("volume")
+            .name(&solo_to_mon_id)
+            .property("volume", 0.0_f64)
             .build()
-            .map_err(|e| BlockBuildError::ElementCreation(format!("pfl master vol: {}", e)))?;
-        elements.push((pfl_master_vol_id.clone(), pfl_master_vol));
+            .map_err(|e| BlockBuildError::ElementCreation(format!("solo_to_mon: {}", e)))?;
+        elements.push((solo_to_mon_id.clone(), solo_to_mon));
 
-        let pfl_level_id = format!("{}:pfl_level", instance_id);
-        let pfl_level = gst::ElementFactory::make("level")
-            .name(&pfl_level_id)
+        let main_to_mon_id = format!("{}:main_to_mon", instance_id);
+        let main_to_mon = gst::ElementFactory::make("volume")
+            .name(&main_to_mon_id)
+            .property("volume", 1.0_f64)
+            .build()
+            .map_err(|e| BlockBuildError::ElementCreation(format!("main_to_mon: {}", e)))?;
+        elements.push((main_to_mon_id.clone(), main_to_mon));
+
+        // Small queues in front of monitor_mixer to decouple the two source
+        // chains and avoid backpressure across them.
+        let solo_to_mon_queue_id = format!("{}:solo_to_mon_queue", instance_id);
+        let solo_to_mon_queue = gst::ElementFactory::make("queue")
+            .name(&solo_to_mon_queue_id)
+            .build()
+            .map_err(|e| BlockBuildError::ElementCreation(format!("solo_to_mon_queue: {}", e)))?;
+        elements.push((solo_to_mon_queue_id.clone(), solo_to_mon_queue));
+
+        let main_to_mon_queue_id = format!("{}:main_to_mon_queue", instance_id);
+        let main_to_mon_queue = gst::ElementFactory::make("queue")
+            .name(&main_to_mon_queue_id)
+            .build()
+            .map_err(|e| BlockBuildError::ElementCreation(format!("main_to_mon_queue: {}", e)))?;
+        elements.push((main_to_mon_queue_id.clone(), main_to_mon_queue));
+
+        // Monitor summing mixer
+        let monitor_mixer_id = format!("{}:monitor_mixer", instance_id);
+        let monitor_mixer = make_audiomixer(
+            &monitor_mixer_id,
+            force_live,
+            latency_ms,
+            min_upstream_latency_ms,
+        )?;
+        elements.push((monitor_mixer_id.clone(), monitor_mixer));
+
+        // Monitor master volume (driven by `monitor_fader` exposed property)
+        let monitor_master_vol_id = format!("{}:monitor_master_vol", instance_id);
+        let monitor_master_level = get_float_prop(properties, "monitor_fader", 1.0);
+        let monitor_master_vol = gst::ElementFactory::make("volume")
+            .name(&monitor_master_vol_id)
+            .property("volume", monitor_master_level)
+            .build()
+            .map_err(|e| BlockBuildError::ElementCreation(format!("monitor master vol: {}", e)))?;
+        elements.push((monitor_master_vol_id.clone(), monitor_master_vol));
+
+        // Monitor level meter (broadcast as `{instance}:meter:monitor`)
+        let monitor_level_id = format!("{}:monitor_level", instance_id);
+        let monitor_level = gst::ElementFactory::make("level")
+            .name(&monitor_level_id)
             .property("interval", METER_INTERVAL_NS)
             .property("post-messages", true)
             .build()
-            .map_err(|e| BlockBuildError::ElementCreation(format!("pfl_level: {}", e)))?;
-        elements.push((pfl_level_id.clone(), pfl_level));
+            .map_err(|e| BlockBuildError::ElementCreation(format!("monitor_level: {}", e)))?;
+        elements.push((monitor_level_id.clone(), monitor_level));
 
-        // PFL output tee (allow-not-linked so unconnected pfl_out doesn't stall pipeline)
-        let pfl_out_tee_id = format!("{}:pfl_out_tee", instance_id);
-        let pfl_out_tee = gst::ElementFactory::make("tee")
-            .name(&pfl_out_tee_id)
+        // Monitor output tee (allow-not-linked so unconnected monitor_out
+        // doesn't stall the pipeline)
+        let monitor_out_tee_id = format!("{}:monitor_out_tee", instance_id);
+        let monitor_out_tee = gst::ElementFactory::make("tee")
+            .name(&monitor_out_tee_id)
             .property("allow-not-linked", true)
             .build()
-            .map_err(|e| BlockBuildError::ElementCreation(format!("pfl_out_tee: {}", e)))?;
-        elements.push((pfl_out_tee_id.clone(), pfl_out_tee));
+            .map_err(|e| BlockBuildError::ElementCreation(format!("monitor_out_tee: {}", e)))?;
+        elements.push((monitor_out_tee_id.clone(), monitor_out_tee));
 
-        // Link: pfl_mixer → pfl_master_vol → pfl_level → pfl_out_tee
+        // Wiring:
+        //   solo_mixer  → solo_to_mon  → solo_to_mon_queue ─┐
+        //                                                   ├→ monitor_mixer → monitor_master_vol → monitor_level → monitor_out_tee
+        //   main_out_tee→ main_to_mon  → main_to_mon_queue ─┘
         internal_links.push((
-            ElementPadRef::pad(&pfl_mixer_id, "src"),
-            ElementPadRef::pad(&pfl_master_vol_id, "sink"),
+            ElementPadRef::pad(&solo_mixer_id, "src"),
+            ElementPadRef::pad(&solo_to_mon_id, "sink"),
         ));
         internal_links.push((
-            ElementPadRef::pad(&pfl_master_vol_id, "src"),
-            ElementPadRef::pad(&pfl_level_id, "sink"),
+            ElementPadRef::pad(&solo_to_mon_id, "src"),
+            ElementPadRef::pad(&solo_to_mon_queue_id, "sink"),
         ));
         internal_links.push((
-            ElementPadRef::pad(&pfl_level_id, "src"),
-            ElementPadRef::pad(&pfl_out_tee_id, "sink"),
+            ElementPadRef::pad(&solo_to_mon_queue_id, "src"),
+            ElementPadRef::element(&monitor_mixer_id),
+        ));
+        internal_links.push((
+            ElementPadRef::element(&main_out_tee_id),
+            ElementPadRef::pad(&main_to_mon_id, "sink"),
+        ));
+        internal_links.push((
+            ElementPadRef::pad(&main_to_mon_id, "src"),
+            ElementPadRef::pad(&main_to_mon_queue_id, "sink"),
+        ));
+        internal_links.push((
+            ElementPadRef::pad(&main_to_mon_queue_id, "src"),
+            ElementPadRef::element(&monitor_mixer_id),
+        ));
+        internal_links.push((
+            ElementPadRef::pad(&monitor_mixer_id, "src"),
+            ElementPadRef::pad(&monitor_master_vol_id, "sink"),
+        ));
+        internal_links.push((
+            ElementPadRef::pad(&monitor_master_vol_id, "src"),
+            ElementPadRef::pad(&monitor_level_id, "sink"),
+        ));
+        internal_links.push((
+            ElementPadRef::pad(&monitor_level_id, "src"),
+            ElementPadRef::pad(&monitor_out_tee_id, "sink"),
         ));
 
         // ========================================================================
@@ -723,9 +792,11 @@ impl BlockBuilder for MixerBuilder {
             elements.push((routing_tee_id.clone(), routing_tee));
 
             // ----------------------------------------------------------------
-            // PFL path (pre-fader listen)
+            // Solo bus sends: PFL taps pre-fader, AFL taps post-fader.
+            // Each is an independent volume-gate that sums into solo_mixer.
             // ----------------------------------------------------------------
             let pfl_enabled = get_bool_prop(properties, &format!("ch{}_pfl", ch_num), false);
+            let afl_enabled = get_bool_prop(properties, &format!("ch{}_afl", ch_num), false);
 
             let pfl_volume_id = format!("{}:pfl_volume_{}", instance_id, ch);
             let pfl_volume = gst::ElementFactory::make("volume")
@@ -745,6 +816,25 @@ impl BlockBuilder for MixerBuilder {
                     BlockBuildError::ElementCreation(format!("pfl_queue ch{}: {}", ch_num, e))
                 })?;
             elements.push((pfl_queue_id.clone(), pfl_queue));
+
+            let afl_volume_id = format!("{}:afl_volume_{}", instance_id, ch);
+            let afl_volume = gst::ElementFactory::make("volume")
+                .name(&afl_volume_id)
+                .property("volume", if afl_enabled { 1.0 } else { 0.0 })
+                .build()
+                .map_err(|e| {
+                    BlockBuildError::ElementCreation(format!("afl_volume ch{}: {}", ch_num, e))
+                })?;
+            elements.push((afl_volume_id.clone(), afl_volume));
+
+            let afl_queue_id = format!("{}:afl_queue_{}", instance_id, ch);
+            let afl_queue = gst::ElementFactory::make("queue")
+                .name(&afl_queue_id)
+                .build()
+                .map_err(|e| {
+                    BlockBuildError::ElementCreation(format!("afl_queue ch{}: {}", ch_num, e))
+                })?;
+            elements.push((afl_queue_id.clone(), afl_queue));
 
             // ----------------------------------------------------------------
             // Aux send paths (pre or post fader)
@@ -868,14 +958,9 @@ impl BlockBuilder for MixerBuilder {
                 ElementPadRef::pad(&routing_tee_id, "sink"),
             ));
 
-            // Solo path: PFL (pre-fader) or AFL (post-fader) based on solo_mode
-            let solo_source_tee_id = if solo_mode_afl {
-                &post_fader_tee_id
-            } else {
-                &pre_fader_tee_id
-            };
+            // PFL path: pre_fader_tee → pfl_volume → pfl_queue → solo_mixer
             internal_links.push((
-                ElementPadRef::element(solo_source_tee_id),
+                ElementPadRef::element(&pre_fader_tee_id),
                 ElementPadRef::pad(&pfl_volume_id, "sink"),
             ));
             internal_links.push((
@@ -884,7 +969,21 @@ impl BlockBuilder for MixerBuilder {
             ));
             internal_links.push((
                 ElementPadRef::pad(&pfl_queue_id, "src"),
-                ElementPadRef::element(&pfl_mixer_id), // Request pad from pfl_mixer
+                ElementPadRef::element(&solo_mixer_id),
+            ));
+
+            // AFL path: post_fader_tee → afl_volume → afl_queue → solo_mixer
+            internal_links.push((
+                ElementPadRef::element(&post_fader_tee_id),
+                ElementPadRef::pad(&afl_volume_id, "sink"),
+            ));
+            internal_links.push((
+                ElementPadRef::pad(&afl_volume_id, "src"),
+                ElementPadRef::pad(&afl_queue_id, "sink"),
+            ));
+            internal_links.push((
+                ElementPadRef::pad(&afl_queue_id, "src"),
+                ElementPadRef::element(&solo_mixer_id),
             ));
 
             // ----------------------------------------------------------------
@@ -982,8 +1081,8 @@ impl BlockBuilder for MixerBuilder {
             }
 
             debug!(
-                "Channel {} created: gain={:.1}dB, pan={}, fader={}, mute={}, pfl={}, to_main={}",
-                ch_num, gain_db, pan, fader, mute, pfl_enabled, to_main_enabled
+                "Channel {} created: gain={:.1}dB, pan={}, fader={}, mute={}, pfl={}, afl={}, to_main={}",
+                ch_num, gain_db, pan, fader, mute, pfl_enabled, afl_enabled, to_main_enabled
             );
         }
 

--- a/backend/src/blocks/builtin/mixer/builder.rs
+++ b/backend/src/blocks/builtin/mixer/builder.rs
@@ -23,6 +23,13 @@ impl BlockBuilder for MixerBuilder {
         let num_channels = parse_num_channels(properties);
         let num_aux_buses = parse_num_aux_buses(properties);
         let num_groups = parse_num_groups(properties);
+        // Label the solo output port "PFL" or "AFL" based on solo_mode so the
+        // graph view matches what the user sees in the mixer strip header.
+        let solo_label = if get_string_prop(properties, "solo_mode", "pfl") == "afl" {
+            "AFL"
+        } else {
+            "PFL"
+        };
         // Create input pads dynamically
         let inputs = (0..num_channels)
             .map(|i| ExternalPad {
@@ -45,10 +52,10 @@ impl BlockBuilder for MixerBuilder {
                 internal_element_id: "main_out_tee".to_string(),
                 internal_pad_name: "src_%u".to_string(),
             },
-            // PFL output (always present)
+            // Solo output (PFL or AFL depending on solo_mode; always present)
             ExternalPad {
                 name: "pfl_out".to_string(),
-                label: Some("PFL".to_string()),
+                label: Some(solo_label.to_string()),
                 media_type: MediaType::Audio,
                 internal_element_id: "pfl_out_tee".to_string(),
                 internal_pad_name: "src_%u".to_string(),
@@ -751,7 +758,7 @@ impl BlockBuilder for MixerBuilder {
                 let aux_pre = get_bool_prop(
                     properties,
                     &format!("ch{}_aux{}_pre", ch_num, aux + 1),
-                    aux < 2, // Default: aux 1-2 pre-fader, aux 3-4 post-fader
+                    aux < 2, // Default: aux 1-2 pre-fader (monitor/IEM), rest post-fader (FX)
                 );
 
                 let aux_send_id = format!("{}:aux_send_{}_{}", instance_id, ch, aux);

--- a/backend/src/blocks/builtin/mixer/definition.rs
+++ b/backend/src/blocks/builtin/mixer/definition.rs
@@ -543,7 +543,7 @@ pub(super) fn mixer_definition() -> BlockDefinition {
                     ch, aux
                 ),
                 property_type: PropertyType::Bool,
-                default_value: Some(PropertyValue::Bool(aux <= 2)), // aux 1-2 pre (monitor/IEM), rest post (FX)
+                default_value: Some(PropertyValue::Bool(false)), // all aux sends default post-fader
                 mapping: PropertyMapping {
                     element_id: "_block".to_string(),
                     property_name: format!("ch{}_aux{}_pre", ch, aux),

--- a/backend/src/blocks/builtin/mixer/definition.rs
+++ b/backend/src/blocks/builtin/mixer/definition.rs
@@ -543,7 +543,7 @@ pub(super) fn mixer_definition() -> BlockDefinition {
                     ch, aux
                 ),
                 property_type: PropertyType::Bool,
-                default_value: Some(PropertyValue::Bool(aux <= 2)), // aux 1-2 pre, 3-4 post
+                default_value: Some(PropertyValue::Bool(aux <= 2)), // aux 1-2 pre (monitor/IEM), rest post (FX)
                 mapping: PropertyMapping {
                     element_id: "_block".to_string(),
                     property_name: format!("ch{}_aux{}_pre", ch, aux),

--- a/backend/src/blocks/builtin/mixer/definition.rs
+++ b/backend/src/blocks/builtin/mixer/definition.rs
@@ -92,41 +92,18 @@ pub(super) fn mixer_definition() -> BlockDefinition {
             },
             live: false,
         },
-        // PFL master level
+        // Monitor master level — drives the Monitor bus output. The Monitor
+        // bus follows Main when no channel has PFL or AFL active, and
+        // switches to the solo mix as soon as any PFL/AFL is engaged.
         ExposedProperty {
-            name: "pfl_level".to_string(),
-            label: "PFL Level".to_string(),
-            description: "PFL/AFL bus master level (0.0 to 2.0)".to_string(),
+            name: "monitor_fader".to_string(),
+            label: "Monitor Fader".to_string(),
+            description: "Monitor bus master level (0.0 to 2.0)".to_string(),
             property_type: PropertyType::Float,
             default_value: Some(PropertyValue::Float(1.0)),
             mapping: PropertyMapping {
-                element_id: "pfl_master_vol".to_string(),
+                element_id: "monitor_master_vol".to_string(),
                 property_name: "volume".to_string(),
-                transform: None,
-            },
-            live: false,
-        },
-        // Solo mode (PFL or AFL)
-        ExposedProperty {
-            name: "solo_mode".to_string(),
-            label: "Solo Mode".to_string(),
-            description: "Solo listen mode: PFL (pre-fader) or AFL (after-fader)".to_string(),
-            property_type: PropertyType::Enum {
-                values: vec![
-                    EnumValue {
-                        value: "pfl".to_string(),
-                        label: Some("PFL".to_string()),
-                    },
-                    EnumValue {
-                        value: "afl".to_string(),
-                        label: Some("AFL".to_string()),
-                    },
-                ],
-            },
-            default_value: Some(PropertyValue::String("pfl".to_string())),
-            mapping: PropertyMapping {
-                element_id: "_block".to_string(),
-                property_name: "solo_mode".to_string(),
                 transform: None,
             },
             live: false,
@@ -482,6 +459,21 @@ pub(super) fn mixer_definition() -> BlockDefinition {
             default_value: Some(PropertyValue::Bool(false)),
             mapping: PropertyMapping {
                 element_id: format!("pfl_volume_{}", ch - 1),
+                property_name: "volume".to_string(),
+                transform: Some("bool_to_volume".to_string()),
+            },
+            live: false,
+        });
+
+        // AFL (After-Fader Listen)
+        exposed_properties.push(ExposedProperty {
+            name: format!("ch{}_afl", ch),
+            label: format!("Ch {} AFL", ch),
+            description: format!("Enable AFL (After-Fader Listen) on channel {}", ch),
+            property_type: PropertyType::Bool,
+            default_value: Some(PropertyValue::Bool(false)),
+            mapping: PropertyMapping {
+                element_id: format!("afl_volume_{}", ch - 1),
                 property_name: "volume".to_string(),
                 transform: Some("bool_to_volume".to_string()),
             },
@@ -850,10 +842,10 @@ pub(super) fn mixer_definition() -> BlockDefinition {
                     internal_pad_name: "src_%u".to_string(),
                 },
                 ExternalPad {
-                    name: "pfl_out".to_string(),
-                    label: Some("PFL".to_string()),
+                    name: "monitor_out".to_string(),
+                    label: Some("Monitor".to_string()),
                     media_type: MediaType::Audio,
-                    internal_element_id: "pfl_out_tee".to_string(),
+                    internal_element_id: "monitor_out_tee".to_string(),
                     internal_pad_name: "src_%u".to_string(),
                 },
             ],

--- a/backend/src/blocks/builtin/mixer/metering.rs
+++ b/backend/src/blocks/builtin/mixer/metering.rs
@@ -33,7 +33,7 @@ pub(super) fn connect_mixer_meter_handler(
 
     let level_prefix = format!("{}:level_", instance_id);
     let main_level_id = format!("{}:main_level", instance_id);
-    let pfl_level_id = format!("{}:pfl_level", instance_id);
+    let monitor_level_id = format!("{}:monitor_level", instance_id);
     let aux_level_prefix = format!("{}:aux", instance_id);
     let group_level_prefix = format!("{}:group", instance_id);
 
@@ -66,10 +66,10 @@ pub(super) fn connect_mixer_meter_handler(
                             return;
                         }
 
-                        // Check if this is the PFL level meter
-                        if source_name == pfl_level_id {
-                            trace!("Mixer PFL meter: rms={:?}, peak={:?}", rms, peak);
-                            let element_id = format!("{}:meter:pfl", instance_id);
+                        // Check if this is the monitor bus level meter
+                        if source_name == monitor_level_id {
+                            trace!("Mixer monitor meter: rms={:?}, peak={:?}", rms, peak);
+                            let element_id = format!("{}:meter:monitor", instance_id);
                             events.broadcast(StromEvent::MeterData {
                                 flow_id,
                                 element_id,

--- a/backend/src/blocks/builtin/mixer/mod.rs
+++ b/backend/src/blocks/builtin/mixer/mod.rs
@@ -1,11 +1,13 @@
 //! Stereo Mixer block - a digital mixing console for audio.
 //!
 //! This block provides a mixer similar to digital consoles like Behringer X32:
-//! - Configurable number of input channels (1-32)
+//! - Configurable number of input channels (1-128)
 //! - Per-channel: input gain, gate, compressor, 4-band parametric EQ, pan, fader, mute
-//! - Aux sends (0-4 configurable aux buses, switchable pre/post fader)
-//! - Groups (0-4 configurable, with output pads)
-//! - PFL (Pre-Fader Listen) bus with master level
+//! - Aux sends (0-32 configurable aux buses, switchable pre/post fader)
+//! - Groups (0-32 configurable, with output pads)
+//! - Independent per-channel PFL (pre-fader) and AFL (post-fader) sends
+//! - Monitor bus that follows Main when no PFL/AFL is engaged and switches
+//!   to the solo mix as soon as any channel toggles PFL or AFL
 //! - Main stereo bus with compressor, EQ, limiter, and master fader
 //! - Per-channel and bus metering
 //!
@@ -15,12 +17,21 @@
 //!           pre_fader_tee → audiopanorama_N → volume_N → post_fader_tee →
 //!           level_N → [group or main audiomixer]
 //!
-//! (pre_fader_tee | post_fader_tee) → solo_volume_N → solo_queue_N → pfl_mixer
-//!   (source depends on solo_mode: pfl=pre-fader, afl=post-fader)
+//! pre_fader_tee  → pfl_volume_N → pfl_queue_N ─┐
+//!                                              ├→ solo_mixer
+//! post_fader_tee → afl_volume_N → afl_queue_N ─┘
+//!
 //! (pre_fader_tee | post_fader_tee) → aux_send_N_M → aux_queue_N_M → aux_M_mixer
 //! ```
 //!
 //! Main bus: audiomixer → main_comp → main_eq → main_limiter → main_volume → main_level → main_out_tee
+//!
+//! Monitor bus: the solo_mixer and a tap from main_out_tee both feed a
+//! monitor_mixer through two volume-gate elements (solo_to_mon and
+//! main_to_mon). The frontend toggles those gates whenever any ch{N}_pfl or
+//! ch{N}_afl property changes — no PFL/AFL active → main_to_mon=1,
+//! solo_to_mon=0; any solo active → reversed. monitor_mixer feeds
+//! monitor_master_vol → monitor_level → monitor_out_tee → monitor_out pad.
 //!
 //! All output buses terminate in a tee with allow-not-linked=true, so unconnected
 //! output pads don't cause NOT_LINKED flow errors. Audiomixer elements use

--- a/backend/src/blocks/builtin/mixer/tests.rs
+++ b/backend/src/blocks/builtin/mixer/tests.rs
@@ -104,7 +104,7 @@ fn test_parse_num_aux_buses_clamped() {
     let mut props = HashMap::new();
     props.insert(
         "num_aux_buses".to_string(),
-        PropertyValue::String("10".to_string()),
+        PropertyValue::String("999".to_string()),
     );
     assert_eq!(parse_num_aux_buses(&props), MAX_AUX_BUSES);
 }
@@ -316,15 +316,15 @@ fn test_mixer_definition_channel_count() {
 #[test]
 fn test_mixer_definition_aux_group_outputs() {
     let def = mixer_definition();
-    // Should have main, PFL, aux, and group output pads
+    // Should have main, Monitor, aux, and group output pads
     let pads = &def.external_pads;
     assert!(
         pads.outputs.iter().any(|p| p.name == "main_out"),
         "Should have main_out pad"
     );
     assert!(
-        pads.outputs.iter().any(|p| p.name == "pfl_out"),
-        "Should have pfl_out pad"
+        pads.outputs.iter().any(|p| p.name == "monitor_out"),
+        "Should have monitor_out pad"
     );
 }
 

--- a/backend/src/blocks/builtin/mixer/tests.rs
+++ b/backend/src/blocks/builtin/mixer/tests.rs
@@ -82,7 +82,7 @@ fn test_parse_num_channels_clamped() {
     let mut props = HashMap::new();
     props.insert(
         "num_channels".to_string(),
-        PropertyValue::String("100".to_string()),
+        PropertyValue::String("9999".to_string()),
     );
     assert_eq!(parse_num_channels(&props), MAX_CHANNELS);
 

--- a/frontend/src/mixer/api.rs
+++ b/frontend/src/mixer/api.rs
@@ -368,6 +368,11 @@ impl MixerEditor {
                 "volume",
                 PropertyValue::Float(if channel.pfl { 1.0 } else { 0.0 }),
             ),
+            "afl" => (
+                format!("afl_volume_{}", index),
+                "volume",
+                PropertyValue::Float(if channel.afl { 1.0 } else { 0.0 }),
+            ),
             _ => return,
         };
 
@@ -457,8 +462,8 @@ impl MixerEditor {
         });
     }
 
-    /// Push the solo bus master fader to `pfl_master_vol` via API.
-    pub(super) fn update_solo_master_fader(&mut self, ctx: &Context) {
+    /// Push the monitor bus master fader to `monitor_master_vol` via API.
+    pub(super) fn update_monitor_master_fader(&mut self, ctx: &Context) {
         if !self.live_updates || !self.pipeline_running {
             return;
         }
@@ -470,8 +475,8 @@ impl MixerEditor {
         let ramp_ms = Some(self.fade_ms);
         let api = self.api.clone();
         let flow_id = self.flow_id;
-        let element_id = format!("{}:pfl_master_vol", self.block_id);
-        let value = PropertyValue::Float(self.solo_master_fader as f64);
+        let element_id = format!("{}:monitor_master_vol", self.block_id);
+        let value = PropertyValue::Float(self.monitor_fader as f64);
         let ctx = ctx.clone();
 
         crate::app::spawn_task(async move {
@@ -480,6 +485,56 @@ impl MixerEditor {
                 .await
             {
                 tracing::warn!("Mixer API update failed: {}", e);
+            }
+            ctx.request_repaint();
+        });
+    }
+
+    /// Drive the monitor source-switching gates based on whether any channel
+    /// currently has PFL or AFL engaged.
+    ///
+    /// `solo_to_mon` opens when any solo is active, `main_to_mon` closes.
+    /// When all solo is released, the gates flip back so the monitor follows
+    /// the main output. Both gates ramp via the standard `fade_ms` to avoid
+    /// clicks on transition.
+    pub(super) fn update_monitor_gates(&mut self, ctx: &Context) {
+        if !self.live_updates || !self.pipeline_running {
+            return;
+        }
+        let solo_active = self.any_solo_active();
+        let solo_vol = if solo_active { 1.0_f64 } else { 0.0 };
+        let main_vol = if solo_active { 0.0_f64 } else { 1.0 };
+        let ramp_ms = Some(self.fade_ms);
+        let api = self.api.clone();
+        let flow_id = self.flow_id;
+        let solo_id = format!("{}:solo_to_mon", self.block_id);
+        let main_id = format!("{}:main_to_mon", self.block_id);
+        let ctx = ctx.clone();
+
+        crate::app::spawn_task(async move {
+            if let Err(e) = api
+                .update_element_property(
+                    &flow_id,
+                    &solo_id,
+                    "volume",
+                    PropertyValue::Float(solo_vol),
+                    ramp_ms,
+                )
+                .await
+            {
+                tracing::warn!("Monitor gate (solo) update failed: {}", e);
+            }
+            if let Err(e) = api
+                .update_element_property(
+                    &flow_id,
+                    &main_id,
+                    "volume",
+                    PropertyValue::Float(main_vol),
+                    ramp_ms,
+                )
+                .await
+            {
+                tracing::warn!("Monitor gate (main) update failed: {}", e);
             }
             ctx.request_repaint();
         });

--- a/frontend/src/mixer/api.rs
+++ b/frontend/src/mixer/api.rs
@@ -457,6 +457,34 @@ impl MixerEditor {
         });
     }
 
+    /// Push the solo bus master fader to `pfl_master_vol` via API.
+    pub(super) fn update_solo_master_fader(&mut self, ctx: &Context) {
+        if !self.live_updates || !self.pipeline_running {
+            return;
+        }
+        if self.last_update.elapsed().as_millis() < 50 {
+            return;
+        }
+        self.last_update = instant::Instant::now();
+
+        let ramp_ms = Some(self.fade_ms);
+        let api = self.api.clone();
+        let flow_id = self.flow_id;
+        let element_id = format!("{}:pfl_master_vol", self.block_id);
+        let value = PropertyValue::Float(self.solo_master_fader as f64);
+        let ctx = ctx.clone();
+
+        crate::app::spawn_task(async move {
+            if let Err(e) = api
+                .update_element_property(&flow_id, &element_id, "volume", value, ramp_ms)
+                .await
+            {
+                tracing::warn!("Mixer API update failed: {}", e);
+            }
+            ctx.request_repaint();
+        });
+    }
+
     /// Update aux send level via API.
     pub(super) fn update_aux_send(&mut self, ctx: &Context, ch_idx: usize, aux_idx: usize) {
         if !self.live_updates || !self.pipeline_running {

--- a/frontend/src/mixer/keyboard.rs
+++ b/frontend/src/mixer/keyboard.rs
@@ -56,6 +56,16 @@ impl MixerEditor {
             if let Some(ch) = selected_ch {
                 self.channels[ch].pfl = !self.channels[ch].pfl;
                 self.update_channel_property(ctx, ch, "pfl");
+                self.update_monitor_gates(ctx);
+            }
+        }
+
+        // A = AFL selected channel
+        if ui.input(|i| i.key_pressed(egui::Key::A)) {
+            if let Some(ch) = selected_ch {
+                self.channels[ch].afl = !self.channels[ch].afl;
+                self.update_channel_property(ctx, ch, "afl");
+                self.update_monitor_gates(ctx);
             }
         }
 

--- a/frontend/src/mixer/mod.rs
+++ b/frontend/src/mixer/mod.rs
@@ -66,8 +66,10 @@ struct ChannelStrip {
     fader: f32,
     /// Mute state
     mute: bool,
-    /// PFL (Pre-Fader Listen) state
+    /// PFL (Pre-Fader Listen) state — taps signal before fader/mute
     pfl: bool,
+    /// AFL (After-Fader Listen) state — taps signal after fader/mute/pan
+    afl: bool,
     /// Route to main mix
     to_main: bool,
     /// Route to groups (up to 4)
@@ -140,6 +142,7 @@ impl ChannelStrip {
             fader: DEFAULT_FADER,
             mute: false,
             pfl: false,
+            afl: false,
             to_main: true,
             to_grp: [false; MAX_GROUPS],
             aux_sends: [0.0; MAX_AUX_BUSES],
@@ -232,12 +235,10 @@ pub struct MixerEditor {
     main_fader: f32,
     /// Main mute
     main_mute: bool,
-    /// Solo bus master level (drives `pfl_master_vol`)
-    solo_master_fader: f32,
-    /// Solo mode: "pfl" (pre-fader) or "afl" (after-fader).
-    /// Drives the solo-button label, the keyboard legend, the solo strip
-    /// header, and the `pfl_out` port label on the backend.
-    solo_mode: String,
+    /// Monitor bus master level (drives `monitor_master_vol`).
+    /// The monitor bus follows Main when no PFL/AFL is engaged anywhere,
+    /// and switches to the solo mix as soon as any channel toggles PFL or AFL.
+    monitor_fader: f32,
     /// Main bus compressor enabled
     main_comp_enabled: bool,
     /// Main bus compressor threshold (dB)
@@ -291,14 +292,12 @@ pub struct MixerEditor {
 }
 
 impl MixerEditor {
-    /// Display label for the solo bus / per-channel solo button — "PFL" when
-    /// `solo_mode == "pfl"`, "AFL" otherwise.
-    pub(super) fn solo_label(&self) -> &'static str {
-        if self.solo_mode == "afl" {
-            "AFL"
-        } else {
-            "PFL"
-        }
+    /// True if any channel currently has PFL or AFL engaged.
+    /// Drives the monitor bus source-switching gates (`solo_to_mon` /
+    /// `main_to_mon`) — when any solo is active the monitor listens to
+    /// the solo mix, otherwise it follows the main output.
+    pub(super) fn any_solo_active(&self) -> bool {
+        self.channels.iter().any(|c| c.pfl || c.afl)
     }
 }
 

--- a/frontend/src/mixer/mod.rs
+++ b/frontend/src/mixer/mod.rs
@@ -50,8 +50,6 @@ const MIN_STRIP_INNER: f32 = 42.0;
 const BUS_FADER_HEIGHT: f32 = 120.0;
 /// Fixed inner width for bus master strips
 const BUS_STRIP_INNER: f32 = 52.0;
-/// Minimum height for the bus master row
-const BUS_ROW_MIN_HEIGHT: f32 = 200.0;
 
 /// A single channel strip in the mixer.
 #[derive(Debug, Clone)]
@@ -234,6 +232,12 @@ pub struct MixerEditor {
     main_fader: f32,
     /// Main mute
     main_mute: bool,
+    /// Solo bus master level (drives `pfl_master_vol`)
+    solo_master_fader: f32,
+    /// Solo mode: "pfl" (pre-fader) or "afl" (after-fader).
+    /// Drives the solo-button label, the keyboard legend, the solo strip
+    /// header, and the `pfl_out` port label on the backend.
+    solo_mode: String,
     /// Main bus compressor enabled
     main_comp_enabled: bool,
     /// Main bus compressor threshold (dB)
@@ -287,6 +291,18 @@ pub struct MixerEditor {
 }
 
 impl MixerEditor {
+    /// Display label for the solo bus / per-channel solo button — "PFL" when
+    /// `solo_mode == "pfl"`, "AFL" otherwise.
+    pub(super) fn solo_label(&self) -> &'static str {
+        if self.solo_mode == "afl" {
+            "AFL"
+        } else {
+            "PFL"
+        }
+    }
+}
+
+impl MixerEditor {
     /// Get the block ID.
     pub fn block_id(&self) -> &str {
         &self.block_id
@@ -318,14 +334,18 @@ impl MixerEditor {
         self.is_reset
     }
 
-    /// Compute the usable inner width of a strip based on number of aux buses.
-    /// The aux knob row is typically the widest element.
+    /// Compute the usable inner width of a strip.
+    ///
+    /// The aux knob row wraps every 4 knobs (see `AUX_PER_ROW` in
+    /// `rendering.rs`), so the strip only needs to be wide enough for one
+    /// row's worth of knobs — capped at 4 — rather than scaling with the
+    /// total aux count.
     fn strip_inner(&self) -> f32 {
         if self.num_aux_buses == 0 {
             return MIN_STRIP_INNER;
         }
-        let knob_row =
-            self.num_aux_buses as f32 * KNOB_SIZE + (self.num_aux_buses as f32 - 1.0) * 2.0;
+        let per_row = self.num_aux_buses.min(4) as f32;
+        let knob_row = per_row * KNOB_SIZE + (per_row - 1.0).max(0.0) * 2.0;
         knob_row.max(MIN_STRIP_INNER)
     }
 }

--- a/frontend/src/mixer/rendering.rs
+++ b/frontend/src/mixer/rendering.rs
@@ -505,8 +505,18 @@ impl MixerEditor {
                     self.render_lcd(ui, &display_text, strip_inner - 4.0, LCD_H);
 
                     // ── Pan knob (centered within the strip) ──
-                    let pan_response =
-                        centered_row(ui, PAN_KNOB_SIZE, |ui| self.render_pan_knob(ui, index));
+                    // Explicit add_space padding avoids any centered-layout
+                    // ambiguity since this is a single fixed-size child.
+                    let pan_response = ui
+                        .horizontal(|ui| {
+                            let avail = ui.available_width();
+                            let pad = ((avail - PAN_KNOB_SIZE) / 2.0).max(0.0);
+                            if pad > 0.0 {
+                                ui.add_space(pad);
+                            }
+                            self.render_pan_knob(ui, index)
+                        })
+                        .inner;
                     if pan_response.double_clicked() {
                         self.bypass_throttle();
                         self.update_channel_property(ctx, index, "pan");

--- a/frontend/src/mixer/rendering.rs
+++ b/frontend/src/mixer/rendering.rs
@@ -1,5 +1,47 @@
 use super::*;
 
+/// Center small fixed-size children horizontally on their own row.
+///
+/// Allocates `(ui.available_width(), height)` and lays out children with
+/// `left_to_right(Center).with_main_align(Center).with_main_justify(false)`
+/// — children keep their natural widths and the *group* is centered on the
+/// row's main axis. Critical for rows of knobs where justification would
+/// otherwise spread the knobs apart with empty space between them.
+fn centered_row<R>(ui: &mut Ui, height: f32, add_contents: impl FnOnce(&mut Ui) -> R) -> R {
+    let width = ui.available_width();
+    ui.allocate_ui_with_layout(
+        egui::Vec2::new(width, height),
+        egui::Layout::left_to_right(egui::Align::Center)
+            .with_main_align(egui::Align::Center)
+            .with_main_justify(false),
+        add_contents,
+    )
+    .inner
+}
+
+/// Add a non-interactive header label horizontally centered in the strip.
+fn centered_label(ui: &mut Ui, rich_text: egui::RichText) {
+    let h = ui.spacing().interact_size.y;
+    centered_row(ui, h, |ui| {
+        // Extend wrap-mode keeps short labels at their natural width so the
+        // surrounding centered-and-justified layout actually centers them.
+        ui.add(egui::Label::new(rich_text).wrap_mode(egui::TextWrapMode::Extend));
+    });
+}
+
+/// Same as `centered_label` but for click-sensitive labels (e.g. the
+/// channel-strip name that can be double-clicked to enter edit mode).
+fn centered_clickable_label(ui: &mut Ui, rich_text: egui::RichText) -> egui::Response {
+    let h = ui.spacing().interact_size.y;
+    centered_row(ui, h, |ui| {
+        ui.add(
+            egui::Label::new(rich_text)
+                .wrap_mode(egui::TextWrapMode::Extend)
+                .sense(egui::Sense::click()),
+        )
+    })
+}
+
 impl MixerEditor {
     /// Show the mixer in fullscreen mode.
     pub fn show_fullscreen(&mut self, ui: &mut Ui, ctx: &Context, meter_store: &MeterDataStore) {
@@ -16,95 +58,107 @@ impl MixerEditor {
         self.handle_keyboard(ui, ctx);
         self.strip_interacted = false;
 
-        // Outer vertical scroll wraps the entire mixer.
-        // Each row is sized to its content so the bus-master row sits flush
-        // against the channel strips above, rather than being pushed to the
-        // bottom of the window by an expanded channel-area allocation.
-        egui::ScrollArea::vertical()
-            .id_salt("mixer_v_scroll")
-            .auto_shrink([false, false])
-            .show(ui, |ui| {
-                ui.vertical(|ui| {
-                    // ── Row 1: Channel strips ──
-                    egui::ScrollArea::horizontal()
-                        .id_salt("ch_h_scroll")
-                        .auto_shrink([false, true])
-                        .show(ui, |ui| {
-                            ui.horizontal(|ui| {
-                                for i in 0..self.channels.len() {
-                                    let meter_key = format!("{}:meter:{}", self.block_id, i + 1);
-                                    let meter_data = meter_store.get(&self.flow_id, &meter_key);
-                                    self.render_channel_strip(ui, ctx, i, meter_data);
-                                    ui.add_space(STRIP_GAP);
-                                }
-                            });
-                        });
+        // Split the available height into a scrollable content area (strips
+        // + bus row + detail panel) at the top and a fixed status/footer
+        // row pinned to the bottom. The strips and bus row remain docked
+        // together at the top of the content area.
+        let footer_h: f32 = 32.0;
+        let total_h = ui.available_height();
+        let content_h = (total_h - footer_h - 4.0).max(120.0);
 
-                    ui.separator();
-
-                    // ── Row 2: Bus masters (aux + groups + main) ──
-                    egui::ScrollArea::horizontal()
-                        .id_salt("bus_h_scroll")
-                        .auto_shrink([false, true])
-                        .show(ui, |ui| {
-                            ui.horizontal(|ui| {
-                                if self.num_aux_buses > 0 {
-                                    self.render_aux_masters(ui, ctx, meter_store);
-                                    ui.add_space(8.0);
-                                    ui.separator();
-                                    ui.add_space(8.0);
-                                }
-
-                                if self.num_groups > 0 {
-                                    self.render_group_strips(ui, ctx, meter_store);
-                                    ui.add_space(8.0);
-                                    ui.separator();
-                                    ui.add_space(8.0);
-                                }
-
-                                self.render_solo_master_strip(ui, ctx, meter_store);
-                                ui.add_space(4.0);
-                                self.render_main_strip(ui, ctx, meter_store);
-                            });
-                        });
-
-                    // ── Row 3: Detail panel (Gate/Comp/EQ) ──
-                    if self.selection.is_some() {
-                        ui.separator();
-                        let detail_resp = ui.scope(|ui| {
+        ui.allocate_ui_with_layout(
+            Vec2::new(ui.available_width(), content_h),
+            egui::Layout::top_down(egui::Align::Min),
+            |ui| {
+                egui::ScrollArea::vertical()
+                    .id_salt("mixer_v_scroll")
+                    .auto_shrink([false, false])
+                    .show(ui, |ui| {
+                        ui.vertical(|ui| {
+                            // ── Row 1: Channel strips ──
                             egui::ScrollArea::horizontal()
-                                .id_salt("detail_h_scroll")
-                                .auto_shrink([false, false])
+                                .id_salt("ch_h_scroll")
+                                .auto_shrink([false, true])
                                 .show(ui, |ui| {
-                                    self.render_detail_panel(ui, ctx);
+                                    ui.horizontal(|ui| {
+                                        for i in 0..self.channels.len() {
+                                            let meter_key =
+                                                format!("{}:meter:{}", self.block_id, i + 1);
+                                            let meter_data =
+                                                meter_store.get(&self.flow_id, &meter_key);
+                                            self.render_channel_strip(ui, ctx, i, meter_data);
+                                            ui.add_space(STRIP_GAP);
+                                        }
+                                    });
                                 });
-                        });
-                        if ui.input(|i| i.pointer.any_pressed()) {
-                            if let Some(pos) = ui.input(|i| i.pointer.interact_pos()) {
-                                if detail_resp.response.rect.contains(pos) {
-                                    self.strip_interacted = true;
+
+                            ui.separator();
+
+                            // ── Row 2: Bus masters (aux + groups + monitor + main) ──
+                            egui::ScrollArea::horizontal()
+                                .id_salt("bus_h_scroll")
+                                .auto_shrink([false, true])
+                                .show(ui, |ui| {
+                                    ui.horizontal(|ui| {
+                                        if self.num_aux_buses > 0 {
+                                            self.render_aux_masters(ui, ctx, meter_store);
+                                            ui.add_space(8.0);
+                                            ui.separator();
+                                            ui.add_space(8.0);
+                                        }
+
+                                        if self.num_groups > 0 {
+                                            self.render_group_strips(ui, ctx, meter_store);
+                                            ui.add_space(8.0);
+                                            ui.separator();
+                                            ui.add_space(8.0);
+                                        }
+
+                                        self.render_monitor_master_strip(ui, ctx, meter_store);
+                                        ui.add_space(4.0);
+                                        self.render_main_strip(ui, ctx, meter_store);
+                                    });
+                                });
+
+                            // ── Row 3: Detail panel (Gate/Comp/EQ) ──
+                            if self.selection.is_some() {
+                                ui.separator();
+                                let detail_resp = ui.scope(|ui| {
+                                    egui::ScrollArea::horizontal()
+                                        .id_salt("detail_h_scroll")
+                                        .auto_shrink([false, false])
+                                        .show(ui, |ui| {
+                                            self.render_detail_panel(ui, ctx);
+                                        });
+                                });
+                                if ui.input(|i| i.pointer.any_pressed()) {
+                                    if let Some(pos) = ui.input(|i| i.pointer.interact_pos()) {
+                                        if detail_resp.response.rect.contains(pos) {
+                                            self.strip_interacted = true;
+                                        }
+                                    }
                                 }
                             }
-                        }
-                    }
+                        });
+                    });
+            },
+        );
 
-                    // ── Status bar ──
-                    ui.separator();
-                    let status_resp = ui.horizontal(|ui| {
+        // ── Status bar (pinned to bottom of window) ──
+        ui.separator();
+        let status_resp = ui.horizontal(|ui| {
                         if let Some(error) = &self.error {
                             ui.colored_label(Color32::RED, error);
                         } else if !self.status.is_empty() {
                             ui.label(&self.status);
                         }
-                        // Keyboard shortcuts legend (P toggles PFL or AFL based on solo_mode)
-                        let legend = format!(
-                            "1-0: Select ch | M: Mute | P: {} | Esc: Deselect | Arrows: Fader/Pan",
-                            self.solo_label(),
-                        );
+                        // Keyboard shortcuts legend
                         ui.label(
-                            egui::RichText::new(legend)
-                                .small()
-                                .color(Color32::from_gray(90)),
+                            egui::RichText::new(
+                                "1-0: Select ch | M: Mute | P: PFL | A: AFL | Esc: Deselect | Arrows: Fader/Pan",
+                            )
+                            .small()
+                            .color(Color32::from_gray(90)),
                         );
                         ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                             match &self.selection {
@@ -159,20 +213,18 @@ impl MixerEditor {
                             }
                         });
                     });
-                    if ui.input(|i| i.pointer.any_pressed()) {
-                        if let Some(pos) = ui.input(|i| i.pointer.interact_pos()) {
-                            if status_resp.response.rect.contains(pos) {
-                                self.strip_interacted = true;
-                            }
-                        }
-                    }
+        if ui.input(|i| i.pointer.any_pressed()) {
+            if let Some(pos) = ui.input(|i| i.pointer.interact_pos()) {
+                if status_resp.response.rect.contains(pos) {
+                    self.strip_interacted = true;
+                }
+            }
+        }
 
-                    // ── Background click to deselect ──
-                    if ui.input(|i| i.pointer.any_pressed()) && !self.strip_interacted {
-                        self.selection = None;
-                    }
-                });
-            });
+        // ── Background click to deselect ──
+        if ui.input(|i| i.pointer.any_pressed()) && !self.strip_interacted {
+            self.selection = None;
+        }
     }
 
     /// Render a single channel strip.
@@ -205,8 +257,7 @@ impl MixerEditor {
             .corner_radius(CornerRadius::same(3))
             .inner_margin(STRIP_MARGIN)
             .show(ui, |ui| {
-                ui.set_min_width(strip_inner);
-                ui.set_max_width(strip_inner);
+                ui.set_width(strip_inner);
 
                 ui.vertical_centered(|ui| {
                     ui.spacing_mut().item_spacing.y = 2.0;
@@ -225,13 +276,11 @@ impl MixerEditor {
                         // Auto-focus when first shown
                         response.request_focus();
                     } else {
-                        let label_response = ui.add(
-                            egui::Label::new(
-                                egui::RichText::new(&self.channels[index].label)
-                                    .strong()
-                                    .size(11.0),
-                            )
-                            .sense(Sense::click()),
+                        let label_response = centered_clickable_label(
+                            ui,
+                            egui::RichText::new(&self.channels[index].label)
+                                .strong()
+                                .size(11.0),
                         );
                         if label_response.double_clicked() {
                             self.editing_label = Some(index);
@@ -329,14 +378,16 @@ impl MixerEditor {
                     });
 
                     // ── Aux send knobs ──
-                    // Wrap to a new row every 4 knobs so a strip with many aux
-                    // buses doesn't spill horizontally past the strip width.
+                    // Wrap to a new row every 4 knobs and center each row
+                    // within the strip — `centered_row` allocates a fixed
+                    // (strip_inner, KNOB_SIZE) area with main-axis centering
+                    // so the last (possibly short) row is centered too.
                     const AUX_PER_ROW: usize = 4;
                     if self.num_aux_buses > 0 {
                         let total_aux = self.num_aux_buses.min(MAX_AUX_BUSES);
                         for row_start in (0..total_aux).step_by(AUX_PER_ROW) {
                             let row_end = (row_start + AUX_PER_ROW).min(total_aux);
-                            ui.horizontal(|ui| {
+                            centered_row(ui, KNOB_SIZE, |ui| {
                                 ui.spacing_mut().item_spacing.x = 1.0;
                                 for aux_idx in row_start..row_end {
                                     let response = self.render_knob(ui, index, aux_idx);
@@ -453,8 +504,9 @@ impl MixerEditor {
                     };
                     self.render_lcd(ui, &display_text, strip_inner - 4.0, LCD_H);
 
-                    // ── Pan knob ──
-                    let pan_response = self.render_pan_knob(ui, index);
+                    // ── Pan knob (centered within the strip) ──
+                    let pan_response =
+                        centered_row(ui, PAN_KNOB_SIZE, |ui| self.render_pan_knob(ui, index));
                     if pan_response.double_clicked() {
                         self.bypass_throttle();
                         self.update_channel_property(ctx, index, "pan");
@@ -511,30 +563,66 @@ impl MixerEditor {
                         self.update_channel_property(ctx, index, "mute");
                     }
 
-                    // ── Solo (PFL/AFL) button ──
-                    let solo_color = if channel_pfl {
-                        Color32::from_rgb(200, 200, 0)
-                    } else {
-                        Color32::from_rgb(48, 48, 52)
-                    };
-                    let solo_text_col = if channel_pfl {
-                        Color32::BLACK
-                    } else {
-                        Color32::from_gray(100)
-                    };
-                    let solo_label = self.solo_label();
-                    if ui
-                        .add(
-                            egui::Button::new(
-                                egui::RichText::new(solo_label).small().color(solo_text_col),
-                            )
-                            .fill(solo_color)
-                            .min_size(Vec2::new(strip_inner - 4.0, BTN_H)),
-                        )
-                        .clicked()
+                    // ── PFL + AFL buttons (independent solo sends, stacked) ──
                     {
-                        self.channels[index].pfl = !self.channels[index].pfl;
-                        self.update_channel_property(ctx, index, "pfl");
+                        let channel_afl = self.channels[index].afl;
+                        let mut solo_changed: Option<&'static str> = None;
+
+                        // PFL — pre-fader listen
+                        let pfl_fill = if channel_pfl {
+                            Color32::from_rgb(200, 200, 0)
+                        } else {
+                            Color32::from_rgb(48, 48, 52)
+                        };
+                        let pfl_text = if channel_pfl {
+                            Color32::BLACK
+                        } else {
+                            Color32::from_gray(100)
+                        };
+                        if ui
+                            .add(
+                                egui::Button::new(
+                                    egui::RichText::new("PFL").small().color(pfl_text),
+                                )
+                                .fill(pfl_fill)
+                                .min_size(Vec2::new(strip_inner - 4.0, BTN_H)),
+                            )
+                            .clicked()
+                        {
+                            self.channels[index].pfl = !self.channels[index].pfl;
+                            solo_changed = Some("pfl");
+                        }
+
+                        // AFL — after-fader listen
+                        let afl_fill = if channel_afl {
+                            Color32::from_rgb(160, 200, 80)
+                        } else {
+                            Color32::from_rgb(48, 48, 52)
+                        };
+                        let afl_text = if channel_afl {
+                            Color32::BLACK
+                        } else {
+                            Color32::from_gray(100)
+                        };
+                        if ui
+                            .add(
+                                egui::Button::new(
+                                    egui::RichText::new("AFL").small().color(afl_text),
+                                )
+                                .fill(afl_fill)
+                                .min_size(Vec2::new(strip_inner - 4.0, BTN_H)),
+                            )
+                            .clicked()
+                        {
+                            self.channels[index].afl = !self.channels[index].afl;
+                            solo_changed = Some("afl");
+                        }
+
+                        if let Some(prop) = solo_changed {
+                            self.update_channel_property(ctx, index, prop);
+                            // Switch the monitor source whenever any PFL/AFL toggles.
+                            self.update_monitor_gates(ctx);
+                        }
                     }
 
                     // ── Select button ──
@@ -602,8 +690,7 @@ impl MixerEditor {
             .corner_radius(CornerRadius::same(3))
             .inner_margin(STRIP_MARGIN)
             .show(ui, |ui| {
-                ui.set_min_width(BUS_STRIP_INNER);
-                ui.set_max_width(BUS_STRIP_INNER);
+                ui.set_width(BUS_STRIP_INNER);
 
                 let bg_rect = ui.available_rect_before_wrap();
                 let bg_response =
@@ -615,7 +702,8 @@ impl MixerEditor {
                 ui.vertical_centered(|ui| {
                     ui.spacing_mut().item_spacing.y = 2.0;
 
-                    ui.label(
+                    centered_label(
+                        ui,
                         egui::RichText::new("MAIN")
                             .strong()
                             .size(12.0)
@@ -763,43 +851,59 @@ impl MixerEditor {
         }
     }
 
-    /// Render the solo bus master strip (PFL or AFL, depending on `solo_mode`).
+    /// Render the Monitor bus master strip.
     ///
-    /// Drives `pfl_master_vol` and receives metering from `pfl_level`. The
-    /// strip has only a header + LCD + fader/meter — no mute/select since
-    /// the backend has no solo mute property and the solo bus has no
-    /// processing detail panel.
-    pub(super) fn render_solo_master_strip(
+    /// The Monitor bus follows Main when no PFL/AFL is engaged anywhere on
+    /// the desk, and switches to the solo mix as soon as any channel
+    /// engages PFL or AFL. Drives `monitor_master_vol` and receives metering
+    /// from `monitor_level`.
+    pub(super) fn render_monitor_master_strip(
         &mut self,
         ui: &mut Ui,
         ctx: &Context,
         meter_store: &MeterDataStore,
     ) {
-        let solo_meter_key = format!("{}:meter:pfl", self.block_id);
-        let solo_meter_data = meter_store.get(&self.flow_id, &solo_meter_key);
-        let label = self.solo_label();
+        let meter_key = format!("{}:meter:monitor", self.block_id);
+        let meter_data = meter_store.get(&self.flow_id, &meter_key);
+        let solo_active = self.any_solo_active();
+        let source_hint = if solo_active { "SOLO" } else { "MAIN" };
 
         egui::Frame::default()
-            .fill(Color32::from_rgb(50, 48, 32))
+            .fill(Color32::from_rgb(32, 48, 50))
             .corner_radius(CornerRadius::same(3))
             .inner_margin(STRIP_MARGIN)
             .show(ui, |ui| {
-                ui.set_min_width(BUS_STRIP_INNER);
-                ui.set_max_width(BUS_STRIP_INNER);
+                ui.set_width(BUS_STRIP_INNER);
 
                 ui.vertical_centered(|ui| {
                     ui.spacing_mut().item_spacing.y = 2.0;
 
-                    ui.label(
-                        egui::RichText::new(label)
+                    // Header row: "MON" with a tiny MAIN/SOLO indicator next
+                    // to it, centered as a pair within the strip width.
+                    {
+                        let mon_rt = egui::RichText::new("MON")
                             .strong()
                             .size(12.0)
-                            .color(Color32::from_rgb(220, 200, 100)),
-                    );
+                            .color(Color32::from_rgb(120, 210, 220));
+                        let hint_rt =
+                            egui::RichText::new(source_hint)
+                                .small()
+                                .color(if solo_active {
+                                    Color32::from_rgb(230, 200, 80)
+                                } else {
+                                    Color32::from_gray(140)
+                                });
+                        let row_h = ui.spacing().interact_size.y;
+                        centered_row(ui, row_h, |ui| {
+                            ui.spacing_mut().item_spacing.x = 4.0;
+                            ui.add(egui::Label::new(mon_rt).wrap_mode(egui::TextWrapMode::Extend));
+                            ui.add(egui::Label::new(hint_rt).wrap_mode(egui::TextWrapMode::Extend));
+                        });
+                    }
 
                     self.render_lcd(
                         ui,
-                        &format_db(self.solo_master_fader),
+                        &format_db(self.monitor_fader),
                         BUS_STRIP_INNER - 4.0,
                         LCD_H,
                     );
@@ -810,34 +914,34 @@ impl MixerEditor {
                         Vec2::new(ui.available_width(), BUS_FADER_HEIGHT),
                         egui::Layout::left_to_right(egui::Align::Center),
                         |ui| {
-                            self.render_stereo_meter(ui, solo_meter_data, BUS_FADER_HEIGHT);
+                            self.render_stereo_meter(ui, meter_data, BUS_FADER_HEIGHT);
                             ui.add_space(1.0);
                             self.render_db_scale(ui, BUS_FADER_HEIGHT);
                             ui.add_space(1.0);
 
-                            let mut fader_db = linear_to_db(self.solo_master_fader as f64) as f32;
+                            let mut fader_db = linear_to_db(self.monitor_fader as f64) as f32;
                             let (rect, response) = ui.allocate_exact_size(
                                 Vec2::new(20.0, BUS_FADER_HEIGHT),
                                 Sense::click_and_drag(),
                             );
                             if response.double_clicked() {
                                 if (fader_db - 0.0).abs() < 0.5 {
-                                    self.solo_master_fader = 0.0;
+                                    self.monitor_fader = 0.0;
                                     fader_db = -60.0;
                                 } else {
-                                    self.solo_master_fader = 1.0;
+                                    self.monitor_fader = 1.0;
                                     fader_db = 0.0;
                                 }
                                 self.bypass_throttle();
-                                self.update_solo_master_fader(ctx);
+                                self.update_monitor_master_fader(ctx);
                             } else if response.dragged() {
                                 let delta = -response.drag_delta().y;
                                 let db_per_pixel = 66.0 / (BUS_FADER_HEIGHT - 10.0);
                                 fader_db = (fader_db + delta * db_per_pixel).clamp(-60.0, 6.0);
-                                self.solo_master_fader = db_to_linear_f32(fader_db);
-                                self.update_solo_master_fader(ctx);
+                                self.monitor_fader = db_to_linear_f32(fader_db);
+                                self.update_monitor_master_fader(ctx);
                             } else if response.drag_stopped() {
-                                self.update_solo_master_fader(ctx);
+                                self.update_monitor_master_fader(ctx);
                             }
                             let painter = ui.painter();
                             let track_rect = Rect::from_center_size(
@@ -855,11 +959,11 @@ impl MixerEditor {
                                 Vec2::new(14.0, 30.0),
                             );
                             let handle_color = if response.dragged() {
-                                Color32::from_rgb(230, 200, 80)
+                                Color32::from_rgb(120, 210, 220)
                             } else if response.hovered() {
-                                Color32::from_rgb(210, 195, 130)
+                                Color32::from_rgb(180, 215, 220)
                             } else {
-                                Color32::from_rgb(175, 165, 110)
+                                Color32::from_rgb(140, 175, 180)
                             };
                             painter.rect_filled(handle_rect, CornerRadius::same(3), handle_color);
                             painter.line_segment(
@@ -871,6 +975,40 @@ impl MixerEditor {
                             );
                         },
                     );
+
+                    ui.add_space(2.0);
+
+                    // ── Clear: release every active PFL/AFL across all channels ──
+                    let (clear_fill, clear_text) = if solo_active {
+                        (Color32::from_rgb(180, 80, 80), Color32::WHITE)
+                    } else {
+                        (Color32::from_rgb(48, 48, 52), Color32::from_gray(110))
+                    };
+                    let clear_button =
+                        egui::Button::new(egui::RichText::new("Clear").small().color(clear_text))
+                            .fill(clear_fill)
+                            .min_size(Vec2::new(BUS_STRIP_INNER - 4.0, BTN_H));
+                    let clear_resp = ui
+                        .add_enabled(solo_active, clear_button)
+                        .on_hover_text("Clear all active PFL and AFL");
+                    if clear_resp.clicked() {
+                        let mut changed_indices: Vec<usize> = Vec::new();
+                        for (i, ch) in self.channels.iter_mut().enumerate() {
+                            if ch.pfl || ch.afl {
+                                ch.pfl = false;
+                                ch.afl = false;
+                                changed_indices.push(i);
+                            }
+                        }
+                        for i in changed_indices {
+                            // Push both volumes to 0 so the backend sees the
+                            // release on each per-channel solo send.
+                            self.update_channel_property(ctx, i, "pfl");
+                            self.update_channel_property(ctx, i, "afl");
+                        }
+                        // Flip the monitor gates back to follow Main.
+                        self.update_monitor_gates(ctx);
+                    }
                 });
             });
     }
@@ -895,13 +1033,13 @@ impl MixerEditor {
                 .corner_radius(CornerRadius::same(3))
                 .inner_margin(STRIP_MARGIN)
                 .show(ui, |ui| {
-                    ui.set_min_width(BUS_STRIP_INNER);
-                    ui.set_max_width(BUS_STRIP_INNER);
+                    ui.set_width(BUS_STRIP_INNER);
 
                     ui.vertical_centered(|ui| {
                         ui.spacing_mut().item_spacing.y = 2.0;
 
-                        ui.label(
+                        centered_label(
+                            ui,
                             egui::RichText::new(format!("GRP{}", sg_idx + 1))
                                 .strong()
                                 .size(11.0)
@@ -995,13 +1133,13 @@ impl MixerEditor {
                 .corner_radius(CornerRadius::same(3))
                 .inner_margin(STRIP_MARGIN)
                 .show(ui, |ui| {
-                    ui.set_min_width(BUS_STRIP_INNER);
-                    ui.set_max_width(BUS_STRIP_INNER);
+                    ui.set_width(BUS_STRIP_INNER);
 
                     ui.vertical_centered(|ui| {
                         ui.spacing_mut().item_spacing.y = 2.0;
 
-                        ui.label(
+                        centered_label(
+                            ui,
                             egui::RichText::new(format!("AUX{}", aux_idx + 1))
                                 .strong()
                                 .size(11.0)

--- a/frontend/src/mixer/rendering.rs
+++ b/frontend/src/mixer/rendering.rs
@@ -16,76 +16,57 @@ impl MixerEditor {
         self.handle_keyboard(ui, ctx);
         self.strip_interacted = false;
 
-        let available_height = ui.available_height();
-        let detail_panel_height = if self.selection.is_some() { 220.0 } else { 0.0 };
-        let status_bar_height = 30.0;
-        let channel_area_height = (available_height
-            - BUS_ROW_MIN_HEIGHT
-            - detail_panel_height
-            - status_bar_height
-            - 16.0)
-            .max(300.0);
-
-        // Outer vertical scroll wraps the entire mixer
+        // Outer vertical scroll wraps the entire mixer.
+        // Each row is sized to its content so the bus-master row sits flush
+        // against the channel strips above, rather than being pushed to the
+        // bottom of the window by an expanded channel-area allocation.
         egui::ScrollArea::vertical()
             .id_salt("mixer_v_scroll")
             .auto_shrink([false, false])
             .show(ui, |ui| {
                 ui.vertical(|ui| {
                     // ── Row 1: Channel strips ──
-                    ui.allocate_ui_with_layout(
-                        Vec2::new(ui.available_width(), channel_area_height),
-                        egui::Layout::left_to_right(egui::Align::Min),
-                        |ui| {
-                            egui::ScrollArea::horizontal()
-                                .id_salt("ch_h_scroll")
-                                .auto_shrink([false, false])
-                                .show(ui, |ui| {
-                                    ui.horizontal(|ui| {
-                                        for i in 0..self.channels.len() {
-                                            let meter_key =
-                                                format!("{}:meter:{}", self.block_id, i + 1);
-                                            let meter_data =
-                                                meter_store.get(&self.flow_id, &meter_key);
-                                            self.render_channel_strip(ui, ctx, i, meter_data);
-                                            ui.add_space(STRIP_GAP);
-                                        }
-                                    });
-                                });
-                        },
-                    );
+                    egui::ScrollArea::horizontal()
+                        .id_salt("ch_h_scroll")
+                        .auto_shrink([false, true])
+                        .show(ui, |ui| {
+                            ui.horizontal(|ui| {
+                                for i in 0..self.channels.len() {
+                                    let meter_key = format!("{}:meter:{}", self.block_id, i + 1);
+                                    let meter_data = meter_store.get(&self.flow_id, &meter_key);
+                                    self.render_channel_strip(ui, ctx, i, meter_data);
+                                    ui.add_space(STRIP_GAP);
+                                }
+                            });
+                        });
 
                     ui.separator();
 
                     // ── Row 2: Bus masters (aux + groups + main) ──
-                    ui.allocate_ui_with_layout(
-                        Vec2::new(ui.available_width(), BUS_ROW_MIN_HEIGHT),
-                        egui::Layout::left_to_right(egui::Align::Min),
-                        |ui| {
-                            egui::ScrollArea::horizontal()
-                                .id_salt("bus_h_scroll")
-                                .auto_shrink([false, false])
-                                .show(ui, |ui| {
-                                    ui.horizontal(|ui| {
-                                        if self.num_aux_buses > 0 {
-                                            self.render_aux_masters(ui, ctx, meter_store);
-                                            ui.add_space(8.0);
-                                            ui.separator();
-                                            ui.add_space(8.0);
-                                        }
+                    egui::ScrollArea::horizontal()
+                        .id_salt("bus_h_scroll")
+                        .auto_shrink([false, true])
+                        .show(ui, |ui| {
+                            ui.horizontal(|ui| {
+                                if self.num_aux_buses > 0 {
+                                    self.render_aux_masters(ui, ctx, meter_store);
+                                    ui.add_space(8.0);
+                                    ui.separator();
+                                    ui.add_space(8.0);
+                                }
 
-                                        if self.num_groups > 0 {
-                                            self.render_group_strips(ui, ctx, meter_store);
-                                            ui.add_space(8.0);
-                                            ui.separator();
-                                            ui.add_space(8.0);
-                                        }
+                                if self.num_groups > 0 {
+                                    self.render_group_strips(ui, ctx, meter_store);
+                                    ui.add_space(8.0);
+                                    ui.separator();
+                                    ui.add_space(8.0);
+                                }
 
-                                        self.render_main_strip(ui, ctx, meter_store);
-                                    });
-                                });
-                        },
-                    );
+                                self.render_solo_master_strip(ui, ctx, meter_store);
+                                ui.add_space(4.0);
+                                self.render_main_strip(ui, ctx, meter_store);
+                            });
+                        });
 
                     // ── Row 3: Detail panel (Gate/Comp/EQ) ──
                     if self.selection.is_some() {
@@ -115,13 +96,15 @@ impl MixerEditor {
                         } else if !self.status.is_empty() {
                             ui.label(&self.status);
                         }
-                        // Keyboard shortcuts legend
+                        // Keyboard shortcuts legend (P toggles PFL or AFL based on solo_mode)
+                        let legend = format!(
+                            "1-0: Select ch | M: Mute | P: {} | Esc: Deselect | Arrows: Fader/Pan",
+                            self.solo_label(),
+                        );
                         ui.label(
-                            egui::RichText::new(
-                                "1-0: Select ch | M: Mute | P: PFL | Esc: Deselect | Arrows: Fader/Pan",
-                            )
-                            .small()
-                            .color(Color32::from_gray(90)),
+                            egui::RichText::new(legend)
+                                .small()
+                                .color(Color32::from_gray(90)),
                         );
                         ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                             match &self.selection {
@@ -156,11 +139,20 @@ impl MixerEditor {
                                     .small()
                                     .color(Color32::from_gray(120)),
                             );
-                            if ui.button(format!("{} Save", egui_phosphor::regular::FLOPPY_DISK)).clicked() {
+                            if ui
+                                .button(format!("{} Save", egui_phosphor::regular::FLOPPY_DISK))
+                                .clicked()
+                            {
                                 self.save_requested = true;
                                 self.status = "Saving mixer state...".to_string();
                             }
-                            if ui.button(format!("{} Reset All", egui_phosphor::regular::ARROW_COUNTER_CLOCKWISE)).clicked() {
+                            if ui
+                                .button(format!(
+                                    "{} Reset All",
+                                    egui_phosphor::regular::ARROW_COUNTER_CLOCKWISE
+                                ))
+                                .clicked()
+                            {
                                 self.reset_to_defaults();
                                 self.save_requested = true;
                                 self.status = "Reset to defaults, saving...".to_string();
@@ -337,86 +329,112 @@ impl MixerEditor {
                     });
 
                     // ── Aux send knobs ──
+                    // Wrap to a new row every 4 knobs so a strip with many aux
+                    // buses doesn't spill horizontally past the strip width.
+                    const AUX_PER_ROW: usize = 4;
                     if self.num_aux_buses > 0 {
-                        ui.horizontal(|ui| {
-                            ui.spacing_mut().item_spacing.x = 1.0;
-                            for aux_idx in 0..self.num_aux_buses.min(MAX_AUX_BUSES) {
-                                let response = self.render_knob(ui, index, aux_idx);
-                                if response.double_clicked() {
-                                    self.bypass_throttle();
-                                    self.update_aux_send(ctx, index, aux_idx);
-                                } else if response.dragged() {
-                                    self.active_control = ActiveControl::AuxSend(index, aux_idx);
-                                    self.update_aux_send(ctx, index, aux_idx);
-                                } else if response.drag_stopped() {
-                                    self.active_control = ActiveControl::None;
+                        let total_aux = self.num_aux_buses.min(MAX_AUX_BUSES);
+                        for row_start in (0..total_aux).step_by(AUX_PER_ROW) {
+                            let row_end = (row_start + AUX_PER_ROW).min(total_aux);
+                            ui.horizontal(|ui| {
+                                ui.spacing_mut().item_spacing.x = 1.0;
+                                for aux_idx in row_start..row_end {
+                                    let response = self.render_knob(ui, index, aux_idx);
+                                    if response.double_clicked() {
+                                        self.bypass_throttle();
+                                        self.update_aux_send(ctx, index, aux_idx);
+                                    } else if response.dragged() {
+                                        self.active_control =
+                                            ActiveControl::AuxSend(index, aux_idx);
+                                        self.update_aux_send(ctx, index, aux_idx);
+                                    } else if response.drag_stopped() {
+                                        self.active_control = ActiveControl::None;
+                                    }
                                 }
-                            }
-                        });
+                            });
+                        }
                     }
 
                     // ── Routing buttons (M + group numbers) ──
+                    // M and the group buttons are laid out as a single
+                    // left-to-right sequence; we wrap to a new row every 4
+                    // buttons (matching the aux-knob wrap) so a strip with
+                    // many subgroups doesn't spill horizontally.
+                    const ROUTING_PER_ROW: usize = 4;
                     {
-                        let num_dest = 1 + self.num_groups;
+                        let num_groups = self.num_groups.min(MAX_GROUPS);
+                        let num_dest = 1 + num_groups;
+                        let row_size = num_dest.clamp(1, ROUTING_PER_ROW);
                         let btn_w =
-                            (strip_inner - 4.0 - (num_dest as f32 - 1.0) * 2.0) / num_dest as f32;
-                        ui.horizontal(|ui| {
-                            ui.spacing_mut().item_spacing.x = 2.0;
-                            // Main
-                            let to_main = self.channels[index].to_main;
-                            let fill = if to_main {
-                                Color32::from_rgb(70, 110, 70)
-                            } else {
-                                Color32::from_rgb(48, 48, 52)
-                            };
-                            let text_col = if to_main {
-                                Color32::WHITE
-                            } else {
-                                Color32::from_gray(100)
-                            };
-                            if ui
-                                .add(
-                                    egui::Button::new(
-                                        egui::RichText::new("M").small().color(text_col),
-                                    )
-                                    .fill(fill)
-                                    .min_size(Vec2::new(btn_w, SMALL_BTN_H)),
-                                )
-                                .clicked()
-                            {
-                                self.channels[index].to_main = !to_main;
-                                self.update_routing(ctx, index);
-                            }
-                            // Groups
-                            for g in 0..self.num_groups.min(MAX_GROUPS) {
-                                let on = self.channels[index].to_grp[g];
-                                let fill = if on {
-                                    Color32::from_rgb(140, 90, 140)
-                                } else {
-                                    Color32::from_rgb(48, 48, 52)
-                                };
-                                let text_col = if on {
-                                    Color32::WHITE
-                                } else {
-                                    Color32::from_gray(100)
-                                };
-                                if ui
-                                    .add(
-                                        egui::Button::new(
-                                            egui::RichText::new(format!("{}", g + 1))
-                                                .small()
-                                                .color(text_col),
-                                        )
-                                        .fill(fill)
-                                        .min_size(Vec2::new(btn_w, SMALL_BTN_H)),
-                                    )
-                                    .clicked()
-                                {
-                                    self.channels[index].to_grp[g] = !on;
-                                    self.update_routing(ctx, index);
+                            (strip_inner - 4.0 - (row_size as f32 - 1.0) * 2.0) / row_size as f32;
+
+                        // Build a flat list of routing buttons: (label, on, on-color)
+                        // index 0 = Main, 1..=num_groups = groups
+                        for row_start in (0..num_dest).step_by(ROUTING_PER_ROW) {
+                            let row_end = (row_start + ROUTING_PER_ROW).min(num_dest);
+                            ui.horizontal(|ui| {
+                                ui.spacing_mut().item_spacing.x = 2.0;
+                                for slot in row_start..row_end {
+                                    if slot == 0 {
+                                        // Main destination
+                                        let to_main = self.channels[index].to_main;
+                                        let fill = if to_main {
+                                            Color32::from_rgb(70, 110, 70)
+                                        } else {
+                                            Color32::from_rgb(48, 48, 52)
+                                        };
+                                        let text_col = if to_main {
+                                            Color32::WHITE
+                                        } else {
+                                            Color32::from_gray(100)
+                                        };
+                                        if ui
+                                            .add(
+                                                egui::Button::new(
+                                                    egui::RichText::new("M")
+                                                        .small()
+                                                        .color(text_col),
+                                                )
+                                                .fill(fill)
+                                                .min_size(Vec2::new(btn_w, SMALL_BTN_H)),
+                                            )
+                                            .clicked()
+                                        {
+                                            self.channels[index].to_main = !to_main;
+                                            self.update_routing(ctx, index);
+                                        }
+                                    } else {
+                                        let g = slot - 1;
+                                        let on = self.channels[index].to_grp[g];
+                                        let fill = if on {
+                                            Color32::from_rgb(140, 90, 140)
+                                        } else {
+                                            Color32::from_rgb(48, 48, 52)
+                                        };
+                                        let text_col = if on {
+                                            Color32::WHITE
+                                        } else {
+                                            Color32::from_gray(100)
+                                        };
+                                        if ui
+                                            .add(
+                                                egui::Button::new(
+                                                    egui::RichText::new(format!("{}", g + 1))
+                                                        .small()
+                                                        .color(text_col),
+                                                )
+                                                .fill(fill)
+                                                .min_size(Vec2::new(btn_w, SMALL_BTN_H)),
+                                            )
+                                            .clicked()
+                                        {
+                                            self.channels[index].to_grp[g] = !on;
+                                            self.update_routing(ctx, index);
+                                        }
+                                    }
                                 }
-                            }
-                        });
+                            });
+                        }
                     }
 
                     // ── LCD display ──
@@ -493,23 +511,24 @@ impl MixerEditor {
                         self.update_channel_property(ctx, index, "mute");
                     }
 
-                    // ── PFL button ──
-                    let pfl_color = if channel_pfl {
+                    // ── Solo (PFL/AFL) button ──
+                    let solo_color = if channel_pfl {
                         Color32::from_rgb(200, 200, 0)
                     } else {
                         Color32::from_rgb(48, 48, 52)
                     };
-                    let pfl_text_col = if channel_pfl {
+                    let solo_text_col = if channel_pfl {
                         Color32::BLACK
                     } else {
                         Color32::from_gray(100)
                     };
+                    let solo_label = self.solo_label();
                     if ui
                         .add(
                             egui::Button::new(
-                                egui::RichText::new("PFL").small().color(pfl_text_col),
+                                egui::RichText::new(solo_label).small().color(solo_text_col),
                             )
-                            .fill(pfl_color)
+                            .fill(solo_color)
                             .min_size(Vec2::new(strip_inner - 4.0, BTN_H)),
                         )
                         .clicked()
@@ -742,6 +761,118 @@ impl MixerEditor {
         {
             self.strip_interacted = true;
         }
+    }
+
+    /// Render the solo bus master strip (PFL or AFL, depending on `solo_mode`).
+    ///
+    /// Drives `pfl_master_vol` and receives metering from `pfl_level`. The
+    /// strip has only a header + LCD + fader/meter — no mute/select since
+    /// the backend has no solo mute property and the solo bus has no
+    /// processing detail panel.
+    pub(super) fn render_solo_master_strip(
+        &mut self,
+        ui: &mut Ui,
+        ctx: &Context,
+        meter_store: &MeterDataStore,
+    ) {
+        let solo_meter_key = format!("{}:meter:pfl", self.block_id);
+        let solo_meter_data = meter_store.get(&self.flow_id, &solo_meter_key);
+        let label = self.solo_label();
+
+        egui::Frame::default()
+            .fill(Color32::from_rgb(50, 48, 32))
+            .corner_radius(CornerRadius::same(3))
+            .inner_margin(STRIP_MARGIN)
+            .show(ui, |ui| {
+                ui.set_min_width(BUS_STRIP_INNER);
+                ui.set_max_width(BUS_STRIP_INNER);
+
+                ui.vertical_centered(|ui| {
+                    ui.spacing_mut().item_spacing.y = 2.0;
+
+                    ui.label(
+                        egui::RichText::new(label)
+                            .strong()
+                            .size(12.0)
+                            .color(Color32::from_rgb(220, 200, 100)),
+                    );
+
+                    self.render_lcd(
+                        ui,
+                        &format_db(self.solo_master_fader),
+                        BUS_STRIP_INNER - 4.0,
+                        LCD_H,
+                    );
+
+                    ui.add_space(2.0);
+
+                    ui.allocate_ui_with_layout(
+                        Vec2::new(ui.available_width(), BUS_FADER_HEIGHT),
+                        egui::Layout::left_to_right(egui::Align::Center),
+                        |ui| {
+                            self.render_stereo_meter(ui, solo_meter_data, BUS_FADER_HEIGHT);
+                            ui.add_space(1.0);
+                            self.render_db_scale(ui, BUS_FADER_HEIGHT);
+                            ui.add_space(1.0);
+
+                            let mut fader_db = linear_to_db(self.solo_master_fader as f64) as f32;
+                            let (rect, response) = ui.allocate_exact_size(
+                                Vec2::new(20.0, BUS_FADER_HEIGHT),
+                                Sense::click_and_drag(),
+                            );
+                            if response.double_clicked() {
+                                if (fader_db - 0.0).abs() < 0.5 {
+                                    self.solo_master_fader = 0.0;
+                                    fader_db = -60.0;
+                                } else {
+                                    self.solo_master_fader = 1.0;
+                                    fader_db = 0.0;
+                                }
+                                self.bypass_throttle();
+                                self.update_solo_master_fader(ctx);
+                            } else if response.dragged() {
+                                let delta = -response.drag_delta().y;
+                                let db_per_pixel = 66.0 / (BUS_FADER_HEIGHT - 10.0);
+                                fader_db = (fader_db + delta * db_per_pixel).clamp(-60.0, 6.0);
+                                self.solo_master_fader = db_to_linear_f32(fader_db);
+                                self.update_solo_master_fader(ctx);
+                            } else if response.drag_stopped() {
+                                self.update_solo_master_fader(ctx);
+                            }
+                            let painter = ui.painter();
+                            let track_rect = Rect::from_center_size(
+                                rect.center(),
+                                Vec2::new(4.0, BUS_FADER_HEIGHT - 10.0),
+                            );
+                            painter.rect_filled(
+                                track_rect,
+                                CornerRadius::same(2),
+                                Color32::from_gray(55),
+                            );
+                            let handle_y = db_to_y(fader_db, rect.min.y, rect.max.y);
+                            let handle_rect = Rect::from_center_size(
+                                egui::pos2(rect.center().x, handle_y),
+                                Vec2::new(14.0, 30.0),
+                            );
+                            let handle_color = if response.dragged() {
+                                Color32::from_rgb(230, 200, 80)
+                            } else if response.hovered() {
+                                Color32::from_rgb(210, 195, 130)
+                            } else {
+                                Color32::from_rgb(175, 165, 110)
+                            };
+                            painter.rect_filled(handle_rect, CornerRadius::same(3), handle_color);
+                            painter.line_segment(
+                                [
+                                    egui::pos2(handle_rect.left() + 2.0, handle_y),
+                                    egui::pos2(handle_rect.right() - 2.0, handle_y),
+                                ],
+                                Stroke::new(1.5, Color32::from_gray(40)),
+                            );
+                        },
+                    );
+                });
+            });
     }
 
     /// Render the group strips section (compact, for bus row).

--- a/frontend/src/mixer/state.rs
+++ b/frontend/src/mixer/state.rs
@@ -18,8 +18,7 @@ impl MixerEditor {
             active_control: ActiveControl::None,
             main_fader: DEFAULT_FADER,
             main_mute: false,
-            solo_master_fader: DEFAULT_FADER,
-            solo_mode: "pfl".to_string(),
+            monitor_fader: DEFAULT_FADER,
             main_comp_enabled: false,
             main_comp_threshold: DEFAULT_COMP_THRESHOLD,
             main_comp_ratio: DEFAULT_COMP_RATIO,
@@ -55,12 +54,9 @@ impl MixerEditor {
             self.main_mute = *b;
         }
 
-        // Solo bus master + mode (PFL/AFL)
-        if let Some(PropertyValue::Float(f)) = properties.get("pfl_level") {
-            self.solo_master_fader = *f as f32;
-        }
-        if let Some(PropertyValue::String(s)) = properties.get("solo_mode") {
-            self.solo_mode = s.clone();
+        // Monitor bus master fader
+        if let Some(PropertyValue::Float(f)) = properties.get("monitor_fader") {
+            self.monitor_fader = *f as f32;
         }
 
         // Load main bus processing
@@ -192,6 +188,9 @@ impl MixerEditor {
             }
             if let Some(PropertyValue::Bool(b)) = properties.get(&format!("ch{}_pfl", ch_num)) {
                 ch.pfl = *b;
+            }
+            if let Some(PropertyValue::Bool(b)) = properties.get(&format!("ch{}_afl", ch_num)) {
+                ch.afl = *b;
             }
             // Routing to main
             if let Some(PropertyValue::Bool(b)) = properties.get(&format!("ch{}_to_main", ch_num)) {
@@ -353,18 +352,12 @@ impl MixerEditor {
         set_f!("main_fader".to_string(), self.main_fader, DEFAULT_FADER);
         set_b!("main_mute".to_string(), self.main_mute, false);
 
-        // Solo bus (master fader + mode)
+        // Monitor bus master fader
         set_f!(
-            "pfl_level".to_string(),
-            self.solo_master_fader,
+            "monitor_fader".to_string(),
+            self.monitor_fader,
             DEFAULT_FADER
         );
-        if self.solo_mode != "pfl" {
-            props.insert(
-                "solo_mode".to_string(),
-                PropertyValue::String(self.solo_mode.clone()),
-            );
-        }
         set_b!(
             "main_comp_enabled".to_string(),
             self.main_comp_enabled,
@@ -448,6 +441,7 @@ impl MixerEditor {
             set_f!(format!("ch{}_fader", n), ch.fader, DEFAULT_FADER);
             set_b!(format!("ch{}_mute", n), ch.mute, false);
             set_b!(format!("ch{}_pfl", n), ch.pfl, false);
+            set_b!(format!("ch{}_afl", n), ch.afl, false);
             set_b!(format!("ch{}_to_main", n), ch.to_main, true);
             for (sg, &enabled) in ch.to_grp.iter().enumerate().take(self.num_groups) {
                 set_b!(format!("ch{}_to_grp{}", n, sg + 1), enabled, false);
@@ -537,9 +531,7 @@ impl MixerEditor {
         // Main bus
         self.main_fader = DEFAULT_FADER;
         self.main_mute = false;
-        self.solo_master_fader = DEFAULT_FADER;
-        // solo_mode is intentionally NOT reset — it's a structural choice
-        // (which bus the solo path taps from), not a value to flatten.
+        self.monitor_fader = DEFAULT_FADER;
         self.main_comp_enabled = false;
         self.main_comp_threshold = DEFAULT_COMP_THRESHOLD;
         self.main_comp_ratio = DEFAULT_COMP_RATIO;
@@ -571,6 +563,7 @@ impl MixerEditor {
             ch.fader = DEFAULT_FADER;
             ch.mute = false;
             ch.pfl = false;
+            ch.afl = false;
             ch.to_main = true;
             ch.to_grp = [false; MAX_GROUPS];
             ch.aux_sends = [0.0; MAX_AUX_BUSES];

--- a/frontend/src/mixer/state.rs
+++ b/frontend/src/mixer/state.rs
@@ -18,6 +18,8 @@ impl MixerEditor {
             active_control: ActiveControl::None,
             main_fader: DEFAULT_FADER,
             main_mute: false,
+            solo_master_fader: DEFAULT_FADER,
+            solo_mode: "pfl".to_string(),
             main_comp_enabled: false,
             main_comp_threshold: DEFAULT_COMP_THRESHOLD,
             main_comp_ratio: DEFAULT_COMP_RATIO,
@@ -51,6 +53,14 @@ impl MixerEditor {
         }
         if let Some(PropertyValue::Bool(b)) = properties.get("main_mute") {
             self.main_mute = *b;
+        }
+
+        // Solo bus master + mode (PFL/AFL)
+        if let Some(PropertyValue::Float(f)) = properties.get("pfl_level") {
+            self.solo_master_fader = *f as f32;
+        }
+        if let Some(PropertyValue::String(s)) = properties.get("solo_mode") {
+            self.solo_mode = s.clone();
         }
 
         // Load main bus processing
@@ -342,6 +352,19 @@ impl MixerEditor {
         // Main bus
         set_f!("main_fader".to_string(), self.main_fader, DEFAULT_FADER);
         set_b!("main_mute".to_string(), self.main_mute, false);
+
+        // Solo bus (master fader + mode)
+        set_f!(
+            "pfl_level".to_string(),
+            self.solo_master_fader,
+            DEFAULT_FADER
+        );
+        if self.solo_mode != "pfl" {
+            props.insert(
+                "solo_mode".to_string(),
+                PropertyValue::String(self.solo_mode.clone()),
+            );
+        }
         set_b!(
             "main_comp_enabled".to_string(),
             self.main_comp_enabled,
@@ -514,6 +537,9 @@ impl MixerEditor {
         // Main bus
         self.main_fader = DEFAULT_FADER;
         self.main_mute = false;
+        self.solo_master_fader = DEFAULT_FADER;
+        // solo_mode is intentionally NOT reset — it's a structural choice
+        // (which bus the solo path taps from), not a value to flatten.
         self.main_comp_enabled = false;
         self.main_comp_threshold = DEFAULT_COMP_THRESHOLD;
         self.main_comp_ratio = DEFAULT_COMP_RATIO;

--- a/frontend/src/mixer/util.rs
+++ b/frontend/src/mixer/util.rs
@@ -1,6 +1,6 @@
 //! Utility functions for dB/linear conversions and formatting.
 
-use egui::Color32;
+use egui::{Color32, Painter, Rect, Stroke};
 
 /// Format a linear fader value as dB string.
 pub(super) fn format_db(linear: f32) -> String {
@@ -38,26 +38,83 @@ pub(super) fn db_to_y(db: f32, y_min: f32, y_max: f32) -> f32 {
     y_max - margin - normalized * usable
 }
 
-/// Convert dB to linear level (0.0-1.0).
-pub(super) fn db_to_level(db: f64) -> f32 {
-    if !db.is_finite() {
-        return 0.0;
+/// Meter zone boundaries in dB, matching the standalone VU meter block
+/// and EBU/broadcast convention.
+/// - Green:  -60 dB .. -18 dB (safe operational level)
+/// - Yellow: -18 dB ..  -9 dB (loud but acceptable)
+/// - Orange:  -9 dB ..  -6 dB (getting hot)
+/// - Red:    -6 dB ..  +6 dB (clipping risk)
+pub(super) const METER_ZONES_DB: [(f32, f32, Color32, Color32); 4] = [
+    (
+        -60.0,
+        -18.0,
+        Color32::from_rgb(0, 220, 0),
+        Color32::from_rgb(0, 60, 0),
+    ),
+    (
+        -18.0,
+        -9.0,
+        Color32::from_rgb(255, 220, 0),
+        Color32::from_rgb(60, 60, 0),
+    ),
+    (
+        -9.0,
+        -6.0,
+        Color32::from_rgb(255, 165, 0),
+        Color32::from_rgb(60, 45, 0),
+    ),
+    (
+        -6.0,
+        6.0,
+        Color32::from_rgb(255, 0, 0),
+        Color32::from_rgb(60, 0, 0),
+    ),
+];
+
+/// Draw the dim background sectors of a segmented level meter.
+/// Sectors are positioned in dB using `db_to_y` so they align with the
+/// shared dB scale (e.g. the fader).
+pub(super) fn draw_meter_zones_background(painter: &Painter, rect: Rect) {
+    for (zone_min_db, zone_max_db, _bright, dim) in METER_ZONES_DB {
+        let y_top = db_to_y(zone_max_db, rect.min.y, rect.max.y);
+        let y_bottom = db_to_y(zone_min_db, rect.min.y, rect.max.y);
+        let zone_rect = Rect::from_min_max(
+            egui::pos2(rect.min.x, y_top),
+            egui::pos2(rect.max.x, y_bottom),
+        );
+        painter.rect(
+            zone_rect,
+            0.0,
+            dim,
+            Stroke::NONE,
+            egui::epaint::StrokeKind::Inside,
+        );
     }
-    let min_db = -60.0;
-    let max_db = 6.0;
-    ((db - min_db) / (max_db - min_db)).clamp(0.0, 1.0) as f32
 }
 
-/// Get color for a level value.
-pub(super) fn level_to_color(level: f32) -> Color32 {
-    if level < 0.7 {
-        Color32::from_rgb(0, 200, 0) // Green
-    } else if level < 0.85 {
-        Color32::from_rgb(255, 220, 0) // Yellow
-    } else if level < 0.9 {
-        Color32::from_rgb(255, 165, 0) // Orange
-    } else {
-        Color32::from_rgb(255, 0, 0) // Red
+/// Light up the segmented level meter from the bottom up to `peak_db`.
+/// Each zone keeps its own bright colour, so the visible color band reflects
+/// the actual dB range — not just the highest reached level.
+pub(super) fn draw_meter_zones_lit(painter: &Painter, rect: Rect, peak_db: f32) {
+    let peak_db = if peak_db.is_finite() { peak_db } else { -60.0 };
+    for (zone_min_db, zone_max_db, bright, _dim) in METER_ZONES_DB {
+        if peak_db <= zone_min_db {
+            break;
+        }
+        let lit_top_db = peak_db.min(zone_max_db);
+        let y_top = db_to_y(lit_top_db, rect.min.y, rect.max.y);
+        let y_bottom = db_to_y(zone_min_db, rect.min.y, rect.max.y);
+        let lit_rect = Rect::from_min_max(
+            egui::pos2(rect.min.x, y_top),
+            egui::pos2(rect.max.x, y_bottom),
+        );
+        painter.rect(
+            lit_rect,
+            0.0,
+            bright,
+            Stroke::NONE,
+            egui::epaint::StrokeKind::Inside,
+        );
     }
 }
 

--- a/frontend/src/mixer/widgets.rs
+++ b/frontend/src/mixer/widgets.rs
@@ -467,6 +467,11 @@ impl MixerEditor {
             Color32::from_rgb(20, 20, 20),
         );
 
+        // Always draw the dim zone background so the meter shows the colored
+        // sectors (green/yellow/orange/red) even when no signal has arrived.
+        draw_meter_zones_background(painter, left_rect);
+        draw_meter_zones_background(painter, right_rect);
+
         if let Some(data) = meter_data {
             // Get L/R peak values (or use same for both if mono)
             let (left_peak, right_peak) = if data.peak.len() >= 2 {
@@ -477,33 +482,10 @@ impl MixerEditor {
                 return;
             };
 
-            let bottom_y = db_to_y(-60.0, rect.min.y, rect.max.y);
-
-            // Draw left channel
-            let left_level = db_to_level(left_peak);
-            let left_top_y = db_to_y(left_peak as f32, rect.min.y, rect.max.y);
-            let left_bar_rect = Rect::from_min_max(
-                egui::pos2(left_rect.min.x, left_top_y),
-                egui::pos2(left_rect.max.x, bottom_y),
-            );
-            painter.rect_filled(
-                left_bar_rect,
-                CornerRadius::same(2),
-                level_to_color(left_level),
-            );
-
-            // Draw right channel
-            let right_level = db_to_level(right_peak);
-            let right_top_y = db_to_y(right_peak as f32, rect.min.y, rect.max.y);
-            let right_bar_rect = Rect::from_min_max(
-                egui::pos2(right_rect.min.x, right_top_y),
-                egui::pos2(right_rect.max.x, bottom_y),
-            );
-            painter.rect_filled(
-                right_bar_rect,
-                CornerRadius::same(2),
-                level_to_color(right_level),
-            );
+            // Light up each zone from the bottom up to the peak. Each zone
+            // keeps its own colour, matching the standalone VU meter block.
+            draw_meter_zones_lit(painter, left_rect, left_peak as f32);
+            draw_meter_zones_lit(painter, right_rect, right_peak as f32);
 
             // Draw decay lines if available
             if data.decay.len() >= 2 {

--- a/frontend/src/properties.rs
+++ b/frontend/src/properties.rs
@@ -807,21 +807,23 @@ impl PropertyInspector {
                                 network_interfaces,
                                 available_channels,
                             );
+                        } else if definition.id == "builtin.mixer" {
+                            Self::show_mixer_properties(
+                                ui,
+                                block,
+                                definition,
+                                flow_id,
+                                network_interfaces,
+                                available_channels,
+                                video_devices,
+                                audio_devices,
+                                local_devices_loading,
+                                taken_endpoint_ids,
+                                &mut device_picker_actions,
+                                &mut result,
+                            );
                         } else {
-                            // Build skip-set for mixer blocks: skip properties for
-                            // channels/aux/groups beyond the configured count.
-                            let mixer_skip = if definition.id == "builtin.mixer" {
-                                Some(Self::mixer_skip_set(block))
-                            } else {
-                                None
-                            };
-
                             for exposed_prop in &definition.exposed_properties {
-                                if let Some(ref skip) = mixer_skip {
-                                    if skip.contains(exposed_prop.name.as_str()) {
-                                        continue;
-                                    }
-                                }
                                 let changed = Self::show_exposed_property(
                                     ui,
                                     block,
@@ -1304,11 +1306,32 @@ impl PropertyInspector {
         result
     }
 
-    /// Build a set of mixer property names to skip based on current config.
+    /// Show mixer properties grouped into collapsing sections.
     ///
-    /// Properties for channels beyond `num_channels`, aux buses beyond
-    /// `num_aux_buses`, and groups beyond `num_groups` are excluded.
-    fn mixer_skip_set(block: &BlockInstance) -> std::collections::HashSet<String> {
+    /// Properties are bucketed by name pattern into Config / Main Bus /
+    /// per-Channel / per-Aux / per-Group sections. Channel sections also have
+    /// nested sub-sections for Gate, Compressor, EQ, Aux Sends and Group
+    /// Routing. Children of closed `CollapsingHeader`s are not rendered, which
+    /// is what avoids the per-frame cost of drawing every property for
+    /// high-channel-count configurations.
+    ///
+    /// Properties for inactive channels/aux/groups (beyond the configured
+    /// counts) are filtered out during bucketing.
+    #[allow(clippy::too_many_arguments)]
+    fn show_mixer_properties(
+        ui: &mut Ui,
+        block: &mut BlockInstance,
+        definition: &BlockDefinition,
+        flow_id: Option<strom_types::FlowId>,
+        network_interfaces: &[strom_types::NetworkInterfaceInfo],
+        available_channels: &[strom_types::api::AvailableOutput],
+        video_devices: &[strom_types::discovery::DeviceResponse],
+        audio_devices: &[strom_types::discovery::DeviceResponse],
+        local_devices_loading: bool,
+        taken_endpoint_ids: &std::collections::HashSet<String>,
+        device_picker_actions: &mut DevicePickerActions,
+        result: &mut BlockInspectorResult,
+    ) {
         use strom_types::mixer::{MAX_AUX_BUSES, MAX_CHANNELS, MAX_GROUPS};
 
         let get_uint = |key: &str, default: usize| -> usize {
@@ -1323,81 +1346,499 @@ impl PropertyInspector {
                 })
                 .unwrap_or(default)
         };
+        let num_ch = get_uint("num_channels", 8).min(MAX_CHANNELS);
+        let num_aux = get_uint("num_aux_buses", 0).min(MAX_AUX_BUSES);
+        let num_grp = get_uint("num_groups", 0).min(MAX_GROUPS);
 
-        let num_ch = get_uint("num_channels", 8);
-        let num_aux = get_uint("num_aux_buses", 0);
-        let num_grp = get_uint("num_groups", 0);
+        // Index buckets into definition.exposed_properties
+        let mut config_idx: Vec<usize> = Vec::new();
+        let mut main_idx: Vec<usize> = Vec::new();
+        let mut ch_basic: Vec<Vec<usize>> = vec![Vec::new(); num_ch];
+        let mut ch_hpf: Vec<Vec<usize>> = vec![Vec::new(); num_ch];
+        let mut ch_gate: Vec<Vec<usize>> = vec![Vec::new(); num_ch];
+        let mut ch_comp: Vec<Vec<usize>> = vec![Vec::new(); num_ch];
+        let mut ch_eq: Vec<Vec<usize>> = vec![Vec::new(); num_ch];
+        let mut ch_aux_sends: Vec<Vec<usize>> = vec![Vec::new(); num_ch];
+        let mut ch_groups: Vec<Vec<usize>> = vec![Vec::new(); num_ch];
+        let mut aux_buckets: Vec<Vec<usize>> = vec![Vec::new(); num_aux];
+        let mut grp_buckets: Vec<Vec<usize>> = vec![Vec::new(); num_grp];
 
-        let mut skip = std::collections::HashSet::new();
+        // Extract leading digits after `prefix`. Returns None if prefix doesn't match.
+        fn extract_index(s: &str, prefix: &str) -> Option<usize> {
+            let rest = s.strip_prefix(prefix)?;
+            let end = rest
+                .find(|c: char| !c.is_ascii_digit())
+                .unwrap_or(rest.len());
+            rest[..end].parse().ok()
+        }
 
-        for ch in (num_ch + 1)..=MAX_CHANNELS {
-            for name in [
-                format!("ch{}_label", ch),
-                format!("ch{}_gain", ch),
-                format!("ch{}_pan", ch),
-                format!("ch{}_fader", ch),
-                format!("ch{}_mute", ch),
-                format!("ch{}_pfl", ch),
-                format!("ch{}_to_main", ch),
-                format!("ch{}_hpf_enabled", ch),
-                format!("ch{}_hpf_freq", ch),
-                format!("ch{}_gate_enabled", ch),
-                format!("ch{}_gate_threshold", ch),
-                format!("ch{}_gate_attack", ch),
-                format!("ch{}_gate_release", ch),
-                format!("ch{}_comp_enabled", ch),
-                format!("ch{}_comp_threshold", ch),
-                format!("ch{}_comp_ratio", ch),
-                format!("ch{}_comp_attack", ch),
-                format!("ch{}_comp_release", ch),
-                format!("ch{}_comp_makeup", ch),
-                format!("ch{}_comp_knee", ch),
-                format!("ch{}_eq_enabled", ch),
-            ] {
-                skip.insert(name);
+        for (i, prop) in definition.exposed_properties.iter().enumerate() {
+            let name = prop.name.as_str();
+
+            // Mixer-level configuration
+            if matches!(
+                name,
+                "num_channels"
+                    | "num_aux_buses"
+                    | "num_groups"
+                    | "dsp_backend"
+                    | "solo_mode"
+                    | "force_live"
+                    | "latency"
+                    | "min_upstream_latency"
+                    | "pfl_level"
+            ) {
+                config_idx.push(i);
+                continue;
             }
-            for band in 1..=4 {
-                for suffix in ["freq", "gain", "q"] {
-                    skip.insert(format!("ch{}_eq{}_{}", ch, band, suffix));
+
+            // Main bus (compressor, EQ, limiter, fader)
+            if name.starts_with("main_") {
+                main_idx.push(i);
+                continue;
+            }
+
+            // ch{N}_...  — channel-scoped property
+            if let Some(rest) = name.strip_prefix("ch") {
+                if let Some(underscore) = rest.find('_') {
+                    if let Ok(n) = rest[..underscore].parse::<usize>() {
+                        // Recognized as a channel property: always consume (drop
+                        // it entirely if the channel is inactive — never let it
+                        // fall through into Configuration).
+                        if !(1..=num_ch).contains(&n) {
+                            continue;
+                        }
+                        let ch_i = n - 1;
+                        let suffix = &rest[underscore + 1..];
+
+                        let bucket = if suffix.starts_with("aux") {
+                            // ch{N}_aux{M}_*  — only include if aux M is active
+                            match extract_index(suffix, "aux") {
+                                Some(m) if (1..=num_aux).contains(&m) => &mut ch_aux_sends[ch_i],
+                                _ => continue,
+                            }
+                        } else if suffix.starts_with("to_grp") {
+                            // ch{N}_to_grp{M} — only include if group M is active
+                            match extract_index(suffix, "to_grp") {
+                                Some(m) if (1..=num_grp).contains(&m) => &mut ch_groups[ch_i],
+                                _ => continue,
+                            }
+                        } else if suffix.starts_with("gate") {
+                            &mut ch_gate[ch_i]
+                        } else if suffix.starts_with("comp") {
+                            &mut ch_comp[ch_i]
+                        } else if suffix.starts_with("eq") {
+                            &mut ch_eq[ch_i]
+                        } else if suffix.starts_with("hpf") {
+                            &mut ch_hpf[ch_i]
+                        } else {
+                            &mut ch_basic[ch_i]
+                        };
+                        bucket.push(i);
+                        continue;
+                    }
                 }
             }
-            for aux in 1..=MAX_AUX_BUSES {
-                skip.insert(format!("ch{}_aux{}_level", ch, aux));
-                skip.insert(format!("ch{}_aux{}_pre", ch, aux));
+
+            // aux{N}_*  — aux master property
+            if let Some(rest) = name.strip_prefix("aux") {
+                if let Some(underscore) = rest.find('_') {
+                    if let Ok(n) = rest[..underscore].parse::<usize>() {
+                        // Recognized as aux property: consume regardless of range.
+                        if (1..=num_aux).contains(&n) {
+                            aux_buckets[n - 1].push(i);
+                        }
+                        continue;
+                    }
+                }
             }
-            for grp in 1..=MAX_GROUPS {
-                skip.insert(format!("ch{}_to_grp{}", ch, grp));
+
+            // group{N}_*  — group master property
+            if let Some(rest) = name.strip_prefix("group") {
+                if let Some(underscore) = rest.find('_') {
+                    if let Ok(n) = rest[..underscore].parse::<usize>() {
+                        // Recognized as group property: consume regardless of range.
+                        if (1..=num_grp).contains(&n) {
+                            grp_buckets[n - 1].push(i);
+                        }
+                        continue;
+                    }
+                }
+            }
+
+            // Truly unrecognized — surface it under Configuration so a newly
+            // added property is never silently hidden from the user.
+            config_idx.push(i);
+        }
+
+        // Channel header labels: use the user-set ch{N}_label if present,
+        // otherwise fall back to "Channel {N}". Precomputed so the immutable
+        // borrow of `block.properties` is released before we re-borrow it
+        // mutably to render properties.
+        let channel_labels: Vec<String> = (1..=num_ch)
+            .map(|ch| {
+                let key = format!("ch{}_label", ch);
+                match block.properties.get(&key) {
+                    Some(PropertyValue::String(s)) if !s.is_empty() => {
+                        format!("Channel {} — {}", ch, s)
+                    }
+                    _ => format!("Channel {}", ch),
+                }
+            })
+            .collect();
+
+        // --- Render ---
+
+        // Configuration: open by default (small, always relevant)
+        if !config_idx.is_empty() {
+            egui::CollapsingHeader::new("Configuration")
+                .id_salt("mixer_config")
+                .default_open(true)
+                .show(ui, |ui| {
+                    Self::render_mixer_bucket(
+                        ui,
+                        block,
+                        &config_idx,
+                        definition,
+                        flow_id,
+                        network_interfaces,
+                        available_channels,
+                        video_devices,
+                        audio_devices,
+                        local_devices_loading,
+                        taken_endpoint_ids,
+                        device_picker_actions,
+                        result,
+                    );
+                });
+        }
+
+        // Main bus
+        if !main_idx.is_empty() {
+            egui::CollapsingHeader::new("Main Bus")
+                .id_salt("mixer_main")
+                .default_open(false)
+                .show(ui, |ui| {
+                    Self::render_mixer_bucket(
+                        ui,
+                        block,
+                        &main_idx,
+                        definition,
+                        flow_id,
+                        network_interfaces,
+                        available_channels,
+                        video_devices,
+                        audio_devices,
+                        local_devices_loading,
+                        taken_endpoint_ids,
+                        device_picker_actions,
+                        result,
+                    );
+                });
+        }
+
+        // Channels — one collapsing header per channel, with nested sub-sections
+        if num_ch > 0 {
+            egui::CollapsingHeader::new(format!("Channels ({})", num_ch))
+                .id_salt("mixer_channels")
+                .default_open(false)
+                .show(ui, |ui| {
+                    for ch in 1..=num_ch {
+                        let ch_i = ch - 1;
+                        egui::CollapsingHeader::new(&channel_labels[ch_i])
+                            .id_salt(format!("mixer_ch_{}", ch))
+                            .default_open(false)
+                            .show(ui, |ui| {
+                                // Basic controls (label, gain, pan, fader, mute, pfl, to_main)
+                                Self::render_mixer_bucket(
+                                    ui,
+                                    block,
+                                    &ch_basic[ch_i],
+                                    definition,
+                                    flow_id,
+                                    network_interfaces,
+                                    available_channels,
+                                    video_devices,
+                                    audio_devices,
+                                    local_devices_loading,
+                                    taken_endpoint_ids,
+                                    device_picker_actions,
+                                    result,
+                                );
+
+                                // High-pass filter
+                                if !ch_hpf[ch_i].is_empty() {
+                                    egui::CollapsingHeader::new("High-Pass Filter")
+                                        .id_salt(format!("mixer_ch_{}_hpf", ch))
+                                        .default_open(false)
+                                        .show(ui, |ui| {
+                                            Self::render_mixer_bucket(
+                                                ui,
+                                                block,
+                                                &ch_hpf[ch_i],
+                                                definition,
+                                                flow_id,
+                                                network_interfaces,
+                                                available_channels,
+                                                video_devices,
+                                                audio_devices,
+                                                local_devices_loading,
+                                                taken_endpoint_ids,
+                                                device_picker_actions,
+                                                result,
+                                            );
+                                        });
+                                }
+
+                                // Gate
+                                if !ch_gate[ch_i].is_empty() {
+                                    egui::CollapsingHeader::new("Gate")
+                                        .id_salt(format!("mixer_ch_{}_gate", ch))
+                                        .default_open(false)
+                                        .show(ui, |ui| {
+                                            Self::render_mixer_bucket(
+                                                ui,
+                                                block,
+                                                &ch_gate[ch_i],
+                                                definition,
+                                                flow_id,
+                                                network_interfaces,
+                                                available_channels,
+                                                video_devices,
+                                                audio_devices,
+                                                local_devices_loading,
+                                                taken_endpoint_ids,
+                                                device_picker_actions,
+                                                result,
+                                            );
+                                        });
+                                }
+
+                                // Compressor
+                                if !ch_comp[ch_i].is_empty() {
+                                    egui::CollapsingHeader::new("Compressor")
+                                        .id_salt(format!("mixer_ch_{}_comp", ch))
+                                        .default_open(false)
+                                        .show(ui, |ui| {
+                                            Self::render_mixer_bucket(
+                                                ui,
+                                                block,
+                                                &ch_comp[ch_i],
+                                                definition,
+                                                flow_id,
+                                                network_interfaces,
+                                                available_channels,
+                                                video_devices,
+                                                audio_devices,
+                                                local_devices_loading,
+                                                taken_endpoint_ids,
+                                                device_picker_actions,
+                                                result,
+                                            );
+                                        });
+                                }
+
+                                // EQ
+                                if !ch_eq[ch_i].is_empty() {
+                                    egui::CollapsingHeader::new("EQ")
+                                        .id_salt(format!("mixer_ch_{}_eq", ch))
+                                        .default_open(false)
+                                        .show(ui, |ui| {
+                                            Self::render_mixer_bucket(
+                                                ui,
+                                                block,
+                                                &ch_eq[ch_i],
+                                                definition,
+                                                flow_id,
+                                                network_interfaces,
+                                                available_channels,
+                                                video_devices,
+                                                audio_devices,
+                                                local_devices_loading,
+                                                taken_endpoint_ids,
+                                                device_picker_actions,
+                                                result,
+                                            );
+                                        });
+                                }
+
+                                // Aux sends
+                                if !ch_aux_sends[ch_i].is_empty() {
+                                    egui::CollapsingHeader::new("Aux Sends")
+                                        .id_salt(format!("mixer_ch_{}_aux", ch))
+                                        .default_open(false)
+                                        .show(ui, |ui| {
+                                            Self::render_mixer_bucket(
+                                                ui,
+                                                block,
+                                                &ch_aux_sends[ch_i],
+                                                definition,
+                                                flow_id,
+                                                network_interfaces,
+                                                available_channels,
+                                                video_devices,
+                                                audio_devices,
+                                                local_devices_loading,
+                                                taken_endpoint_ids,
+                                                device_picker_actions,
+                                                result,
+                                            );
+                                        });
+                                }
+
+                                // Group routing
+                                if !ch_groups[ch_i].is_empty() {
+                                    egui::CollapsingHeader::new("Group Routing")
+                                        .id_salt(format!("mixer_ch_{}_groups", ch))
+                                        .default_open(false)
+                                        .show(ui, |ui| {
+                                            Self::render_mixer_bucket(
+                                                ui,
+                                                block,
+                                                &ch_groups[ch_i],
+                                                definition,
+                                                flow_id,
+                                                network_interfaces,
+                                                available_channels,
+                                                video_devices,
+                                                audio_devices,
+                                                local_devices_loading,
+                                                taken_endpoint_ids,
+                                                device_picker_actions,
+                                                result,
+                                            );
+                                        });
+                                }
+                            });
+                    }
+                });
+        }
+
+        // Aux Buses
+        if num_aux > 0 {
+            egui::CollapsingHeader::new(format!("Aux Buses ({})", num_aux))
+                .id_salt("mixer_aux")
+                .default_open(false)
+                .show(ui, |ui| {
+                    for aux in 1..=num_aux {
+                        let bucket = &aux_buckets[aux - 1];
+                        if bucket.is_empty() {
+                            continue;
+                        }
+                        egui::CollapsingHeader::new(format!("Aux {}", aux))
+                            .id_salt(format!("mixer_aux_{}", aux))
+                            .default_open(false)
+                            .show(ui, |ui| {
+                                Self::render_mixer_bucket(
+                                    ui,
+                                    block,
+                                    bucket,
+                                    definition,
+                                    flow_id,
+                                    network_interfaces,
+                                    available_channels,
+                                    video_devices,
+                                    audio_devices,
+                                    local_devices_loading,
+                                    taken_endpoint_ids,
+                                    device_picker_actions,
+                                    result,
+                                );
+                            });
+                    }
+                });
+        }
+
+        // Groups
+        if num_grp > 0 {
+            egui::CollapsingHeader::new(format!("Groups ({})", num_grp))
+                .id_salt("mixer_groups")
+                .default_open(false)
+                .show(ui, |ui| {
+                    for grp in 1..=num_grp {
+                        let bucket = &grp_buckets[grp - 1];
+                        if bucket.is_empty() {
+                            continue;
+                        }
+                        egui::CollapsingHeader::new(format!("Group {}", grp))
+                            .id_salt(format!("mixer_grp_{}", grp))
+                            .default_open(false)
+                            .show(ui, |ui| {
+                                Self::render_mixer_bucket(
+                                    ui,
+                                    block,
+                                    bucket,
+                                    definition,
+                                    flow_id,
+                                    network_interfaces,
+                                    available_channels,
+                                    video_devices,
+                                    audio_devices,
+                                    local_devices_loading,
+                                    taken_endpoint_ids,
+                                    device_picker_actions,
+                                    result,
+                                );
+                            });
+                    }
+                });
+        }
+    }
+
+    /// Render a list of property indices into `definition.exposed_properties`,
+    /// collecting any live-update events into `result`.
+    #[allow(clippy::too_many_arguments)]
+    fn render_mixer_bucket(
+        ui: &mut Ui,
+        block: &mut BlockInstance,
+        indices: &[usize],
+        definition: &BlockDefinition,
+        flow_id: Option<strom_types::FlowId>,
+        network_interfaces: &[strom_types::NetworkInterfaceInfo],
+        available_channels: &[strom_types::api::AvailableOutput],
+        video_devices: &[strom_types::discovery::DeviceResponse],
+        audio_devices: &[strom_types::discovery::DeviceResponse],
+        local_devices_loading: bool,
+        taken_endpoint_ids: &std::collections::HashSet<String>,
+        device_picker_actions: &mut DevicePickerActions,
+        result: &mut BlockInspectorResult,
+    ) {
+        for &i in indices {
+            let exposed_prop = &definition.exposed_properties[i];
+            let changed = Self::show_exposed_property(
+                ui,
+                block,
+                exposed_prop,
+                definition,
+                flow_id,
+                network_interfaces,
+                available_channels,
+                video_devices,
+                audio_devices,
+                local_devices_loading,
+                taken_endpoint_ids,
+                device_picker_actions,
+            );
+
+            if changed && exposed_prop.live {
+                if let Some(fid) = flow_id {
+                    let element_id = format!("{}:{}", block.id, exposed_prop.mapping.element_id);
+                    let value = block
+                        .properties
+                        .get(&exposed_prop.name)
+                        .or(exposed_prop.default_value.as_ref())
+                        .cloned();
+                    if let Some(value) = value {
+                        result.live_property_updates.push(LivePropertyUpdate {
+                            flow_id: fid,
+                            element_id,
+                            property_name: exposed_prop.mapping.property_name.clone(),
+                            value,
+                        });
+                    }
+                }
             }
         }
-
-        // Skip aux bus master properties beyond configured count
-        for aux in (num_aux + 1)..=MAX_AUX_BUSES {
-            skip.insert(format!("aux{}_fader", aux));
-            skip.insert(format!("aux{}_mute", aux));
-        }
-
-        // Skip per-channel aux send properties for unconfigured aux buses
-        for ch in 1..=num_ch {
-            for aux in (num_aux + 1)..=MAX_AUX_BUSES {
-                skip.insert(format!("ch{}_aux{}_level", ch, aux));
-                skip.insert(format!("ch{}_aux{}_pre", ch, aux));
-            }
-        }
-
-        // Skip group properties beyond configured count
-        for grp in (num_grp + 1)..=MAX_GROUPS {
-            skip.insert(format!("group{}_fader", grp));
-            skip.insert(format!("group{}_mute", grp));
-        }
-
-        // Skip per-channel group routing for unconfigured groups
-        for ch in 1..=num_ch {
-            for grp in (num_grp + 1)..=MAX_GROUPS {
-                skip.insert(format!("ch{}_to_grp{}", ch, grp));
-            }
-        }
-
-        skip
     }
 
     /// Show Audio Router properties with filtered view.

--- a/frontend/src/properties.rs
+++ b/frontend/src/properties.rs
@@ -1382,11 +1382,10 @@ impl PropertyInspector {
                     | "num_aux_buses"
                     | "num_groups"
                     | "dsp_backend"
-                    | "solo_mode"
                     | "force_live"
                     | "latency"
                     | "min_upstream_latency"
-                    | "pfl_level"
+                    | "monitor_fader"
             ) {
                 config_idx.push(i);
                 continue;

--- a/types/src/mixer.rs
+++ b/types/src/mixer.rs
@@ -36,13 +36,16 @@ pub const DEFAULT_LIMITER_THRESHOLD: f32 = -3.0;
 
 // ── Structural defaults ─────────────────────────────────────────────
 pub const DEFAULT_CHANNELS: usize = 8;
-pub const MAX_CHANNELS: usize = 32;
-pub const MAX_AUX_BUSES: usize = 4;
-pub const MAX_GROUPS: usize = 4;
+pub const MAX_CHANNELS: usize = 128;
+pub const MAX_AUX_BUSES: usize = 32;
+pub const MAX_GROUPS: usize = 32;
 
 // ── Routing defaults ──────────────────────────────────────────────
-/// Default aux send pre/post-fader mode per bus (aux 1-2 pre, 3-4 post)
-pub const DEFAULT_AUX_PRE: [bool; MAX_AUX_BUSES] = [true, true, false, false];
+/// Default aux send pre/post-fader mode per bus.
+/// All aux buses default to post-fader (FX/headphone sends, affected by
+/// the channel fader). Flip individual buses to pre-fader in the UI when
+/// using them for monitor/IEM sends.
+pub const DEFAULT_AUX_PRE: [bool; MAX_AUX_BUSES] = [false; MAX_AUX_BUSES];
 
 /// Minimum compressor knee value in linear scale (corresponds to -24 dB)
 pub const MIN_KNEE_LINEAR: f64 = 0.0631;


### PR DESCRIPTION
## Summary

- **Monitor bus replaces the PFL/AFL switch.** Each channel now has independent PFL (pre-fader) and AFL (post-fader) sends that sum into a `solo_mixer`. A new Monitor bus (`monitor_out`) follows Main when no PFL/AFL is engaged anywhere and switches to the solo mix as soon as any channel toggles PFL or AFL. The switch is driven by two `volume`-gate elements (`solo_to_mon` / `main_to_mon`) ramped by the standard `fade_ms` — no pad probes, no pipeline rebuilds, glitch-free.
- **Property panel rewritten to scale.** Mixer properties are bucketed into collapsing sections (Configuration / Main / per-Channel with nested HPF/Gate/Comp/EQ/Aux Sends/Group Routing / per-Aux / per-Group), all default closed. Necessary because `MAX_CHANNELS` is raised 32 → 128 and `MAX_AUX_BUSES` / `MAX_GROUPS` 4 → 32 — the flat renderer would otherwise draw hundreds of fields per frame.
- **Channel strip layout improvements.** Aux-send knobs and routing buttons (M + group numbers) wrap every 4 entries so strip width no longer scales linearly with aux/group count. Bus master row docks directly under the channel strips; status footer is pinned to the bottom of the window.
- **Aux-send defaults standardized to post-fader** across all buses (was pre-fader for aux 1-2, post-fader for 3+).
- **Meter zones now use dB-anchored boundaries** matching the standalone VU meter block and the fader scale.
- **`build.rs` hashes `strom-types`** so WASM rebuilds when shared types change.

## Schema impact

- New properties: `monitor_fader`, `ch{N}_afl`.
- Removed properties: `solo_mode`, `pfl_level`.
- Renamed output pad: `pfl_out` → `monitor_out`.
- `MAX_CHANNELS` 32 → 128, `MAX_AUX_BUSES` 4 → 32, `MAX_GROUPS` 4 → 32 in `strom-types`.

Saved flows from earlier versions will silently drop `solo_mode` / `pfl_level` and pick up definition defaults for `monitor_fader` / `ch{N}_afl`. No OpenAPI snapshot change (mixer block definition is not part of the REST schema).

## Test plan

- [x] `cargo test --lib mixer` — 67 passed
- [x] `cargo test --test openapi_test` — passes (no schema drift)
- [x] `cargo check` clean
- [ ] Smoke-test a running mixer instance — verify PFL+AFL toggle individually, Monitor strip switches MAIN/SOLO indicator, Clear button releases all soloes
- [ ] Verify property panel renders smoothly with high channel/aux/group counts
- [ ] Verify pan knob centering and aux knob row wrapping at various strip widths
- [ ] Confirm aux sends default to post-fader on a fresh mixer block

🤖 Generated with [Claude Code](https://claude.com/claude-code)