### PR TITLE
fix(qos): drop upstream QoS events at sink source to stop GstEvent leak

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6611,7 +6611,7 @@ dependencies = [
 
 [[package]]
 name = "strom"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6686,7 +6686,7 @@ dependencies = [
 
 [[package]]
 name = "strom-frontend"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "base64",
  "chrono",
@@ -6722,7 +6722,7 @@ dependencies = [
 
 [[package]]
 name = "strom-mcp-server"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "reqwest 0.13.4",
@@ -6736,7 +6736,7 @@ dependencies = [
 
 [[package]]
 name = "strom-types"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "garde",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["types", "backend", "frontend", "mcp-server"]
 default-members = ["backend"]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Per Enstedt <per.enstedt@eyevinn.se>"]

--- a/backend/src/gst/pipeline/construction.rs
+++ b/backend/src/gst/pipeline/construction.rs
@@ -11,6 +11,30 @@ use std::sync::{Arc, Mutex};
 use strom_types::{BlockDefinition, Element, Flow, PipelineState};
 use tracing::{debug, error, info, warn};
 
+/// Whether `element` is a sink (its factory klass advertises "Sink").
+fn is_sink_element(element: &gst::Element) -> bool {
+    element
+        .factory()
+        .and_then(|f| f.metadata("klass").map(|k| k.contains("Sink")))
+        .unwrap_or(false)
+}
+
+/// Install a probe on `pad` that drops upstream QoS events.
+///
+/// Used on qos-enabled sink pads to stop the per-buffer upstream QoS event
+/// storm from propagating (and leaking) into the rest of the pipeline. See the
+/// call site in `add_element` for the rationale.
+fn drop_upstream_qos_events(pad: &gst::Pad) {
+    pad.add_probe(gst::PadProbeType::EVENT_UPSTREAM, |_pad, info| {
+        if let Some(gst::PadProbeData::Event(ref event)) = info.data {
+            if event.type_() == gst::EventType::Qos {
+                return gst::PadProbeReturn::Drop;
+            }
+        }
+        gst::PadProbeReturn::Pass
+    });
+}
+
 impl PipelineManager {
     /// Create a new pipeline from a flow definition.
     #[allow(clippy::too_many_arguments)]
@@ -297,10 +321,26 @@ impl PipelineManager {
                 ))
             })?;
 
-        // Enable QoS by default if the element supports it (for buffer drop monitoring)
+        // Enable QoS by default if the element supports it. QoS drop statistics
+        // are surfaced as StromEvent::QoSStats; they come from QoS *bus messages*
+        // (posted by sinks on dropped buffers), not from the upstream QoS *events*.
         if element.has_property("qos") {
             element.set_property("qos", true);
             debug!("Enabled QoS on element {}", element_def.id);
+
+            // A qos-enabled sink emits one upstream QoS event per buffer. These
+            // events are not freed by every element in the WebRTC/RTP receive
+            // chains and accumulate — a per-buffer GstEvent leak that slowly eats
+            // memory (~580 leaked QoS events/s measured under load). They serve no
+            // purpose propagating upstream in our pipelines (a live source cannot
+            // be throttled by a local QoS event), and dropping them does not
+            // affect QoSStats (bus-message based). Kill them at the source: drop
+            // the upstream QoS events on the sink's own sink pad.
+            if is_sink_element(&element) {
+                if let Some(sink_pad) = element.static_pad("sink") {
+                    drop_upstream_qos_events(&sink_pad);
+                }
+            }
         }
 
         // Default is-live=true for test sources (unless explicitly set by user)


### PR DESCRIPTION
## Problem

Long-running WHEP/WHIP/AES67 flows slowly exhausted memory (~1 GB/h). The leak was a per-buffer **GstEvent** accumulation: QoS events piling up and never freed (measured at ~580 leaked QoS events/s).

## Root cause

`PipelineManager::add_element` enables `qos=true` on every element that supports it (for buffer-drop monitoring). On sinks this makes each sink emit **one upstream QoS event per buffer**. Those upstream events are not freed by every element in the WebRTC/RTP receive chains, so they accumulate.

The upstream QoS events serve no purpose in these pipelines — a live source cannot be throttled by a local QoS event — and the QoS statistics surfaced as `StromEvent::QoSStats` are derived from QoS **bus messages** (posted by sinks on dropped buffers), not from these events. So the events are pure overhead that happens to leak.

## Fix

Kill the QoS events at the source: for each qos-enabled sink, install an `EVENT_UPSTREAM` pad probe on its sink pad that drops `GST_EVENT_QOS`. Sinks still do their own internal QoS handling (sync/drop) and still post QoS bus messages, so `QoSStats` is unaffected; the events simply never propagate upstream and never accumulate.

## Verification

Verified on a live deployment with the GStreamer `leaks` tracer:

| | Before | After |
|---|---|---|
| Alive QoS events | 320k → 508k (+583/s) | 0 |
| QoS growth / 120s | +75,380 | 0 |
| RSS slope (tracer off) | ~290 KB/s | ~2 KB/s (flat) |

Media throughput unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)