### PR TITLE
fix(tests): vision mixer FX tests — skip without a working GL context, drop fixed-sleep sampling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6595,7 +6595,7 @@ dependencies = [
 
 [[package]]
 name = "strom"
-version = "0.6.2-dev"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6670,7 +6670,7 @@ dependencies = [
 
 [[package]]
 name = "strom-frontend"
-version = "0.6.2-dev"
+version = "0.6.2"
 dependencies = [
  "base64",
  "chrono",
@@ -6706,7 +6706,7 @@ dependencies = [
 
 [[package]]
 name = "strom-mcp-server"
-version = "0.6.2-dev"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "reqwest 0.13.4",
@@ -6720,7 +6720,7 @@ dependencies = [
 
 [[package]]
 name = "strom-types"
-version = "0.6.2-dev"
+version = "0.6.2"
 dependencies = [
  "garde",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["types", "backend", "frontend", "mcp-server"]
 default-members = ["backend"]
 
 [workspace.package]
-version = "0.6.2-dev"
+version = "0.6.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Per Enstedt <per.enstedt@eyevinn.se>"]

--- a/backend/tests/vision_mixer_fx_test.rs
+++ b/backend/tests/vision_mixer_fx_test.rs
@@ -83,8 +83,26 @@ async fn vision_mixer_fx_engine_end_to_end() {
         return;
     }
 
-    // Let the pipeline roll a few frames.
-    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+    // Wait until the mixer actually produces output (its position query
+    // answers). A fixed sleep is not enough on cold software-GL CI runners,
+    // where the first frame can take many seconds (GL context creation +
+    // llvmpipe shader JIT) — and trigger_transition needs the mixer
+    // position for its timebase, so taking before that errors.
+    {
+        use gstreamer::prelude::*;
+        let mixer = manager
+            .pipeline()
+            .by_name(&format!("{}:mixer", BLOCK_ID))
+            .expect("mixer in pipeline");
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        while mixer.query_position::<gstreamer::ClockTime>().is_none() {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "mixer never produced output (position query still failing after 30s)"
+            );
+            tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+        }
+    }
 
     // FX engine must be detected on the GPU path with default enable_fx.
     assert!(
@@ -351,11 +369,8 @@ async fn wipe_between_letterboxed_sources_animates() {
         .downcast::<gstreamer_app::AppSink>()
         .expect("appsink type");
 
-    // Fraction of pixels that are white-ish / red-ish in the latest frame.
-    let sample_fractions = |appsink: &gstreamer_app::AppSink| -> (f64, f64) {
-        let sample = appsink
-            .try_pull_sample(gstreamer::ClockTime::from_seconds(5))
-            .expect("PGM frame");
+    // Fraction of pixels that are white-ish / red-ish in a frame.
+    let fractions_of = |sample: &gstreamer::Sample| -> (f64, f64) {
         let caps = sample.caps().expect("caps");
         let s = caps.structure(0).unwrap();
         let w = s.get::<i32>("width").unwrap() as usize;
@@ -390,9 +405,58 @@ async fn wipe_between_letterboxed_sources_animates() {
         eprintln!("{} sink linked: {}", name, linked);
     }
 
-    let (w0, r0) = sample_fractions(&appsink);
+    // First frame: a cold software-GL CI runner can take many seconds to
+    // produce it (GL context creation + llvmpipe shader JIT) — poll
+    // generously instead of a single short pull.
+    let first = {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        loop {
+            if let Some(s) = appsink.try_pull_sample(gstreamer::ClockTime::from_mseconds(500)) {
+                break s;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "no PGM frame within 30s of start"
+            );
+        }
+    };
+    let (w0, r0) = fractions_of(&first);
     assert!(w0 > 0.5, "PGM should start mostly white, got {}", w0);
     assert!(r0 < 0.05, "no red expected before take, got {}", r0);
+
+    // Watch a wipe to completion: pull every PGM frame, record whether any
+    // frame showed a substantial amount of BOTH sources (the wipe animated
+    // rather than hard-switching), and stop once the picture settles on the
+    // incoming source. Watching the whole window instead of sampling at
+    // fixed wall-clock offsets keeps the test honest on slow runners, where
+    // a single "mid-wipe" sample can land after the wipe already finished.
+    let observe_wipe = |incoming_is_red: bool| -> (bool, f64, f64) {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        let mut saw_both = false;
+        let mut last = (0.0, 0.0);
+        while std::time::Instant::now() < deadline {
+            let Some(s) = appsink.try_pull_sample(gstreamer::ClockTime::from_mseconds(500)) else {
+                continue;
+            };
+            let f = fractions_of(&s);
+            if f.0 > 0.10 && f.1 > 0.10 {
+                saw_both = true;
+            }
+            last = f;
+            let (incoming, outgoing) = if incoming_is_red {
+                (f.1, f.0)
+            } else {
+                (f.0, f.1)
+            };
+            // Settled on the incoming source after animating — done. (A
+            // hard-switch regression never sets saw_both and runs out the
+            // deadline, failing the animation assert below.)
+            if saw_both && incoming > 0.5 && outgoing < 0.05 {
+                break;
+            }
+        }
+        (saw_both, last.0, last.1)
+    };
 
     // --- classic orientation: 2.40:1 -> 2.34:1 (outgoing does not cover) ---
     manager
@@ -404,12 +468,11 @@ async fn wipe_between_letterboxed_sources_animates() {
     manager
         .update_vision_mixer_after_take(BLOCK_ID, Some(1), Some(0), 2)
         .expect("after take 0->1");
-    tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
-    let (w_mid, r_mid) = sample_fractions(&appsink);
-    eprintln!("classic mid-wipe: white={:.2} red={:.2}", w_mid, r_mid);
-    tokio::time::sleep(tokio::time::Duration::from_millis(1500)).await;
-    let (w_end, r_end) = sample_fractions(&appsink);
-    eprintln!("classic end: white={:.2} red={:.2}", w_end, r_end);
+    let (animated, w_end, r_end) = observe_wipe(true);
+    eprintln!(
+        "classic wipe: animated={} end white={:.2} red={:.2}",
+        animated, w_end, r_end
+    );
     assert!(r_end > 0.5, "wipe 0->1 should end on red, got {}", r_end);
     assert!(
         w_end < 0.05,
@@ -417,10 +480,8 @@ async fn wipe_between_letterboxed_sources_animates() {
         w_end
     );
     assert!(
-        w_mid > 0.10 && r_mid > 0.10,
-        "classic wipe should animate (both sources visible mid-wipe), got white={:.2} red={:.2}",
-        w_mid,
-        r_mid
+        animated,
+        "classic wipe should animate (no frame showed both sources)"
     );
 
     // --- inverted orientation: 2.34:1 -> 2.40:1 (outgoing covers) ---
@@ -430,12 +491,11 @@ async fn wipe_between_letterboxed_sources_animates() {
     manager
         .update_vision_mixer_after_take(BLOCK_ID, Some(0), Some(1), 2)
         .expect("after take 1->0");
-    tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
-    let (w_mid2, r_mid2) = sample_fractions(&appsink);
-    eprintln!("inverted mid-wipe: white={:.2} red={:.2}", w_mid2, r_mid2);
-    tokio::time::sleep(tokio::time::Duration::from_millis(1500)).await;
-    let (w_end2, r_end2) = sample_fractions(&appsink);
-    eprintln!("inverted end: white={:.2} red={:.2}", w_end2, r_end2);
+    let (animated2, w_end2, r_end2) = observe_wipe(false);
+    eprintln!(
+        "inverted wipe: animated={} end white={:.2} red={:.2}",
+        animated2, w_end2, r_end2
+    );
     // Debug: pad + fx state at the broken end state.
     let mixer = manager.pipeline().by_name("vmfx:mixer").expect("mixer");
     for i in 0..2 {
@@ -465,10 +525,13 @@ async fn wipe_between_letterboxed_sources_animates() {
         w_end2
     );
     assert!(
-        w_mid2 > 0.10 && r_mid2 > 0.10,
-        "inverted wipe should animate (both sources visible mid-wipe), got white={:.2} red={:.2}",
-        w_mid2,
-        r_mid2
+        r_end2 < 0.05,
+        "red should be gone after 1->0, got {}",
+        r_end2
+    );
+    assert!(
+        animated2,
+        "inverted wipe should animate (no frame showed both sources)"
     );
 
     manager.stop().expect("stop");

--- a/backend/tests/vision_mixer_fx_test.rs
+++ b/backend/tests/vision_mixer_fx_test.rs
@@ -3,7 +3,9 @@
 //! Builds a real vision mixer flow on the GPU (OpenGL) backend, starts it,
 //! and exercises the FX surface: FX slot presence, applying looks (input +
 //! master), shader wipe takes and master-FX takes. Runs on software GL
-//! (llvmpipe), so it works in CI — skips when GL is unavailable.
+//! (llvmpipe) — skips when the environment cannot actually create a GL
+//! context (probed like `shader_validation_test`; merely having the GL
+//! plugins installed is not enough, as headless CI runners show).
 
 use std::collections::HashMap;
 use strom::blocks::BlockRegistry;
@@ -14,6 +16,47 @@ use strom_types::Flow;
 use tempfile::NamedTempFile;
 
 const BLOCK_ID: &str = "vmfx";
+
+/// Probe whether this environment can actually render through GL: the GL
+/// plugins being installed is not enough — on headless CI runners the
+/// elements exist but no GL context can be created, and a GPU pipeline
+/// builds, starts and then silently never produces a frame. Same probe as
+/// `shader_validation_test`: a trivial `gltestsrc ! glshader ! fakesink`
+/// run must reach EOS.
+fn gl_environment_available() -> bool {
+    use gstreamer::prelude::*;
+    if gstreamer::ElementFactory::find("glvideomixerelement").is_none()
+        || gstreamer::ElementFactory::find("glshader").is_none()
+        || gstreamer::ElementFactory::find("gltestsrc").is_none()
+    {
+        return false;
+    }
+    let Ok(pipeline) = gstreamer::parse::launch(
+        "gltestsrc num-buffers=3 ! video/x-raw(memory:GLMemory),format=RGBA,width=64,height=64,framerate=30/1 ! glshader name=fx ! fakesink sync=false",
+    ) else {
+        return false;
+    };
+    let Ok(pipeline) = pipeline.downcast::<gstreamer::Pipeline>() else {
+        return false;
+    };
+    if let Some(fx) = pipeline.by_name("fx") {
+        fx.set_property("fragment", strom::gst::shaders::identity_fragment());
+    }
+    if pipeline.set_state(gstreamer::State::Playing).is_err() {
+        return false;
+    }
+    let bus = pipeline.bus().expect("pipeline has a bus");
+    // 20 s budget: software GL context creation can be slow on loaded CI.
+    let ok = matches!(
+        bus.timed_pop_filtered(
+            gstreamer::ClockTime::from_seconds(20),
+            &[gstreamer::MessageType::Eos, gstreamer::MessageType::Error],
+        ),
+        Some(msg) if matches!(msg.view(), gstreamer::MessageView::Eos(_))
+    );
+    let _ = pipeline.set_state(gstreamer::State::Null);
+    ok
+}
 
 /// A flow with a single vision mixer block forced onto the GPU backend.
 /// Inputs are left unlinked — force-live compositors output regardless.
@@ -46,10 +89,8 @@ fn build_vm_flow() -> Flow {
 async fn vision_mixer_fx_engine_end_to_end() {
     gstreamer::init().unwrap();
 
-    if gstreamer::ElementFactory::find("glvideomixerelement").is_none()
-        || gstreamer::ElementFactory::find("glshader").is_none()
-    {
-        eprintln!("SKIP: GStreamer GL elements not available");
+    if !gl_environment_available() {
+        eprintln!("SKIP: GL environment unavailable (no context or GL elements missing)");
         return;
     }
 
@@ -226,10 +267,8 @@ async fn wipe_between_letterboxed_sources_animates() {
     use gstreamer::prelude::*;
     gstreamer::init().unwrap();
 
-    if gstreamer::ElementFactory::find("glvideomixerelement").is_none()
-        || gstreamer::ElementFactory::find("glshader").is_none()
-    {
-        eprintln!("SKIP: GStreamer GL elements not available");
+    if !gl_environment_available() {
+        eprintln!("SKIP: GL environment unavailable (no context or GL elements missing)");
         return;
     }
 


### PR DESCRIPTION
## What

Both FX integration tests from #626 failed on the GitHub Actions runner ([failing run](https://github.com/Eyevinn/strom/actions/runs/27008349039/job/79705500525)). Two distinct problems, fixed in two commits:

### 1. The CI runner cannot create a GL context — skip there (the actual CI failure)

The runner has the GStreamer GL *plugins* installed, but no GL context can be created (headless, no usable software GL): a GPU pipeline builds, starts, and then silently never produces a frame. The telltale was `shader_validation_test` "passing" in 0.03s on the same runner — its environment probe fails fast and skips, while the FX tests only checked `ElementFactory::find()` (plugins present ≠ GL works).

The FX tests now use the same probe: a trivial `gltestsrc ! glshader ! fakesink` run with the identity fragment must reach EOS, otherwise the test skips. No CI-specific detection — the tests skip wherever GL genuinely cannot run, and keep running fully on dev boxes and GPU machines, where this coverage effectively lives.

### 2. Fixed sleeps made the tests flaky under load (a real local issue, fixed while diagnosing)

- **`vision_mixer_fx_engine_end_to_end`** slept a fixed 500ms after start, then took a wipe — too early and the position query behind `trigger_transition` fails. Now polls the mixer's position query (30s deadline) before taking.
- **`wipe_between_letterboxed_sources_animates`** sampled "mid-wipe" frames at fixed wall-clock offsets, which flaked ~1 in 3 under load when a sample landed after the wipe finished. Now watches **every** frame during a wipe: any frame showing both sources at once satisfies the animation assert, and observation stops once the picture settles on the incoming source. Also tightens the inverted-wipe end assert (red must be fully gone), matching the classic orientation.

A hard-switch regression still fails deterministically: `saw_both` never sets, the observe loop runs out its deadline, and the animation assert fires.

Also carries the workspace version bump to **0.6.2**.

## Testing

- Local (working GL): both tests run fully — 5+ consecutive green runs (previously flaked ~1 in 3 under load)
- CI (no GL context): both tests skip via the probe, like `shader_validation_test` already does

🤖 Generated with [Claude Code](https://claude.com/claude-code)