### PR TITLE
feat(api): per-property ramp_ms overrides on block PATCH

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6611,7 +6611,7 @@ dependencies = [
 
 [[package]]
 name = "strom"
-version = "0.6.1-dev"
+version = "0.6.1-dev2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6686,7 +6686,7 @@ dependencies = [
 
 [[package]]
 name = "strom-frontend"
-version = "0.6.1-dev"
+version = "0.6.1-dev2"
 dependencies = [
  "base64",
  "chrono",
@@ -6722,7 +6722,7 @@ dependencies = [
 
 [[package]]
 name = "strom-mcp-server"
-version = "0.6.1-dev"
+version = "0.6.1-dev2"
 dependencies = [
  "anyhow",
  "reqwest 0.13.3",
@@ -6736,7 +6736,7 @@ dependencies = [
 
 [[package]]
 name = "strom-types"
-version = "0.6.1-dev"
+version = "0.6.1-dev2"
 dependencies = [
  "garde",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["types", "backend", "frontend", "mcp-server"]
 default-members = ["backend"]
 
 [workspace.package]
-version = "0.6.1-dev"
+version = "0.6.1-dev2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Per Enstedt <per.enstedt@eyevinn.se>"]

--- a/backend/src/api/flows.rs
+++ b/backend/src/api/flows.rs
@@ -1187,7 +1187,10 @@ pub async fn get_block_properties(
 /// underlying GStreamer element via the block definition's PropertyMapping,
 /// applies the declared transform (`bool_to_volume`, `db_to_linear`, …), and
 /// writes through the standard live-property path (so `ramp_ms` produces the
-/// usual anti-click fade where applicable).
+/// usual anti-click fade where applicable). `ramp_ms_overrides` lets the
+/// caller pin a different ramp duration for individual properties in the same
+/// batch — useful for crossfades where one fader rises while another falls at
+/// the same rate but other properties move instantly.
 ///
 /// Only properties marked `live: true` are accepted. Unknown, non-live, or
 /// type-mismatched entries are returned in the `rejected` map without aborting
@@ -1212,7 +1215,13 @@ pub async fn update_block_properties(
     ValidatedJson(req): ValidatedJson<UpdateBlockPropertiesRequest>,
 ) -> Result<Json<BlockPropertiesResponse>, (StatusCode, Json<ErrorResponse>)> {
     let (properties, rejected) = state
-        .update_block_properties(&flow_id, &block_id, req.properties, req.ramp_ms)
+        .update_block_properties(
+            &flow_id,
+            &block_id,
+            req.properties,
+            req.ramp_ms,
+            req.ramp_ms_overrides,
+        )
         .await
         .map_err(|e| {
             (

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -95,6 +95,18 @@ struct AppStateInner {
     mixer_solo_state: RwLock<HashMap<FlowId, HashMap<String, HashSet<String>>>>,
 }
 
+/// Pick the ramp_ms that should apply to a single property in a batched
+/// `update_block_properties` call. A per-name entry in `overrides` wins over
+/// the batch-level `global` default; absent both, returns `None` so the
+/// pipeline layer falls back to its own per-route default.
+fn resolve_ramp_ms(
+    name: &str,
+    overrides: Option<&HashMap<String, u32>>,
+    global: Option<u32>,
+) -> Option<u32> {
+    overrides.and_then(|m| m.get(name).copied()).or(global)
+}
+
 impl AppState {
     /// Create new application state with the given storage backend.
     pub fn new(
@@ -1571,6 +1583,7 @@ impl AppState {
         block_instance_id: &str,
         properties: HashMap<String, PropertyValue>,
         ramp_ms: Option<u32>,
+        ramp_ms_overrides: Option<HashMap<String, u32>>,
     ) -> Result<(HashMap<String, PropertyValue>, HashMap<String, String>), PipelineError> {
         // Resolve block instance → definition_id → BlockDefinition.
         let definition_id = {
@@ -1640,13 +1653,15 @@ impl AppState {
             // Element IDs in block definitions are relative to the instance — prepend.
             let full_element_id = format!("{}:{}", block_instance_id, exposed.mapping.element_id);
 
+            let effective_ramp_ms = resolve_ramp_ms(&name, ramp_ms_overrides.as_ref(), ramp_ms);
+
             if let Err(e) = self
                 .update_element_property(
                     flow_id,
                     &full_element_id,
                     &exposed.mapping.property_name,
                     transformed,
-                    ramp_ms,
+                    effective_ramp_ms,
                 )
                 .await
             {
@@ -2731,5 +2746,51 @@ mod mixer_solo_intent_tests {
         assert!(!state.mixer_any_solo_active(&flow, "mix1").await);
         let map = state.inner.mixer_solo_state.read().await;
         assert!(map.is_empty(), "no flow entry should be created for false");
+    }
+}
+
+#[cfg(test)]
+mod ramp_ms_resolution_tests {
+    use super::resolve_ramp_ms;
+    use std::collections::HashMap;
+
+    #[test]
+    fn override_wins_over_global() {
+        let mut overrides = HashMap::new();
+        overrides.insert("ch1_fader_db".to_string(), 500);
+        assert_eq!(
+            resolve_ramp_ms("ch1_fader_db", Some(&overrides), Some(50)),
+            Some(500)
+        );
+    }
+
+    #[test]
+    fn falls_back_to_global_when_no_override_for_name() {
+        let mut overrides = HashMap::new();
+        overrides.insert("ch2_fader_db".to_string(), 500);
+        assert_eq!(
+            resolve_ramp_ms("ch1_fader_db", Some(&overrides), Some(50)),
+            Some(50)
+        );
+    }
+
+    #[test]
+    fn falls_back_to_global_when_overrides_absent() {
+        assert_eq!(resolve_ramp_ms("ch1_fader_db", None, Some(50)), Some(50));
+    }
+
+    #[test]
+    fn returns_none_when_neither_set() {
+        assert_eq!(resolve_ramp_ms("ch1_fader_db", None, None), None);
+    }
+
+    #[test]
+    fn override_used_even_when_global_is_none() {
+        let mut overrides = HashMap::new();
+        overrides.insert("ch1_fader_db".to_string(), 500);
+        assert_eq!(
+            resolve_ramp_ms("ch1_fader_db", Some(&overrides), None),
+            Some(500)
+        );
     }
 }

--- a/frontend/src/api/elements.rs
+++ b/frontend/src/api/elements.rs
@@ -193,6 +193,7 @@ impl ApiClient {
         let request = UpdateBlockPropertiesRequest {
             properties,
             ramp_ms,
+            ramp_ms_overrides: None,
         };
 
         let response = self

--- a/openapi.json
+++ b/openapi.json
@@ -10,7 +10,7 @@
     "license": {
       "name": "MIT OR Apache-2.0"
     },
-    "version": "0.5.2-dev"
+    "version": "0.6.1-dev"
   },
   "paths": {
     "/api/auth/status": {
@@ -1604,7 +1604,7 @@
           "flows"
         ],
         "summary": "Update one or more exposed properties on a block instance live.",
-        "description": "Properties are expressed in block-level (user-facing) units — e.g.\n`{\"ch1_pfl\": true, \"fader_db\": -3.0}`. The backend resolves each name to its\nunderlying GStreamer element via the block definition's PropertyMapping,\napplies the declared transform (`bool_to_volume`, `db_to_linear`, …), and\nwrites through the standard live-property path (so `ramp_ms` produces the\nusual anti-click fade where applicable).\n\nOnly properties marked `live: true` are accepted. Unknown, non-live, or\ntype-mismatched entries are returned in the `rejected` map without aborting\nthe rest of the batch.",
+        "description": "Properties are expressed in block-level (user-facing) units — e.g.\n`{\"ch1_pfl\": true, \"fader_db\": -3.0}`. The backend resolves each name to its\nunderlying GStreamer element via the block definition's PropertyMapping,\napplies the declared transform (`bool_to_volume`, `db_to_linear`, …), and\nwrites through the standard live-property path (so `ramp_ms` produces the\nusual anti-click fade where applicable). `ramp_ms_overrides` lets the\ncaller pin a different ramp duration for individual properties in the same\nbatch — useful for crossfades where one fader rises while another falls at\nthe same rate but other properties move instantly.\n\nOnly properties marked `live: true` are accepted. Unknown, non-live, or\ntype-mismatched entries are returned in the `rejected` map without aborting\nthe rest of the batch.",
         "operationId": "update_block_properties",
         "parameters": [
           {
@@ -10427,8 +10427,23 @@
               "null"
             ],
             "format": "int32",
-            "description": "Optional ramp duration in ms (honored for volume-element writes — produces\nanti-click fades for bool/dB toggles that map to a `volume` property).",
+            "description": "Optional default ramp duration in ms applied to every property in this\nbatch (honored for volume-element writes — produces anti-click fades for\nbool/dB toggles that map to a `volume` property). Acts as the fallback\nwhen no per-property override is set in `ramp_ms_overrides`.",
             "minimum": 0
+          },
+          "ramp_ms_overrides": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "description": "Optional per-property ramp duration overrides, keyed by exposed\nproperty name. When a property in `properties` has an entry here, that\nduration is used instead of the batch-level `ramp_ms`. Entries for\nnames not present in `properties` are silently ignored. Only effective\nfor properties whose underlying write goes through the ramp path\n(currently audio `volume`-element `volume` and `mute`); for other\nproperties the override is accepted but has no effect, matching the\nbehavior of the batch-level `ramp_ms`. Enables crossfades where\nindividual faders ramp at different rates within a single PATCH.",
+            "additionalProperties": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            },
+            "propertyNames": {
+              "type": "string"
+            }
           }
         }
       },

--- a/types/src/api.rs
+++ b/types/src/api.rs
@@ -227,11 +227,25 @@ pub struct UpdateBlockPropertiesRequest {
     /// Map of exposed property name → new value (in block-level units).
     #[cfg_attr(feature = "validation", garde(skip))]
     pub properties: HashMap<String, PropertyValue>,
-    /// Optional ramp duration in ms (honored for volume-element writes — produces
-    /// anti-click fades for bool/dB toggles that map to a `volume` property).
+    /// Optional default ramp duration in ms applied to every property in this
+    /// batch (honored for volume-element writes — produces anti-click fades for
+    /// bool/dB toggles that map to a `volume` property). Acts as the fallback
+    /// when no per-property override is set in `ramp_ms_overrides`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "validation", garde(range(max = 60000)))]
     pub ramp_ms: Option<u32>,
+    /// Optional per-property ramp duration overrides, keyed by exposed
+    /// property name. When a property in `properties` has an entry here, that
+    /// duration is used instead of the batch-level `ramp_ms`. Entries for
+    /// names not present in `properties` are silently ignored. Only effective
+    /// for properties whose underlying write goes through the ramp path
+    /// (currently audio `volume`-element `volume` and `mute`); for other
+    /// properties the override is accepted but has no effect, matching the
+    /// behavior of the batch-level `ramp_ms`. Enables crossfades where
+    /// individual faders ramp at different rates within a single PATCH.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "validation", garde(skip))]
+    pub ramp_ms_overrides: Option<HashMap<String, u32>>,
 }
 
 /// Response containing current block-level exposed property values and any rejections.


### PR DESCRIPTION
## Summary
- Adds optional `ramp_ms_overrides: Map<String, u32>` to `UpdateBlockPropertiesRequest` so a single PATCH can ramp individual properties at different rates — enabling asymmetric crossfades and mixed instant/ramped writes in one batch.
- Precedence: per-property override → batch-level `ramp_ms` → pipeline per-route default. Resolution extracted to `resolve_ramp_ms` with 5 unit tests.
- Backwards-compatible: both fields are `Option`, existing clients keep working unchanged. Frontend client passes `None` until UI exposes the feature.

## Example
```json
{
  "properties":        { "ch1_fader_db": -90, "ch2_fader_db": 0, "ch3_fader_db": -6 },
  "ramp_ms":           50,
  "ramp_ms_overrides": { "ch1_fader_db": 500, "ch2_fader_db": 800 }
}
```
ch1 fades 500 ms, ch2 fades 800 ms, ch3 ramps with the 50 ms default. As today, only effective on volume-element writes (volume / mute, incl. faders/mutes that transform to a `volume` write).

## Test plan
- [x] `cargo check` — clean
- [x] `cargo test --lib` — 484 passed (incl. 5 new `ramp_ms_resolution_tests`)
- [x] `cargo test --test openapi_test` — snapshot regenerated and passes
- [ ] Smoke test the asymmetric crossfade against a running mixer flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)