### PR TITLE
feat(mixer): derive monitor source gates from PFL/AFL writes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6664,7 +6664,7 @@ dependencies = [
 
 [[package]]
 name = "strom"
-version = "0.5.2-dev"
+version = "0.6.0-dev"
 dependencies = [
  "agua-gst",
  "anyhow",
@@ -6740,7 +6740,7 @@ dependencies = [
 
 [[package]]
 name = "strom-frontend"
-version = "0.5.2-dev"
+version = "0.6.0-dev"
 dependencies = [
  "base64",
  "chrono",
@@ -6776,7 +6776,7 @@ dependencies = [
 
 [[package]]
 name = "strom-mcp-server"
-version = "0.5.2-dev"
+version = "0.6.0-dev"
 dependencies = [
  "anyhow",
  "reqwest 0.13.3",
@@ -6790,7 +6790,7 @@ dependencies = [
 
 [[package]]
 name = "strom-types"
-version = "0.5.2-dev"
+version = "0.6.0-dev"
 dependencies = [
  "garde",
  "serde",

--- a/backend/src/blocks/builtin/mixer/builder.rs
+++ b/backend/src/blocks/builtin/mixer/builder.rs
@@ -270,12 +270,12 @@ impl BlockBuilder for MixerBuilder {
         // Create solo bus (sums PFL pre-fader + AFL post-fader sends from every
         // channel) and the Monitor bus that listens to either Main or solo.
         //
-        // Routing rule (driven by frontend gate updates, never by pad probes):
+        // Routing rule (driven by the state layer as a side effect of any
+        // ch{N}_pfl/ch{N}_afl write, not by clients):
         //   - no PFL/AFL active anywhere → main_to_mon=1, solo_to_mon=0
         //   - any PFL/AFL active        → main_to_mon=0, solo_to_mon=1
-        // The frontend computes "any solo active" whenever a ch{N}_pfl /
-        // ch{N}_afl toggles and ramps both gate volumes via the standard
-        // volume-element ramp.
+        // PFL/AFL bools are `persist: false`, so the build-time defaults below
+        // are always the no-solo case — no need to inspect properties here.
         // ========================================================================
         let solo_mixer_id = format!("{}:solo_mixer", instance_id);
         let solo_mixer = make_audiomixer(

--- a/backend/src/blocks/builtin/mixer/mod.rs
+++ b/backend/src/blocks/builtin/mixer/mod.rs
@@ -28,9 +28,10 @@
 //!
 //! Monitor bus: the solo_mixer and a tap from main_out_tee both feed a
 //! monitor_mixer through two volume-gate elements (solo_to_mon and
-//! main_to_mon). The frontend toggles those gates whenever any ch{N}_pfl or
-//! ch{N}_afl property changes — no PFL/AFL active → main_to_mon=1,
-//! solo_to_mon=0; any solo active → reversed. monitor_mixer feeds
+//! main_to_mon). The state layer flips those gates as a side effect of any
+//! `chN_pfl`/`chN_afl` write — no PFL/AFL active → main_to_mon=1,
+//! solo_to_mon=0; any solo active → reversed. Clients only write the bools;
+//! the gates are not part of the public API. monitor_mixer feeds
 //! monitor_master_vol → monitor_level → monitor_out_tee → monitor_out pad.
 //!
 //! All output buses terminate in a tee with allow-not-linked=true, so unconnected
@@ -60,6 +61,26 @@ const EQ_BAND_TYPE_BELL: i32 = 7;
 pub use builder::MixerBuilder;
 pub use definition::get_blocks;
 pub use properties::translate_property_for_element;
+
+/// Block definition ID for the audio mixer. Used by state-layer hooks that
+/// need to recognize mixer instances (e.g. the PFL/AFL → monitor-gate derivation).
+pub const MIXER_BLOCK_ID: &str = "builtin.mixer";
+
+/// Element IDs (relative to the block instance) for the two monitor-source gates.
+/// These are pure derived state driven by PFL/AFL — external clients never
+/// write them directly.
+pub const SOLO_TO_MON_ELEMENT: &str = "solo_to_mon";
+pub const MAIN_TO_MON_ELEMENT: &str = "main_to_mon";
+
+/// Return the 1-indexed channel number if `name` matches a `chN_pfl` / `chN_afl`
+/// exposed property, otherwise `None`. Used to detect solo-affecting writes in
+/// the block-properties batch path.
+pub fn parse_solo_property_name(name: &str) -> Option<usize> {
+    let stripped = name
+        .strip_suffix("_pfl")
+        .or_else(|| name.strip_suffix("_afl"))?;
+    stripped.strip_prefix("ch")?.parse::<usize>().ok()
+}
 
 // Crate-internal re-imports (accessible via super::* in tests)
 #[cfg(test)]

--- a/backend/src/blocks/builtin/mixer/tests.rs
+++ b/backend/src/blocks/builtin/mixer/tests.rs
@@ -353,6 +353,17 @@ fn test_mixer_pfl_afl_are_transient() {
 }
 
 #[test]
+fn test_parse_solo_property_name_matches_pfl_and_afl() {
+    use super::parse_solo_property_name;
+    assert_eq!(parse_solo_property_name("ch1_pfl"), Some(1));
+    assert_eq!(parse_solo_property_name("ch12_afl"), Some(12));
+    assert_eq!(parse_solo_property_name("ch1_mute"), None);
+    assert_eq!(parse_solo_property_name("main_fader"), None);
+    assert_eq!(parse_solo_property_name("ch_pfl"), None);
+    assert_eq!(parse_solo_property_name("chA_pfl"), None);
+}
+
+#[test]
 fn test_mixer_mute_maps_to_gstvolume_mute_property() {
     // Mute is implemented via GstVolume's native `mute` property, not the
     // legacy "volume = 0 if muted" trick. The mapping must point at the

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -84,6 +84,15 @@ struct AppStateInner {
     gst_debug_filter: parking_lot::Mutex<String>,
     /// The GStreamer debug filter the server started with
     default_gst_debug_filter: parking_lot::Mutex<String>,
+    /// Authoritative solo intent for each mixer block instance: the set of
+    /// `chN_pfl` / `chN_afl` exposed property names that the user has currently
+    /// engaged. Updated as a side effect of every `update_block_properties`
+    /// call that touches PFL/AFL bools, and consulted by the monitor-gate
+    /// refresh — never derived from element values (which would race with the
+    /// per-channel volume ramp). PFL/AFL bools are `persist: false`, so the
+    /// per-flow entry is cleared on `stop_flow`; a fresh start sees an empty
+    /// set, which matches the build-time element defaults (gates closed).
+    mixer_solo_state: RwLock<HashMap<FlowId, HashMap<String, HashSet<String>>>>,
 }
 
 impl AppState {
@@ -126,6 +135,7 @@ impl AppState {
                 default_log_filter: parking_lot::Mutex::new("info".to_string()),
                 gst_debug_filter: parking_lot::Mutex::new(String::new()),
                 default_gst_debug_filter: parking_lot::Mutex::new(String::new()),
+                mixer_solo_state: RwLock::new(HashMap::new()),
             }),
         }
     }
@@ -1255,6 +1265,13 @@ impl AppState {
     pub async fn stop_flow(&self, id: &FlowId) -> Result<PipelineState, PipelineError> {
         info!("Stopping flow: {}", id);
 
+        // Drop any cached mixer solo intent — PFL/AFL bools are `persist: false`
+        // and the rebuilt pipeline will start with the no-solo defaults.
+        {
+            let mut state = self.inner.mixer_solo_state.write().await;
+            state.remove(id);
+        }
+
         // Get and remove the pipeline
         let manager = {
             let mut pipelines = self.inner.pipelines.write().await;
@@ -1571,10 +1588,10 @@ impl AppState {
 
         let mut rejected: HashMap<String, String> = HashMap::new();
         let mut to_persist: Vec<(String, PropertyValue)> = Vec::new();
-        // Captures successfully applied chN_pfl / chN_afl bools from this batch
-        // so the mixer monitor-gate post-step can compute "any solo active"
-        // without having to read mid-ramp element values back.
-        let mut mixer_solo_overrides: HashMap<String, bool> = HashMap::new();
+        // True iff this batch successfully applied at least one chN_pfl /
+        // chN_afl write. We update the per-block solo-intent cache below as
+        // those writes succeed, then run the monitor-gate refresh once.
+        let mut mixer_solo_changed = false;
 
         for (name, value) in properties {
             let Some(exposed) = definition
@@ -1629,7 +1646,9 @@ impl AppState {
                 && crate::blocks::builtin::mixer::parse_solo_property_name(&name).is_some()
             {
                 if let PropertyValue::Bool(b) = &value {
-                    mixer_solo_overrides.insert(name.clone(), *b);
+                    self.set_mixer_solo_intent(flow_id, block_instance_id, &name, *b)
+                        .await;
+                    mixer_solo_changed = true;
                 }
             }
 
@@ -1640,18 +1659,13 @@ impl AppState {
 
         // Mixer: PFL/AFL bools are the only public API for solo. The two
         // monitor-source gates (solo_to_mon / main_to_mon) are pure derived
-        // state — any chN_pfl or chN_afl true → solo bus to monitor; otherwise
-        // main bus to monitor. We apply this exactly once per batch so the two
-        // gates are atomic relative to the bool writes that triggered them.
-        if !mixer_solo_overrides.is_empty() {
-            self.refresh_mixer_monitor_gates(
-                flow_id,
-                block_instance_id,
-                &definition,
-                &mixer_solo_overrides,
-                ramp_ms,
-            )
-            .await;
+        // state — any chN_pfl or chN_afl currently engaged → solo bus to
+        // monitor; otherwise main bus to monitor. We apply this exactly once
+        // per batch so the two gates are atomic relative to the bool writes
+        // that triggered them.
+        if mixer_solo_changed {
+            self.refresh_mixer_monitor_gates(flow_id, block_instance_id, ramp_ms)
+                .await;
         }
 
         // Sync persisted values back to the block instance so they survive a
@@ -1714,56 +1728,67 @@ impl AppState {
             .await
     }
 
+    /// Record a single chN_pfl / chN_afl write in the per-block solo-intent
+    /// cache. `true` adds the property name to the set, `false` removes it.
+    /// The empty-set case is the no-solo state and matches the build-time
+    /// gate defaults, so we clean up empty inner / outer maps.
+    async fn set_mixer_solo_intent(
+        &self,
+        flow_id: &FlowId,
+        block_instance_id: &str,
+        property_name: &str,
+        value: bool,
+    ) {
+        let mut state = self.inner.mixer_solo_state.write().await;
+        let by_block = state.entry(*flow_id).or_default();
+        let set = by_block.entry(block_instance_id.to_string()).or_default();
+        if value {
+            set.insert(property_name.to_string());
+        } else {
+            set.remove(property_name);
+        }
+        if set.is_empty() {
+            by_block.remove(block_instance_id);
+        }
+        if by_block.is_empty() {
+            state.remove(flow_id);
+        }
+    }
+
+    /// True iff at least one chN_pfl / chN_afl is currently engaged on the
+    /// given mixer block instance. Reads only the in-memory intent cache —
+    /// never touches the running pipeline, so it is immune to mid-ramp races.
+    async fn mixer_any_solo_active(&self, flow_id: &FlowId, block_instance_id: &str) -> bool {
+        let state = self.inner.mixer_solo_state.read().await;
+        state
+            .get(flow_id)
+            .and_then(|by_block| by_block.get(block_instance_id))
+            .map(|set| !set.is_empty())
+            .unwrap_or(false)
+    }
+
     /// Mixer-specific derived state: refresh the monitor-source gates after a
     /// batch that contained one or more chN_pfl / chN_afl writes.
     ///
-    /// "Any solo active" is computed across all of the block's PFL/AFL bools:
-    /// values that were in this batch are taken from `solo_overrides` (the
-    /// authoritative post-batch intent), and the rest are read back from the
-    /// corresponding `pfl_volume_N` / `afl_volume_N` elements and run through
-    /// the inverse `bool_to_volume` transform. Then `solo_to_mon` is opened
-    /// (or closed) and `main_to_mon` is set to the inverse, both ramped with
-    /// the caller's `ramp_ms` so the gate change stays in sync with the
-    /// per-channel PFL/AFL ramp that just kicked off.
+    /// "Any solo active" is computed purely from the in-memory solo-intent
+    /// cache (see [`Self::set_mixer_solo_intent`]) — the running element
+    /// values are not consulted, so a long volume ramp on one channel cannot
+    /// race with a release on another. Both gates are written with the
+    /// caller's `ramp_ms` so they stay in sync with the per-channel PFL/AFL
+    /// ramp that just kicked off.
     ///
     /// Gate-write failures are logged but never bubble up — a transient
-    /// element-not-found shouldn't fail the user's solo toggle.
+    /// element-not-found shouldn't fail the user's solo toggle. Note that a
+    /// partial failure (one gate written, the other not) leaves both buses
+    /// audible on the monitor until the next solo write retries — an
+    /// acceptable degraded mode but worth knowing about when debugging.
     async fn refresh_mixer_monitor_gates(
         &self,
         flow_id: &FlowId,
         block_instance_id: &str,
-        definition: &strom_types::BlockDefinition,
-        solo_overrides: &HashMap<String, bool>,
         ramp_ms: Option<u32>,
     ) {
-        let mut any_solo = false;
-        for exposed in &definition.exposed_properties {
-            if crate::blocks::builtin::mixer::parse_solo_property_name(&exposed.name).is_none() {
-                continue;
-            }
-            let on = if let Some(b) = solo_overrides.get(&exposed.name) {
-                *b
-            } else {
-                let full_element_id =
-                    format!("{}:{}", block_instance_id, exposed.mapping.element_id);
-                match self
-                    .get_element_property(flow_id, &full_element_id, &exposed.mapping.property_name)
-                    .await
-                {
-                    Ok(v) => {
-                        let t =
-                            crate::blocks::transforms::lookup(exposed.mapping.transform.as_deref());
-                        matches!((t.inverse)(v), Some(PropertyValue::Bool(true)))
-                    }
-                    Err(_) => false,
-                }
-            };
-            if on {
-                any_solo = true;
-                break;
-            }
-        }
-
+        let any_solo = self.mixer_any_solo_active(flow_id, block_instance_id).await;
         let (solo_vol, main_vol) = if any_solo { (1.0, 0.0) } else { (0.0, 1.0) };
         let solo_id = format!(
             "{}:{}",
@@ -2574,5 +2599,125 @@ fn parse_gst_level(s: &str) -> Result<gstreamer::DebugLevel, String> {
             "Invalid GStreamer debug level '{}': expected 0-7 or 9",
             n
         )),
+    }
+}
+
+#[cfg(test)]
+mod mixer_solo_intent_tests {
+    use super::*;
+    use crate::storage::JsonFileStorage;
+    use std::sync::Once;
+    use tempfile::NamedTempFile;
+
+    static GST_INIT: Once = Once::new();
+
+    fn new_state() -> AppState {
+        // AppState construction touches GStreamer registries; init once.
+        GST_INIT.call_once(|| {
+            gstreamer::init().expect("gstreamer init failed in test");
+        });
+        let storage_file = NamedTempFile::new().unwrap();
+        let blocks_file = NamedTempFile::new().unwrap();
+        let storage = JsonFileStorage::new(storage_file.path());
+        AppState::new(
+            storage,
+            blocks_file.path(),
+            std::env::temp_dir(),
+            vec![],
+            "all".to_string(),
+            vec![],
+        )
+    }
+
+    #[tokio::test]
+    async fn solo_intent_starts_empty_and_records_writes() {
+        let state = new_state();
+        let flow = FlowId::new_v4();
+        assert!(!state.mixer_any_solo_active(&flow, "mix1").await);
+
+        state
+            .set_mixer_solo_intent(&flow, "mix1", "ch1_pfl", true)
+            .await;
+        assert!(state.mixer_any_solo_active(&flow, "mix1").await);
+
+        state
+            .set_mixer_solo_intent(&flow, "mix1", "ch1_pfl", false)
+            .await;
+        assert!(!state.mixer_any_solo_active(&flow, "mix1").await);
+    }
+
+    #[tokio::test]
+    async fn solo_intent_tracks_multiple_channels_independently() {
+        let state = new_state();
+        let flow = FlowId::new_v4();
+        // Two channels engaged on the same block.
+        state
+            .set_mixer_solo_intent(&flow, "mix1", "ch1_pfl", true)
+            .await;
+        state
+            .set_mixer_solo_intent(&flow, "mix1", "ch2_afl", true)
+            .await;
+        assert!(state.mixer_any_solo_active(&flow, "mix1").await);
+
+        // Releasing only one channel must not flip the gate.
+        state
+            .set_mixer_solo_intent(&flow, "mix1", "ch1_pfl", false)
+            .await;
+        assert!(
+            state.mixer_any_solo_active(&flow, "mix1").await,
+            "monitor should stay on solo while ch2_afl is still engaged"
+        );
+
+        // Releasing the last engaged channel returns to no-solo.
+        state
+            .set_mixer_solo_intent(&flow, "mix1", "ch2_afl", false)
+            .await;
+        assert!(!state.mixer_any_solo_active(&flow, "mix1").await);
+    }
+
+    #[tokio::test]
+    async fn solo_intent_is_scoped_per_block_and_per_flow() {
+        let state = new_state();
+        let flow_a = FlowId::new_v4();
+        let flow_b = FlowId::new_v4();
+        state
+            .set_mixer_solo_intent(&flow_a, "mixA", "ch1_pfl", true)
+            .await;
+        assert!(state.mixer_any_solo_active(&flow_a, "mixA").await);
+        assert!(!state.mixer_any_solo_active(&flow_a, "mixB").await);
+        assert!(!state.mixer_any_solo_active(&flow_b, "mixA").await);
+    }
+
+    #[tokio::test]
+    async fn solo_intent_is_cleared_on_stop_flow() {
+        let state = new_state();
+        let flow = FlowId::new_v4();
+        state
+            .set_mixer_solo_intent(&flow, "mix1", "ch1_pfl", true)
+            .await;
+        assert!(state.mixer_any_solo_active(&flow, "mix1").await);
+
+        // stop_flow on an unknown flow is a no-op for the pipeline map but
+        // still drops the solo intent — matches the `persist: false`
+        // semantics of the underlying PFL/AFL bools.
+        let _ = state.stop_flow(&flow).await;
+        assert!(
+            !state.mixer_any_solo_active(&flow, "mix1").await,
+            "stop_flow must purge cached solo intent so a restart starts clean"
+        );
+    }
+
+    #[tokio::test]
+    async fn solo_intent_set_false_is_idempotent_when_empty() {
+        // Writing false to a channel that was never engaged should leave
+        // the cache empty (no spurious entry).
+        let state = new_state();
+        let flow = FlowId::new_v4();
+        state
+            .set_mixer_solo_intent(&flow, "mix1", "ch1_pfl", false)
+            .await;
+        assert!(!state.mixer_any_solo_active(&flow, "mix1").await);
+        let map = state.inner.mixer_solo_state.read().await;
+        assert!(map.is_empty(), "no flow entry should be created for false");
     }
 }

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -1525,6 +1525,12 @@ impl AppState {
     /// written to the resolved underlying element via [`Self::update_element_property`]
     /// — so all the existing anti-click / ramp behaviour is inherited.
     ///
+    /// Block-specific derived state: for the audio mixer, any chN_pfl or chN_afl
+    /// write in the batch triggers a post-step that recomputes "any solo active"
+    /// and writes the two monitor-source gates (`solo_to_mon` / `main_to_mon`) with
+    /// the same `ramp_ms`. Those gates are pure derived state — clients must never
+    /// touch them directly.
+    ///
     /// Returns `(current_values, rejected)`:
     /// - `current_values`: block-level (inverse-transformed) values after the writes.
     /// - `rejected`: per-property reason strings for entries that could not be applied
@@ -1565,6 +1571,10 @@ impl AppState {
 
         let mut rejected: HashMap<String, String> = HashMap::new();
         let mut to_persist: Vec<(String, PropertyValue)> = Vec::new();
+        // Captures successfully applied chN_pfl / chN_afl bools from this batch
+        // so the mixer monitor-gate post-step can compute "any solo active"
+        // without having to read mid-ramp element values back.
+        let mut mixer_solo_overrides: HashMap<String, bool> = HashMap::new();
 
         for (name, value) in properties {
             let Some(exposed) = definition
@@ -1615,9 +1625,33 @@ impl AppState {
                 continue;
             }
 
+            if definition.id == crate::blocks::builtin::mixer::MIXER_BLOCK_ID
+                && crate::blocks::builtin::mixer::parse_solo_property_name(&name).is_some()
+            {
+                if let PropertyValue::Bool(b) = &value {
+                    mixer_solo_overrides.insert(name.clone(), *b);
+                }
+            }
+
             if exposed.persist() {
                 to_persist.push((name, value));
             }
+        }
+
+        // Mixer: PFL/AFL bools are the only public API for solo. The two
+        // monitor-source gates (solo_to_mon / main_to_mon) are pure derived
+        // state — any chN_pfl or chN_afl true → solo bus to monitor; otherwise
+        // main bus to monitor. We apply this exactly once per batch so the two
+        // gates are atomic relative to the bool writes that triggered them.
+        if !mixer_solo_overrides.is_empty() {
+            self.refresh_mixer_monitor_gates(
+                flow_id,
+                block_instance_id,
+                &definition,
+                &mixer_solo_overrides,
+                ramp_ms,
+            )
+            .await;
         }
 
         // Sync persisted values back to the block instance so they survive a
@@ -1678,6 +1712,99 @@ impl AppState {
             })?;
         self.get_block_properties_inner(flow_id, block_instance_id, &definition)
             .await
+    }
+
+    /// Mixer-specific derived state: refresh the monitor-source gates after a
+    /// batch that contained one or more chN_pfl / chN_afl writes.
+    ///
+    /// "Any solo active" is computed across all of the block's PFL/AFL bools:
+    /// values that were in this batch are taken from `solo_overrides` (the
+    /// authoritative post-batch intent), and the rest are read back from the
+    /// corresponding `pfl_volume_N` / `afl_volume_N` elements and run through
+    /// the inverse `bool_to_volume` transform. Then `solo_to_mon` is opened
+    /// (or closed) and `main_to_mon` is set to the inverse, both ramped with
+    /// the caller's `ramp_ms` so the gate change stays in sync with the
+    /// per-channel PFL/AFL ramp that just kicked off.
+    ///
+    /// Gate-write failures are logged but never bubble up — a transient
+    /// element-not-found shouldn't fail the user's solo toggle.
+    async fn refresh_mixer_monitor_gates(
+        &self,
+        flow_id: &FlowId,
+        block_instance_id: &str,
+        definition: &strom_types::BlockDefinition,
+        solo_overrides: &HashMap<String, bool>,
+        ramp_ms: Option<u32>,
+    ) {
+        let mut any_solo = false;
+        for exposed in &definition.exposed_properties {
+            if crate::blocks::builtin::mixer::parse_solo_property_name(&exposed.name).is_none() {
+                continue;
+            }
+            let on = if let Some(b) = solo_overrides.get(&exposed.name) {
+                *b
+            } else {
+                let full_element_id =
+                    format!("{}:{}", block_instance_id, exposed.mapping.element_id);
+                match self
+                    .get_element_property(flow_id, &full_element_id, &exposed.mapping.property_name)
+                    .await
+                {
+                    Ok(v) => {
+                        let t =
+                            crate::blocks::transforms::lookup(exposed.mapping.transform.as_deref());
+                        matches!((t.inverse)(v), Some(PropertyValue::Bool(true)))
+                    }
+                    Err(_) => false,
+                }
+            };
+            if on {
+                any_solo = true;
+                break;
+            }
+        }
+
+        let (solo_vol, main_vol) = if any_solo { (1.0, 0.0) } else { (0.0, 1.0) };
+        let solo_id = format!(
+            "{}:{}",
+            block_instance_id,
+            crate::blocks::builtin::mixer::SOLO_TO_MON_ELEMENT
+        );
+        let main_id = format!(
+            "{}:{}",
+            block_instance_id,
+            crate::blocks::builtin::mixer::MAIN_TO_MON_ELEMENT
+        );
+        if let Err(e) = self
+            .update_element_property(
+                flow_id,
+                &solo_id,
+                "volume",
+                PropertyValue::Float(solo_vol),
+                ramp_ms,
+            )
+            .await
+        {
+            warn!(
+                "Mixer {} solo_to_mon gate update failed (any_solo={}): {}",
+                block_instance_id, any_solo, e
+            );
+        }
+        if let Err(e) = self
+            .update_element_property(
+                flow_id,
+                &main_id,
+                "volume",
+                PropertyValue::Float(main_vol),
+                ramp_ms,
+            )
+            .await
+        {
+            warn!(
+                "Mixer {} main_to_mon gate update failed (any_solo={}): {}",
+                block_instance_id, any_solo, e
+            );
+        }
     }
 
     async fn get_block_properties_inner(

--- a/frontend/src/api/elements.rs
+++ b/frontend/src/api/elements.rs
@@ -166,14 +166,29 @@ impl ApiClient {
         ramp_ms: Option<u32>,
     ) -> ApiResult<()> {
         use std::collections::HashMap;
+        let mut properties = HashMap::new();
+        properties.insert(property_name.to_string(), value);
+        self.update_block_properties(flow_id, block_id, properties, ramp_ms)
+            .await
+    }
+
+    /// Batched variant of [`Self::update_block_property`]. All writes in `properties`
+    /// arrive at the backend in a single PATCH and are applied atomically relative to
+    /// any block-level derived state (e.g. the mixer monitor-gate refresh fires once
+    /// per batch, not once per property).
+    pub async fn update_block_properties(
+        &self,
+        flow_id: &FlowId,
+        block_id: &str,
+        properties: std::collections::HashMap<String, strom_types::PropertyValue>,
+        ramp_ms: Option<u32>,
+    ) -> ApiResult<()> {
         use strom_types::api::UpdateBlockPropertiesRequest;
 
         let url = format!(
             "{}/flows/{}/blocks/{}/properties",
             self.base_url, flow_id, block_id
         );
-        let mut properties = HashMap::new();
-        properties.insert(property_name.to_string(), value);
 
         let request = UpdateBlockPropertiesRequest {
             properties,

--- a/frontend/src/mixer/api.rs
+++ b/frontend/src/mixer/api.rs
@@ -385,56 +385,6 @@ impl MixerEditor {
         );
     }
 
-    /// Drive the monitor source-switching gates based on whether any channel
-    /// currently has PFL or AFL engaged.
-    ///
-    /// `solo_to_mon` opens when any solo is active, `main_to_mon` closes.
-    /// When all solo is released, the gates flip back so the monitor follows
-    /// the main output. Both gates ramp via the standard `fade_ms` to avoid
-    /// clicks on transition.
-    pub(super) fn update_monitor_gates(&mut self, ctx: &Context) {
-        if !self.live_updates || !self.pipeline_running {
-            return;
-        }
-        let solo_active = self.any_solo_active();
-        let solo_vol = if solo_active { 1.0_f64 } else { 0.0 };
-        let main_vol = if solo_active { 0.0_f64 } else { 1.0 };
-        let ramp_ms = Some(self.fade_ms);
-        let api = self.api.clone();
-        let flow_id = self.flow_id;
-        let solo_id = format!("{}:solo_to_mon", self.block_id);
-        let main_id = format!("{}:main_to_mon", self.block_id);
-        let ctx = ctx.clone();
-
-        crate::app::spawn_task(async move {
-            if let Err(e) = api
-                .update_element_property(
-                    &flow_id,
-                    &solo_id,
-                    "volume",
-                    PropertyValue::Float(solo_vol),
-                    ramp_ms,
-                )
-                .await
-            {
-                tracing::warn!("Monitor gate (solo) update failed: {}", e);
-            }
-            if let Err(e) = api
-                .update_element_property(
-                    &flow_id,
-                    &main_id,
-                    "volume",
-                    PropertyValue::Float(main_vol),
-                    ramp_ms,
-                )
-                .await
-            {
-                tracing::warn!("Monitor gate (main) update failed: {}", e);
-            }
-            ctx.request_repaint();
-        });
-    }
-
     /// Update aux send level via the block-properties endpoint.
     pub(super) fn update_aux_send(&mut self, ctx: &Context, ch_idx: usize, aux_idx: usize) {
         if !self.live_updates || !self.pipeline_running {

--- a/frontend/src/mixer/api.rs
+++ b/frontend/src/mixer/api.rs
@@ -385,6 +385,39 @@ impl MixerEditor {
         );
     }
 
+    /// Release every PFL/AFL on the given channels in a single batched PATCH.
+    ///
+    /// The Clear-all button needs to send 2N writes at once, and the per-property
+    /// throttle in [`Self::update_channel_property`] would otherwise drop all
+    /// but the first. Routing through the batched endpoint also collapses N
+    /// monitor-gate refreshes on the backend into one — gates ramp back to Main
+    /// exactly once.
+    pub(super) fn update_solo_clear_batch(&mut self, ctx: &Context, channels: &[usize]) {
+        if !self.live_updates || !self.pipeline_running {
+            return;
+        }
+        let mut properties = HashMap::new();
+        for &i in channels {
+            let ch1 = i + 1;
+            properties.insert(format!("ch{}_pfl", ch1), PropertyValue::Bool(false));
+            properties.insert(format!("ch{}_afl", ch1), PropertyValue::Bool(false));
+        }
+        let ramp_ms = Some(self.fade_ms);
+        let api = self.api.clone();
+        let flow_id = self.flow_id;
+        let block_id = self.block_id.clone();
+        let ctx = ctx.clone();
+        crate::app::spawn_task(async move {
+            if let Err(e) = api
+                .update_block_properties(&flow_id, &block_id, properties, ramp_ms)
+                .await
+            {
+                tracing::warn!("Mixer solo-clear batch failed: {}", e);
+            }
+            ctx.request_repaint();
+        });
+    }
+
     /// Update aux send level via the block-properties endpoint.
     pub(super) fn update_aux_send(&mut self, ctx: &Context, ch_idx: usize, aux_idx: usize) {
         if !self.live_updates || !self.pipeline_running {

--- a/frontend/src/mixer/keyboard.rs
+++ b/frontend/src/mixer/keyboard.rs
@@ -56,7 +56,6 @@ impl MixerEditor {
             if let Some(ch) = selected_ch {
                 self.channels[ch].pfl = !self.channels[ch].pfl;
                 self.update_channel_property(ctx, ch, "pfl");
-                self.update_monitor_gates(ctx);
             }
         }
 
@@ -65,7 +64,6 @@ impl MixerEditor {
             if let Some(ch) = selected_ch {
                 self.channels[ch].afl = !self.channels[ch].afl;
                 self.update_channel_property(ctx, ch, "afl");
-                self.update_monitor_gates(ctx);
             }
         }
 

--- a/frontend/src/mixer/mod.rs
+++ b/frontend/src/mixer/mod.rs
@@ -291,9 +291,10 @@ pub struct MixerEditor {
 
 impl MixerEditor {
     /// True if any channel currently has PFL or AFL engaged.
-    /// Drives the monitor bus source-switching gates (`solo_to_mon` /
-    /// `main_to_mon`) — when any solo is active the monitor listens to
-    /// the solo mix, otherwise it follows the main output.
+    /// Used only to render the MAIN/SOLO indicator on the monitor strip — the
+    /// backend owns the actual monitor source switching as a side effect of
+    /// any chN_pfl / chN_afl write. The frontend never touches the internal
+    /// monitor gates directly; PFL/AFL bools are the entire solo API.
     pub(super) fn any_solo_active(&self) -> bool {
         self.channels.iter().any(|c| c.pfl || c.afl)
     }

--- a/frontend/src/mixer/rendering.rs
+++ b/frontend/src/mixer/rendering.rs
@@ -630,8 +630,6 @@ impl MixerEditor {
 
                         if let Some(prop) = solo_changed {
                             self.update_channel_property(ctx, index, prop);
-                            // Switch the monitor source whenever any PFL/AFL toggles.
-                            self.update_monitor_gates(ctx);
                         }
                     }
 
@@ -1012,12 +1010,12 @@ impl MixerEditor {
                         }
                         for i in changed_indices {
                             // Push both volumes to 0 so the backend sees the
-                            // release on each per-channel solo send.
+                            // release on each per-channel solo send. The
+                            // backend flips the monitor gates back to Main as
+                            // a side effect once any_solo goes false.
                             self.update_channel_property(ctx, i, "pfl");
                             self.update_channel_property(ctx, i, "afl");
                         }
-                        // Flip the monitor gates back to follow Main.
-                        self.update_monitor_gates(ctx);
                     }
                 });
             });

--- a/frontend/src/mixer/rendering.rs
+++ b/frontend/src/mixer/rendering.rs
@@ -1008,13 +1008,14 @@ impl MixerEditor {
                                 changed_indices.push(i);
                             }
                         }
-                        for i in changed_indices {
-                            // Push both volumes to 0 so the backend sees the
-                            // release on each per-channel solo send. The
-                            // backend flips the monitor gates back to Main as
-                            // a side effect once any_solo goes false.
-                            self.update_channel_property(ctx, i, "pfl");
-                            self.update_channel_property(ctx, i, "afl");
+                        // Send every chN_pfl=false / chN_afl=false in a single
+                        // batched PATCH. Per-property calls go through a 50 ms
+                        // throttle that would silently drop all but the first
+                        // release in a tight loop; one call sidesteps that and
+                        // also lets the backend flip the monitor gates back to
+                        // Main exactly once (single any_solo recomputation).
+                        if !changed_indices.is_empty() {
+                            self.update_solo_clear_batch(ctx, &changed_indices);
                         }
                     }
                 });


### PR DESCRIPTION
## Summary
- Make the PFL/AFL bools (`chN_pfl`, `chN_afl`) the sole public API for solo on the audio mixer. The backend now derives the monitor-source gates (`solo_to_mon` / `main_to_mon`) as a side effect of any solo write — any solo active → solo bus to monitor, otherwise main bus to monitor.
- Both gates ramp with the same `ramp_ms` as the triggering bool so they stay in sync with the per-channel solo ramp, atomic relative to the batch.
- Frontend is now a thin client like any other; only the "any solo active" UI label remains on that side.

Previously the frontend owned this logic, which meant every external API client would have had to re-implement the convention to get audible solo — effectively a silent footgun for any non-egui consumer.

## Test plan
- [ ] `cargo test -p strom-backend mixer` passes (new `tests.rs` cases included).
- [ ] Toggle PFL on a single channel via the UI → monitor switches to solo bus, with smooth ramp.
- [ ] Toggle PFL via raw API call (e.g. `curl`) → same behaviour, no frontend involved.
- [ ] Clear all PFL/AFL → monitor returns to main bus, ramped.