### PR TITLE
chore: bump version to 0.6.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6595,7 +6595,7 @@ dependencies = [
 
 [[package]]
 name = "strom"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6671,7 +6671,7 @@ dependencies = [
 
 [[package]]
 name = "strom-frontend"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "base64",
  "chrono",
@@ -6707,7 +6707,7 @@ dependencies = [
 
 [[package]]
 name = "strom-mcp-server"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "reqwest 0.13.4",
@@ -6721,7 +6721,7 @@ dependencies = [
 
 [[package]]
 name = "strom-types"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "garde",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["types", "backend", "frontend", "mcp-server"]
 default-members = ["backend"]
 
 [workspace.package]
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Per Enstedt <per.enstedt@eyevinn.se>"]

--- a/openapi.json
+++ b/openapi.json
@@ -10,7 +10,7 @@
     "license": {
       "name": "MIT OR Apache-2.0"
     },
-    "version": "0.6.2-dev"
+    "version": "0.6.3"
   },
   "paths": {
     "/api/auth/status": {


### PR DESCRIPTION
Bump workspace version 0.6.2 → 0.6.3 (Cargo.toml, Cargo.lock, openapi.json).

🤖 Generated with [Claude Code](https://claude.com/claude-code)