### PR TITLE
ci: cut GHA cache footprint — save rust-cache on main only, drop one-shot caches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,17 +39,24 @@ jobs:
         with:
           components: rustfmt, clippy
 
+      # Package list must stay identical to build-linux-x86_64 so both jobs
+      # share one apt cache entry (the action keys by package list + arch).
       - name: Cache apt packages
         uses: awalsh128/cache-apt-pkgs-action@v1
         with:
-          packages: libssl-dev libcairo2-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-bad1.0-dev gstreamer1.0-plugins-base gstreamer1.0-plugins-good cmake libclang-dev
+          packages: libunwind-dev libssl-dev libcairo2-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-bad1.0-dev gstreamer1.0-plugins-base gstreamer1.0-plugins-good pkg-config cmake libclang-dev
           version: 1.5
 
+      # save-if main: PR runs restore the main-branch cache (GHA cache scoping
+      # falls back to the base branch) but don't save their own per-branch
+      # copy — that copy doubled every rust-cache entry against the 10 GB
+      # repo ceiling. Changed workspace crates rebuild on PRs but hit sccache.
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: linux-x86_64
           cache-on-failure: true
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
@@ -102,11 +109,13 @@ jobs:
         run: |
           wget -qO- https://github.com/trunk-rs/trunk/releases/download/v${{ env.TRUNK_VERSION }}/trunk-x86_64-unknown-linux-gnu.tar.gz | tar -xzf- -C ~/.cargo/bin
 
+      # save-if main: see check-linux.
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: wasm
           cache-on-failure: true
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
@@ -185,11 +194,13 @@ jobs:
       # first and wins the save race, so its debug/clippy target dir (host
       # target) gets cached instead of the zigbuild release artifacts — and
       # this job then rebuilds the entire dependency tree on every run.
+      # save-if main: see check-linux.
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: linux-x86_64-release
           cache-on-failure: true
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Cache Zig tarball
         uses: actions/cache@v4
@@ -234,14 +245,14 @@ jobs:
         env:
           RUSTC_WRAPPER: sccache
 
-      # Cached apt install (mirrors the Check job) — avoids re-downloading the
-      # GStreamer dev stack (~1 min) on every build. cache-apt-pkgs-action keys
-      # the cache by package list + version + runner arch, so x86_64 and arm64
-      # get separate entries automatically.
+      # Cached apt install — avoids re-downloading the GStreamer dev stack
+      # (~1 min) on every build. The package list must stay identical to
+      # check-linux so both x86_64 jobs share one apt cache entry; arm64 gets
+      # its own entry automatically (the action keys by list + runner arch).
       - name: Install GStreamer (cached)
         uses: awalsh128/cache-apt-pkgs-action@v1
         with:
-          packages: libunwind-dev libcairo2-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-bad1.0-dev libssl-dev pkg-config cmake libclang-dev
+          packages: libunwind-dev libssl-dev libcairo2-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-bad1.0-dev gstreamer1.0-plugins-base gstreamer1.0-plugins-good pkg-config cmake libclang-dev
           version: 1.5
 
       - name: Download frontend dist
@@ -295,11 +306,13 @@ jobs:
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
 
+      # save-if main: see check-linux.
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: linux-arm64
           cache-on-failure: true
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Cache Zig tarball
         uses: actions/cache@v4
@@ -342,14 +355,14 @@ jobs:
         env:
           RUSTC_WRAPPER: sccache
 
-      # Cached apt install (mirrors the Check job) — avoids re-downloading the
-      # GStreamer dev stack (~1 min) on every build. cache-apt-pkgs-action keys
-      # the cache by package list + version + runner arch, so x86_64 and arm64
-      # get separate entries automatically.
+      # Cached apt install — avoids re-downloading the GStreamer dev stack
+      # (~1 min) on every build. The package list must stay identical to
+      # check-linux so both x86_64 jobs share one apt cache entry; arm64 gets
+      # its own entry automatically (the action keys by list + runner arch).
       - name: Install GStreamer (cached)
         uses: awalsh128/cache-apt-pkgs-action@v1
         with:
-          packages: libunwind-dev libcairo2-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-bad1.0-dev libssl-dev pkg-config cmake libclang-dev
+          packages: libunwind-dev libssl-dev libcairo2-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-bad1.0-dev gstreamer1.0-plugins-base gstreamer1.0-plugins-good pkg-config cmake libclang-dev
           version: 1.5
 
       - name: Download frontend dist
@@ -432,12 +445,10 @@ jobs:
           name: frontend-dist
           path: backend/dist
 
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: windows
-          cache-on-failure: true
-
+      # No rust-cache here: this job is workflow_dispatch-only, so a saved
+      # target/ (~1-2 GB against the 10 GB repo ceiling) is almost always
+      # stale or evicted by the next manual run. sccache via MinIO covers
+      # recompiles instead.
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
 
@@ -512,12 +523,7 @@ jobs:
           name: frontend-dist
           path: backend/dist
 
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: macos
-          cache-on-failure: true
-
+      # No rust-cache here: workflow_dispatch-only, see the Windows job.
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,10 @@ env:
   CARGO_INCREMENTAL: 0
   CARGO_BUILD_JOBS: 2
   # sccache -> self-hosted MinIO (S3) cache in OSC. Tag builds run weeks apart,
-  # so the rust-cache target/ is usually evicted (10 GB GHA ceiling) and every
-  # release recompiles cold. A persistent remote compiler cache cuts that.
+  # so a GHA-cached target/ would always be evicted (10 GB repo ceiling) and
+  # every release recompiles cold — that is why this workflow deliberately has
+  # NO Swatinem/rust-cache steps: saving ~5-7 GB of one-shot caches per tag
+  # only evicted the CI workflow's hot caches. sccache is the persistent cache.
   # Requires repo secrets SCCACHE_S3_ACCESS_KEY_ID / SCCACHE_S3_SECRET_ACCESS_KEY.
   SCCACHE_BUCKET: strom
   SCCACHE_ENDPOINT: https://eyevinnlab-rustcache.minio-minio.auto.prod.osaas.io
@@ -45,12 +47,6 @@ jobs:
         if: steps.cache-trunk.outputs.cache-hit != 'true'
         run: |
           wget -qO- https://github.com/trunk-rs/trunk/releases/download/v${{ env.TRUNK_VERSION }}/trunk-x86_64-unknown-linux-gnu.tar.gz | tar -xzf- -C ~/.cargo/bin
-
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: frontend-wasm
-          cache-on-failure: true
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
@@ -244,12 +240,6 @@ jobs:
         with:
           name: frontend-dist
           path: backend/dist
-
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: release-${{ matrix.platform }}
-          cache-on-failure: true
 
       # Linux: Build with zigbuild for glibc compatibility
       - name: Build backend (Linux - glibc ${{ matrix.glibc }})


### PR DESCRIPTION
## Problem

The repo sits at the 10 GB GHA cache ceiling (**10.7 GB used**, see inventory below), so entries constantly evict each other — and #613 adds one more ~1.7 GB key. Meanwhile sccache against self-hosted MinIO is a *separate, persistent* cache area that already absorbs recompiles. The GHA cache should only hold what sccache cannot cover: `target/` fingerprints for hot per-PR jobs (skips cargo orchestration + linking entirely, worth ~3 min), apt packages, and tool tarballs.

Current inventory — note that **every entry exists twice** (main + PR branch scope):

| Size | Entry | Used by |
|---|---|---|
| 1.95 GB | `v0-rust-macos` | dispatch-only job |
| 1.72 GB ×2 | `v0-rust-linux-x86_64` | every PR |
| 0.91 GB ×2 | `v0-rust-linux-arm64` | every PR |
| 0.50 GB ×2 | `v0-rust-wasm` | every PR |
| ~1.7 GB | 6× `cache-apt-pkgs` (3 lists × 2 scopes) | every PR |
| 0.46 GB | buildkit blob | docker publish |

## Changes

1. **`save-if: main` on all rust-cache steps in ci.yml.** PR runs still restore the main-branch cache (GHA scope fallback) but no longer save a per-branch copy — halves every rust-cache entry (~2.6 GB). Workspace crates changed in a PR rebuild, but those compiles hit sccache.

2. **Drop rust-cache from rare jobs.** ci.yml Windows/macOS are workflow_dispatch-only; release.yml runs weeks apart. Their saved `target/` is stale or evicted by the next run — release.yml alone dumped **~5–7 GB of one-shot caches per tag**, evicting the hot CI caches right after every release (its own comment admitted they were "usually evicted"). sccache covers the recompiles.

3. **Unify the apt package list** (superset) between `check-linux` and `build-linux-x86_64` — cache-apt-pkgs keys by package list + arch, so the two x86_64 jobs now share one entry instead of two.

## Expected steady state

~6.5 GB — comfortably under the ceiling *including* the new `linux-x86_64-release` key from #613, so eviction roulette stops. Raising the paid cache limit (possible since Nov 2025, ~$0.07/GB-month) remains an option but shouldn't be needed after this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)