### PR TITLE
chore: bump version to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6611,7 +6611,7 @@ dependencies = [
 
 [[package]]
 name = "strom"
-version = "0.6.1-dev2"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6686,7 +6686,7 @@ dependencies = [
 
 [[package]]
 name = "strom-frontend"
-version = "0.6.1-dev2"
+version = "0.6.0"
 dependencies = [
  "base64",
  "chrono",
@@ -6722,7 +6722,7 @@ dependencies = [
 
 [[package]]
 name = "strom-mcp-server"
-version = "0.6.1-dev2"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "reqwest 0.13.4",
@@ -6736,7 +6736,7 @@ dependencies = [
 
 [[package]]
 name = "strom-types"
-version = "0.6.1-dev2"
+version = "0.6.0"
 dependencies = [
  "garde",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["types", "backend", "frontend", "mcp-server"]
 default-members = ["backend"]
 
 [workspace.package]
-version = "0.6.1-dev2"
+version = "0.6.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Per Enstedt <per.enstedt@eyevinn.se>"]

--- a/openapi.json
+++ b/openapi.json
@@ -10,7 +10,7 @@
     "license": {
       "name": "MIT OR Apache-2.0"
     },
-    "version": "0.6.1-dev"
+    "version": "0.6.0"
   },
   "paths": {
     "/api/auth/status": {


### PR DESCRIPTION
## Summary
- Bump workspace version from `0.6.1-dev2` to `0.6.0` for the first tagged 0.6 release.

## Notes
- Last tagged release is `v0.5.1`. The `0.6.0-dev` / `0.6.1-dev*` versions were only ever in dev builds — no `v0.6.0` tag has been published, so the slot is free.
- Bump to 0.6.0 (rather than 0.6.2) matches the breaking-change rationale from #582 ("several api breaking changes") and avoids implying that 0.6.0/0.6.1 were ever real releases.
- Tag `v0.6.0` will be created after merge.

## Test plan
- [x] `cargo fmt` + clippy pass via pre-commit hook
- [ ] CI green