### PR TITLE
ci: route sccache through self-hosted MinIO (S3) cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,19 +230,15 @@ jobs:
         env:
           RUSTC_WRAPPER: sccache
 
-      - name: Install GStreamer
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libunwind-dev \
-            libcairo2-dev \
-            libgstreamer1.0-dev \
-            libgstreamer-plugins-base1.0-dev \
-            libgstreamer-plugins-bad1.0-dev \
-            libssl-dev \
-            pkg-config \
-            cmake \
-            libclang-dev
+      # Cached apt install (mirrors the Check job) — avoids re-downloading the
+      # GStreamer dev stack (~1 min) on every build. cache-apt-pkgs-action keys
+      # the cache by package list + version + runner arch, so x86_64 and arm64
+      # get separate entries automatically.
+      - name: Install GStreamer (cached)
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: libunwind-dev libcairo2-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-bad1.0-dev libssl-dev pkg-config cmake libclang-dev
+          version: 1.5
 
       - name: Download frontend dist
         uses: actions/download-artifact@v4
@@ -342,19 +338,15 @@ jobs:
         env:
           RUSTC_WRAPPER: sccache
 
-      - name: Install GStreamer
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libunwind-dev \
-            libcairo2-dev \
-            libgstreamer1.0-dev \
-            libgstreamer-plugins-base1.0-dev \
-            libgstreamer-plugins-bad1.0-dev \
-            libssl-dev \
-            pkg-config \
-            cmake \
-            libclang-dev
+      # Cached apt install (mirrors the Check job) — avoids re-downloading the
+      # GStreamer dev stack (~1 min) on every build. cache-apt-pkgs-action keys
+      # the cache by package list + version + runner arch, so x86_64 and arm64
+      # get separate entries automatically.
+      - name: Install GStreamer (cached)
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: libunwind-dev libcairo2-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-bad1.0-dev libssl-dev pkg-config cmake libclang-dev
+          version: 1.5
 
       - name: Download frontend dist
         uses: actions/download-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,18 @@ env:
   RUST_BACKTRACE: 1
   TRUNK_VERSION: "0.21.14"
   CARGO_INCREMENTAL: 0
-  SCCACHE_GHA_ENABLED: "true"
+  # sccache -> self-hosted MinIO (S3-compatible) cache in OSC.
+  # Replaces the GitHub Actions cache backend, which shares a hard 10 GB/repo
+  # ceiling with the docker buildkit blobs. The same backend is reused by the
+  # release workflow and the Dockerfile builder, where rust-cache cannot reach.
+  # Requires repo secrets SCCACHE_S3_ACCESS_KEY_ID / SCCACHE_S3_SECRET_ACCESS_KEY
+  # (a service account scoped to the strom bucket, no admin).
+  SCCACHE_BUCKET: strom
+  SCCACHE_ENDPOINT: https://eyevinnlab-rustcache.minio-minio.auto.prod.osaas.io
+  SCCACHE_REGION: us-east-1
+  SCCACHE_S3_USE_SSL: "true"
+  AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_S3_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_S3_SECRET_ACCESS_KEY }}
 
 jobs:
   # Fast checks on Linux: fmt + clippy + test

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -67,7 +67,10 @@ jobs:
           tags: ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}-amd64
           platforms: linux/amd64
           cache-from: type=gha,scope=docker-amd64
-          cache-to: type=gha,mode=max,scope=docker-amd64
+          # mode=min: cache only the final image layers. mode=max also exported
+          # the builder's multi-GB target/ each build (~6 min), which COPY . .
+          # busts anyway and sccache now covers — net loss. See PR discussion.
+          cache-to: type=gha,mode=min,scope=docker-amd64
           provenance: false
           sbom: false
           # sccache S3 credentials, consumed by the Dockerfile builder stages.
@@ -118,7 +121,8 @@ jobs:
           tags: ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}-arm64
           platforms: linux/arm64
           cache-from: type=gha,scope=docker-arm64
-          cache-to: type=gha,mode=max,scope=docker-arm64
+          # mode=min: see the AMD64 job above.
+          cache-to: type=gha,mode=min,scope=docker-arm64
           provenance: false
           sbom: false
           # sccache S3 credentials, consumed by the Dockerfile builder stages.

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -70,6 +70,11 @@ jobs:
           cache-to: type=gha,mode=max,scope=docker-amd64
           provenance: false
           sbom: false
+          # sccache S3 credentials, consumed by the Dockerfile builder stages.
+          # If these secrets are unset the build compiles normally (no cache).
+          secrets: |
+            aws_access_key_id=${{ secrets.SCCACHE_S3_ACCESS_KEY_ID }}
+            aws_secret_access_key=${{ secrets.SCCACHE_S3_SECRET_ACCESS_KEY }}
 
   # Build ARM64 image natively on ARM64 runner (no cross-compilation!)
   build-arm64:
@@ -116,6 +121,11 @@ jobs:
           cache-to: type=gha,mode=max,scope=docker-arm64
           provenance: false
           sbom: false
+          # sccache S3 credentials, consumed by the Dockerfile builder stages.
+          # If these secrets are unset the build compiles normally (no cache).
+          secrets: |
+            aws_access_key_id=${{ secrets.SCCACHE_S3_ACCESS_KEY_ID }}
+            aws_secret_access_key=${{ secrets.SCCACHE_S3_SECRET_ACCESS_KEY }}
 
   # Create multi-arch manifest combining AMD64 and ARM64 images
   create-manifest:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,16 @@ env:
   TRUNK_VERSION: "0.21.14"
   CARGO_INCREMENTAL: 0
   CARGO_BUILD_JOBS: 2
+  # sccache -> self-hosted MinIO (S3) cache in OSC. Tag builds run weeks apart,
+  # so the rust-cache target/ is usually evicted (10 GB GHA ceiling) and every
+  # release recompiles cold. A persistent remote compiler cache cuts that.
+  # Requires repo secrets SCCACHE_S3_ACCESS_KEY_ID / SCCACHE_S3_SECRET_ACCESS_KEY.
+  SCCACHE_BUCKET: strom
+  SCCACHE_ENDPOINT: https://eyevinnlab-rustcache.minio-minio.auto.prod.osaas.io
+  SCCACHE_REGION: us-east-1
+  SCCACHE_S3_USE_SSL: "true"
+  AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_S3_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_S3_SECRET_ACCESS_KEY }}
 
 jobs:
   build-frontend:
@@ -42,10 +52,15 @@ jobs:
           shared-key: frontend-wasm
           cache-on-failure: true
 
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
       - name: Build frontend
         run: |
           cd frontend
           trunk build --release
+        env:
+          RUSTC_WRAPPER: sccache
 
       - name: Upload frontend dist
         uses: actions/upload-artifact@v4
@@ -100,6 +115,9 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
 
       # Linux: Install Zig and cargo-zigbuild for glibc 2.31 compatibility
       - name: Determine Zig/cargo-zigbuild arch (Linux)
@@ -238,6 +256,7 @@ jobs:
         if: startsWith(matrix.platform, 'linux')
         env:
           RUSTFLAGS: "-L /usr/lib/${{ matrix.target == 'aarch64-unknown-linux-gnu' && 'aarch64-linux-gnu' || 'x86_64-linux-gnu' }}"
+          RUSTC_WRAPPER: sccache
         run: |
           set -e
           FEATURES="${{ matrix.features }}"
@@ -252,6 +271,8 @@ jobs:
       - name: Build backend (non-Linux)
         if: ${{ !startsWith(matrix.platform, 'linux') }}
         shell: bash
+        env:
+          RUSTC_WRAPPER: sccache
         run: |
           set -e
           FEATURES="${{ matrix.features }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,11 +27,34 @@ RUN TRUNK_ARCH=$(case ${BUILDARCH} in \
     tar -xz -C /usr/local/bin && \
     rustup target add wasm32-unknown-unknown
 
+# Install sccache (compiler cache backed by the self-hosted MinIO S3 bucket).
+# It only activates when AWS credentials are mounted as build secrets (see the
+# build step below); a plain `docker build` without secrets compiles normally.
+ARG SCCACHE_VERSION=0.15.0
+RUN ARCH="$(uname -m)" && \
+    curl -fsSL "https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/sccache-v${SCCACHE_VERSION}-${ARCH}-unknown-linux-musl.tar.gz" \
+      | tar -xz -C /tmp && \
+    install -m0755 "/tmp/sccache-v${SCCACHE_VERSION}-${ARCH}-unknown-linux-musl/sccache" /usr/local/bin/sccache && \
+    rm -rf /tmp/sccache-*
+ENV SCCACHE_BUCKET=strom \
+    SCCACHE_ENDPOINT=https://eyevinnlab-rustcache.minio-minio.auto.prod.osaas.io \
+    SCCACHE_REGION=us-east-1 \
+    SCCACHE_S3_USE_SSL=true
+
 # Copy workspace
 COPY . .
 
-# Build frontend (WASM is platform-independent)
-RUN cd frontend && trunk build --release
+# Build frontend (WASM is platform-independent).
+# sccache is enabled only when the AWS credential secrets are present.
+RUN --mount=type=secret,id=aws_access_key_id \
+    --mount=type=secret,id=aws_secret_access_key \
+    if [ -s /run/secrets/aws_access_key_id ]; then \
+        export AWS_ACCESS_KEY_ID="$(cat /run/secrets/aws_access_key_id)" && \
+        export AWS_SECRET_ACCESS_KEY="$(cat /run/secrets/aws_secret_access_key)" && \
+        export RUSTC_WRAPPER=sccache; \
+    fi && \
+    cd frontend && trunk build --release && \
+    { command -v sccache >/dev/null && [ -n "$RUSTC_WRAPPER" ] && sccache --show-stats || true; }
 
 # Stage 2: Backend builder - Build backend with Zig cross-compilation support
 # IMPORTANT: Must run on BUILD platform for cross-compilation tools (Zig) to work
@@ -56,6 +79,22 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/* \
     && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
 ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Install sccache (compiler cache backed by the self-hosted MinIO S3 bucket).
+# Activates only when AWS credentials are mounted as build secrets in the build
+# step below; a plain `docker build` without secrets compiles normally.
+# When cross-compiling, this stage runs on the native BUILDPLATFORM, so the
+# host-arch sccache binary is the correct one for the rustc that actually runs.
+ARG SCCACHE_VERSION=0.15.0
+RUN ARCH="$(uname -m)" && \
+    curl -fsSL "https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/sccache-v${SCCACHE_VERSION}-${ARCH}-unknown-linux-musl.tar.gz" \
+      | tar -xz -C /tmp && \
+    install -m0755 "/tmp/sccache-v${SCCACHE_VERSION}-${ARCH}-unknown-linux-musl/sccache" /usr/local/bin/sccache && \
+    rm -rf /tmp/sccache-*
+ENV SCCACHE_BUCKET=strom \
+    SCCACHE_ENDPOINT=https://eyevinnlab-rustcache.minio-minio.auto.prod.osaas.io \
+    SCCACHE_REGION=us-east-1 \
+    SCCACHE_S3_USE_SSL=true
 
 # Cross-compilation setup: Install Zig and ARM64 libraries when cross-compiling
 # Uses Ubuntu ports.ubuntu.com for ARM64 packages (matching local setup)
@@ -145,7 +184,14 @@ ENV RUST_BACKTRACE=1
 
 # Cross-compilation: Use cargo-zigbuild with glibc 2.36 targeting (Raspberry Pi compatible)
 # Native compilation: Use regular cargo build
-RUN if [ "$BUILDPLATFORM" != "$TARGETPLATFORM" ] && [ "$TARGETARCH" = "arm64" ]; then \
+RUN --mount=type=secret,id=aws_access_key_id \
+    --mount=type=secret,id=aws_secret_access_key \
+    if [ -s /run/secrets/aws_access_key_id ]; then \
+        export AWS_ACCESS_KEY_ID="$(cat /run/secrets/aws_access_key_id)" && \
+        export AWS_SECRET_ACCESS_KEY="$(cat /run/secrets/aws_secret_access_key)" && \
+        export RUSTC_WRAPPER=sccache; \
+    fi && \
+    if [ "$BUILDPLATFORM" != "$TARGETPLATFORM" ] && [ "$TARGETARCH" = "arm64" ]; then \
     echo "==> Cross-compiling backend with Zig (targeting glibc 2.36)"; \
     export PKG_CONFIG_ALLOW_CROSS=1 && \
     export PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig && \
@@ -168,7 +214,8 @@ else \
     echo "==> Native build for $TARGETPLATFORM"; \
     cargo build --release --package strom --features no-gui,efp && \
     cargo build --release --package strom-mcp-server; \
-fi
+fi && \
+    { command -v sccache >/dev/null && [ -n "$RUSTC_WRAPPER" ] && sccache --show-stats || true; }
 
 # Stage 3: Runtime - Minimal runtime image with Ubuntu 25.10 (questing) for GStreamer 1.26
 FROM ubuntu:questing AS runtime

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,4 +1,5 @@
 //! Strom backend server.
+// temp: bust docker COPY layer to measure warm sccache hit rate (revert me)
 
 use clap::Parser;
 use gstreamer::glib;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,4 +1,5 @@
 //! Strom backend server.
+// temp2: bust docker COPY layer for mode=min warm measurement (revert me)
 
 use clap::Parser;
 use gstreamer::glib;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,5 +1,4 @@
 //! Strom backend server.
-// temp2: bust docker COPY layer for mode=min warm measurement (revert me)
 
 use clap::Parser;
 use gstreamer::glib;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,5 +1,4 @@
 //! Strom backend server.
-// temp: bust docker COPY layer to measure warm sccache hit rate (revert me)
 
 use clap::Parser;
 use gstreamer::glib;


### PR DESCRIPTION
## What

Point sccache at a self-hosted **MinIO** bucket in OSC instead of the GitHub Actions cache backend, and extend the compiler cache to the build paths the GHA backend could never reach: the **release** workflow and the **Dockerfile** image build.

## Why (measured on current `main`)

| Path | Before | Bottleneck |
|---|---|---|
| `ci.yml` (push/PR) | ~8.5 min warm | fine; but sccache sat on the GHA backend |
| `release.yml` (tag) | **~30–44 min** | **no compiler cache at all**; cold on every tag |
| `docker-publish.yml` (tag) | **~26 min** | **850 Compiling, 0 CACHED** — full cold compile every build |

Root causes:
- The **GHA cache backend** shares a hard **10 GB/repo** ceiling with the docker buildkit blobs (repo is currently pinned at the 10 GB limit), so the Rust cache is under constant LRU eviction.
- **`Swatinem/rust-cache` cannot run inside `docker build`**, and the Dockerfile's `COPY . .` → `cargo build` busts the buildkit layer cache on any source change → all 846 crates recompile cold (~13 min/arch).
- A remote **S3-compatible** backend works in all three contexts and escapes the 10 GB ceiling.

## Changes

- **`ci.yml` / `release.yml`** — sccache now targets the MinIO S3 bucket. `release.yml` gains sccache setup + `RUSTC_WRAPPER` on both the frontend and backend builds (it had none before).
- **`Dockerfile`** — installs sccache in both builder stages; enabled **only when AWS credentials are mounted as build secrets**, so a plain `docker build` / `docker-compose` still compiles normally with no cache and no failure.
- **`docker-publish.yml`** — passes the S3 credentials to the builder as buildkit `secrets:`.

## Required repo secrets — already set

- `SCCACHE_S3_ACCESS_KEY_ID`
- `SCCACHE_S3_SECRET_ACCESS_KEY`

These hold a MinIO **service account scoped to the `strom` bucket** (no admin). The MinIO endpoint is a public OSC ingress committed as plain config; only the access keys are secret.

## Reviewer checklist / follow-ups

- [ ] Decide whether the endpoint host should move to a repo **variable** instead of being committed (it is a public SaaS ingress, not an internal host).
- [ ] **Availability tradeoff:** CI compiler caching now depends on the MinIO instance being reachable. sccache treats backend errors as cache misses (compiles directly), so an outage should degrade speed, not break builds — worth confirming on the first red-network run.
- [ ] Toolchain intentionally **not** pinned (per maintainer preference): a `stable` bump still rotates sccache keys and produces an occasional cold build. Accepted.

## How to verify

Trigger `release` / `docker-publish` (or `workflow_dispatch`) and check the `sccache --show-stats` output at the end of each build step — expect a low hit rate on the first run (cold fill) and a high hit rate on the second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
