### PR TITLE
ci: bump Check (Linux) timeout from 15 to 25 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
   check-linux:
     name: Check (Linux)
     runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v5
 


### PR DESCRIPTION
## Summary
- The \`Check (Linux)\` job hit its 15-minute hard limit on a cold-cache run for PR #583 ([run 26152126641](https://github.com/Eyevinn/strom/actions/runs/26152126641)). sccache reported a **12% hit rate (252 hits / 1907 misses)**, so most of fmt + clippy + tests had to compile from scratch and didn't fit in the budget.
- The job does substantial work — \`cargo fmt\`, clippy on \`strom\` (\`efp,nvidia\` features) and \`strom-mcp-server\`, plus \`cargo test\` on both — so a tighter budget than the Build jobs (which already run 15+ minutes) isn't realistic.
- Bump to **25 minutes** to give cold-cache runs enough headroom without masking genuinely runaway runs.

## Test plan
- [ ] CI passes on this PR.
- [ ] Re-trigger CI on #583 (or wait for another cold-cache run) and confirm \`Check (Linux)\` completes inside 25 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)