### PR TITLE
ci: bump actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/build-gstcefsrc.yml
+++ b/.github/workflows/build-gstcefsrc.yml
@@ -49,7 +49,7 @@ jobs:
             arch: arm64
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -94,7 +94,7 @@ jobs:
         id: archive
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: gstcefsrc-${{ steps.cef.outputs.short_version }}-${{ matrix.platform }}
           path: ${{ steps.archive.outputs.archive_name }}
@@ -102,7 +102,7 @@ jobs:
 
       - name: Upload to GitHub Release
         if: inputs.upload_to_release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ inputs.release_tag }}
           name: "gstcefsrc Dependencies"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
@@ -52,7 +52,7 @@ jobs:
           cache-on-failure: true
 
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: Check formatting
         run: cargo fmt --all -- --check
@@ -82,7 +82,7 @@ jobs:
     name: Check & Build (WASM)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Install Rust stable with WASM target
         uses: dtolnay/rust-toolchain@stable
@@ -92,7 +92,7 @@ jobs:
 
       - name: Cache trunk binary
         id: cache-trunk
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cargo/bin/trunk
           key: trunk-${{ env.TRUNK_VERSION }}-${{ runner.os }}
@@ -109,7 +109,7 @@ jobs:
           cache-on-failure: true
 
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: Run Clippy on frontend
         run: cargo clippy --package strom-frontend --target wasm32-unknown-unknown --all-features -- -D warnings
@@ -124,7 +124,7 @@ jobs:
           RUSTC_WRAPPER: sccache
 
       - name: Upload frontend dist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: frontend-dist
           path: backend/dist
@@ -136,7 +136,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -166,7 +166,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Extract version from Cargo.toml
         id: version
@@ -178,7 +178,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.10
 
       # Must NOT share a key with check-linux: rust-cache saves only once per
       # key and skips saving on a full-match restore. check-linux finishes
@@ -192,13 +192,13 @@ jobs:
           cache-on-failure: true
 
       - name: Cache Zig tarball
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: /tmp/zig.tar.xz
           key: zig-0.13.0-linux-x86_64
 
       - name: Cache cargo-zigbuild tarball
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: /tmp/cargo-zigbuild.tar.xz
           key: cargo-zigbuild-0.22.3-linux-x86_64
@@ -245,7 +245,7 @@ jobs:
           version: 1.5
 
       - name: Download frontend dist
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: frontend-dist
           path: backend/dist
@@ -259,7 +259,7 @@ jobs:
           cargo zigbuild --release --package strom-mcp-server --target x86_64-unknown-linux-gnu.2.31
 
       - name: Upload backend binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: strom-v${{ steps.version.outputs.version }}-linux-x86_64-x86_64-unknown-linux-gnu
           path: target/x86_64-unknown-linux-gnu/release/strom
@@ -267,7 +267,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload MCP server binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: strom-mcp-server-v${{ steps.version.outputs.version }}-linux-x86_64-x86_64-unknown-linux-gnu
           path: target/x86_64-unknown-linux-gnu/release/strom-mcp-server
@@ -281,7 +281,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Extract version from Cargo.toml
         id: version
@@ -293,7 +293,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
@@ -302,13 +302,13 @@ jobs:
           cache-on-failure: true
 
       - name: Cache Zig tarball
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: /tmp/zig.tar.xz
           key: zig-0.13.0-linux-aarch64
 
       - name: Cache cargo-zigbuild tarball
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: /tmp/cargo-zigbuild.tar.xz
           key: cargo-zigbuild-0.22.3-linux-aarch64
@@ -353,7 +353,7 @@ jobs:
           version: 1.5
 
       - name: Download frontend dist
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: frontend-dist
           path: backend/dist
@@ -367,7 +367,7 @@ jobs:
           cargo zigbuild --release --package strom-mcp-server --target aarch64-unknown-linux-gnu.2.31
 
       - name: Upload backend binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: strom-v${{ steps.version.outputs.version }}-linux-arm64-aarch64-unknown-linux-gnu
           path: target/aarch64-unknown-linux-gnu/release/strom
@@ -375,7 +375,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload MCP server binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: strom-mcp-server-v${{ steps.version.outputs.version }}-linux-arm64-aarch64-unknown-linux-gnu
           path: target/aarch64-unknown-linux-gnu/release/strom-mcp-server
@@ -391,7 +391,7 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Extract version from Cargo.toml
         id: version
@@ -427,7 +427,7 @@ jobs:
           echo "PKG_CONFIG_PATH=D:\gstreamer\1.0\msvc_x86_64\lib\pkgconfig" >> $env:GITHUB_ENV
 
       - name: Download frontend dist
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: frontend-dist
           path: backend/dist
@@ -439,7 +439,7 @@ jobs:
           cache-on-failure: true
 
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: Run Clippy
         run: |
@@ -463,7 +463,7 @@ jobs:
           RUSTC_WRAPPER: sccache
 
       - name: Upload backend binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: strom-v${{ steps.version.outputs.version }}-windows-x86_64-pc-windows-msvc
           path: target/release/strom.exe
@@ -471,7 +471,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload MCP server binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: strom-mcp-server-v${{ steps.version.outputs.version }}-windows-x86_64-pc-windows-msvc
           path: target/release/strom-mcp-server.exe
@@ -487,7 +487,7 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Extract version from Cargo.toml
         id: version
@@ -507,7 +507,7 @@ jobs:
           echo "LIBRARY_PATH=$(brew --prefix)/lib" >> $GITHUB_ENV
 
       - name: Download frontend dist
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: frontend-dist
           path: backend/dist
@@ -519,7 +519,7 @@ jobs:
           cache-on-failure: true
 
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: Run Clippy
         run: |
@@ -543,7 +543,7 @@ jobs:
           RUSTC_WRAPPER: sccache
 
       - name: Upload backend binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: strom-v${{ steps.version.outputs.version }}-macos-aarch64-apple-darwin
           path: target/release/strom
@@ -551,7 +551,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload MCP server binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: strom-mcp-server-v${{ steps.version.outputs.version }}-macos-aarch64-apple-darwin
           path: target/release/strom-mcp-server

--- a/.github/workflows/docker-publish-full.yml
+++ b/.github/workflows/docker-publish-full.yml
@@ -34,7 +34,7 @@ jobs:
       version: ${{ steps.version.outputs.version }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -59,7 +59,7 @@ jobs:
           fi
 
       - name: Build and push AMD64 image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: docker/strom-full
           file: docker/strom-full/Dockerfile
@@ -85,7 +85,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -109,7 +109,7 @@ jobs:
           fi
 
       - name: Build and push ARM64 image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: docker/strom-full
           file: docker/strom-full/Dockerfile

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -26,7 +26,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}
 
@@ -58,7 +58,7 @@ jobs:
           fi
 
       - name: Build and push AMD64 image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         env:
           BUILDKIT_PROGRESS: plain
         with:
@@ -89,7 +89,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}
 
@@ -112,7 +112,7 @@ jobs:
           fi
 
       - name: Build and push ARM64 image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         env:
           BUILDKIT_PROGRESS: plain
         with:

--- a/.github/workflows/release-msi.yml
+++ b/.github/workflows/release-msi.yml
@@ -31,7 +31,7 @@ jobs:
     timeout-minutes: 45
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Determine version
         id: version
@@ -257,7 +257,7 @@ jobs:
           Write-Host "MSI built successfully: $([math]::Round($msiSize, 2)) MB"
 
       - name: Upload MSI artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: strom-msi-${{ steps.version.outputs.version }}
           path: installer/windows/build/strom-${{ steps.version.outputs.version }}-windows-x86_64.msi
@@ -266,7 +266,7 @@ jobs:
 
       - name: Upload MSI to release
         if: github.event_name != 'workflow_dispatch' || github.event.inputs.upload_to_release != 'false'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ steps.version.outputs.version }}
           files: installer/windows/build/strom-${{ steps.version.outputs.version }}-windows-x86_64.msi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
     name: Build Frontend (WASM)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Install Rust stable with WASM target
         uses: dtolnay/rust-toolchain@stable
@@ -36,7 +36,7 @@ jobs:
 
       - name: Cache trunk binary
         id: cache-trunk
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cargo/bin/trunk
           key: trunk-${{ env.TRUNK_VERSION }}-${{ runner.os }}
@@ -53,7 +53,7 @@ jobs:
           cache-on-failure: true
 
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: Build frontend
         run: |
@@ -63,7 +63,7 @@ jobs:
           RUSTC_WRAPPER: sccache
 
       - name: Upload frontend dist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: frontend-dist
           path: backend/dist
@@ -101,7 +101,7 @@ jobs:
             binary_ext: ""
             features: "efp"
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Extract version from tag
         id: version
@@ -117,7 +117,7 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.10
 
       # Linux: Install Zig and cargo-zigbuild for glibc 2.31 compatibility
       - name: Determine Zig/cargo-zigbuild arch (Linux)
@@ -137,14 +137,14 @@ jobs:
 
       - name: Cache Zig tarball (Linux)
         if: startsWith(matrix.platform, 'linux')
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: /tmp/zig.tar.xz
           key: zig-0.13.0-linux-${{ env.ZIG_ARCH }}
 
       - name: Cache cargo-zigbuild tarball (Linux)
         if: startsWith(matrix.platform, 'linux')
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: /tmp/cargo-zigbuild.tar.xz
           key: cargo-zigbuild-0.22.3-linux-${{ env.ZIG_ARCH }}
@@ -240,7 +240,7 @@ jobs:
 
       # Download the pre-built frontend from the frontend build job
       - name: Download frontend dist
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: frontend-dist
           path: backend/dist
@@ -284,7 +284,7 @@ jobs:
           cargo build --release --package strom-mcp-server --target ${{ matrix.target }}
 
       - name: Upload backend binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: strom-v${{ steps.version.outputs.version }}-${{ matrix.platform }}-${{ matrix.target }}
           path: target/${{ matrix.target }}/release/strom${{ matrix.binary_ext }}
@@ -292,7 +292,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload MCP server binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: strom-mcp-server-v${{ steps.version.outputs.version }}-${{ matrix.platform }}-${{ matrix.target }}
           path: target/${{ matrix.target }}/release/strom-mcp-server${{ matrix.binary_ext }}
@@ -306,7 +306,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Extract version from tag
         id: version
@@ -315,7 +315,7 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
 
@@ -352,7 +352,7 @@ jobs:
           ls -lh release-assets/
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           draft: false
           prerelease: false


### PR DESCRIPTION
## Why

GitHub forces Node.js 24 for actions on **June 16, 2026** and removes Node 20 from runners on **September 16, 2026**. CI logs already warn:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20: actions/cache/restore@v4, actions/cache/save@v4, mozilla-actions/sccache-action@v0.0.9 …

## What

Bump every pinned action to its current major across all workflows:

| Action | From → To |
|---|---|
| `actions/checkout` | v5 → v6 |
| `actions/upload-artifact` | v4 → v7 |
| `actions/download-artifact` | v4 → v8 |
| `actions/cache` | v4 → v5 |
| `mozilla-actions/sccache-action` | v0.0.9 → v0.0.10 |
| `docker/build-push-action` | v6 → v7 |
| `softprops/action-gh-release` | v2 → v3 |

Floating major tags (`rust-cache@v2`, `cache-apt-pkgs@v1`, `login@v4`, `setup-buildx@v4`, `dtolnay/rust-toolchain@stable`) already track Node 24 releases and stay as-is.

## Breaking-change review

All majors are Node 24/ESM migrations; none affect our usage:
- **download-artifact v5** changed the output path for *by-ID* downloads — we address artifacts by name only.
- **download-artifact v8** errors on digest mismatch by default — desirable.
- **build-push-action v7** removed `DOCKER_BUILD_NO_SUMMARY`/`DOCKER_BUILD_EXPORT_RETENTION_DAYS` — unused here.
- **upload-artifact v7** adds opt-in `archive: false` — not used.

## Verification

ci.yml paths (checkout, cache, artifacts, sccache) are exercised by this PR's own run. release/docker/MSI workflows use the same bumped actions in the same by-name patterns; they get exercised at the next tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)