### PR TITLE
fix(whep): migrate legacy mode to explicit track counts on flow load

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6664,7 +6664,7 @@ dependencies = [
 
 [[package]]
 name = "strom"
-version = "0.5.2-dev"
+version = "0.6.0-dev"
 dependencies = [
  "agua-gst",
  "anyhow",
@@ -6740,7 +6740,7 @@ dependencies = [
 
 [[package]]
 name = "strom-frontend"
-version = "0.5.2-dev"
+version = "0.6.0-dev"
 dependencies = [
  "base64",
  "chrono",
@@ -6776,7 +6776,7 @@ dependencies = [
 
 [[package]]
 name = "strom-mcp-server"
-version = "0.5.2-dev"
+version = "0.6.0-dev"
 dependencies = [
  "anyhow",
  "reqwest 0.13.3",
@@ -6790,7 +6790,7 @@ dependencies = [
 
 [[package]]
 name = "strom-types"
-version = "0.5.2-dev"
+version = "0.6.0-dev"
 dependencies = [
  "garde",
  "serde",

--- a/backend/src/api/flows.rs
+++ b/backend/src/api/flows.rs
@@ -207,6 +207,15 @@ fn prepare_flow(flow: &mut Flow) {
         }
     }
 
+    // Migrate legacy `mode` enum on WHEP Output blocks to explicit track counts.
+    // Old flows had `mode: "audio"|"video"|"audio_video"`; the property panel now
+    // exposes `num_audio_tracks` / `num_video_tracks` instead.
+    for block in &mut flow.blocks {
+        if block.block_definition_id == "builtin.whep_output" {
+            crate::blocks::builtin::whep::migrate_legacy_mode(&mut block.properties);
+        }
+    }
+
     // Compute external pads for all block instances based on their properties
     for block in &mut flow.blocks {
         if let Some(builder) = crate::blocks::builtin::get_builder(&block.block_definition_id) {

--- a/backend/src/blocks/builtin/whep.rs
+++ b/backend/src/blocks/builtin/whep.rs
@@ -167,6 +167,43 @@ fn explicit_track_count(properties: &HashMap<String, PropertyValue>, name: &str)
     })
 }
 
+/// Migrate a legacy `mode` property on a WHEP Output block to explicit
+/// `num_audio_tracks` / `num_video_tracks` counts, and drop `mode`.
+///
+/// Without this, the property panel shows `num_video_tracks = 1` (the schema
+/// default) for an audio-only flow, but the backend keeps computing 0 video
+/// pads from the still-present `mode: "audio"`. Setting the value back to its
+/// default 1 in the UI is a no-op (frontend stores only diffs against the
+/// default), so the block diagram never grows a video port.
+///
+/// Only count fields not already present are filled in, so partial migrations
+/// don't clobber user-set values. Idempotent.
+///
+/// Returns `true` when something changed.
+pub fn migrate_legacy_mode(properties: &mut HashMap<String, PropertyValue>) -> bool {
+    let Some(PropertyValue::String(mode_str)) = properties.get("mode").cloned() else {
+        return false;
+    };
+    let mode = StreamMode::parse(&mode_str);
+
+    // Only insert counts that diverge from the schema default (UInt(1)). This
+    // keeps the saved properties minimal and lets the UI's "reset to default"
+    // still work intuitively.
+    if !mode.has_audio() {
+        properties
+            .entry("num_audio_tracks".to_string())
+            .or_insert(PropertyValue::UInt(0));
+    }
+    if !mode.has_video() {
+        properties
+            .entry("num_video_tracks".to_string())
+            .or_insert(PropertyValue::UInt(0));
+    }
+
+    properties.remove("mode");
+    true
+}
+
 impl BlockBuilder for WHEPInputBuilder {
     fn build(
         &self,
@@ -2495,5 +2532,91 @@ mod tests {
             .expect("expected pads");
         assert_eq!(audio_pad_names(&pads).len(), 2);
         assert_eq!(video_pad_names(&pads).len(), 3);
+    }
+
+    // --- migrate_legacy_mode ---
+
+    #[test]
+    fn migrate_audio_only_inserts_zero_video_and_drops_mode() {
+        let mut p = props(Some("audio"), None, None);
+        let changed = migrate_legacy_mode(&mut p);
+        assert!(changed);
+        assert!(!p.contains_key("mode"));
+        // num_audio_tracks defaults to 1 — leave it implicit
+        assert!(!p.contains_key("num_audio_tracks"));
+        // num_video_tracks must be explicit 0 to match audio-only intent
+        assert!(matches!(
+            p.get("num_video_tracks"),
+            Some(PropertyValue::UInt(0))
+        ));
+    }
+
+    #[test]
+    fn migrate_video_only_inserts_zero_audio_and_drops_mode() {
+        let mut p = props(Some("video"), None, None);
+        let changed = migrate_legacy_mode(&mut p);
+        assert!(changed);
+        assert!(!p.contains_key("mode"));
+        assert!(matches!(
+            p.get("num_audio_tracks"),
+            Some(PropertyValue::UInt(0))
+        ));
+        assert!(!p.contains_key("num_video_tracks"));
+    }
+
+    #[test]
+    fn migrate_audio_video_just_drops_mode() {
+        let mut p = props(Some("audio_video"), None, None);
+        let changed = migrate_legacy_mode(&mut p);
+        assert!(changed);
+        assert!(!p.contains_key("mode"));
+        // Both default to 1 — nothing explicit needed
+        assert!(!p.contains_key("num_audio_tracks"));
+        assert!(!p.contains_key("num_video_tracks"));
+    }
+
+    #[test]
+    fn migrate_is_noop_when_no_mode() {
+        let mut p = props(None, Some(2), Some(3));
+        let before = p.clone();
+        let changed = migrate_legacy_mode(&mut p);
+        assert!(!changed);
+        assert_eq!(p.len(), before.len());
+    }
+
+    #[test]
+    fn migrate_preserves_explicit_counts() {
+        // mode says audio-only but explicit num_video_tracks=2 was set —
+        // user wins, migration must not overwrite it.
+        let mut p = props(Some("audio"), None, Some(2));
+        migrate_legacy_mode(&mut p);
+        assert!(!p.contains_key("mode"));
+        assert!(matches!(
+            p.get("num_video_tracks"),
+            Some(PropertyValue::Int(2))
+        ));
+    }
+
+    #[test]
+    fn migrate_is_idempotent() {
+        let mut p = props(Some("audio"), None, None);
+        migrate_legacy_mode(&mut p);
+        let snapshot = p.clone();
+        let changed = migrate_legacy_mode(&mut p);
+        assert!(!changed);
+        assert_eq!(p.len(), snapshot.len());
+    }
+
+    #[test]
+    fn migrated_audio_then_resolve_yields_no_video() {
+        // After migration the explicit num_video_tracks=0 keeps the legacy
+        // intent without depending on the now-removed mode property.
+        let mut p = props(Some("audio"), None, None);
+        migrate_legacy_mode(&mut p);
+        let pads = WHEPOutputBuilder
+            .get_external_pads(&p)
+            .expect("expected pads");
+        assert!(video_pad_names(&pads).is_empty());
+        assert_eq!(audio_pad_names(&pads), vec!["audio_in"]);
     }
 }

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -392,6 +392,18 @@ impl AppState {
                     self.strip_transient_properties(flow).await;
                 }
 
+                // Migrate legacy `mode` on WHEP Output blocks to explicit track
+                // counts so the property panel and the computed pads agree.
+                for flow in flows.values_mut() {
+                    for block in &mut flow.blocks {
+                        if block.block_definition_id == "builtin.whep_output" {
+                            crate::blocks::builtin::whep::migrate_legacy_mode(
+                                &mut block.properties,
+                            );
+                        }
+                    }
+                }
+
                 // Reset all flow states to None on server restart since pipelines aren't running
                 // This prevents showing stale "Playing" states from before the server stopped
                 for flow in flows.values_mut() {


### PR DESCRIPTION
## Summary
- Old WHEP Output blocks stored a single `mode` enum (audio / video / audio_video). The current schema exposes `num_audio_tracks` and `num_video_tracks` instead, both defaulting to 1.
- For an audio-only flow (`mode: "audio"`, no track counts stored), the property panel shows `num_video_tracks = 1` (schema default) while the backend keeps computing 0 video pads via the legacy fallback in `resolve_track_counts`. The block diagram therefore never grows a video port, and setting the field back to its default 1 in the UI is a no-op since the frontend only persists values that diverge from the default.
- Migrate `mode` to explicit track counts (idempotent, only on `builtin.whep_output` blocks) at both flow load and flow save. An audio-only flow becomes `{ num_video_tracks: 0 }` with `mode` removed; an audio+video flow just drops `mode` (both default to 1). The property panel now reflects what the pipeline actually does, and changing `num_video_tracks` to any value works as expected. WHIP keeps using its `mode` enum and is untouched.

## Test plan
- [x] `cargo test whep::tests` — 19/19 pass, including 7 new tests covering audio-only / video-only / audio+video migration, idempotence, no-op without `mode`, and that user-set explicit counts are preserved.
- [x] Restarted the server with the new binary against the existing flow store: all WHEP Output blocks ended up with `mode` dropped, audio-only blocks correctly gained `num_video_tracks: 0`, no legacy `mode` keys remain.
- [ ] Open an audio-only WHEP flow in the UI: property panel shows `num_video_tracks: 0` (was `1`), block diagram still has no video port, raising `num_video_tracks` to 1 grows the video port as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)