### PR TITLE
fix(srt): don't synthesize phantom caller on idle listener

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6664,7 +6664,7 @@ dependencies = [
 
 [[package]]
 name = "strom"
-version = "0.5.2-dev"
+version = "0.6.0-dev"
 dependencies = [
  "agua-gst",
  "anyhow",
@@ -6740,7 +6740,7 @@ dependencies = [
 
 [[package]]
 name = "strom-frontend"
-version = "0.5.2-dev"
+version = "0.6.0-dev"
 dependencies = [
  "base64",
  "chrono",
@@ -6776,7 +6776,7 @@ dependencies = [
 
 [[package]]
 name = "strom-mcp-server"
-version = "0.5.2-dev"
+version = "0.6.0-dev"
 dependencies = [
  "anyhow",
  "reqwest 0.13.3",
@@ -6790,7 +6790,7 @@ dependencies = [
 
 [[package]]
 name = "strom-types"
-version = "0.5.2-dev"
+version = "0.6.0-dev"
 dependencies = [
  "garde",
  "serde",

--- a/backend/src/gst/pipeline/srt.rs
+++ b/backend/src/gst/pipeline/srt.rs
@@ -67,13 +67,17 @@ fn collect_element_stats(role: SrtRole, element: &gst::Element) -> SrtConnection
     };
 
     // Listener mode (or any srtsink/srtsrc with multiple callers) exposes a
-    // `callers` GstValueArray. If present, treat each entry as a separate caller.
+    // `callers` GstValueArray. Its *presence* is what marks the element as
+    // multi-peer mode — even an empty array means "listener, no peer attached",
+    // not "fall back to single-peer parsing." Skipping this early-return on
+    // empty would push a phantom caller built from top-level link metrics
+    // (libsrt populates `bandwidth-mbps`/`negotiated-latency-ms` at the element
+    // level before any handshake), making the UI report "1p connected" on an
+    // idle listener.
     if let Some(callers) = read_callers_array(&structure) {
-        if !callers.is_empty() {
-            conn.callers = callers;
-            conn.connected = conn.callers.iter().any(caller_is_active);
-            return conn;
-        }
+        conn.callers = callers;
+        conn.connected = conn.callers.iter().any(caller_is_active);
+        return conn;
     }
 
     // Caller / rendezvous / single-peer mode: the top-level structure IS the
@@ -405,6 +409,39 @@ mod tests {
         assert_eq!(callers[0].rtt_ms, Some(5.5));
         assert_eq!(callers[1].packets_sent, Some(50));
         assert_eq!(callers[1].bytes_sent, Some(12_000));
+    }
+
+    #[test]
+    fn empty_callers_array_does_not_fall_through_to_single_peer() {
+        // Listener-mode element with no peer attached exposes `callers` as an
+        // empty array. The previous behaviour fell through to single-peer
+        // parsing and pushed a phantom caller using the top-level link metrics
+        // (which libsrt populates eagerly before any handshake) — the inline
+        // peer count in the graph then read "1p connected" on an idle listener.
+        init();
+        let callers_value = gst::Array::new(std::iter::empty::<gst::glib::SendValue>());
+        let listener_stats = gst::Structure::builder("application/x-srt-statistics")
+            .field("bandwidth-mbps", 1000.0f64)
+            .field("negotiated-latency-ms", 125i32)
+            .field("callers", callers_value)
+            .build();
+
+        // We can't easily build a real srtsrc element here, but the salient
+        // logic lives in the parse branch. Drive it directly via the helpers.
+        let callers = read_callers_array(&listener_stats).expect("callers field present");
+        assert!(callers.is_empty(), "no peer attached → empty callers");
+
+        // The fall-through path would have produced this phantom caller; the
+        // production code must NOT execute it when `callers` is present.
+        let phantom = parse_caller_stats(&listener_stats);
+        assert!(
+            has_any_data(&phantom),
+            "top-level link metrics make has_any_data true — exactly the trap we are avoiding"
+        );
+        assert!(
+            !caller_is_active(&phantom),
+            "phantom has no packet/byte counters, so it would render as 'waiting' but still bump the peer count"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Idle SRT listener blocks (all four: `efpsrt_input`/`output`, `mpegtssrt_input`/`output`) rendered "1p" in green in the graph node and skipped the "Waiting for SRT peer…" message in the property panel, even with no peer connected.
- Root cause: `collect_element_stats` fell through to single-peer parsing when the `callers` field was present but empty. libsrt populates top-level link metrics (`bandwidth-mbps`, `negotiated-latency-ms`) before any handshake, so `has_any_data` returned true and a phantom caller was pushed onto `conn.callers`.
- Fix: the presence of the `callers` field is itself the signal that the element is in multi-peer mode — never fall through to single-peer parsing when it exists.

## Test plan
- [x] Existing SRT unit tests pass (`cargo test --lib srt` — 9 passed)
- [x] New regression test `empty_callers_array_does_not_fall_through_to_single_peer` documents the trap
- [ ] Manual: bring up an idle SRT listener input/output block, confirm graph shows "0p" in gray and the property panel shows "Waiting for SRT peer…"
- [ ] Manual: connect a peer, confirm count flips to "1p" green and full stats render

🤖 Generated with [Claude Code](https://claude.com/claude-code)