### PR TITLE
fix(videoenc): decouple VideoToolbox realtime from quality, wire rate-control + keyframe duration

### DIFF
--- a/backend/src/blocks/builtin/videoenc.rs
+++ b/backend/src/blocks/builtin/videoenc.rs
@@ -532,10 +532,41 @@ fn set_encoder_properties(
     } else if encoder_name.starts_with("vtenc") {
         // Apple VideoToolbox (macOS): bitrate property is in kbps
         encoder.set_property_from_str("bitrate", &bitrate_str);
-        // VideoToolbox: realtime mode for low-latency streaming
+        // VideoToolbox: realtime mode disables frame buffering / lookahead.
+        // That is a *latency* property, orthogonal to compression quality.
+        // Strom is a live mixer/streamer (WebRTC/SRT), so drive it from the
+        // low-latency tune (the same signal x264/x265 use), not the quality
+        // preset — otherwise picking medium/slow would silently add encoder
+        // latency in a live context.
         if encoder.has_property("realtime") {
-            let realtime = matches!(quality_preset, "ultrafast" | "fast");
+            let realtime = tune == "zerolatency";
             encoder.set_property_from_str("realtime", if realtime { "true" } else { "false" });
+        }
+        // VideoToolbox rate control: respect the requested mode. Newer vtenc
+        // exposes a rate-control enum (abr/cbr); CBR gives predictable
+        // bandwidth over constrained SRT/WebRTC links. CQP has no VT
+        // equivalent, so fall back to ABR.
+        if encoder.has_property("rate-control") {
+            let rc = match rate_control {
+                RateControl::CBR => "cbr",
+                RateControl::VBR | RateControl::CQP => "abr",
+            };
+            encoder.set_property_from_str("rate-control", rc);
+        }
+        // VideoToolbox: cap the wall-clock gap between keyframes in addition
+        // to the frame-based max-keyframe-interval set below. WebRTC clients
+        // need a keyframe to start decoding when they join, so an unbounded
+        // wall-clock gap hurts join latency if the source runs slower than
+        // expected. keyframe_interval is in frames; the block's convention
+        // (see property docs) is "60 frames = 2 s at 30 fps", so derive the
+        // ns cap at the same nominal 30 fps. Above 30 fps the frame cap fires
+        // first (tighter); below it this duration holds the line.
+        if keyframe_interval > 0 && encoder.has_property("max-keyframe-interval-duration") {
+            let duration_ns = u64::from(keyframe_interval) * 1_000_000_000 / 30;
+            encoder.set_property_from_str(
+                "max-keyframe-interval-duration",
+                &duration_ns.to_string(),
+            );
         }
         // VideoToolbox defaults to allow-frame-reordering=true, which emits
         // B-frames. B-frames cause non-monotonic PTS in decode order —

--- a/backend/src/blocks/builtin/videoenc.rs
+++ b/backend/src/blocks/builtin/videoenc.rs
@@ -563,10 +563,8 @@ fn set_encoder_properties(
         // first (tighter); below it this duration holds the line.
         if keyframe_interval > 0 && encoder.has_property("max-keyframe-interval-duration") {
             let duration_ns = u64::from(keyframe_interval) * 1_000_000_000 / 30;
-            encoder.set_property_from_str(
-                "max-keyframe-interval-duration",
-                &duration_ns.to_string(),
-            );
+            encoder
+                .set_property_from_str("max-keyframe-interval-duration", &duration_ns.to_string());
         }
         // VideoToolbox defaults to allow-frame-reordering=true, which emits
         // B-frames. B-frames cause non-monotonic PTS in decode order —


### PR DESCRIPTION
## Summary

Three fixes to the vtenc (Apple VideoToolbox) branch in the video encoder block, all verified against `vtenc_h264_hw` on GStreamer 1.28.

- **`realtime` was tied to `quality_preset`.** `realtime` disables frame buffering/lookahead — a *latency* property, orthogonal to compression quality. Picking `medium`/`slow` silently added encoder latency in a live context. Now driven by the low-latency `tune` (the same signal x264/x265 use), so it stays on by default for live regardless of the quality preset.
- **`rate_control` was ignored on macOS.** The block already exposes a `rate_control` property (CQP/VBR/CBR), but the vtenc branch never applied it. Now mapped to vtenc's `rate-control` enum — `CBR` gives predictable bandwidth over constrained SRT/WebRTC links; CQP has no VideoToolbox equivalent so it falls back to ABR.
- **Added `max-keyframe-interval-duration`.** A wall-clock cap on top of the frame-based keyframe interval. WebRTC clients need a keyframe to start decoding on join, so an unbounded wall-clock gap hurts join latency if the source runs below the nominal 30 fps the GOP was sized for. Derived from `keyframe_interval` at the same nominal 30 fps the block already documents (default 60 frames → 2 s).

## Verification

Properties confirmed present on `vtenc_h264_hw` (GStreamer 1.28, macOS):

| Property | Notes |
|---|---|
| `realtime` | Boolean, default `false` |
| `rate-control` | Enum `abr`(0, default) / `cbr`(1) |
| `max-keyframe-interval-duration` | UInt64 ns, default 0 |

Not yet build-verified (`cargo check` not run in this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)