### PR TITLE
fix(clocks): restore PTP statistics panel hidden behind domain list

### DIFF
--- a/frontend/src/clocks.rs
+++ b/frontend/src/clocks.rs
@@ -81,7 +81,7 @@ impl ClocksPage {
     ) {
         ui.horizontal_top(|ui| {
             ui.vertical(|ui| {
-                ui.set_min_width(320.0);
+                ui.set_width(320.0);
                 self.render_domain_list(ui, domain_info);
             });
             ui.separator();
@@ -169,22 +169,21 @@ impl ClocksPage {
         // Get selected domain as string
         let selected_id = self.selected_domain.map(|d| d.to_string());
 
-        let result = egui::ScrollArea::vertical()
-            .auto_shrink([false, false])
-            .show(ui, |ui| {
-                let items =
-                    items_data
-                        .iter()
-                        .map(|(id, label, secondary, status_text, status_color)| {
-                            ListItem::new(id, label)
-                                .with_secondary(secondary.clone())
-                                .with_status(status_text, *status_color)
-                        });
-
-                list_navigator(ui, "ptp_domains", items, selected_id.as_deref())
+        // Render the list directly: the page already lives inside a vertical
+        // ScrollArea, and a nested vertical ScrollArea with auto_shrink([false,
+        // false]) here would expand to the full row width and push the details
+        // panel off-screen.
+        let items = items_data
+            .iter()
+            .map(|(id, label, secondary, status_text, status_color)| {
+                ListItem::new(id, label)
+                    .with_secondary(secondary.clone())
+                    .with_status(status_text, *status_color)
             });
 
-        if let Some(new_id) = result.inner.selected {
+        let result = list_navigator(ui, "ptp_domains", items, selected_id.as_deref());
+
+        if let Some(new_id) = result.selected {
             if let Ok(domain) = new_id.parse::<u8>() {
                 self.selected_domain = Some(domain);
             }


### PR DESCRIPTION
## Problem

Clicking a PTP entry on the Clocks page no longer showed the PTP statistics / Domain Details panel. This regressed in #520 (the commit that added NTP/TAI clocks and the System Clock panel).

## Cause

That commit reworked the PTP section from a `SidePanel` + `CentralPanel` split into an outer vertical `ScrollArea` containing a `horizontal_top` with two columns (domain list left, details right). The left column wrapped its list in an **inner** `ScrollArea::vertical().auto_shrink([false, false])`. With `auto_shrink([false, false])`, that inner scroll area expands to the full row width, so the left column consumed all horizontal space and the details panel was pushed off-screen. The selection was set correctly — the stats were just rendered beyond the visible area.

## Fix

- Remove the redundant inner `ScrollArea` in `render_domain_list` (the page already lives inside a vertical `ScrollArea`).
- Give the left column a fixed width (`set_width(320.0)`) so the details panel sits beside it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)