### PR TITLE
fix(properties): coerce int/uint values for gdouble/gfloat properties

### DIFF
--- a/backend/src/gst/pipeline/properties.rs
+++ b/backend/src/gst/pipeline/properties.rs
@@ -31,34 +31,41 @@ impl PipelineManager {
         );
 
         // Audio volume element: route through the ramp manager to avoid
-        // zipper noise (volume) and click artifacts (mute). The match
-        // guards have side effects (they install a control source / schedule
-        // the mute toggle) and short-circuit when ramp setup succeeds; on
-        // failure (e.g. pipeline not yet running) we fall through to the
-        // direct `set_property` path below.
+        // zipper noise (volume) and click artifacts (mute). The short-circuit
+        // installs a control source / schedules the mute toggle and returns;
+        // on failure (e.g. pipeline not yet running) we fall through to the
+        // direct `set_property` path below. Volume accepts any numeric
+        // PropertyValue (Float/Int/UInt) since clients sometimes send an
+        // integer 0/1 — the underlying property is `gdouble`.
         if VolumeRampManager::is_volume_element(element) {
-            match (prop_name, prop_value) {
-                ("volume", PropertyValue::Float(v))
+            if prop_name == "volume" {
+                let target: Option<f64> = match prop_value {
+                    PropertyValue::Float(v) => Some(*v),
+                    PropertyValue::Int(v) => Some(*v as f64),
+                    PropertyValue::UInt(v) => Some(*v as f64),
+                    _ => None,
+                };
+                if let Some(target) = target {
                     if self.volume_ramps.apply_volume_ramp(
                         element,
                         element_id,
-                        *v,
+                        target,
                         ramp_ms.unwrap_or(DEFAULT_VOLUME_RAMP_MS),
-                    ) =>
-                {
-                    return Ok(());
+                    ) {
+                        return Ok(());
+                    }
                 }
-                ("mute", PropertyValue::Bool(v))
+            } else if prop_name == "mute" {
+                if let PropertyValue::Bool(v) = prop_value {
                     if self.volume_ramps.apply_mute(
                         element,
                         element_id,
                         *v,
                         ramp_ms.unwrap_or(MUTE_ANTICLICK_RAMP_MS),
-                    ) =>
-                {
-                    return Ok(());
+                    ) {
+                        return Ok(());
+                    }
                 }
-                _ => {}
             }
         }
 
@@ -122,6 +129,12 @@ impl PipelineManager {
                     } else if type_name == "gint64" {
                         // Property expects i64
                         element.set_property(prop_name, *v);
+                    } else if type_name == "gdouble" {
+                        // Property expects f64 — coerce (e.g. volume sent as int)
+                        element.set_property(prop_name, *v as f64);
+                    } else if type_name == "gfloat" {
+                        // Property expects f32 — coerce
+                        element.set_property(prop_name, *v as f32);
                     } else {
                         // Try i64, might work
                         element.set_property(prop_name, *v);
@@ -149,6 +162,12 @@ impl PipelineManager {
                     } else if type_name == "guint64" {
                         // Property expects u64
                         element.set_property(prop_name, *v);
+                    } else if type_name == "gdouble" {
+                        // Property expects f64 — coerce
+                        element.set_property(prop_name, *v as f64);
+                    } else if type_name == "gfloat" {
+                        // Property expects f32 — coerce
+                        element.set_property(prop_name, *v as f32);
                     } else {
                         // Try u64, might work
                         element.set_property(prop_name, *v);


### PR DESCRIPTION
## Summary
- Setting the volume element's `volume` via PATCH with a JSON integer (e.g. `0` or `1`) was crashing the tokio worker: GstVolume.volume is a `gdouble`, but the `PropertyValue::Int` branch fell through to a raw `set_property(name, i64)` and panicked with `"expected: 'gdouble', got: 'gint64'"`.
- The `Int` and `UInt` branches in `set_property` now coerce to `f64`/`f32` when the property type is `gdouble`/`gfloat` (mirrors what the `Float` branch already does in the opposite direction).
- The volume-element short-circuit now accepts `Float`/`Int`/`UInt` for the `volume` property, so an integer-valued volume still goes through the anti-zipper ramp instead of being applied raw.

## Repro / panic seen in the wild
```
thread 'tokio-rt-worker' panicked at backend/src/gst/pipeline/properties.rs:127:33:
property 'volume' of type 'GstVolume' can't be set from the given type (expected: 'gdouble', got: 'gint64')
```
Triggered by `PATCH /api/flows/.../blocks/.../properties` with `volume` as an integer.

## Test plan
- [x] `cargo check` clean
- [x] `cargo fmt` / `cargo clippy` clean (pre-commit hook)
- [ ] Manual: set `volume` via PATCH with integer payload (`0`, `1`) — no panic, value applied via ramp
- [ ] Manual: set `volume` via PATCH with float payload — ramp still works (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)