### PR TITLE
perf(state): skip absent elements in block property read-back

### DIFF
--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -1844,21 +1844,54 @@ impl AppState {
         }
     }
 
+    /// Read the current block-level values of all live exposed properties from
+    /// the running pipeline.
+    ///
+    /// A block definition is generated for the block type's MAX sizing (e.g. the
+    /// mixer's 128 channels / 32 aux / 32 groups), so a smaller instance has no
+    /// backing element for the vast majority of its exposed properties. We take
+    /// the pipelines lock once and resolve which elements the instance actually
+    /// built, then skip every property whose element is absent before touching
+    /// GStreamer — instead of re-acquiring the lock and walking the
+    /// element-not-found path thousands of times per call. The output is
+    /// identical to reading each property individually (a property is only
+    /// readable when its element exists), this just avoids the per-property
+    /// lock churn and error-path allocations. Generic: any block that builds
+    /// elements conditionally (mixer, audiorouter, …) benefits.
     async fn get_block_properties_inner(
         &self,
         flow_id: &FlowId,
         block_instance_id: &str,
         definition: &strom_types::BlockDefinition,
     ) -> Result<HashMap<String, PropertyValue>, PipelineError> {
+        let pipelines = self.inner.pipelines.read().await;
+        let Some(manager) = pipelines.get(flow_id) else {
+            // Pipeline not running: every read would fail and be skipped, so the
+            // historical behaviour here is an empty map rather than an error.
+            return Ok(HashMap::new());
+        };
+
+        // Element IDs that exist for this instance, with the "{instance}:" prefix
+        // stripped so the definition's bare `element_id` can be tested without
+        // allocating a full id per property.
+        let prefix_len = block_instance_id.len() + 1;
+        let existing: std::collections::HashSet<&str> = manager
+            .find_block_elements(block_instance_id)
+            .into_iter()
+            .map(|(id, _)| &id[prefix_len..])
+            .collect();
+
         let mut out = HashMap::new();
         for exposed in &definition.exposed_properties {
             if !exposed.live || exposed.mapping.element_id == "_block" {
                 continue;
             }
+            if !existing.contains(exposed.mapping.element_id.as_str()) {
+                continue;
+            }
             let full_element_id = format!("{}:{}", block_instance_id, exposed.mapping.element_id);
-            let raw = match self
-                .get_element_property(flow_id, &full_element_id, &exposed.mapping.property_name)
-                .await
+            let raw = match manager
+                .get_element_property(&full_element_id, &exposed.mapping.property_name)
             {
                 Ok(v) => v,
                 Err(e) => {


### PR DESCRIPTION
## Summary
- `get_block_properties_inner` re-read **every** live exposed property of a block definition from the running pipeline after each block-properties `PATCH`/`GET`. Block definitions are generated for the block type's MAX sizing (the mixer's 128 channels / 32 aux / 32 groups), so a smaller instance has no backing element for the vast majority of those — yet each was resolved by re-acquiring the `pipelines` lock and walking the element-not-found error path, thousands of times per call.
- Now takes the `pipelines` lock **once**, resolves which elements the instance actually built via `find_block_elements`, and skips every property whose element is absent before touching GStreamer.
- **Behaviour-preserving**: the output is identical (a live property is only readable when its element exists) — this only removes the per-property lock churn and error-path allocations. Pipeline-not-running still yields an empty map, matching the previous lazy-skip behaviour.
- **Generic**: any block that builds elements conditionally (mixer, audiorouter, …) benefits — no block-specific knowledge in the state layer.
- **No API change**: `BlockPropertiesResponse` and the OpenAPI schema are unchanged. PATCH still returns the configured block's current state, just cheaply.

## Why
A single `ch1_mute` PATCH was taking ~32 ms even though the actual GStreamer write completes in <1 ms — the tail was this full read-back. See the log trace: `Successfully updated … volume_0.mute` at +0.5 ms, but `finished processing request` only ~26 ms later.

## Measurements
Single `ch1_mute` PATCH on a running mixer (`finished processing request latency=`):

| Build | Total | Post-write read-back tail |
|---|---|---|
| before (debug) | 32 ms | ~26 ms |
| after (debug) | 10–14 ms | ~6.4 ms |
| after (release) | **6 ms** | ~3 ms (FFI/serialize floor) |

The residual ~3 ms in release is the GObject property reads + JSON serialization of the configured surface — an FFI floor no opt level removes. Eliminating it entirely would require changing the PATCH response to echo only the written values (a small contract change), intentionally **not** done here.

## Test plan
- [x] `cargo check` clean on workspace
- [x] `cargo test --test openapi_test` — snapshot unchanged (confirms no API contract drift)
- [x] `cargo test --lib mixer` — 88 passed
- [x] `cargo fmt` + clippy clean (pre-commit hook)
- [x] Verified live against `strom.log`: `ch1_mute` PATCH latency dropped 32 ms → 6 ms (release), behaviour unchanged (200, mute applied, event broadcast)

🤖 Generated with [Claude Code](https://claude.com/claude-code)