### PR TITLE
docs(vision-mixer): add operator-facing user guide

### DIFF
--- a/docs/VISION_MIXER_OPERATOR_GUIDE.md
+++ b/docs/VISION_MIXER_OPERATOR_GUIDE.md
@@ -1,0 +1,412 @@
+# Vision Mixer — Operator Guide
+
+A reference to the production switcher block in strom: the PVW/PGM
+workflow, transitions, Picture-in-Picture, downstream keying, and the
+multiview monitor. Written for vision/video engineers — no software
+internals, just operator-facing behavior.
+
+The mixer behaves like a small broadcast switcher with a green
+preview bus and a red program bus. If you've operated an ATEM, Tricaster
+or vMix, the layout will feel familiar.
+
+---
+
+## 1. At a glance
+
+```mermaid
+flowchart LR
+    classDef input  fill:#1b3a4b,stroke:#7fb3d5,color:#fff
+    classDef stage  fill:#3b2a4e,stroke:#b39ddb,color:#fff
+    classDef pvw    fill:#1e4d2b,stroke:#7fd089,color:#fff
+    classDef pgm    fill:#5c2b29,stroke:#ef9a9a,color:#fff
+    classDef out    fill:#1e3a52,stroke:#90caf9,color:#fff
+
+    IN["Video Inputs<br/>1 … N (2-16)"]:::input
+    PIPS["PiP Compositions<br/>0 … 4 (configurable)"]:::stage
+    PVW["PVW (Preview) Bus<br/>green"]:::pvw
+    PGM["PGM (Program) Bus<br/>red"]:::pgm
+    TRANS["Transition Engine<br/>cut · fade · slide"]:::stage
+    DSK["DSK Layers<br/>0 … 4 (alpha key)"]:::stage
+    FTB["Fade-to-Black"]:::stage
+    PGM_OUT["PGM Out<br/>(distribution)"]:::out
+    MV_OUT["Multiview Out<br/>(operator monitor)"]:::out
+
+    IN --> PVW
+    IN --> PGM
+    PIPS --> PVW
+    PIPS --> PGM
+    PVW -.->|Take / Auto| TRANS
+    TRANS --> PGM
+    PGM --> DSK --> FTB --> PGM_OUT
+    IN --> MV_OUT
+    PIPS --> MV_OUT
+    PVW --> MV_OUT
+    PGM --> MV_OUT
+```
+
+| Input / output | Count | Notes |
+|---|---|---|
+| Video inputs | 2 – 16 (default 4) | Set at construction time. Each input is also exposed on the multiview thumbnail grid. |
+| DSK inputs | 0 – 4 (default 0) | Separate input pads. Alpha-keyed graphics overlaid on PGM. |
+| Audio inputs | One per video input + a dedicated PGM Audio input | Used only for VU-meter rendering on the multiview overlay. They do not pass through the video mixer's outputs. |
+| PiP compositions | 0 – 4 (default 0) | Virtual sources built from a background + overlay zones. |
+| PGM output | 1 video pad | The on-air distribution feed (1920×1080 @ 30 fps by default). |
+| Multiview output | 1 video pad | Operator monitor with PVW/PGM big displays, thumbnails, clock, labels and VU meters. (1280×720 @ 30 fps by default.) |
+
+---
+
+## 2. The PVW / PGM workflow
+
+This is the core operating model. Two buses are always live:
+
+- **PGM (Program)** — the on-air feed. What you send to PGM is what
+  goes out of the `PGM Out` pad to viewers/recorders/streams.
+- **PVW (Preview)** — what comes next. PVW is fully composed and
+  rendered to the multiview, but never reaches the PGM output until you
+  explicitly **take** it.
+
+```
+   Sources                                                Out
+   ───────                                                ───
+   Input 1 ──┐                              ┌──► PGM ──► PGM Out
+   Input 2 ──┼──► [PVW]    Take/Auto        │
+   Input 3 ──┤   (preview)  ─────────────►  ┤
+    …        │                              │
+   PiP 1 ────┤                              │
+   PiP 2 ────┘   [PGM]  ◄──── swaps ──────► [PVW]
+                (live)
+```
+
+**Take rules**
+
+- Pressing **Take** swaps PVW ↔ PGM **atomically**. The previous PGM
+  source automatically becomes the new PVW — never any dead air or
+  in-between state.
+- A take can be a **Cut** (instant) or an **Auto** (animated transition,
+  see §3). The transition you get is whichever type and duration are
+  currently selected.
+- You can **change PVW at any time**, including while a take is in flight.
+  Selecting a new PVW source updates the preview immediately. The next
+  Take will use whatever PVW is at the moment the button is pressed.
+
+**Source types on each bus**
+
+| Source kind | How it shows on the bus |
+|---|---|
+| A regular video **Input** | The input fills the bus output. |
+| A **PiP** composition | The PiP's background fills the bus output and its overlay zones tile on top — exactly as configured in §4. |
+
+A PiP can be put on PVW *or* on PGM, just like any other source.
+
+---
+
+## 3. Transitions
+
+### 3.1 Transition types
+
+| Type | What it does | Duration honored? |
+|---|---|---|
+| `cut` | Instant swap, no animation. | No (always 0). |
+| `fade` *(default)* | Cross-fade (alpha blend) between PVW and PGM. | Yes. |
+| `slide_left` | New source slides in from the right, pushing the old to the left. | Yes. |
+| `slide_right` | Same, mirrored. | Yes. |
+| `slide_up` | New source slides in from the bottom. | Yes. |
+| `slide_down` | New source slides in from the top. | Yes. |
+
+**Duration**: 0 – 60 000 ms. **Default 300 ms.**
+
+### 3.2 Engine downgrade
+
+For some source combinations the engine will quietly substitute a
+different transition. When that happens the response reports both the
+requested type (`transition_type`) and what actually ran
+(`actual_transition_type`).
+
+Concretely: **slide animations between a regular input and a PiP** (or
+between two different PiPs) downgrade to `fade`. The slide geometry is
+not defined for heterogeneous-source pairs.
+
+### 3.3 Cut vs Take/Auto
+
+| Operator button | What it triggers |
+|---|---|
+| **Cut** | Take with `cut` (0 ms). Instant. |
+| **Take / Auto** | Take with the currently selected transition type at the currently selected duration. |
+
+### 3.4 Fade-to-Black (FTB)
+
+FTB is independent of the take engine.
+
+- Press **FTB** once → PGM fades to black over the requested duration
+  (0 = instant). PVW is **not** affected and continues to update.
+- Press **FTB** again → PGM fades back from black to whatever is
+  currently on PGM.
+- **A take while FTB is active automatically cancels the FTB.** You
+  do not need to manually release it before going back to picture.
+
+While FTB is engaged, the multiview shows a centered **FTB** badge over
+the PGM big display so the state is impossible to miss.
+
+---
+
+## 4. Picture-in-Picture (PiP)
+
+A **PiP** in this mixer is not just a single tile on PGM — it is a
+**reusable multi-source composition** that can be selected to PVW or PGM
+just like a regular input.
+
+### 4.1 Anatomy of a PiP
+
+```
+  ┌─────────────────────────────────────────────────────────┐
+  │  PiP region                                             │
+  │  ┌──────────────────────────────────────────────────┐   │
+  │  │                                                  │   │
+  │  │              BACKGROUND (optional)               │   │
+  │  │              one input fills the region          │   │
+  │  │                                                  │   │
+  │  │   ┌──────────┐    ┌──────────┐                   │   │
+  │  │   │  Zone A  │    │  Zone B  │   overlay zones   │   │
+  │  │   │ cap = 1  │    │ cap = 3  │   on top of bg    │   │
+  │  │   │ src: [2] │    │ src:1,4,5│                   │   │
+  │  │   └──────────┘    └──────────┘                   │   │
+  │  └──────────────────────────────────────────────────┘   │
+  └─────────────────────────────────────────────────────────┘
+```
+
+| Element | Meaning |
+|---|---|
+| **Background** | One input that fills the whole PiP region. Optional — a PiP can be overlay-only. |
+| **Zone** | A rectangular sub-region inside the PiP that hosts one or more overlay sources. Each zone has its own position, size and capacity. |
+| **Zone capacity** | Max number of overlay sources allowed in the zone. When full, pushing a new source **evicts the oldest** (FIFO). Capacity `1` is "swap mode" — replacing the source cross-fades. |
+| **Auto-tile** | When a zone holds multiple sources without explicit per-source rectangles, they auto-tile in a grid (1, 2 side-by-side, 2+1, 2×2, 3×2, etc.) that preserves 16:9 aspect inside the zone. |
+
+### 4.2 Limits
+
+| | Value |
+|---|---|
+| Max PiPs in the mixer | 4 |
+| Max overlays per PiP (across all zones) | 15 (= max inputs − 1) |
+| Sources are deduplicated across zones | The same input cannot occupy two zones in the same PiP — first zone wins. |
+
+### 4.3 How the operator configures a PiP
+
+A PiP is configured at runtime from the **operator control page**
+(served by the backend; the page handler at
+`backend/src/api/vision_mixer_page.rs` builds the HTML UI). On that
+page:
+
+- Pick the PiP's **background** input from a dropdown.
+- Add **zones** with the "+ Zone" button. Drag a zone to move it,
+  drag its corner to resize it.
+- For each zone, set a **capacity** (or leave it `∞`).
+- Push **inputs** into the active zone. The zone fills up, auto-tiles,
+  and starts evicting once it hits capacity.
+
+A PiP starts **empty** when the mixer block is first built — there are
+no static "PiP defaults" baked into the flow. Settings the operator
+makes on the page apply live and are reflected in the multiview tile
+for that PiP.
+
+### 4.4 PiPs on the multiview
+
+Each configured PiP occupies one tile in the multiview thumbnail grid,
+next to the input thumbnails. The tile shows the live PiP composition
+(background + zones) so the operator can see what they'd be cutting to
+*before* sending it to PVW or PGM.
+
+---
+
+## 5. Downstream Keyer (DSK)
+
+A DSK channel overlays a graphics input (lower thirds, station logo, a
+CEF-rendered web overlay) **on top of the PGM output**.
+
+```
+   …→ PGM mix ──► [DSK 1] ──► [DSK 2] ──► [DSK 3] ──► [DSK 4] ──► FTB ──► PGM Out
+                  (alpha)     (alpha)     (alpha)     (alpha)
+```
+
+| Aspect | Behavior |
+|---|---|
+| **Channels** | 0 – 4 (default 0). Configured at construction time. |
+| **Keying** | Alpha-channel only. The DSK input must carry its own alpha — there is no separate fill+key pair. Pre-rendered graphics, CEF browser sources, animated video with embedded alpha all work. |
+| **Toggle** | Each DSK is a binary **on/off**. There is **no fade-in/out** — DSK is an instant toggle. (Use a CEF overlay with its own animation if you need to ease graphics in.) |
+| **Stacking** | DSK1 sits closest to the program; DSK4 sits on top. The DSK stack always renders **above** the PGM composition (including PiP overlays). |
+| **Multiview** | DSK overlays do **not** appear in the multiview output. The multiview shows the clean PGM mix without DSK. |
+| **Audio** | DSK pads are **video only**. If your graphics source has audio, route it separately. |
+
+---
+
+## 6. The multiview monitor
+
+The multiview is the operator's monitor. Default resolution 1280×720 @
+30 fps.
+
+```
+  ┌──────────────────────────────────────────────────────────────┐
+  │                          14:35:42 CEST                       │  ← clock (top center)
+  │                                                              │
+  │   ┌─────────────────────────┐   ┌─────────────────────────┐  │
+  │   │ ░░░░░░░░░░░░░░░░░░░░░░░ │   │ ░░░░░░░░░░░░░░░░░░░░░░░ │  │
+  │   │ ░░░░░░░░░░░░░░░░░░░░░░░ │   │ ░░░░░░░░░░░░░░░░░░░░░░░ │  │
+  │   │ ░░░░░░░░  PVW  ░░░░░░░░ │   │ ░░░░░░░░  PGM  ░░░░░░░░ │  │
+  │   │ ░░░░ green border ░░░░░ │   │ ░░░░ red border ░░░░░░░ │  │
+  │   │ ░░░░░░░░░░░░░░░░░░░░░░░ │   │ ░░░░░░░░░░░░░░░░░░░░░░░ │  │
+  │   │ █                    PVW│   │ █                    PGM│  │
+  │   └─────────────────────────┘   └─────────────────────────┘  │
+  │                                                              │
+  │   ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐    │
+  │   │░░░░░░░░│ │░░░░░░░░│ │░░░░░░░░│ │░░░░░░░░│ │░░░░░░░░│    │
+  │   │░ thmb ░│ │░ thmb ░│ │░ thmb ░│ │░ thmb ░│ │░ PiP 1░│    │
+  │   │░░░░░░░░│ │░░░░░░░░│ │░░░░░░░░│ │░░░░░░░░│ │░░░░░░░░│    │
+  │   │█  In 1 │ │█  In 2 │ │█  In 3 │ │█  In 4 │ │█  PiP 1│    │
+  │   └────────┘ └────────┘ └────────┘ └────────┘ └────────┘    │
+  └──────────────────────────────────────────────────────────────┘
+        green border on the PVW source · red border on the PGM source
+        thin VU bar on the bottom-left of each tile (█)
+```
+
+### 6.1 What's on screen
+
+| Element | Where | Notes |
+|---|---|---|
+| **PVW big display** | Top-left of canvas | Shows the current preview source (Input or PiP). |
+| **PGM big display** | Top-right of canvas | Shows the live program. |
+| **Thumbnail grid** | Bottom half | One tile per input, then one tile per configured PiP. Grid columns/rows are chosen automatically based on slot count and source aspect (16:9). |
+| **PVW border** | Around the PVW display **and** around the source tile currently routed to PVW | **Green.** |
+| **PGM border** | Around the PGM display **and** around the source tile currently routed to PGM | **Red.** |
+| **Idle thumbnail border** | Tiles not currently on PVW or PGM | **Gray.** |
+| **"PVW" / "PGM" labels** | Bottom-center of each big display | Colored badge matching the border. |
+| **Tile labels** | Centered below each thumbnail | Uses the operator-set `Input N Label` (defaults to `In 1`, `In 2`, …). PiP tiles label as `PiP 1`, `PiP 2`, etc. |
+| **Clock** | Top center of canvas | Local wall-clock time in `HH:MM:SS TZ` (e.g. `14:35:42 CEST`). Auto-tracks DST changes. |
+| **VU meters** | Thin vertical bar bottom-left of each thumbnail, plus one on PVW and one on PGM | See §6.2. Can be globally disabled with the **Show VU Meters** block property. |
+| **FTB badge** | Centered on PGM display | Appears when Fade-to-Black is engaged. |
+| **Multiview overlay alpha** | Whole overlay | A live operator control fades the entire overlay (borders, labels, clock, VU meters) from 0.0 → 1.0. Useful for clean screenshots / OB cleanfeeds when the multiview is doubling as a confidence monitor. |
+
+### 6.2 VU meter colors
+
+The meters on the multiview show **per-input** audio levels plus a
+dedicated meter on the PVW and PGM big displays. dBFS thresholds:
+
+| Range | Color |
+|---|---|
+| `-60 … -18 dBFS` | Green |
+| `-18 …  -9 dBFS` | Yellow |
+|  `-9 …  -6 dBFS` | Orange |
+|  `-6 …   0 dBFS` | Red |
+
+A thin **white tick** marks the decay peak so transients are easy to
+read. Meters update at 100 ms intervals.
+
+### 6.3 What is *not* shown on the multiview
+
+- **DSK overlays** do not appear on the multiview. The multiview always
+  shows the clean PGM mix.
+- **No transition progress indicator** is drawn during an animated take —
+  the change in border color tells you the new state when the take
+  completes.
+
+---
+
+## 7. Operator controls reference
+
+This is the complete operator-facing control surface. Each row is one
+action.
+
+| Action | What it does | Parameters |
+|---|---|---|
+| **Select PVW source** | Route a regular Input or PiP onto the PVW bus. Updates the multiview PVW display immediately. Never touches the on-air feed. | Source: `input:N` or `pip:N` |
+| **Select PGM source** *(direct)* | Cut a source straight to PGM, bypassing PVW. | Source: `input:N` or `pip:N` |
+| **Take (Auto)** | Animate the transition from PGM to PVW using the currently selected type/duration. Old PGM becomes the new PVW. | Implicit (uses current PVW + selected transition) |
+| **Cut** | Take with `cut` (zero duration). Instant. | — |
+| **Set transition type** | Select which animation Auto will use. | One of `cut`, `fade`, `slide_left`, `slide_right`, `slide_up`, `slide_down` |
+| **Set transition duration** | Set the length of fade/slide takes. | 0 – 60 000 ms (default 300) |
+| **Fade-to-Black** | Toggle FTB on PGM (first press fades to black, second press fades back). | Duration in ms (0 = instant). |
+| **DSK on/off** | Toggle one DSK channel on or off. | DSK number (1 – 4) + `enabled: true/false` |
+| **Configure PiP** | Set a PiP's background and zones (positions, capacities, source lists). Live, no restart. | `pip_idx`, `bg`, `zones[]` |
+| **Set multiview overlay alpha** | Fade the multiview overlay (borders, labels, clock, VU meters). | `alpha`: 0.0 – 1.0 |
+| **Get state** | Snapshot of current PVW/PGM/DSK/FTB/PiP state. Useful when reconnecting to the mixer mid-show. | — |
+
+All state-changing actions broadcast a `VisionMixerStateChanged`
+WebSocket event so multiple operator panels stay in sync in real time.
+
+---
+
+## 8. Defaults reference
+
+### Block-level defaults
+
+| Property | Default |
+|---|---|
+| Compositor backend | Auto (GPU first, fall back to CPU) |
+| Number of inputs | 4 |
+| Number of DSK inputs | 0 |
+| Number of PiPs | 0 |
+| PGM resolution | 1920×1080 |
+| PGM framerate | 30/1 |
+| Multiview resolution | 1280×720 |
+| Multiview framerate | 30/1 |
+| Output pixel format | Auto (negotiated by GStreamer) |
+| GL download | Off (GPU memory passes downstream) |
+| Show VU meters on multiview | **On** |
+| Initial PGM input | Input 0 |
+| Initial PVW input | Input 1 |
+| Compositor latency | 20 ms |
+| Min upstream latency | 20 ms |
+
+### Transition defaults
+
+| | Value |
+|---|---|
+| Default transition type | `fade` |
+| Default transition duration | 300 ms |
+| Max duration | 60 000 ms |
+
+### Visual conventions
+
+| | Value |
+|---|---|
+| PVW color | **Green** |
+| PGM color | **Red** |
+| Idle thumbnail border | Gray |
+| Border width (PVW / PGM / thumbnail) | 4 px @ 720p reference, scales with multiview height |
+| Clock refresh | 1 Hz, with timezone re-check every 60 s for DST |
+| VU meter interval | 100 ms |
+
+---
+
+## 9. Limits
+
+| | Min | Max |
+|---|---|---|
+| Video inputs | 2 | 16 |
+| DSK channels | 0 | 4 |
+| PiP compositions | 0 | 4 |
+| Overlay sources per PiP | 0 | 15 |
+| Transition duration | 0 ms | 60 000 ms |
+
+Input count, DSK count and PiP count are **construction-time** properties
+— changing them requires restarting the flow. Everything else (PVW/PGM
+selection, transitions, DSK toggles, PiP configuration, overlay alpha)
+is live and takes effect immediately.
+
+---
+
+## 10. Glossary
+
+| Term | Meaning |
+|---|---|
+| **PGM (Program)** | The on-air feed. What goes out of the `PGM Out` pad. |
+| **PVW (Preview)** | What's queued up to go on air next. Visible on the multiview, never on PGM until taken. |
+| **Take** | Atomic swap of PVW ↔ PGM, animated (Auto) or instant (Cut). |
+| **Cut** | Zero-duration take. |
+| **Auto** | Animated take, using the currently selected transition type and duration. |
+| **Transition** | The animation that takes one source to another (`cut`, `fade`, `slide_*`). |
+| **Engine downgrade** | When the engine cannot honor the requested transition (e.g. `slide_left` between an input and a PiP) it falls back to `fade`. The response reports both requested and actual. |
+| **FTB (Fade-to-Black)** | Forced fade of PGM to black, independent of takes. |
+| **DSK (Downstream Keyer)** | Alpha-keyed graphics overlay on the PGM output, sitting above the entire PGM composition. |
+| **PiP (Picture-in-Picture)** | A reusable multi-source composition (background + overlay zones) that can be taken to PVW/PGM like any input. |
+| **Zone** | A rectangular sub-region inside a PiP that hosts overlay sources. Has its own position, size, and capacity (FIFO eviction when full). |
+| **Multiview** | The operator monitor output showing PVW, PGM, all input thumbnails, all PiP thumbnails, clock, labels and VU meters. |
+| **Source** | A bus assignment, either `input:N` (a regular input) or `pip:N` (a PiP composition). |


### PR DESCRIPTION
## Summary
- Adds `docs/VISION_MIXER_OPERATOR_GUIDE.md`: a user manual for vision/video engineers operating the strom vision mixer block.
- Covers the PVW/PGM workflow, transition types and defaults, Fade-to-Black, Picture-in-Picture (background + zones + overlays), DSK behavior, and the multiview monitor layout (borders, labels, clock, VU meter color zones).
- Style mirrors the existing audio mixer operator guide — skips GStreamer/code details, focuses on observable behavior and visual conventions.

## Test plan
- [ ] Open the doc on github.com and verify the Mermaid diagram in §1 renders.
- [ ] Verify the ASCII signal-flow blocks and tables render cleanly.
- [ ] Spot-check defaults (transition type/duration, border colors, VU thresholds) against the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)