### PR TITLE
Handle missing pad properties gracefully across GStreamer versions

### DIFF
--- a/backend/src/gst/pipeline/properties.rs
+++ b/backend/src/gst/pipeline/properties.rs
@@ -668,6 +668,20 @@ impl PipelineManager {
             element_id, pad_name, prop_name, prop_value
         );
 
+        // Some pad properties are version- or backend-specific. The clearest
+        // example is `sizing-policy`, which exists on `GstVideoAggregatorPad`
+        // and `GstGLVideoMixerPad` only from GStreamer 1.24 onward. On 1.22
+        // calling `set_property_from_str` for a missing property panics
+        // ("property '...' of type '...' not found"), which would crash the
+        // tokio worker building the pipeline. Skip gracefully instead.
+        if !pad.has_property(prop_name) {
+            debug!(
+                "Pad {}:{} has no property '{}' (likely a GStreamer version/backend difference) - skipping",
+                element_id, pad_name, prop_name
+            );
+            return Ok(());
+        }
+
         // Use set_property_from_str for all types - GStreamer handles type conversion automatically
         let value_str = match prop_value {
             PropertyValue::String(v) => v.clone(),


### PR DESCRIPTION
## Description

Add a version/backend compatibility check before setting pad properties. Some properties (e.g., `sizing-policy` on `GstVideoAggregatorPad` and `GstGLVideoMixerPad`) only exist in GStreamer 1.24+. On earlier versions, calling `set_property_from_str` for a missing property panics and crashes the tokio worker.

This change checks if the pad has the property before attempting to set it, and logs a debug message if it is missing. This allows pipelines to be built successfully across different GStreamer versions and backends without crashing.

## Related Issue

Fixes version compatibility issues when building pipelines on GStreamer 1.22 with properties that only exist in 1.24+.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have run `cargo fmt --all`
- [ ] I have run `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] I have run `cargo test --workspace`
- [ ] I have updated documentation as needed
- [ ] I have added tests for new functionality

## Test Plan

Existing pipeline construction tests will verify that pipelines can be built without panicking when encountering version-specific properties. The graceful skip ensures backward compatibility with GStreamer 1.22 while remaining forward-compatible with 1.24+.

https://claude.ai/code/session_016wPoiLgpoJSUoGWDkPpRYC