### PR TITLE
ci: give x86_64 build job its own rust-cache key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,6 @@ env:
 
 jobs:
   # Fast checks on Linux: fmt + clippy + test
-  # Shares cache with build-linux-x86_64
   check-linux:
     name: Check (Linux)
     runs-on: ubuntu-24.04
@@ -181,10 +180,15 @@ jobs:
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
 
+      # Must NOT share a key with check-linux: rust-cache saves only once per
+      # key and skips saving on a full-match restore. check-linux finishes
+      # first and wins the save race, so its debug/clippy target dir (host
+      # target) gets cached instead of the zigbuild release artifacts — and
+      # this job then rebuilds the entire dependency tree on every run.
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: linux-x86_64
+          shared-key: linux-x86_64-release
           cache-on-failure: true
 
       - name: Cache Zig tarball


### PR DESCRIPTION
## Problem

The `Build (Linux x86_64)` job takes ~6 min while `Build (Linux ARM64)` takes ~3 min, even though both use cargo-zigbuild and sccache. Log analysis of run [26867834269](https://github.com/Eyevinn/strom/actions/runs/26867834269) shows:

| | x86_64 (6m07s) | ARM64 (2m54s) |
|---|---|---|
| `Compiling` lines | **668** | **12** |
| sccache compile requests | **1387** (99.92% hit) | **25** |
| rust-cache restore | full match | full match |

The ARM job restores a `target/` that already contains all release artifacts and only relinks the leaf crate. The x86_64 job rebuilds the entire dependency tree every run — rescued by sccache, but ~1200 cache-fetched compiles + build scripts/proc-macros (always executed for real) + linking still cost ~6 min.

## Root cause

`build-linux-x86_64` shared `shared-key: linux-x86_64` with `check-linux`. rust-cache saves only **once** per key and skips saving entirely on a full-match restore. The two jobs run in parallel and `check-linux` finishes ~3.5 min faster, so whenever the key rotates (Cargo.lock change), `check-linux` wins the save race and caches **its** target dir — debug/clippy artifacts for the host target, not the `target/x86_64-unknown-linux-gnu/release` zigbuild output. The build job's release artifacts were therefore never cached.

The ARM64 job never had this problem because `linux-arm64` is exclusive to it.

## Fix

Give the build job its own key, `linux-x86_64-release`, matching the ARM64 setup. Expected result: x86_64 build drops to ~3 min after the first run on this branch populates the new cache.

Cost: one extra rust-cache entry in the GHA cache (~1–2 GB); sccache blobs already live in MinIO so the 10 GB ceiling is not a concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)