### PR TITLE
fix(videoenc): tame VideoToolbox burst behavior

### DIFF
--- a/backend/src/blocks/builtin/videoenc.rs
+++ b/backend/src/blocks/builtin/videoenc.rs
@@ -576,6 +576,19 @@ fn set_encoder_properties(
             };
             encoder.set_property_from_str("rate-control", rc);
         }
+        // VideoToolbox ABR leaves peak behavior unconstrained: data-rate-limits
+        // defaults to disabled, so single frames can spike far above the
+        // target bitrate — the same failure mode as the NVENC VBR fix above
+        // (line-rate packet bursts overflowing shallow buffers on constrained
+        // viewer paths). Cap output at 1.2x target averaged over a 0.5 s
+        // window (kVTCompressionPropertyKey_DataRateLimits) — the VT
+        // equivalent of the NVENC max-bitrate + vbv-buffer-size pair. vtenc
+        // itself skips this in CBR mode, matching NVENC's "ignored in CBR"
+        // semantics.
+        if bitrate > 0 && encoder.has_property("data-rate-limits") {
+            let max_kbps = bitrate.saturating_mul(12) / 10;
+            encoder.set_property_from_str("data-rate-limits", &format!("{},0.5", max_kbps));
+        }
         // VideoToolbox: cap the wall-clock gap between keyframes in addition
         // to the frame-based max-keyframe-interval set below. WebRTC clients
         // need a keyframe to start decoding when they join, so an unbounded

--- a/backend/src/blocks/builtin/videoenc.rs
+++ b/backend/src/blocks/builtin/videoenc.rs
@@ -682,6 +682,20 @@ fn set_encoder_properties(
         }
     }
 
+    // Rate-limit force-keyunit requests (GstVideoEncoder base-class property,
+    // present on all encoders; default 0 = honor every request). WebRTC
+    // viewers send a PLI on picture loss and webrtcsink converts each one
+    // into a force-keyunit event. With no floor, a burst-induced loss spiral
+    // (big frame -> loss -> PLI -> outsized IDR -> more loss -> more PLIs)
+    // makes the encoder emit back-to-back keyframes and multiplies the burst
+    // it started from. A 1 s floor caps PLI-driven IDRs at one per second:
+    // new viewers and genuine recoveries still get their keyframe quickly,
+    // but a PLI storm can no longer drive the output to many times the
+    // target bitrate.
+    if encoder.has_property("min-force-key-unit-interval") {
+        encoder.set_property("min-force-key-unit-interval", 1_000_000_000u64);
+    }
+
     info!(
         "Set encoder properties: bitrate={} kbps, preset={}, tune={}, rate_control={:?}, gop={}",
         bitrate, quality_preset, tune, rate_control, keyframe_interval

--- a/backend/src/blocks/builtin/videoenc.rs
+++ b/backend/src/blocks/builtin/videoenc.rs
@@ -565,26 +565,39 @@ fn set_encoder_properties(
             let realtime = tune == "zerolatency";
             encoder.set_property_from_str("realtime", if realtime { "true" } else { "false" });
         }
-        // VideoToolbox rate control: respect the requested mode. Newer vtenc
-        // exposes a rate-control enum (abr/cbr); CBR gives predictable
-        // bandwidth over constrained SRT/WebRTC links. CQP has no VT
-        // equivalent, so fall back to ABR.
+        // VideoToolbox rate control. Measured on Apple Silicon hardware
+        // (GStreamer 1.28, 720p30, 5 Mbit/s target, noise content):
+        //
+        // - ABR does NOT follow the bitrate: vtenc unconditionally sets
+        //   kVTCompressionPropertyKey_Quality (property default 0.5) after
+        //   AverageBitRate, and the hardware then encodes at constant quality
+        //   and ignores the bitrate target entirely (~95 Mbit/s measured
+        //   against a 5 Mbit/s target; a direct VTCompressionSession with the
+        //   same settings minus Quality tracks the target fine). Upstream
+        //   GStreamer bug.
+        // - CBR uses a different VT key (ConstantBitRate) that IS honored in
+        //   steady state.
+        //
+        // So map VBR to CBR too: a user asking for VBR means "roughly the
+        // target bitrate", never "unbounded constant quality". CQP maps to
+        // ABR, whose constant-quality behavior is exactly what CQP requests
+        // (the encoder's `quality` property is the dial). Note: scene changes
+        // still produce a multi-frame overshoot (~2-4 MB at 720p30) that no
+        // exposed VT property bounds, in CBR as well — for strictly capped
+        // bursts (e.g. WebRTC on constrained paths) use a software encoder
+        // (x264 with VBV) via encoder_preference=software.
         if encoder.has_property("rate-control") {
             let rc = match rate_control {
-                RateControl::CBR => "cbr",
-                RateControl::VBR | RateControl::CQP => "abr",
+                RateControl::CBR | RateControl::VBR => "cbr",
+                RateControl::CQP => "abr",
             };
             encoder.set_property_from_str("rate-control", rc);
         }
-        // VideoToolbox ABR leaves peak behavior unconstrained: data-rate-limits
-        // defaults to disabled, so single frames can spike far above the
-        // target bitrate — the same failure mode as the NVENC VBR fix above
-        // (line-rate packet bursts overflowing shallow buffers on constrained
-        // viewer paths). Cap output at 1.2x target averaged over a 0.5 s
-        // window (kVTCompressionPropertyKey_DataRateLimits) — the VT
-        // equivalent of the NVENC max-bitrate + vbv-buffer-size pair. vtenc
-        // itself skips this in CBR mode, matching NVENC's "ignored in CBR"
-        // semantics.
+        // data-rate-limits (the VT counterpart of a VBV cap, 1.2x target over
+        // a 0.5 s window). vtenc skips it in CBR mode, and on Apple Silicon
+        // hardware it is accepted (noErr) but measured to have no effect even
+        // in ABR. Still set it: it costs nothing where ignored and other
+        // VideoToolbox backends may honor it on the ABR (CQP) path.
         if bitrate > 0 && encoder.has_property("data-rate-limits") {
             let max_kbps = bitrate.saturating_mul(12) / 10;
             encoder.set_property_from_str("data-rate-limits", &format!("{},0.5", max_kbps));


### PR DESCRIPTION
## Description

Investigation of bursty VideoToolbox encoder output on macOS (WebRTC viewers saw 15-40 Mbit/s bursts from 4-5 Mbit/s encoders during vision mixer transitions, triggering PLI/NACK storms). Three fixes, each verified by measurement on Apple Silicon (GStreamer 1.28, 720p30):

1. **`data-rate-limits` on vtenc** — the VT counterpart of a VBV cap (1.2x target over a 0.5 s window). Measured: accepted (noErr) but without effect on Apple Silicon hardware; kept because other VideoToolbox backends honor it and it costs nothing where ignored.

2. **`min-force-key-unit-interval = 1 s` on all encoders** (GstVideoEncoder base-class property). Default 0 honors every force-keyunit request, so a WebRTC PLI storm (burst → loss → PLI → outsized IDR → more loss → more PLIs) makes the encoder emit back-to-back keyframes and multiplies the burst it started from. A 1 s floor caps PLI-driven IDRs at one per second while new viewers still get their keyframe quickly.

3. **Map VBR → CBR on vtenc.** Measured: VT ABR does not rate-control at all — a 5 Mbit/s target encodes at ~95 Mbit/s on demanding content. Root cause is an upstream GStreamer bug: `vtenc` unconditionally sets `kVTCompressionPropertyKey_Quality` (property default 0.5) after `AverageBitRate`, and Apple Silicon hardware then runs constant-quality, ignoring the bitrate target. A direct `VTCompressionSession` with the same settings minus Quality tracks the target (~6.4 Mbit/s); adding Quality=0.5 reproduces the runaway (~98 Mbit/s). CBR uses a different VT key (`ConstantBitRate`) that is honored in steady state, so VBR (the block default) now maps to CBR — a user asking for VBR means "roughly the target bitrate", never "unbounded constant quality". CQP keeps mapping to ABR, whose constant-quality behavior is exactly what CQP requests.

**Known residual limitation** (documented in the code): Apple's rate control overshoots scene changes by ~2-4 MB across ~10 frames in every mode, bypassing `DataRateLimits` even in a direct VT session. Strictly bounded bursts require a software encoder — `encoder_preference: software` gives x264 with a hard VBV cap (measured: single 311 kB IDR at the exact VBV bound, average on target through the transition).

An upstream issue draft with a self-contained Swift repro is prepared separately (`vtenc_issue01.md`, not part of this PR).

## Verification

- `GST_DEBUG=vtenc:6` confirms `DataRateLimits`/`ConstantBitRate` reach the VT session (status noErr) and that vtenc skips data-rate-limits in CBR mode as documented
- Frame-size measurements before/after over `videotestsrc` worst-case and scene-change content (tables in the commit messages)
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` all clean

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have run `cargo fmt --all`
- [x] I have run `cargo clippy --workspace --all-targets -- -D warnings`
- [x] I have run `cargo test --workspace`
- [ ] I have updated documentation as needed
- [ ] I have added tests for new functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)