### PR TITLE
chore(deps): drop unused agua-gst watermark plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,40 +130,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "aes"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
-dependencies = [
- "cfg-if",
- "cipher 0.4.4",
- "cpufeatures 0.2.17",
-]
-
-[[package]]
-name = "agua-core"
-version = "0.2.4"
-source = "git+https://github.com/srperens/agua?tag=v0.2.4#07cae16b15c540203bf2f095950d82af888339f0"
-dependencies = [
- "aes",
- "cipher 0.5.2",
- "realfft",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "agua-gst"
-version = "0.2.4"
-source = "git+https://github.com/srperens/agua?tag=v0.2.4#07cae16b15c540203bf2f095950d82af888339f0"
-dependencies = [
- "agua-core",
- "gstreamer",
- "gstreamer-audio",
- "gstreamer-base",
- "once_cell",
-]
-
-[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -814,7 +780,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62ce3946557b35e71d1bbe07ec385073ce9eda05043f95de134eb578fcf1a298"
 dependencies = [
  "byteorder",
- "cipher 0.5.2",
+ "cipher",
 ]
 
 [[package]]
@@ -1028,22 +994,12 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
-dependencies = [
- "crypto-common 0.1.7",
- "inout 0.1.4",
-]
-
-[[package]]
-name = "cipher"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
  "crypto-common 0.2.2",
- "inout 0.2.2",
+ "inout",
 ]
 
 [[package]]
@@ -3685,15 +3641,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "inout"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
-dependencies = [
- "generic-array",
 ]
 
 [[package]]
@@ -6666,7 +6613,6 @@ dependencies = [
 name = "strom"
 version = "0.6.1-dev"
 dependencies = [
- "agua-gst",
  "anyhow",
  "async-trait",
  "axum",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -61,7 +61,6 @@ gst-plugin-webrtchttp.workspace = true
 gst-plugin-inter.workspace = true
 gst-plugin-rtp.workspace = true
 gst-plugins-lsp = { git = "https://github.com/srperens/lsp-plugins-rs", tag = "v1.3.1", package = "gst-plugins-lsp" }
-agua-gst = { git = "https://github.com/srperens/agua", tag = "v0.2.4", package = "agua-gst" }
 gst-plugin-efp = { git = "https://github.com/Eyevinn/efp", tag = "v0.3.0", package = "gst-plugin-efp", optional = true }
 
 # Encoding

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -408,7 +408,6 @@ fn run_with_gui(
         gstrsrtp::plugin_register_static().expect("Could not register rtp plugins");
         gstrsaudiofx::plugin_register_static().expect("Could not register audiofx plugins");
         gst_plugins_lsp::plugin_register_static().expect("Could not register lsp-dsp-rs plugins");
-        agua_gst::plugin_register_static().expect("Could not register agua watermark plugins");
         #[cfg(feature = "efp")]
         gst_plugin_efp::plugin_register_static().expect("Could not register efp mux/demux plugins");
 
@@ -564,7 +563,6 @@ async fn run_headless(
     gstrsrtp::plugin_register_static().expect("Could not register rtp plugins");
     gstrsaudiofx::plugin_register_static().expect("Could not register audiofx plugins");
     gst_plugins_lsp::plugin_register_static().expect("Could not register lsp-dsp-rs plugins");
-    agua_gst::plugin_register_static().expect("Could not register agua watermark plugins");
     #[cfg(feature = "efp")]
     gst_plugin_efp::plugin_register_static().expect("Could not register efp mux/demux plugins");
 


### PR DESCRIPTION
## Summary
- Remove the `agua-gst` dependency from `backend/Cargo.toml`
- Drop the two `agua_gst::plugin_register_static()` calls in `main.rs` (GUI + headless paths)
- `Cargo.lock` shrinks (also removes `agua-core`, `aes`, `cipher 0.4.4`, `inout 0.1.4`)

The agua watermark plugins are not used by strom.

## Test plan
- [x] `cargo check` passes
- [x] pre-commit (`cargo fmt`, `clippy`) passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)