### PR TITLE
fix(build): isolate wasm target dir to avoid cargo lock deadlock

### DIFF
--- a/backend/build.rs
+++ b/backend/build.rs
@@ -259,9 +259,13 @@ fn build_frontend(frontend_dir: &Path) {
         return;
     }
 
+    // Use a separate CARGO_TARGET_DIR for the inner WASM build so it doesn't
+    // contend for the same target/release/.cargo-lock the outer cargo holds.
+    // Without this the inner cargo blocks indefinitely on the lock → deadlock.
     let status = Command::new("trunk")
         .arg("build")
         .arg("--release")
+        .env("CARGO_TARGET_DIR", "../target/frontend-wasm")
         .current_dir(frontend_dir)
         .status()
         .expect("Failed to execute trunk build. Make sure trunk is installed: cargo install trunk");


### PR DESCRIPTION
## Summary
- The inner `trunk build` launched from `backend/build.rs` inherited the workspace `CARGO_TARGET_DIR`, so the outer (release) cargo and the inner wasm cargo both contended for `target/release/.cargo-lock` — the outer build deadlocked waiting on a lock the inner build was queued behind.
- Point the inner build at a dedicated `../target/frontend-wasm` directory so the two cargos no longer share the same lock file.

## Test plan
- [ ] `cargo build --release` from a clean target dir completes without hanging on `.cargo-lock`
- [ ] `cargo build` (debug) still produces a working WASM frontend
- [ ] Confirm the inner build artifacts now land under `target/frontend-wasm/` instead of polluting the outer `target/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)