### PR TITLE
Fix vision mixer FX shader crash on macOS core-profile GL

### DIFF
--- a/backend/src/gst/shaders/mod.rs
+++ b/backend/src/gst/shaders/mod.rs
@@ -215,7 +215,11 @@ fn build_shader(
 pub fn attach_create_shader_handler(elem: &gst::Element) {
     elem.connect("create-shader", false, |args| {
         let element = args[0].get::<gst::Element>().ok()?;
-        let fragment = element.property::<Option<String>>("fragment")?;
+        // An unset fragment property must not return None (process abort,
+        // see below) — treat it as a request for passthrough instead.
+        let fragment = element
+            .property::<Option<String>>("fragment")
+            .unwrap_or_else(identity_fragment);
         let Some(context) = element.property::<Option<gst_gl::GLContext>>("context") else {
             // No context means we cannot build any shader to return; this
             // should be unreachable (the signal fires from the GL thread).

--- a/backend/src/gst/shaders/mod.rs
+++ b/backend/src/gst/shaders/mod.rs
@@ -24,11 +24,14 @@
 //! # Compatibility
 //!
 //! All GLSL is written in GLES2 style (`varying`, `texture2D`,
-//! `gl_FragColor`, no `#version`) — the same dialect `gleffects` ships, which
-//! compiles on desktop GL compatibility contexts and GLES alike. A failed
-//! shader compile posts a GST element error and kills the pipeline, so only
-//! fragments from this module (CI-validated, see `shader_validation_test`)
-//! may ever reach a `glshader` element.
+//! `gl_FragColor`, no `#version`) — the same dialect `gleffects` ships. Like
+//! `gleffects`, fragments are compiled with profile `ES | COMPATIBILITY` (see
+//! [`attach_create_shader_handler`]): on desktop compat GL and GLES the
+//! source compiles as-is, and on core-only contexts (macOS exposes only
+//! OpenGL 3.2+ core) GStreamer prepends `#version 100`, which the driver
+//! accepts via `GL_ARB_ES2_compatibility`. Only fragments from this module
+//! (CI-validated, see `shader_validation_test`) may ever reach a `glshader`
+//! element.
 
 use gstreamer as gst;
 use gstreamer::prelude::*;
@@ -161,28 +164,61 @@ pub fn identity_fragment() -> String {
 
 const GL_FRAGMENT_SHADER: u32 = 0x8B30;
 
+/// Compile a complete `glshader` program (default vertex + `fragment`) for
+/// `context`.
+///
+/// The fragment compiles with profile `ES | COMPATIBILITY` and no explicit
+/// version — exactly how GStreamer compiles its own default vertex stage and
+/// the `gleffects` fragments. On desktop compat GL and GLES the GLES2-style
+/// source compiles as-is; on core-only contexts (macOS) GStreamer prepends
+/// `#version 100`, which the driver accepts via `GL_ARB_ES2_compatibility`.
+/// Do not pass a core version/profile here instead: GStreamer never prepends
+/// a `#version` line for non-ES profiles (the source would fail with
+/// "#version required and missing"), and a core-profile fragment could not
+/// link against the ES-compiled default vertex stage anyway.
+fn build_shader(
+    context: &gst_gl::GLContext,
+    fragment: &str,
+) -> Result<gst_gl::GLShader, gst::glib::Error> {
+    let shader = gst_gl::GLShader::new(context);
+    let vertex = gst_gl::GLSLStage::new_default_vertex(context);
+    shader.compile_attach_stage(&vertex)?;
+
+    let frag_stage = gst_gl::GLSLStage::with_string(
+        context,
+        GL_FRAGMENT_SHADER,
+        gst_gl::GLSLVersion::None,
+        gst_gl::GLSLProfile::ES | gst_gl::GLSLProfile::COMPATIBILITY,
+        fragment,
+    );
+    shader.compile_attach_stage(&frag_stage)?;
+    shader.link()?;
+    Ok(shader)
+}
+
 /// Attach the `create-shader` handler that makes runtime fragment swaps
 /// work. `glshader` only compiles from its `fragment` property while it has
 /// **no** shader (the first frame); once one exists, the property is inert
-/// and `update-shader=true` merely emits `create-shader` — with no handler
-/// the existing shader is kept (see `_maybe_recompile_shader` in
-/// gstglfiltershader.c). This handler compiles the element's current
-/// `fragment` string on the GL thread and returns the new shader.
+/// and `update-shader=true` merely emits `create-shader`. This handler
+/// compiles the element's current `fragment` string on the GL thread and
+/// returns the new shader.
 ///
-/// On compile failure it logs and returns `None`, which keeps the previous
-/// shader running — a runtime swap can never kill the pipeline (unlike the
-/// initial property-path compile, which posts an element error).
+/// The signal's return type is a **non-nullable** `GstGLShader`: returning
+/// `None` panics the glib-rs marshaller inside the C signal emission, which
+/// cannot unwind and aborts the whole process. So on compile failure we fall
+/// back to a freshly compiled identity (passthrough) shader rather than
+/// `None` — a bad runtime swap degrades to passthrough instead of killing the
+/// process.
 ///
 /// The closure captures nothing — the element arrives as a signal argument
 /// (no strong-ref cycles, per the project rule for GStreamer closures).
 pub fn attach_create_shader_handler(elem: &gst::Element) {
     elem.connect("create-shader", false, |args| {
-        let element = match args[0].get::<gst::Element>() {
-            Ok(e) => e,
-            Err(_) => return None,
-        };
+        let element = args[0].get::<gst::Element>().ok()?;
         let fragment = element.property::<Option<String>>("fragment")?;
         let Some(context) = element.property::<Option<gst_gl::GLContext>>("context") else {
+            // No context means we cannot build any shader to return; this
+            // should be unreachable (the signal fires from the GL thread).
             error!(
                 "{}: create-shader fired without a GL context",
                 element.name()
@@ -190,33 +226,52 @@ pub fn attach_create_shader_handler(elem: &gst::Element) {
             return None;
         };
 
-        let shader = gst_gl::GLShader::new(&context);
-        let vertex = gst_gl::GLSLStage::new_default_vertex(&context);
-        if let Err(e) = shader.compile_attach_stage(&vertex) {
-            error!("{}: vertex stage failed: {}", element.name(), e);
-            return None;
+        match build_shader(&context, &fragment) {
+            Ok(shader) => {
+                debug!("{}: runtime shader swap compiled OK", element.name());
+                Some(shader.to_value())
+            }
+            Err(e) => {
+                error!(
+                    "{}: fragment compile failed, falling back to passthrough: {}",
+                    element.name(),
+                    e
+                );
+                // Make the degraded FX observable on the bus (also lets the
+                // shader validation test detect compile failures).
+                gst::element_warning!(
+                    element,
+                    gst::ResourceError::Failed,
+                    ("FX shader compile failed, running passthrough: {}", e)
+                );
+                match build_shader(&context, &identity_fragment()) {
+                    Ok(shader) => Some(shader.to_value()),
+                    Err(e2) => {
+                        error!(
+                            "{}: identity fallback also failed to compile: {}",
+                            element.name(),
+                            e2
+                        );
+                        // Last resort: GStreamer's own default passthrough
+                        // shader, compiled by a code path independent of
+                        // build_shader. Returning None here aborts the whole
+                        // process (non-nullable signal return), so this must
+                        // be tried first.
+                        match gst_gl::GLShader::new_default(&context) {
+                            Ok(shader) => Some(shader.to_value()),
+                            Err(e3) => {
+                                error!(
+                                    "{}: default shader fallback also failed: {}",
+                                    element.name(),
+                                    e3
+                                );
+                                None
+                            }
+                        }
+                    }
+                }
+            }
         }
-        let frag_stage = gst_gl::GLSLStage::with_string(
-            &context,
-            GL_FRAGMENT_SHADER,
-            gst_gl::GLSLVersion::None,
-            gst_gl::GLSLProfile::empty(),
-            &fragment,
-        );
-        if let Err(e) = shader.compile_attach_stage(&frag_stage) {
-            error!(
-                "{}: fragment compile failed (keeping previous shader): {}",
-                element.name(),
-                e
-            );
-            return None;
-        }
-        if let Err(e) = shader.link() {
-            error!("{}: shader link failed: {}", element.name(), e);
-            return None;
-        }
-        debug!("{}: runtime shader swap compiled OK", element.name());
-        Some(shader.to_value())
     });
 }
 

--- a/backend/src/server_hardening.rs
+++ b/backend/src/server_hardening.rs
@@ -200,12 +200,15 @@ impl<S: AsyncWrite + Unpin> AsyncWrite for FirstByteTimeoutStream<S> {
 }
 
 /// How often the fd watchdog samples usage.
+#[cfg(target_os = "linux")]
 const FD_WATCHDOG_INTERVAL: Duration = Duration::from_secs(60);
 
 /// Usage ratio above which a warning is logged (once per excursion).
+#[cfg(target_os = "linux")]
 const FD_WARN_RATIO: f64 = 0.80;
 
 /// Usage ratio above which an error is logged on every sample.
+#[cfg(target_os = "linux")]
 const FD_ERROR_RATIO: f64 = 0.95;
 
 /// Current open fd count and the soft `RLIMIT_NOFILE` limit.

--- a/backend/tests/shader_validation_test.rs
+++ b/backend/tests/shader_validation_test.rs
@@ -13,20 +13,24 @@ use gstreamer as gst;
 use gstreamer::prelude::*;
 use gstreamer_app as gst_app;
 
-/// Run one fragment through a short GL pipeline. Returns `Err(message)` if
-/// the pipeline posts an error (shader compile failure, context failure, ...).
-fn run_fragment(fragment: &str) -> Result<(), String> {
-    let pipeline = gst::parse::launch(
-        "gltestsrc num-buffers=3 ! video/x-raw(memory:GLMemory),format=RGBA,width=64,height=64,framerate=30/1 ! glshader name=fx ! fakesink sync=false",
-    )
-    .map_err(|e| format!("parse: {}", e))?
-    .downcast::<gst::Pipeline>()
-    .map_err(|_| "not a pipeline".to_string())?;
+/// Run a launch line until EOS. With `fragment`, the `glshader` element named
+/// `fx` is set up exactly like production (`make_glshader`): fragment property
+/// plus `attach_create_shader_handler`. The handler degrades a failed compile
+/// to passthrough and posts a WARNING on the bus — the test treats that
+/// warning as a failure, so broken fragments cannot hide behind the fallback.
+fn run_gl_pipeline(launch: &str, fragment: Option<&str>) -> Result<(), String> {
+    let pipeline = gst::parse::launch(launch)
+        .map_err(|e| format!("parse: {}", e))?
+        .downcast::<gst::Pipeline>()
+        .map_err(|_| "not a pipeline".to_string())?;
 
-    let fx = pipeline
-        .by_name("fx")
-        .ok_or_else(|| "glshader element not found".to_string())?;
-    fx.set_property("fragment", fragment);
+    if let Some(fragment) = fragment {
+        let fx = pipeline
+            .by_name("fx")
+            .ok_or_else(|| "glshader element not found".to_string())?;
+        fx.set_property("fragment", fragment);
+        strom::gst::shaders::attach_create_shader_handler(&fx);
+    }
 
     pipeline
         .set_state(gst::State::Playing)
@@ -35,19 +39,63 @@ fn run_fragment(fragment: &str) -> Result<(), String> {
     let bus = pipeline.bus().expect("pipeline has a bus");
     // 20 s budget: software GL context creation can be slow on loaded CI.
     let timeout = gst::ClockTime::from_seconds(20);
-    let result =
-        match bus.timed_pop_filtered(timeout, &[gst::MessageType::Eos, gst::MessageType::Error]) {
-            None => Err("timeout waiting for EOS".to_string()),
+    let result = loop {
+        match bus.timed_pop_filtered(
+            timeout,
+            &[
+                gst::MessageType::Eos,
+                gst::MessageType::Error,
+                gst::MessageType::Warning,
+            ],
+        ) {
+            None => break Err("timeout waiting for EOS".to_string()),
             Some(msg) => match msg.view() {
-                gst::MessageView::Eos(_) => Ok(()),
+                gst::MessageView::Eos(_) => break Ok(()),
                 gst::MessageView::Error(e) => {
-                    Err(format!("{} ({})", e.error(), e.debug().unwrap_or_default()))
+                    break Err(format!("{} ({})", e.error(), e.debug().unwrap_or_default()))
+                }
+                gst::MessageView::Warning(w) => {
+                    let text = w.error().to_string();
+                    if text.contains("shader compile failed") {
+                        break Err(format!(
+                            "compile fell back to passthrough: {} ({})",
+                            text,
+                            w.debug().unwrap_or_default()
+                        ));
+                    }
+                    // Unrelated warning — keep waiting.
                 }
                 _ => unreachable!("filtered"),
             },
-        };
+        }
+    };
     let _ = pipeline.set_state(gst::State::Null);
     result
+}
+
+/// Run one fragment through a short GL pipeline with the production shader
+/// setup. Returns `Err(message)` on compile failure or pipeline error.
+fn run_fragment(fragment: &str) -> Result<(), String> {
+    run_gl_pipeline(
+        "gltestsrc num-buffers=3 ! video/x-raw(memory:GLMemory),format=RGBA,width=64,height=64,framerate=30/1 ! glshader name=fx ! fakesink sync=false",
+        Some(fragment),
+    )
+}
+
+/// Can this environment create a GL context at all? Probed with a GL pipeline
+/// that contains no `glshader`, so a shader compile bug can never masquerade
+/// as "no GL here" and silently skip the whole test.
+fn gl_environment_available() -> bool {
+    match run_gl_pipeline(
+        "gltestsrc num-buffers=3 ! video/x-raw(memory:GLMemory),format=RGBA,width=64,height=64,framerate=30/1 ! fakesink sync=false",
+        None,
+    ) {
+        Ok(()) => true,
+        Err(e) => {
+            eprintln!("SKIP: GL environment unavailable ({})", e);
+            false
+        }
+    }
 }
 
 #[test]
@@ -61,12 +109,9 @@ fn all_shader_fragments_compile() {
         return;
     }
 
-    // Environment probe: the identity fragment is trivially valid — if it
-    // fails, this machine cannot create a GL context (headless without
-    // llvmpipe). Skip rather than fail.
-    let identity = strom::gst::shaders::identity_fragment();
-    if let Err(e) = run_fragment(&identity) {
-        eprintln!("SKIP: GL environment unavailable ({})", e);
+    // Environment probe: skip only when no GL context can be created at all
+    // (headless without llvmpipe) — never on a shader compile failure.
+    if !gl_environment_available() {
         return;
     }
 
@@ -107,8 +152,7 @@ fn runtime_fragment_swap_takes_effect() {
         eprintln!("SKIP: GStreamer GL elements not available");
         return;
     }
-    if run_fragment(&strom::gst::shaders::identity_fragment()).is_err() {
-        eprintln!("SKIP: GL environment unavailable");
+    if !gl_environment_available() {
         return;
     }
 

--- a/backend/tests/vision_mixer_fx_test.rs
+++ b/backend/tests/vision_mixer_fx_test.rs
@@ -21,8 +21,9 @@ const BLOCK_ID: &str = "vmfx";
 /// plugins being installed is not enough — on headless CI runners the
 /// elements exist but no GL context can be created, and a GPU pipeline
 /// builds, starts and then silently never produces a frame. Same probe as
-/// `shader_validation_test`: a trivial `gltestsrc ! glshader ! fakesink`
-/// run must reach EOS.
+/// `shader_validation_test`: a trivial shader-free GL run must reach EOS
+/// (no `glshader` in the probe — a shader compile bug must fail the test,
+/// not skip it).
 fn gl_environment_available() -> bool {
     use gstreamer::prelude::*;
     if gstreamer::ElementFactory::find("glvideomixerelement").is_none()
@@ -32,16 +33,13 @@ fn gl_environment_available() -> bool {
         return false;
     }
     let Ok(pipeline) = gstreamer::parse::launch(
-        "gltestsrc num-buffers=3 ! video/x-raw(memory:GLMemory),format=RGBA,width=64,height=64,framerate=30/1 ! glshader name=fx ! fakesink sync=false",
+        "gltestsrc num-buffers=3 ! video/x-raw(memory:GLMemory),format=RGBA,width=64,height=64,framerate=30/1 ! fakesink sync=false",
     ) else {
         return false;
     };
     let Ok(pipeline) = pipeline.downcast::<gstreamer::Pipeline>() else {
         return false;
     };
-    if let Some(fx) = pipeline.by_name("fx") {
-        fx.set_property("fragment", strom::gst::shaders::identity_fragment());
-    }
     if pipeline.set_state(gstreamer::State::Playing).is_err() {
         return false;
     }


### PR DESCRIPTION
## Description

`strom` aborted on macOS as soon as a vision mixer FX shader compiled: the shader library's GLES2-style dialect (`varying` / `texture2D` / `gl_FragColor`, no `#version`) is rejected by macOS's core-only OpenGL contexts ("#version required and missing"), and the failed `create-shader` handler then returned `None` for a non-nullable signal return — a panic inside the C signal emission that cannot unwind, killing the whole process.

**Key changes:**

1. **Compile fragments with profile `ES | COMPATIBILITY` and no explicit version** — exactly how GStreamer compiles its own default vertex stage and the `gleffects` fragments. On desktop compat GL and GLES the source compiles as-is; on core-only contexts (macOS) GStreamer prepends `#version 100`, which the driver accepts via `GL_ARB_ES2_compatibility`. No platform detection, no shims. (A core version/profile cannot work: GStreamer only auto-prepends a `#version` line for ES profiles, and a core fragment could not link against the ES-compiled default vertex stage anyway.)

2. **Never abort on compile failure**: a failed runtime swap degrades to a passthrough shader (identity, then `GLShader::new_default` as a last, independent resort) instead of returning `None`, and posts a bus WARNING for observability.

3. **Fix silently-skipping shader tests**: on macOS the GL probes in `shader_validation_test` and `vision_mixer_fx_test` ran `glshader` without the production `create-shader` handler, hit this very compile bug, and misread it as "GL environment unavailable" → SKIP. Probes are now shader-free (pure GL-context checks), `run_fragment` uses the production setup (fragment property + `attach_create_shader_handler`), and the passthrough-fallback warning counts as a test failure — broken fragments can no longer hide behind the fallback or skip the suite.

4. **`server_hardening.rs`**: cfg-gate the fd watchdog constants to Linux, matching `spawn_fd_watchdog` (fixes dead_code warnings on macOS).

Verified on macOS: all 40 fragments compile, the runtime swap test renders, `vision_mixer_fx_test` passes (previously skipped), and a flow with mixer FX plays without errors where it previously aborted within seconds.

## Related Issue

Fixes the vision mixer FX shader abort on macOS core-profile GL.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have run `cargo fmt --all`
- [x] I have run `cargo clippy --workspace --all-targets -- -D warnings`
- [x] I have run `cargo test --workspace`
- [ ] I have updated documentation as needed
- [x] I have added tests for new functionality

https://claude.ai/code/session_016wPoiLgpoJSUoGWDkPpRYC

🤖 Generated with [Claude Code](https://claude.com/claude-code)