### PR TITLE
fix(sources): deinterlace interlaced SRT/EFP inputs for the GL vision mixer

### DIFF
--- a/backend/src/blocks/builtin/decode_chain.rs
+++ b/backend/src/blocks/builtin/decode_chain.rs
@@ -11,13 +11,14 @@ use tracing::debug;
 /// Link a decoded raw-video source pad into the block's video output `identity`
 /// through a `deinterlace` element.
 ///
-/// The element starts in `mode=auto` and a one-shot CAPS-event probe upgrades it
-/// to `mode=interlaced` (force) when the negotiated `interlace-mode` is
-/// `interleaved` or `mixed`. Forcing is required because H.264 `mixed` streams
-/// report mixed caps without flagging individual buffers as interlaced, so
-/// `mode=auto` would silently pass everything through (relabelling to
-/// progressive) and leave visible combing. Genuinely progressive sources keep
-/// `mode=auto`, i.e. passthrough, so they are untouched.
+/// A one-shot CAPS-event probe pins the deinterlace mode from the negotiated
+/// `interlace-mode`: `interleaved`/`mixed` -> `mode=interlaced` (force),
+/// everything else -> `mode=disabled` (explicit passthrough). Forcing is
+/// required because H.264 `mixed` streams report mixed caps without flagging
+/// individual buffers as interlaced, so `mode=auto` would silently pass
+/// everything through (relabelling to progressive) and leave visible combing.
+/// Progressive sources use `disabled` rather than `auto` so a source marked
+/// progressive is never deinterlaced, even if a stray buffer is flagged.
 ///
 /// The probe reads the element from the pad itself, so its closure captures no
 /// GStreamer references — no circular-ref leak (see CLAUDE.md). EVENT probes
@@ -75,18 +76,15 @@ pub(crate) fn link_raw_video_through_deinterlace(
             interlace_mode.as_deref(),
             Some("interleaved") | Some("mixed")
         );
+        // Force deinterlacing for interlaced/mixed; explicit passthrough
+        // otherwise (never deinterlace a source marked progressive).
+        let mode = if interlaced { "interlaced" } else { "disabled" };
         if let Some(element) = pad.parent().and_then(|p| p.downcast::<gst::Element>().ok()) {
-            if interlaced {
-                element.set_property_from_str("mode", "interlaced");
-            }
+            element.set_property_from_str("mode", mode);
             debug!(
                 "{}: deinterlace mode={} (source interlace-mode={:?})",
                 element.name(),
-                if interlaced {
-                    "interlaced (forced)"
-                } else {
-                    "auto (passthrough)"
-                },
+                mode,
                 interlace_mode
             );
         }

--- a/backend/src/blocks/builtin/decode_chain.rs
+++ b/backend/src/blocks/builtin/decode_chain.rs
@@ -1,0 +1,108 @@
+//! Shared helpers for decoded-video chains in source blocks.
+//!
+//! Source blocks that decode H.264 to raw video feed the GL-based vision mixer,
+//! which rejects interlaced frames at `glupload`. Interlaced broadcast feeds
+//! (e.g. 1080i50) must therefore be deinterlaced in the source.
+
+use gstreamer as gst;
+use gstreamer::prelude::*;
+use tracing::debug;
+
+/// Link a decoded raw-video source pad into the block's video output `identity`
+/// through a `deinterlace` element.
+///
+/// The element starts in `mode=auto` and a one-shot CAPS-event probe upgrades it
+/// to `mode=interlaced` (force) when the negotiated `interlace-mode` is
+/// `interleaved` or `mixed`. Forcing is required because H.264 `mixed` streams
+/// report mixed caps without flagging individual buffers as interlaced, so
+/// `mode=auto` would silently pass everything through (relabelling to
+/// progressive) and leave visible combing. Genuinely progressive sources keep
+/// `mode=auto`, i.e. passthrough, so they are untouched.
+///
+/// The probe reads the element from the pad itself, so its closure captures no
+/// GStreamer references — no circular-ref leak (see CLAUDE.md). EVENT probes
+/// fire infrequently. Because the decision is driven by the CAPS event rather
+/// than caps-at-link-time, this works for both decodebin pads (caps known at
+/// pad-added) and explicit decoder pads (caps known only once data flows).
+///
+/// Links downstream first (`deinterlace -> identity`), syncs state, then links
+/// `raw_src` last so data only flows once the chain is fully connected.
+///
+/// `pad_label` is used only to build a unique element name.
+pub(crate) fn link_raw_video_through_deinterlace(
+    bin: &gst::Bin,
+    raw_src: &gst::Pad,
+    identity: &gst::Element,
+    instance_id: &str,
+    pad_label: &str,
+) -> Result<(), String> {
+    let name = format!("{}:deinterlace_{}", instance_id, pad_label);
+    let deinterlace = gst::ElementFactory::make("deinterlace")
+        .name(&name)
+        .property_from_str("mode", "auto")
+        .build()
+        .map_err(|e| format!("deinterlace: {}", e))?;
+
+    bin.add(&deinterlace)
+        .map_err(|e| format!("add deinterlace: {}", e))?;
+
+    let deinterlace_sink = deinterlace
+        .static_pad("sink")
+        .ok_or("deinterlace has no sink pad")?;
+    let deinterlace_src = deinterlace
+        .static_pad("src")
+        .ok_or("deinterlace has no src pad")?;
+    let identity_sink = identity
+        .static_pad("sink")
+        .ok_or("identity has no sink pad")?;
+
+    // Force real deinterlacing for interlaced/mixed sources once caps arrive.
+    deinterlace_sink.add_probe(gst::PadProbeType::EVENT_DOWNSTREAM, |pad, info| {
+        let Some(gst::PadProbeData::Event(event)) = &info.data else {
+            return gst::PadProbeReturn::Ok;
+        };
+        let gst::EventView::Caps(caps_event) = event.view() else {
+            return gst::PadProbeReturn::Ok;
+        };
+        let interlace_mode = caps_event
+            .caps()
+            .structure(0)
+            .and_then(|s| s.get::<String>("interlace-mode").ok());
+        let interlaced = matches!(
+            interlace_mode.as_deref(),
+            Some("interleaved") | Some("mixed")
+        );
+        if let Some(element) = pad.parent().and_then(|p| p.downcast::<gst::Element>().ok()) {
+            if interlaced {
+                element.set_property_from_str("mode", "interlaced");
+            }
+            debug!(
+                "{}: deinterlace mode={} (source interlace-mode={:?})",
+                element.name(),
+                if interlaced {
+                    "interlaced (forced)"
+                } else {
+                    "auto (passthrough)"
+                },
+                interlace_mode
+            );
+        }
+        gst::PadProbeReturn::Remove
+    });
+
+    // Link downstream first: deinterlace -> identity
+    deinterlace_src
+        .link(&identity_sink)
+        .map_err(|e| format!("link deinterlace -> identity: {:?}", e))?;
+
+    deinterlace
+        .sync_state_with_parent()
+        .map_err(|e| format!("sync deinterlace: {}", e))?;
+
+    // Link source pad last to start data flow only when the chain is ready
+    raw_src
+        .link(&deinterlace_sink)
+        .map_err(|e| format!("link pad -> deinterlace: {:?}", e))?;
+
+    Ok(())
+}

--- a/backend/src/blocks/builtin/decode_chain.rs
+++ b/backend/src/blocks/builtin/decode_chain.rs
@@ -40,6 +40,9 @@ pub(crate) fn link_raw_video_through_deinterlace(
     let deinterlace = gst::ElementFactory::make("deinterlace")
         .name(&name)
         .property_from_str("mode", "auto")
+        // High-quality motion-adaptive method; the default `linear` softens
+        // detail and leaves residual artifacts on broadcast content.
+        .property_from_str("method", "yadif")
         .build()
         .map_err(|e| format!("deinterlace: {}", e))?;
 

--- a/backend/src/blocks/builtin/efpsrt_input.rs
+++ b/backend/src/blocks/builtin/efpsrt_input.rs
@@ -473,7 +473,7 @@ impl BlockBuilder for EfpSrtInputBuilder {
 }
 
 /// Dynamically insert h264parse + video decoder between an efpdemux video pad and identity.
-/// efpdemux pad -> h264parse -> nvh264dec/avdec_h264 -> identity
+/// efpdemux pad -> h264parse -> nvh264dec/avdec_h264 -> deinterlace -> identity
 fn link_decoded_video(
     element: &gst::Element,
     src_pad: &gst::Pad,
@@ -507,17 +507,10 @@ fn link_decoded_video(
     bin.add_many([&parser, &decoder])
         .map_err(|e| format!("add video decode chain: {}", e))?;
 
-    // Link downstream: h264parse -> decoder -> identity
+    // Link downstream: h264parse -> decoder
     parser
         .link(&decoder)
         .map_err(|e| format!("link h264parse -> decoder: {}", e))?;
-    let decoder_src = decoder.static_pad("src").ok_or("decoder has no src pad")?;
-    let identity_sink = identity
-        .static_pad("sink")
-        .ok_or("identity has no sink pad")?;
-    decoder_src
-        .link(&identity_sink)
-        .map_err(|e| format!("link decoder -> identity: {:?}", e))?;
 
     parser
         .sync_state_with_parent()
@@ -525,6 +518,18 @@ fn link_decoded_video(
     decoder
         .sync_state_with_parent()
         .map_err(|e| format!("sync decoder: {}", e))?;
+
+    // decoder -> deinterlace -> identity. Interlaced broadcast feeds (e.g.
+    // 1080i50) must be deinterlaced before the GL vision mixer; the helper's
+    // caps probe forces deinterlacing only when the source is interlaced/mixed.
+    let decoder_src = decoder.static_pad("src").ok_or("decoder has no src pad")?;
+    super::decode_chain::link_raw_video_through_deinterlace(
+        &bin,
+        &decoder_src,
+        identity,
+        instance_id,
+        &src_pad.name(),
+    )?;
 
     // Link source pad last
     let parser_sink = parser

--- a/backend/src/blocks/builtin/mod.rs
+++ b/backend/src/blocks/builtin/mod.rs
@@ -7,6 +7,7 @@ pub mod audiogain;
 pub mod audiorouter;
 pub mod compositor;
 pub mod decklink;
+pub(crate) mod decode_chain;
 pub mod devicesrc;
 #[cfg(feature = "efp")]
 pub mod efpsrt;

--- a/backend/src/blocks/builtin/mpegtssrt_input.rs
+++ b/backend/src/blocks/builtin/mpegtssrt_input.rs
@@ -5,7 +5,7 @@
 //!
 //! Pipeline structure (decode=true, default):
 //! ```text
-//! srtsrc -> decodebin -> videoconvert -> video_output (identity) -> [external video_out]
+//! srtsrc -> decodebin -> deinterlace -> video_output (identity) -> [external video_out]
 //!                     -> audioconvert -> audioresample -> audio_output_0 (identity) -> [external audio_out_0]
 //! ```
 //!
@@ -471,8 +471,12 @@ impl BlockBuilder for MpegTsSrtInputBuilder {
     }
 }
 
-/// Dynamically insert videoconvert between a decoded video pad and an identity element.
-/// decodebin pad -> videoconvert -> identity
+/// decodebin (raw) pad -> deinterlace -> identity
+///
+/// The GL-based vision mixer rejects interlaced frames at `glupload`, so
+/// interlaced broadcast feeds (e.g. 1080i50) are deinterlaced here. See
+/// [`super::decode_chain::link_raw_video_through_deinterlace`] for how the
+/// deinterlace mode is chosen from the negotiated caps.
 fn link_decoded_video(
     element: &gst::Element,
     src_pad: &gst::Pad,
@@ -484,43 +488,16 @@ fn link_decoded_video(
         .and_then(|p| p.downcast::<gst::Bin>().ok())
         .ok_or("parent is not a Bin")?;
 
-    let convert_name = format!("{}:videoconvert_{}", instance_id, src_pad.name());
-    let videoconvert = gst::ElementFactory::make("videoconvert")
-        .name(&convert_name)
-        .build()
-        .map_err(|e| format!("videoconvert: {}", e))?;
-
-    // Add to bin, link internal chain, sync state, then connect source pad LAST
-    // to avoid data flowing before the chain is fully connected.
-    bin.add(&videoconvert)
-        .map_err(|e| format!("add videoconvert: {}", e))?;
-
-    let convert_sink = videoconvert
-        .static_pad("sink")
-        .ok_or("videoconvert has no sink pad")?;
-    let convert_src = videoconvert
-        .static_pad("src")
-        .ok_or("videoconvert has no src pad")?;
-    let identity_sink = identity
-        .static_pad("sink")
-        .ok_or("identity has no sink pad")?;
-
-    // Link downstream first: videoconvert -> identity
-    convert_src
-        .link(&identity_sink)
-        .map_err(|e| format!("link videoconvert -> identity: {:?}", e))?;
-
-    videoconvert
-        .sync_state_with_parent()
-        .map_err(|e| format!("sync videoconvert: {}", e))?;
-
-    // Link source pad last to start data flow only when chain is ready
-    src_pad
-        .link(&convert_sink)
-        .map_err(|e| format!("link pad -> videoconvert: {:?}", e))?;
+    super::decode_chain::link_raw_video_through_deinterlace(
+        &bin,
+        src_pad,
+        identity,
+        instance_id,
+        &src_pad.name(),
+    )?;
 
     debug!(
-        "MPEGTSSRT Input {}: Inserted videoconvert for pad {}",
+        "MPEGTSSRT Input {}: Inserted deinterlace for pad {}",
         instance_id,
         src_pad.name()
     );


### PR DESCRIPTION
## Problem
Interlaced broadcast contribution feeds (e.g. a 1080i50 H.264 SRT source) failed to play, surfacing as a pipeline error:

```
not-negotiated (-4) — GstSRTSrc ... streaming stopped
```

This is **not** a connectivity problem — the SRT source connects, demuxes the MPEG-TS, identifies the streams and links its pads. The failure is purely a **downstream caps issue**: the GL-based vision mixer rejects interlaced frames at `glupload` (GL textures are progressive), and the decoded video path had no deinterlacing. Progressive sources (WHIP, progressive SRT) were unaffected.

## Fix
A shared helper `decode_chain::link_raw_video_through_deinterlace` inserts a `deinterlace` element between a decoded raw-video pad and the block's video output, used by both `mpegtssrt_input` and `efpsrt_input` (their decode flows are identical — both end up on `nvh264dec`).

- Starts in `mode=auto`; a one-shot **CAPS-event probe** forces `mode=interlaced` when the negotiated `interlace-mode` is `interleaved`/`mixed`, leaving genuinely progressive sources untouched.
- Forcing is required because H.264 decoders commonly report `interlace-mode=mixed` **without** flagging individual buffers as interlaced, so `mode=auto` silently passes everything through (relabelling to progressive) and leaves visible combing.
- Driving the decision from the CAPS event makes the helper work for both decodebin pads (caps known at pad-added) and explicit decoder pads (caps known only once data flows).
- The probe reads the element from the pad, so its closure captures **no** GStreamer references — no circular-ref leak (per `CLAUDE.md`).
- mpegtssrt's now-redundant `videoconvert` is dropped; `deinterlace` accepts the decoder's raw formats directly.

## Testing
- `cargo build` and `cargo build --features efp` — clean
- `pipeline_lifecycle_test` — 3/3 pass (no leak from the added probe)
- `deinterlace mode=interlaced` and `gldeinterlace` GL paths verified in standalone `gst-launch` pipelines

⚠️ **Not verified end-to-end against a live interlaced stream** — the test source stopped delivering during development. Worth a visual check that combing is gone; the helper logs the chosen mode (`interlaced (forced)` / `auto (passthrough)`) at debug level.

## Follow-up (not in this PR)
Both decoders are `nvh264dec` (GPU), so CPU `deinterlace` incurs a GPU→system download (then the mixer's `glupload` re-uploads). A GL-native `gldeinterlace` path would keep everything on GPU and remove the bounce for all GPU-decoded sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)