### PR TITLE
feat(setup): make NVIDIA driver install non-interactive via REBOOT

### DIFF
--- a/scripts/setup/nvidia/README.md
+++ b/scripts/setup/nvidia/README.md
@@ -22,6 +22,13 @@ Installs the recommended NVIDIA driver using `ubuntu-drivers`. This script:
 - Installs the recommended driver version
 - Prompts for reboot to load the new driver
 
+For automation, set `REBOOT` to skip the prompt: `REBOOT=no` installs the driver
+without rebooting (reboot later yourself), `REBOOT=yes` reboots immediately.
+
+```bash
+REBOOT=no ./install-nvidia-driver.sh
+```
+
 **Important:** Do NOT install the `nvidia-headless` driver variant - it lacks the OpenGL/EGL capabilities required for CUDA-GL interop.
 
 ### 2. Install NVIDIA Container Toolkit

--- a/scripts/setup/nvidia/install-nvidia-driver.sh
+++ b/scripts/setup/nvidia/install-nvidia-driver.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 set -e
 
+# Reboot behavior. For automation (e.g. golden-image builds) set REBOOT
+# explicitly so the script never blocks on a prompt:
+#   REBOOT=no   install the driver but do NOT reboot (the caller reboots later)
+#   REBOOT=yes  reboot immediately once the driver is installed
+# Left unset, the script asks interactively, and skips the reboot when there is
+# no terminal to ask on.
+REBOOT="${REBOOT:-}"
+
 echo "=== Installing NVIDIA Driver ==="
 
 # Install ubuntu-drivers utility
@@ -22,10 +30,28 @@ echo ""
 echo "=== Driver installed ==="
 echo "A reboot is required for the driver to load."
 echo ""
-read -p "Reboot now? [y/N] " -n 1 -r
-echo
-if [[ $REPLY =~ ^[Yy]$ ]]; then
-    sudo reboot
-else
-    echo "Run 'sudo reboot' when ready, then verify with 'nvidia-smi'"
-fi
+case "$REBOOT" in
+    1 | y | Y | yes | YES | true | TRUE)
+        echo "REBOOT=$REBOOT: rebooting now..."
+        sudo reboot
+        ;;
+    0 | n | N | no | NO | false | FALSE)
+        echo "REBOOT=$REBOOT: skipping reboot. Run 'sudo reboot' when ready, then verify with 'nvidia-smi'."
+        ;;
+    "")
+        if [ -t 0 ]; then
+            read -p "Reboot now? [y/N] " -n 1 -r
+            echo
+            if [[ $REPLY =~ ^[Yy]$ ]]; then
+                sudo reboot
+            else
+                echo "Run 'sudo reboot' when ready, then verify with 'nvidia-smi'"
+            fi
+        else
+            echo "No terminal and REBOOT unset; skipping reboot. Set REBOOT=yes to reboot automatically, or run 'sudo reboot' manually."
+        fi
+        ;;
+    *)
+        echo "Unrecognized REBOOT value '$REBOOT' (expected yes/no); skipping reboot." >&2
+        ;;
+esac


### PR DESCRIPTION
## What

`scripts/setup/nvidia/install-nvidia-driver.sh` blocked on an interactive `Reboot now? [y/N]` prompt at the end. That's awkward for automation — golden-image builds had to pipe `n` into the script to get past it.

Add a `REBOOT` env var (matching the repo's existing `${VAR:-default}` convention):

- `REBOOT=no` — install the driver but do **not** reboot (the caller reboots later)
- `REBOOT=yes` — reboot immediately once installed
- **unset + terminal** — ask interactively, exactly as before (no change for manual use)
- **unset + no terminal** — skip the reboot instead of blocking on a prompt with no one to answer it

The prompt block is now a `set -e`-safe `case`. README updated to document the variable.

## Why

This unblocks the `strom-gpu` golden-image build in `Eyevinn/osaas-vm-provisioner`, which now runs `REBOOT=no bash install-nvidia-driver.sh` instead of the `printf 'n' | ...` hack.

## Test

`bash -n` passes; the install path is unchanged — only the final reboot decision is now controllable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)