### PR TITLE
test(volume-ramp): shrink buffer size to stabilize mid-fade samples

### DIFF
--- a/backend/tests/volume_ramp_test.rs
+++ b/backend/tests/volume_ramp_test.rs
@@ -33,7 +33,12 @@ impl TestPipe {
         let pipeline = gst::Pipeline::new();
         let src = gst::ElementFactory::make("audiotestsrc")
             .property("is-live", true)
-            .property("samplesperbuffer", 480_i32) // 10ms @ 48k → frequent sync_values
+            // 1ms buffers so the controlled `volume` property is re-synced
+            // ~1000 times per second. Larger buffer sizes make mid-fade
+            // sampling flaky (the volume property only refreshes per buffer,
+            // so an 8 ms sample window can fall entirely inside a 10 ms
+            // buffer and miss the ramp).
+            .property("samplesperbuffer", 48_i32)
             .build()
             .expect("audiotestsrc");
         let volume = gst::ElementFactory::make("volume").build().expect("volume");


### PR DESCRIPTION
## Summary
- `unmute_after_mid_mute_fader_change_fades_in_from_zero` flaked ~40% of runs with `volume=0.3` at +8 ms, falsely reporting a P0 regression
- Root cause: `audiotestsrc` was producing 10 ms buffers, so the controlled `volume` property only refreshed ~100 times/sec. The test's 8 ms post-unmute sample window can fall entirely inside a single buffer, so no `gst_object_sync_values` call has happened yet and the property still reads the pre-unmute value
- Verified via diagnostic prints: in failing runs `query_position` was identical before and 9 ms after `apply_mute(false)` (no buffer crossed the volume element); in passing runs it advanced by ~10.9 ms
- Drop `samplesperbuffer` to 48 (1 ms) so the property is re-synced ~1000×/sec, well above the assertion window. No production code touched; pure test fix

## Test plan
- [x] `cargo test --test volume_ramp_test` — 10 consecutive full runs of all 10 tests, 100/100 pass (previously this one test was failing 2-3 out of 5 runs)
- [x] Other tests in the file continue to pass (smaller buffers only make the volume property *more* responsive, not less)

🤖 Generated with [Claude Code](https://claude.com/claude-code)