### PR TITLE
Vision mixer UX: pixel zone editor, snap feedback, honest bus tally

### DIFF
--- a/backend/src/api/vision_mixer_page.rs
+++ b/backend/src/api/vision_mixer_page.rs
@@ -112,6 +112,11 @@ async fn render_vision_mixer_page(
     let labels = vm_props::parse_input_labels(&vm_block.properties, num_inputs);
     let num_dsk_inputs = vm_props::parse_num_dsk_inputs(&vm_block.properties);
     let num_pips = vm_props::parse_num_pips(&vm_block.properties);
+    let (pgm_w, pgm_h) = vm_props::parse_resolution(
+        &vm_block.properties,
+        "pgm_resolution",
+        strom_types::vision_mixer::DEFAULT_PGM_RESOLUTION,
+    );
 
     // Get current state from live overlay state or fall back to defaults.
     // `None` means the bus is showing a PiP (see `pvw_pip` / `pgm_pip` below).
@@ -181,6 +186,8 @@ async fn render_vision_mixer_page(
         "pips": pips,
         "pvw_pip": pvw_pip,
         "pgm_pip": pgm_pip,
+        "pgm_w": pgm_w,
+        "pgm_h": pgm_h,
     });
 
     let html = VISION_MIXER_HTML.replace("{{VM_CONFIG_JSON}}", &config.to_string());

--- a/backend/src/blocks/builtin/vision_mixer/overlay.rs
+++ b/backend/src/blocks/builtin/vision_mixer/overlay.rs
@@ -449,7 +449,9 @@ const PGM_VIA_PIP_B: f64 = 0.55;
 
 // Yellow for background indicator: want output R=1.0, G=0.8, B=0
 
-const GRAY: f64 = 0.5;
+// Default (inactive) border for thumbnail and PiP tiles. Darker than mid-gray
+// so the colored PGM/PVW/via-PiP status borders read as clearly brighter.
+const GRAY: f64 = 0.2;
 
 /// Vertical VU meter sectors matching the audio mixer live UI and the
 /// standalone meter block. Boundaries follow [`vision_mixer::VU_METER_*_DB`]

--- a/backend/src/blocks/builtin/vision_mixer/overlay.rs
+++ b/backend/src/blocks/builtin/vision_mixer/overlay.rs
@@ -420,6 +420,33 @@ const PGM_R: f64 = 0.0; // want R=1.0 in output → feed to cairo B channel
 const PGM_G: f64 = 0.0;
 const PGM_B: f64 = 1.0; // want B=0 in output → feed to cairo R channel
 
+// Colors for "visible indirectly via a PiP that's on this bus".
+//
+// Active palette: dark green / dark red — kept in the same hue family as the
+// direct PVW/PGM colours so the relation is obvious at a glance.
+//
+// Alternative palettes tried (kept here as a reference for easy swap-in):
+//
+// Amber + deep orange (PVW leans yellow, PGM leans red):
+//   PVW_VIA_PIP: output R=1.0, G=0.75, B=0.0 → (_R=0.0, _G=0.75, _B=1.0)
+//   PGM_VIA_PIP: output R=1.0, G=0.35, B=0.0 → (_R=0.0, _G=0.35, _B=1.0)
+//
+// Sky blue + vivid blue (both clearly outside red/green hue space):
+//   PVW_VIA_PIP: output R=0.4, G=0.7, B=1.0  → (_R=1.0, _G=0.7,  _B=0.4)
+//   PGM_VIA_PIP: output R=0.0, G=0.2, B=1.0  → (_R=1.0, _G=0.2,  _B=0.0)
+
+// Dark green for "visible in PVW indirectly via a PiP that's on PVW".
+// Output target: R=0, G=0.55, B=0.
+const PVW_VIA_PIP_R: f64 = 0.0;
+const PVW_VIA_PIP_G: f64 = 0.55;
+const PVW_VIA_PIP_B: f64 = 0.0;
+
+// Dark red for "visible in PGM indirectly via a PiP that's on PGM".
+// Output target: R=0.55, G=0, B=0.
+const PGM_VIA_PIP_R: f64 = 0.0;
+const PGM_VIA_PIP_G: f64 = 0.0;
+const PGM_VIA_PIP_B: f64 = 0.55;
+
 // Yellow for background indicator: want output R=1.0, G=0.8, B=0
 
 const GRAY: f64 = 0.5;
@@ -581,6 +608,29 @@ fn hash_meters(state: &VisionMixerOverlayState) -> u64 {
     h
 }
 
+/// Cheap rolling hash over PiP composition state (per-PiP bg input + zone
+/// source lists). Used in the overlay dirty-check so zone or bg edits trigger
+/// a re-render even when no PGM/PVW bus index changes — the via-PiP thumbnail
+/// rings depend on these.
+fn hash_pip_compose(state: &VisionMixerOverlayState) -> u64 {
+    let mut h: u64 = 0xDEADBEEFCAFEBABE;
+    for slot in &state.pip_bg {
+        h = h.rotate_left(7).wrapping_add(slot.load(Ordering::Relaxed));
+    }
+    for zones_lock in &state.pip_zones {
+        if let Ok(zones) = zones_lock.lock() {
+            for zone in zones.iter() {
+                for &src in zone.effective_sources() {
+                    h = h.rotate_left(5).wrapping_add(src as u64 + 1);
+                }
+                // Zone separator so [1,2][3] hashes differently from [1][2,3].
+                h = h.rotate_left(11).wrapping_add(0xA55A);
+            }
+        }
+    }
+    h
+}
+
 /// Helper to get text extents, returning (width, height) with a fallback.
 fn text_size(cr: &cairo::Context, text: &str) -> (f64, f64) {
     match cr.text_extents(text) {
@@ -651,6 +701,10 @@ pub struct OverlayRenderer {
     last_pgm_pip: u64,
     /// Previous PVW-on-PiP index packed (NO_PIP if PVW was an input).
     last_pvw_pip: u64,
+    /// Hash of PiP composition (per-PiP bg + zone sources). Captures changes
+    /// that affect which thumbnails get a via-PiP status ring but no other
+    /// tracked atomic changed.
+    last_pip_compose_hash: u64,
 }
 
 // SAFETY: OverlayRenderer is accessed via Mutex from the timer thread and API
@@ -682,6 +736,7 @@ impl OverlayRenderer {
             last_show_vu: false,
             last_pgm_pip: u64::MAX - 2,
             last_pvw_pip: u64::MAX - 2,
+            last_pip_compose_hash: u64::MAX - 3,
         }
     }
 
@@ -700,6 +755,7 @@ impl OverlayRenderer {
         let clock_secs = h as u64 * 3600 + m as u64 * 60 + s as u64;
         let show_vu = self.state.show_vu_meters();
         let meters_hash = if show_vu { hash_meters(&self.state) } else { 0 };
+        let pip_compose_hash = hash_pip_compose(&self.state);
 
         let dirty = self.last_pgm != pgm_packed
             || self.last_pvw != pvw_packed
@@ -708,7 +764,8 @@ impl OverlayRenderer {
             || self.last_pvw_pip != pvw_pip_packed
             || self.last_clock_secs != clock_secs
             || self.last_show_vu != show_vu
-            || (show_vu && self.last_meters_hash != meters_hash);
+            || (show_vu && self.last_meters_hash != meters_hash)
+            || self.last_pip_compose_hash != pip_compose_hash;
 
         if dirty {
             let pgm = (pgm_packed != NO_SOURCE).then_some(pgm_packed as usize);
@@ -735,6 +792,7 @@ impl OverlayRenderer {
                 self.last_clock_secs = clock_secs;
                 self.last_show_vu = show_vu;
                 self.last_meters_hash = meters_hash;
+                self.last_pip_compose_hash = pip_compose_hash;
             }
             pushed
         } else {
@@ -975,6 +1033,59 @@ pub fn start_overlay_timer(
         });
 }
 
+/// Collect the input indices that contribute to a PiP composition (background
+/// plus all zone sources). Used to determine which thumbnails should be
+/// highlighted as "visible indirectly via this PiP".
+fn collect_pip_inputs(state: &VisionMixerOverlayState, pip_idx: Option<usize>) -> Vec<usize> {
+    let mut out = Vec::new();
+    let Some(idx) = pip_idx else {
+        return out;
+    };
+    if let Some(bg) = state.pip_bg_input(idx) {
+        out.push(bg);
+    }
+    for zone in state.pip_zones(idx) {
+        for &src in zone.effective_sources() {
+            if !out.contains(&src) {
+                out.push(src);
+            }
+        }
+    }
+    out
+}
+
+/// Draw concentric border rings around `rect`. Colors are ordered weakest → strongest;
+/// the first colour becomes the outermost ring, the last colour the innermost.
+/// Each ring uses `line_width` and sits flush against the next so total border
+/// width grows linearly with `colors.len()`.
+///
+/// Centralising the stroke logic here keeps it cheap to switch later to a
+/// different presentation (dashed alternation, sectioned borders, etc.).
+fn draw_status_border(
+    cr: &cairo::Context,
+    rect: &super::layout::Rect,
+    line_width: f64,
+    colors: &[(f64, f64, f64)],
+) {
+    if colors.is_empty() {
+        return;
+    }
+    cr.set_line_width(line_width);
+    for (k, &(r, g, b)) in colors.iter().enumerate() {
+        let inset = k as f64 * line_width;
+        let x = rect.x + inset;
+        let y = rect.y + inset;
+        let w = rect.w - 2.0 * inset;
+        let h = rect.h - 2.0 * inset;
+        if w <= 0.0 || h <= 0.0 {
+            break;
+        }
+        cr.set_source_rgb(r, g, b);
+        cr.rectangle(x, y, w, h);
+        let _ = cr.stroke();
+    }
+}
+
 /// Render overlay content to a cairo context (called only when state changes).
 #[allow(clippy::too_many_arguments)]
 fn render_overlay(
@@ -1003,26 +1114,45 @@ fn render_overlay(
     cr.rectangle(r.x, r.y, r.w, r.h);
     let _ = cr.stroke();
 
+    // PiPs currently on PGM/PVW determine which thumbnails get a via-PiP
+    // status ring. Collect their participating input indices once.
+    let pgm_pip_idx = state.pgm_pip();
+    let pvw_pip_idx = state.pvw_pip();
+    let via_pgm_pip = collect_pip_inputs(state, pgm_pip_idx);
+    let via_pvw_pip = collect_pip_inputs(state, pvw_pip_idx);
+
     // --- Thumbnail borders (drawn around full slot including label area) ---
+    // Status rings in weak→strong order: indirect-PVW (dark green), indirect-PGM
+    // (dark red), direct-PVW (green), direct-PGM (red). PGM ends up innermost.
+    let mut colors: Vec<(f64, f64, f64)> = Vec::with_capacity(4);
     for i in 0..layout.num_inputs.min(layout.thumbnail_slot_rects.len()) {
-        let r = &layout.thumbnail_slot_rects[i];
-        if pgm == Some(i) {
-            cr.set_source_rgb(PGM_R, PGM_G, PGM_B);
-        } else if pvw == Some(i) {
-            cr.set_source_rgb(PVW_R, PVW_G, PVW_B);
-        } else {
-            cr.set_source_rgb(GRAY, GRAY, GRAY);
+        colors.clear();
+        if via_pvw_pip.contains(&i) {
+            colors.push((PVW_VIA_PIP_R, PVW_VIA_PIP_G, PVW_VIA_PIP_B));
         }
-        cr.set_line_width(layout.thumb_border_width);
-        cr.rectangle(r.x, r.y, r.w, r.h);
-        let _ = cr.stroke();
+        if via_pgm_pip.contains(&i) {
+            colors.push((PGM_VIA_PIP_R, PGM_VIA_PIP_G, PGM_VIA_PIP_B));
+        }
+        if pvw == Some(i) {
+            colors.push((PVW_R, PVW_G, PVW_B));
+        }
+        if pgm == Some(i) {
+            colors.push((PGM_R, PGM_G, PGM_B));
+        }
+        if colors.is_empty() {
+            colors.push((GRAY, GRAY, GRAY));
+        }
+        draw_status_border(
+            cr,
+            &layout.thumbnail_slot_rects[i],
+            layout.thumb_border_width,
+            &colors,
+        );
     }
 
     // --- PiP tile borders ---
     // Mirror the thumbnail color scheme: red if this PiP is on PGM, green if on
     // PVW, gray otherwise. PGM wins over PVW if both somehow apply.
-    let pgm_pip_idx = state.pgm_pip();
-    let pvw_pip_idx = state.pvw_pip();
     for (i, r) in layout
         .pip_tile_slot_rects
         .iter()

--- a/backend/static/vision-mixer.html
+++ b/backend/static/vision-mixer.html
@@ -953,7 +953,7 @@
             <span class="conn-dot" id="wsDot" title="WebSocket control">WS</span>
         </div>
         <span class="status-text" id="statusText">Connecting...</span>
-        <span class="shortcut-hint">v2.16-bus-cleanup | 1-9,0 = PVW | Space = AUTO | X = CUT | F = FTB | M = Hide</span>
+        <span class="shortcut-hint">v2.17-bus-cleanup | 1-9,0 = PVW | Space = AUTO | X = CUT | F = FTB | M = Hide</span>
     </div>
 
     <!-- Server-injected configuration (safe JSON encoding) -->
@@ -1251,7 +1251,13 @@
             if (!pipCfg) return set;
             if (pipCfg.bg != null) set.add(pipCfg.bg);
             for (const zone of pipCfg.zones) {
-                for (const src of zone.sources) set.add(src);
+                // Mirror Rust `Zone::effective_sources`: cap to `capacity`,
+                // keeping the newest entries, so the bus tally and the
+                // multiview ring agree even if sources outgrow capacity.
+                const srcs = (zone.capacity != null && zone.capacity < zone.sources.length)
+                    ? zone.sources.slice(zone.sources.length - zone.capacity)
+                    : zone.sources;
+                for (const src of srcs) set.add(src);
             }
             return set;
         }
@@ -1905,10 +1911,6 @@
             }
             return { value: bestPos, anchor: bestAnchor };
         }
-
-        // Thin wrappers preserved for any call sites that only need the value.
-        function snapEdge(v) { return snapEdgeDetect(v).value; }
-        function snapMoveAxis(pos, size) { return snapMoveAxisDetect(pos, size).value; }
 
         // Highlight the grid line for a given (axis, anchor). axis is 'x' for
         // a vertical line, 'y' for a horizontal one. Looks up the DOM element

--- a/backend/static/vision-mixer.html
+++ b/backend/static/vision-mixer.html
@@ -125,6 +125,25 @@
             color: #999;
         }
 
+        /* "Via PiP" tally: an input is visible on this bus indirectly because
+           the PiP currently on the bus uses it as bg or as a zone source.
+           Dimmer hue than the direct active tally so the eye still ranks
+           "direct > via-pip" at a glance. Matches the multiview thumbnail
+           rings in overlay.rs (PGM_VIA_PIP / PVW_VIA_PIP).
+           Declared BEFORE the direct .pgm-active / .pvw-active blocks so the
+           direct tally wins on equal specificity — JS keeps them mutually
+           exclusive today, but the source order is the safety net. */
+        .src-btn.pgm-via-pip {
+            background: #4a0000;
+            border-color: #8c0000;
+            color: #f0bbbb;
+        }
+        .src-btn.pvw-via-pip {
+            background: #002a00;
+            border-color: #008c00;
+            color: #bbf0bb;
+        }
+
         .src-btn.pgm-active {
             background: #cc0000;
             border-color: #ff3333;
@@ -137,22 +156,6 @@
             border-color: #33cc33;
             color: #fff;
             box-shadow: 0 0 8px rgba(0, 255, 0, 0.3);
-        }
-
-        /* "Via PiP" tally: an input is visible on this bus indirectly because
-           the PiP currently on the bus uses it as bg or as a zone source.
-           Dimmer hue than the direct active tally so the eye still ranks
-           "direct > via-pip" at a glance. Matches the multiview thumbnail
-           rings in overlay.rs (PGM_VIA_PIP / PVW_VIA_PIP). */
-        .src-btn.pgm-via-pip {
-            background: #4a0000;
-            border-color: #8c0000;
-            color: #f0bbbb;
-        }
-        .src-btn.pvw-via-pip {
-            background: #002a00;
-            border-color: #008c00;
-            color: #bbf0bb;
         }
 
         /* Transition section */
@@ -950,7 +953,7 @@
             <span class="conn-dot" id="wsDot" title="WebSocket control">WS</span>
         </div>
         <span class="status-text" id="statusText">Connecting...</span>
-        <span class="shortcut-hint">v2.15-via-pip-tally | 1-9,0 = PVW | Space = AUTO | X = CUT | F = FTB | M = Hide</span>
+        <span class="shortcut-hint">v2.16-bus-cleanup | 1-9,0 = PVW | Space = AUTO | X = CUT | F = FTB | M = Hide</span>
     </div>
 
     <!-- Server-injected configuration (safe JSON encoding) -->
@@ -1310,7 +1313,7 @@
                 const pgmBtn = document.createElement('div');
                 pgmBtn.className = 'src-btn indicator' + (currentPgm === i ? ' pgm-active' : '');
                 pgmBtn.textContent = btnText;
-                pgmBtn.title = label + ' — on PGM';
+                pgmBtn.title = label;
                 pgmBus.appendChild(pgmBtn);
 
                 // PVW button (single select). Multi-source layouts are built via PiPs.
@@ -1334,7 +1337,7 @@
                 const pgmPipBtn = document.createElement('div');
                 pgmPipBtn.className = 'pip-btn indicator' + (currentPgmPip === p ? ' pgm-active' : '');
                 pgmPipBtn.textContent = labelText;
-                pgmPipBtn.title = 'PiP ' + (p + 1) + ' on PGM';
+                pgmPipBtn.title = 'PiP ' + (p + 1);
                 pgmBus.appendChild(pgmPipBtn);
 
                 const pvwPipBtn = document.createElement('button');

--- a/backend/static/vision-mixer.html
+++ b/backend/static/vision-mixer.html
@@ -634,6 +634,79 @@
             font-size: 11px;
             font-weight: 600;
         }
+        /* Pixel-precise rect editor for the active zone. Two rows of two
+           inputs — X/Y above, W/H below — sized to fit the 220px toolbar. */
+        .pip-zone-px-row {
+            display: flex;
+            align-items: center;
+            gap: 4px;
+            color: var(--pip-text-dim);
+        }
+        .pip-zone-px-label {
+            font-size: 11px;
+            font-weight: 600;
+            width: 10px;
+            text-align: center;
+        }
+        .pip-zone-px-input {
+            width: 64px;
+            height: 24px;
+            background: var(--pip-bg-control);
+            border: 1px solid var(--pip-border-strong);
+            border-radius: 3px;
+            color: var(--pip-text);
+            padding: 0 6px;
+            font-size: 11px;
+            font-weight: 600;
+        }
+        .pip-zone-px-input:disabled {
+            opacity: 0.4;
+            cursor: not-allowed;
+        }
+        /* Snap + grid toggle checkboxes for the layout editor. */
+        .pip-zone-toggle-row {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            color: var(--pip-text-dim);
+            font-size: 11px;
+        }
+        .pip-zone-toggle {
+            display: inline-flex;
+            align-items: center;
+            gap: 4px;
+            cursor: pointer;
+            user-select: none;
+        }
+        .pip-zone-toggle input[type="checkbox"] {
+            cursor: pointer;
+            margin: 0;
+        }
+        /* Grid overlay drawn on top of the canvas BG and under the zone rects.
+           Quarter lines stay subtle (white) so layouts dominate visually;
+           rule-of-thirds lines pop slightly (gold) to read at a glance. */
+        .pip-canvas-grid {
+            position: absolute;
+            inset: 0;
+            pointer-events: none;
+            z-index: 1;
+        }
+        .pip-grid-line {
+            position: absolute;
+        }
+        .pip-grid-line.v { top: 0; bottom: 0; width: 1px; }
+        .pip-grid-line.h { left: 0; right: 0; height: 1px; }
+        .pip-grid-line.quarter { background: rgba(255, 255, 255, 0.14); }
+        .pip-grid-line.third { background: rgba(255, 200, 80, 0.45); }
+        /* Lit-up while a drag/resize/px-input lands on this line. Bumped to a
+           2px solid bright cyan with a faint glow so it pops above both the
+           subtle quarter and the gold third base colors. */
+        .pip-grid-line.active-snap {
+            background: rgba(120, 230, 255, 0.95);
+            box-shadow: 0 0 6px rgba(120, 230, 255, 0.7);
+        }
+        .pip-grid-line.active-snap.v { width: 2px; margin-left: -0.5px; }
+        .pip-grid-line.active-snap.h { height: 2px; margin-top: -0.5px; }
         .pip-canvas-hint {
             font-size: 10px;
             font-weight: 400;
@@ -846,7 +919,7 @@
             <span class="conn-dot" id="wsDot" title="WebSocket control">WS</span>
         </div>
         <span class="status-text" id="statusText">Connecting...</span>
-        <span class="shortcut-hint">v2.10-zones | 1-9,0 = PVW | Space = AUTO | X = CUT | F = FTB | M = Hide</span>
+        <span class="shortcut-hint">v2.13-snap-glow | 1-9,0 = PVW | Space = AUTO | X = CUT | F = FTB | M = Hide</span>
     </div>
 
     <!-- Server-injected configuration (safe JSON encoding) -->
@@ -864,6 +937,12 @@
         const INPUT_LABELS = _cfg.input_labels;
         const NUM_DSK_INPUTS = _cfg.num_dsk_inputs || 0;
         const NUM_PIPS = _cfg.num_pips || 0;
+        // PGM canvas size in pixels. Zone rects are stored normalized (0..1) so
+        // they project cleanly into the multiview tile, big-PVW rect, and the
+        // PGM/PVW outputs alike. The pixel input fields display values in PGM
+        // coordinates because that's the broadcast canvas operators think in.
+        const PGM_W = (_cfg.pgm_w && _cfg.pgm_w > 0) ? _cfg.pgm_w : 1920;
+        const PGM_H = (_cfg.pgm_h && _cfg.pgm_h > 0) ? _cfg.pgm_h : 1080;
 
         // ---- State ----
         // PGM/PVW source: each bus shows either an input (number) or a PiP (currentPvwPip/currentPgmPip).
@@ -905,6 +984,21 @@
         let ftbActive = _cfg.ftb_active || false;
         let overlayAlpha = _cfg.overlay_alpha != null ? _cfg.overlay_alpha : 1.0;
         let controlsMinimized = localStorage.getItem('vm-controls-minimized') === 'true';
+        // Snap & grid toggles for the zone layout editor. Snap defaults ON
+        // (preserves the original drag behavior); grid defaults OFF so the
+        // editor stays visually clean unless the operator wants the guides.
+        let snapEnabled = localStorage.getItem('vm-zone-snap') !== 'false';
+        let gridVisible = localStorage.getItem('vm-zone-grid') === 'true';
+        function toggleSnap() {
+            snapEnabled = !snapEnabled;
+            localStorage.setItem('vm-zone-snap', snapEnabled);
+            buildPipConfigPanel();
+        }
+        function toggleGrid() {
+            gridVisible = !gridVisible;
+            localStorage.setItem('vm-zone-grid', gridVisible);
+            buildPipConfigPanel();
+        }
 
         function toggleMinimize() {
             controlsMinimized = !controlsMinimized;
@@ -1316,6 +1410,47 @@
             postPipConfig(pipIdx);
         }
 
+        // Update one component of an explicit (non-auto) zone rect from a pixel
+        // value entered into the X/Y/W/H toolbar inputs. Pixel values are in PGM
+        // canvas coordinates (PGM_W × PGM_H); we divide by the same dimension
+        // the backend uses on the way back (NormRect::to_pixels), so a round-trip
+        // through px → norm → px lands on the same integer pixel.
+        //
+        // Position fields (x, y) preserve the current size; size fields (w, h)
+        // preserve the current position. Out-of-range entries are clamped to
+        // keep the rect inside [0,1].
+        function setZoneRectPx(pipIdx, zoneIdx, field, pixelValue) {
+            const zone = pipConfigs[pipIdx].zones[zoneIdx];
+            if (!zone || !zone.rect) return;
+            const parsed = parseFloat(pixelValue);
+            if (!Number.isFinite(parsed)) return;
+            const dim = (field === 'x' || field === 'w') ? PGM_W : PGM_H;
+            // Snap the input value to a nearby anchor when snap is on. The
+            // Detect variant also returns which anchor was hit so we can
+            // flash the matching grid line during the network roundtrip
+            // (postPipConfig rebuilds the panel on response and wipes the
+            // highlight naturally).
+            const res = snapEdgeDetect(parsed / dim);
+            const norm = res.value;
+            const next = { ...zone.rect };
+            if (field === 'x') {
+                next.x = Math.max(0, Math.min(1 - next.w, norm));
+            } else if (field === 'y') {
+                next.y = Math.max(0, Math.min(1 - next.h, norm));
+            } else if (field === 'w') {
+                next.w = Math.max(1 / PGM_W, Math.min(1 - next.x, norm));
+            } else if (field === 'h') {
+                next.h = Math.max(1 / PGM_H, Math.min(1 - next.y, norm));
+            }
+            zone.rect = next;
+            if (res.anchor != null) {
+                const canvas = document.querySelector('.pip-canvas[data-pip="' + pipIdx + '"]');
+                const axis = (field === 'x' || field === 'w') ? 'x' : 'y';
+                showSnapHighlight(canvas, axis, res.anchor);
+            }
+            postPipConfig(pipIdx);
+        }
+
         function buildPipConfigPanel() {
             const panel = document.getElementById('pipConfigPanel');
             if (NUM_PIPS === 0) {
@@ -1414,6 +1549,31 @@
                     ? ('BG: ' + (INPUT_LABELS[cfg.bg] || ('Input ' + (cfg.bg + 1))))
                     : '(no background)';
                 canvas.appendChild(bgDiv);
+
+                // Optional grid overlay: vertical + horizontal lines at every
+                // snap anchor. Thirds get a brighter (gold) line so the rule-
+                // of-thirds intersections read at a glance; quarters stay
+                // subtle. Sits above the BG fill and below the zones.
+                if (gridVisible) {
+                    const grid = document.createElement('div');
+                    grid.className = 'pip-canvas-grid';
+                    SNAP_ANCHORS.forEach(a => {
+                        if (a === 0 || a === 1) return; // edges are the canvas border
+                        const isThird = SNAP_THIRDS.some(t => Math.abs(t - a) < 1e-6);
+                        const cls = 'pip-grid-line ' + (isThird ? 'third' : 'quarter');
+                        const vl = document.createElement('div');
+                        vl.className = cls + ' v';
+                        vl.style.left = (a * 100) + '%';
+                        vl.dataset.anchor = String(a);
+                        grid.appendChild(vl);
+                        const hl = document.createElement('div');
+                        hl.className = cls + ' h';
+                        hl.style.top = (a * 100) + '%';
+                        hl.dataset.anchor = String(a);
+                        grid.appendChild(hl);
+                    });
+                    canvas.appendChild(grid);
+                }
 
                 cfg.zones.forEach((zone, zi) => {
                     const isAuto = zone.rect == null;
@@ -1525,6 +1685,33 @@
                 addBtn.onclick = () => addZone(p);
                 toolbar.appendChild(addBtn);
 
+                // Snap + grid toggles. Affect drag, px-input, and the optional
+                // overlay rendered above. State persists across reloads via
+                // localStorage (see snapEnabled / gridVisible).
+                const toggleRow = document.createElement('div');
+                toggleRow.className = 'pip-zone-toggle-row';
+                const snapLabel = document.createElement('label');
+                snapLabel.className = 'pip-zone-toggle';
+                const snapCb = document.createElement('input');
+                snapCb.type = 'checkbox';
+                snapCb.checked = snapEnabled;
+                snapCb.onchange = () => toggleSnap();
+                snapLabel.appendChild(snapCb);
+                snapLabel.append(' Snap');
+                snapLabel.title = 'Snap drag and pixel input to quarters and rule-of-thirds';
+                toggleRow.appendChild(snapLabel);
+                const gridLabel = document.createElement('label');
+                gridLabel.className = 'pip-zone-toggle';
+                const gridCb = document.createElement('input');
+                gridCb.type = 'checkbox';
+                gridCb.checked = gridVisible;
+                gridCb.onchange = () => toggleGrid();
+                gridLabel.appendChild(gridCb);
+                gridLabel.append(' Grid');
+                gridLabel.title = 'Show quarter (white) and rule-of-thirds (gold) guide lines';
+                toggleRow.appendChild(gridLabel);
+                toolbar.appendChild(toggleRow);
+
                 if (cfg.zones.length > 0) {
                     const zi = Math.min(activeZoneIdx[p], cfg.zones.length - 1);
                     const zone = cfg.zones[zi];
@@ -1540,11 +1727,70 @@
                     capInput.onchange = () => setZoneCapacity(p, zi, capInput.value);
                     capRow.appendChild(capInput);
                     toolbar.appendChild(capRow);
+
+                    // Pixel-precise rect editor for the active zone. Values are
+                    // in PGM canvas coordinates and round-trip through the same
+                    // formula the backend uses (NormRect::to_pixels). Disabled
+                    // for auto zones — right-click the zone to promote it to a
+                    // manual rect first.
+                    const isAuto = zone.rect == null;
+                    const pxRect = isAuto
+                        ? { x: 0, y: 0, w: PGM_W, h: PGM_H }
+                        : {
+                            x: Math.round(zone.rect.x * PGM_W),
+                            y: Math.round(zone.rect.y * PGM_H),
+                            w: Math.round(zone.rect.w * PGM_W),
+                            h: Math.round(zone.rect.h * PGM_H),
+                        };
+
+                    const mkPxInput = (field, max) => {
+                        const inp = document.createElement('input');
+                        inp.className = 'pip-zone-px-input';
+                        inp.type = 'number';
+                        inp.min = (field === 'w' || field === 'h') ? '1' : '0';
+                        inp.max = String(max);
+                        inp.step = '1';
+                        inp.value = String(pxRect[field]);
+                        inp.disabled = isAuto;
+                        inp.title = isAuto
+                            ? 'Auto-tile mode — right-click the zone to set a manual rect'
+                            : (field.toUpperCase() + ' in PGM pixels (' + PGM_W + '×' + PGM_H + ')');
+                        inp.onchange = () => setZoneRectPx(p, zi, field, inp.value);
+                        return inp;
+                    };
+
+                    const pxRow1 = document.createElement('div');
+                    pxRow1.className = 'pip-zone-px-row';
+                    const xLabel = document.createElement('span');
+                    xLabel.className = 'pip-zone-px-label';
+                    xLabel.textContent = 'X';
+                    pxRow1.appendChild(xLabel);
+                    pxRow1.appendChild(mkPxInput('x', PGM_W));
+                    const yLabel = document.createElement('span');
+                    yLabel.className = 'pip-zone-px-label';
+                    yLabel.textContent = 'Y';
+                    pxRow1.appendChild(yLabel);
+                    pxRow1.appendChild(mkPxInput('y', PGM_H));
+                    toolbar.appendChild(pxRow1);
+
+                    const pxRow2 = document.createElement('div');
+                    pxRow2.className = 'pip-zone-px-row';
+                    const wLabel = document.createElement('span');
+                    wLabel.className = 'pip-zone-px-label';
+                    wLabel.textContent = 'W';
+                    pxRow2.appendChild(wLabel);
+                    pxRow2.appendChild(mkPxInput('w', PGM_W));
+                    const hLabel = document.createElement('span');
+                    hLabel.className = 'pip-zone-px-label';
+                    hLabel.textContent = 'H';
+                    pxRow2.appendChild(hLabel);
+                    pxRow2.appendChild(mkPxInput('h', PGM_H));
+                    toolbar.appendChild(pxRow2);
                 }
 
                 const hint = document.createElement('div');
                 hint.className = 'pip-canvas-hint';
-                hint.innerHTML = 'Click a zone to activate. Push-chip adds the input to the active zone (oldest evicts at cap). Chip inside a zone = remove. Right-click a zone to toggle auto / manual rect.';
+                hint.innerHTML = 'Click a zone to activate. Push-chip adds the input to the active zone (oldest evicts at cap). Chip inside a zone = remove. Right-click a zone to toggle auto / manual rect. X/Y/W/H inputs are in PGM pixels.';
                 toolbar.appendChild(hint);
                 canvasWrap.appendChild(toolbar);
                 editor.appendChild(canvasWrap);
@@ -1554,34 +1800,70 @@
             }
         }
 
-        // Snap anchors for layout rects (edges, halves, quarters).
-        const SNAP_ANCHORS = [0, 0.25, 0.5, 0.75, 1];
+        // Snap anchors for layout rects: edges, quarters, and rule-of-thirds.
+        // Thirds (1/3, 2/3) are broadcast composition guides — placing a PiP
+        // overlay on a third often reads better than dead-center. Quarters
+        // are kept for symmetric splits (left/right half, exact center).
+        const SNAP_QUARTERS = [0.25, 0.5, 0.75];
+        const SNAP_THIRDS = [1 / 3, 2 / 3];
+        const SNAP_ANCHORS = [0, ...SNAP_QUARTERS, ...SNAP_THIRDS, 1].sort((a, b) => a - b);
         const SNAP_TOL = 0.022; // ~10px on a 480-px canvas; tight enough to not fight free dragging
 
-        // Snap a single coordinate to nearby anchors. Used when resizing — only
-        // the corner being dragged snaps; the opposite corner stays put.
-        function snapEdge(v) {
+        // Snap a single coordinate to a nearby anchor. Returns the snapped
+        // value plus the matched anchor (null when no snap happens or when
+        // snapping is disabled). Caller passes `anchor` to showSnapHighlight
+        // so the user sees which guide line locked the value in.
+        function snapEdgeDetect(v) {
+            if (!snapEnabled) return { value: v, anchor: null };
             for (const a of SNAP_ANCHORS) {
-                if (Math.abs(v - a) < SNAP_TOL) return a;
+                if (Math.abs(v - a) < SNAP_TOL) return { value: a, anchor: a };
             }
-            return v;
+            return { value: v, anchor: null };
         }
 
-        // Snap a moving rect along one axis to whichever of {left edge, right edge,
-        // center} is closest to a snap anchor. Lets a centered rect "dent" into
-        // the canvas center, and lets the right/bottom edge dock against an anchor.
-        function snapMoveAxis(pos, size) {
+        // Snap a moving rect along one axis to whichever of {left edge, right
+        // edge, center} is closest to a snap anchor. Returns the snapped
+        // position plus the matched anchor so the caller can light it up.
+        function snapMoveAxisDetect(pos, size) {
+            if (!snapEnabled) return { value: pos, anchor: null };
             let bestDelta = SNAP_TOL;
             let bestPos = pos;
+            let bestAnchor = null;
             for (const a of SNAP_ANCHORS) {
                 const d1 = Math.abs(a - pos);
-                if (d1 < bestDelta) { bestDelta = d1; bestPos = a; }
+                if (d1 < bestDelta) { bestDelta = d1; bestPos = a; bestAnchor = a; }
                 const d2 = Math.abs(a - (pos + size));
-                if (d2 < bestDelta) { bestDelta = d2; bestPos = a - size; }
+                if (d2 < bestDelta) { bestDelta = d2; bestPos = a - size; bestAnchor = a; }
                 const d3 = Math.abs(a - (pos + size / 2));
-                if (d3 < bestDelta) { bestDelta = d3; bestPos = a - size / 2; }
+                if (d3 < bestDelta) { bestDelta = d3; bestPos = a - size / 2; bestAnchor = a; }
             }
-            return bestPos;
+            return { value: bestPos, anchor: bestAnchor };
+        }
+
+        // Thin wrappers preserved for any call sites that only need the value.
+        function snapEdge(v) { return snapEdgeDetect(v).value; }
+        function snapMoveAxis(pos, size) { return snapMoveAxisDetect(pos, size).value; }
+
+        // Highlight the grid line for a given (axis, anchor). axis is 'x' for
+        // a vertical line, 'y' for a horizontal one. Looks up the DOM element
+        // by data-anchor; silently no-ops when grid lines aren't rendered
+        // (gridVisible off) — the snap still happens, just without the cue.
+        function showSnapHighlight(canvas, axis, anchor) {
+            if (!canvas || anchor == null) return;
+            const cls = axis === 'x' ? '.pip-grid-line.v' : '.pip-grid-line.h';
+            const lines = canvas.querySelectorAll(cls);
+            for (const el of lines) {
+                if (Math.abs(parseFloat(el.dataset.anchor) - anchor) < 1e-6) {
+                    el.classList.add('active-snap');
+                    return;
+                }
+            }
+        }
+
+        function clearSnapHighlights(canvas) {
+            if (!canvas) return;
+            canvas.querySelectorAll('.pip-grid-line.active-snap')
+                .forEach(el => el.classList.remove('active-snap'));
         }
 
         // Drag-and-resize handler for a zone. Promotes auto zones to explicit
@@ -1609,31 +1891,58 @@
                     const dx = (ev.clientX - startX) / canvasRect.width;
                     const dy = (ev.clientY - startY) / canvasRect.height;
                     let next = { ...initial };
+                    // Track which anchor (if any) each axis snapped to so we
+                    // can light up the matching grid line. Move snaps once
+                    // per axis; resize snaps the dragged edges (which may be
+                    // left or right, top or bottom depending on the corner).
+                    let snapX = null;
+                    let snapY = null;
                     if (!corner) {
                         // Move: snap to whichever of {left, right, center} is closest
                         // to an anchor — gives a satisfying detent at canvas-center.
-                        next.x = snapMoveAxis(initial.x + dx, initial.w);
-                        next.y = snapMoveAxis(initial.y + dy, initial.h);
+                        const sx = snapMoveAxisDetect(initial.x + dx, initial.w);
+                        const sy = snapMoveAxisDetect(initial.y + dy, initial.h);
+                        next.x = sx.value;
+                        next.y = sy.value;
+                        snapX = sx.anchor;
+                        snapY = sy.anchor;
                     } else {
-                        // Resize: only the dragged corner snaps to anchors.
+                        // Resize: only the dragged corner snaps. The anchor each
+                        // dragged edge lands on is what we light up.
                         const right = initial.x + initial.w;
                         const bottom = initial.y + initial.h;
                         if (corner === 'nw') {
-                            next.x = snapEdge(initial.x + dx);
-                            next.y = snapEdge(initial.y + dy);
+                            const sx = snapEdgeDetect(initial.x + dx);
+                            const sy = snapEdgeDetect(initial.y + dy);
+                            next.x = sx.value;
+                            next.y = sy.value;
                             next.w = right - next.x;
                             next.h = bottom - next.y;
+                            snapX = sx.anchor;
+                            snapY = sy.anchor;
                         } else if (corner === 'ne') {
-                            next.y = snapEdge(initial.y + dy);
-                            next.w = snapEdge(right + dx) - initial.x;
+                            const sy = snapEdgeDetect(initial.y + dy);
+                            const sr = snapEdgeDetect(right + dx);
+                            next.y = sy.value;
+                            next.w = sr.value - initial.x;
                             next.h = bottom - next.y;
+                            snapX = sr.anchor;
+                            snapY = sy.anchor;
                         } else if (corner === 'sw') {
-                            next.x = snapEdge(initial.x + dx);
+                            const sx = snapEdgeDetect(initial.x + dx);
+                            const sb = snapEdgeDetect(bottom + dy);
+                            next.x = sx.value;
                             next.w = right - next.x;
-                            next.h = snapEdge(bottom + dy) - initial.y;
+                            next.h = sb.value - initial.y;
+                            snapX = sx.anchor;
+                            snapY = sb.anchor;
                         } else if (corner === 'se') {
-                            next.w = snapEdge(right + dx) - initial.x;
-                            next.h = snapEdge(bottom + dy) - initial.y;
+                            const sr = snapEdgeDetect(right + dx);
+                            const sb = snapEdgeDetect(bottom + dy);
+                            next.w = sr.value - initial.x;
+                            next.h = sb.value - initial.y;
+                            snapX = sr.anchor;
+                            snapY = sb.anchor;
                         }
                     }
                     next.w = Math.max(0.05, Math.min(1, next.w));
@@ -1650,10 +1959,16 @@
                     zoneEl.style.top = (next.y * 100) + '%';
                     zoneEl.style.width = (next.w * 100) + '%';
                     zoneEl.style.height = (next.h * 100) + '%';
+                    // Update snap-line highlights. Clears any stale highlight
+                    // first so a line doesn't stay lit after the snap is lost.
+                    clearSnapHighlights(canvas);
+                    showSnapHighlight(canvas, 'x', snapX);
+                    showSnapHighlight(canvas, 'y', snapY);
                 };
                 const onUp = () => {
                     document.removeEventListener('mousemove', onMove);
                     document.removeEventListener('mouseup', onUp);
+                    clearSnapHighlights(canvas);
                     if (dirty) postPipConfig(pipIdx);
                 };
                 document.addEventListener('mousemove', onMove);

--- a/backend/static/vision-mixer.html
+++ b/backend/static/vision-mixer.html
@@ -109,6 +109,21 @@
         .src-btn:focus {
             outline: none;
         }
+        /* Indicator variant used by the PGM bus — display only, no click.
+           Removes the pointer cursor + hover affordance so it doesn't look
+           interactive. The active (red) tally still shows what's on air. */
+        .src-btn.indicator,
+        .pip-btn.indicator {
+            cursor: default;
+        }
+        .src-btn.indicator:hover {
+            border-color: #444;
+            color: #999;
+        }
+        .pip-btn.indicator:hover {
+            border-color: #555;
+            color: #999;
+        }
 
         .src-btn.pgm-active {
             background: #cc0000;
@@ -122,6 +137,22 @@
             border-color: #33cc33;
             color: #fff;
             box-shadow: 0 0 8px rgba(0, 255, 0, 0.3);
+        }
+
+        /* "Via PiP" tally: an input is visible on this bus indirectly because
+           the PiP currently on the bus uses it as bg or as a zone source.
+           Dimmer hue than the direct active tally so the eye still ranks
+           "direct > via-pip" at a glance. Matches the multiview thumbnail
+           rings in overlay.rs (PGM_VIA_PIP / PVW_VIA_PIP). */
+        .src-btn.pgm-via-pip {
+            background: #4a0000;
+            border-color: #8c0000;
+            color: #f0bbbb;
+        }
+        .src-btn.pvw-via-pip {
+            background: #002a00;
+            border-color: #008c00;
+            color: #bbf0bb;
         }
 
         /* Transition section */
@@ -919,7 +950,7 @@
             <span class="conn-dot" id="wsDot" title="WebSocket control">WS</span>
         </div>
         <span class="status-text" id="statusText">Connecting...</span>
-        <span class="shortcut-hint">v2.13-snap-glow | 1-9,0 = PVW | Space = AUTO | X = CUT | F = FTB | M = Hide</span>
+        <span class="shortcut-hint">v2.15-via-pip-tally | 1-9,0 = PVW | Space = AUTO | X = CUT | F = FTB | M = Hide</span>
     </div>
 
     <!-- Server-injected configuration (safe JSON encoding) -->
@@ -1209,12 +1240,37 @@
         }
 
         // ---- UI update ----
+        // Inputs that participate in a PiP composition (bg + every zone source).
+        // Mirrors `collect_pip_inputs` in overlay.rs so the bus buttons and the
+        // multiview status rings agree on what "visible via this PiP" means.
+        function collectPipInputs(pipCfg) {
+            const set = new Set();
+            if (!pipCfg) return set;
+            if (pipCfg.bg != null) set.add(pipCfg.bg);
+            for (const zone of pipCfg.zones) {
+                for (const src of zone.sources) set.add(src);
+            }
+            return set;
+        }
+
         function updateButtons() {
+            // Inputs reachable through the PiP currently on each bus. Used to
+            // shade the input buttons with a dimmer tally — dark red on PGM,
+            // dark green on PVW — matching the multiview thumbnail rings.
+            const pgmViaPip = currentPgmPip != null
+                ? collectPipInputs(pipConfigs[currentPgmPip])
+                : new Set();
+            const pvwViaPip = currentPvwPip != null
+                ? collectPipInputs(pipConfigs[currentPvwPip])
+                : new Set();
+
             document.querySelectorAll('#pgmBus .src-btn').forEach((btn, i) => {
                 btn.classList.toggle('pgm-active', currentPgm === i && currentPgmPip == null);
+                btn.classList.toggle('pgm-via-pip', pgmViaPip.has(i));
             });
             document.querySelectorAll('#pvwBus .src-btn').forEach((btn, i) => {
                 btn.classList.toggle('pvw-active', currentPvwPip == null && currentPvw === i);
+                btn.classList.toggle('pvw-via-pip', pvwViaPip.has(i));
             });
             document.querySelectorAll('#pgmBus .pip-btn').forEach((btn, i) => {
                 btn.classList.toggle('pgm-active', currentPgmPip === i);
@@ -1247,11 +1303,14 @@
                 const btnText = String(i + 1);
                 const keyHint = i < 9 ? (i + 1) : (i === 9 ? '0' : '');
 
-                // PGM button (display only)
-                const pgmBtn = document.createElement('button');
-                pgmBtn.className = 'src-btn' + (currentPgm === i ? ' pgm-active' : '');
+                // PGM indicator (display only — PGM changes via Take/Cut/Auto,
+                // never via direct click). A <div> with the indicator modifier
+                // strips the button affordance: no pointer cursor, no hover
+                // state, no tab focus, no keyboard activation.
+                const pgmBtn = document.createElement('div');
+                pgmBtn.className = 'src-btn indicator' + (currentPgm === i ? ' pgm-active' : '');
                 pgmBtn.textContent = btnText;
-                pgmBtn.title = label + (keyHint ? ' (' + keyHint + ')' : '');
+                pgmBtn.title = label + ' — on PGM';
                 pgmBus.appendChild(pgmBtn);
 
                 // PVW button (single select). Multi-source layouts are built via PiPs.
@@ -1271,10 +1330,11 @@
                 const labelText = slotNum + ' - PiP' + (p + 1);
                 const keyHint = slotNum <= 10 ? (slotNum === 10 ? '0' : String(slotNum)) : '';
 
-                const pgmPipBtn = document.createElement('button');
-                pgmPipBtn.className = 'pip-btn' + (currentPgmPip === p ? ' pgm-active' : '');
+                // PGM PiP indicator (display only — see PGM input indicator above).
+                const pgmPipBtn = document.createElement('div');
+                pgmPipBtn.className = 'pip-btn indicator' + (currentPgmPip === p ? ' pgm-active' : '');
                 pgmPipBtn.textContent = labelText;
-                pgmPipBtn.title = 'PiP ' + (p + 1) + ' on PGM' + (keyHint ? ' (' + keyHint + ')' : '');
+                pgmPipBtn.title = 'PiP ' + (p + 1) + ' on PGM';
                 pgmBus.appendChild(pgmPipBtn);
 
                 const pvwPipBtn = document.createElement('button');
@@ -1322,6 +1382,9 @@
                     activeZoneIdx[pipIdx] = nz - 1;
                 }
                 buildPipConfigPanel();
+                // The via-pip tally on the input buttons depends on this PiP's
+                // bg + zone sources, so refresh the buses too.
+                updateButtons();
                 setStatus(r.message);
             }).catch(e => setStatus('PiP config error: ' + e.message));
         }


### PR DESCRIPTION
## Summary

Four commits sharpening the vision mixer control page and multiview overlay:

- **Pixel zone editor** (61cefd3): X/Y/W/H inputs in PGM pixels alongside the visual canvas. Snap-to-grid toggle (quarters + rule-of-thirds), optional grid overlay, and an active-snap glow so the operator sees which guide line a drag, resize, or typed value locks onto.
- **Multiview via-PiP rings** (753de45): input thumbnails get a dark-red / dark-green status ring when the input is visible indirectly via the PiP on PGM / PVW. Concentric stacking when multiple states apply (PGM-direct always wins visually).
- **Honest bus UI** (213d032): PGM input + PiP buttons are now `<div>` indicators instead of `<button>` — they were never clickable (PGM only changes via Take/Cut/Auto), but their button shape advertised affordance they didn't have. PVW stays a real button. Inputs reachable via the bus PiP get the same dark-red / dark-green tally on the bus button as the multiview ring.
- **Follow-up fixes** (36845e7): drops misleading "on PGM" tooltips from every PGM indicator (color already conveys the state) and reorders the via-PiP / direct CSS blocks so the direct tally wins on equal specificity.

Only one backend change: `vision_mixer_page.rs` now exposes `pgm_w` / `pgm_h` in the page config so the pixel inputs can round-trip through the same dimensions the backend's `NormRect::to_pixels` uses. All other rect math stays in the page. The thumbnail ring work in 753de45 lives in `overlay.rs` and tracks a new dirty-hash over PiP composition so zone edits trigger re-render.

Data model and wire format are unchanged.

## Test plan

- [ ] Open vision mixer page on a flow with ≥1 PiP. Verify version string reads `v2.16-bus-cleanup`.
- [ ] Open a PiP layout editor. Confirm X/Y/W/H inputs appear under the cap field and reflect the current zone rect in PGM pixels.
- [ ] Toggle Snap off, drag a zone — verify free-drag without anchor pull.
- [ ] Toggle Grid on, drag a zone toward 1/3 / 1/2 / 2/3 — verify guide line glows cyan when snapped.
- [ ] Type `640` into the X field on a 1920-wide PGM — verify it snaps to 1/3 with a brief cyan flash.
- [ ] Put a PiP on PGM whose bg = Input 2 and one zone source = Input 5. Verify PGM bus indicators for Input 2 and Input 5 are dark red, and the PVW bus stays unaffected.
- [ ] Take that PiP to PVW instead — verify the dark-green tally appears on the PVW bus for the same inputs and clears from PGM.
- [ ] Hover a non-active PGM indicator — tooltip should read just `Input N`, not `Input N — on PGM`.
- [ ] Confirm multiview thumbnails show concentric rings matching bus state (dark red / dark green) when the input is in a bus PiP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)