### PR TITLE
fix(vision-mixer): shader FX time-precision freeze, heart wipe pop, real TV roll

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6595,7 +6595,7 @@ dependencies = [
 
 [[package]]
 name = "strom"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6671,7 +6671,7 @@ dependencies = [
 
 [[package]]
 name = "strom-frontend"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "base64",
  "chrono",
@@ -6707,7 +6707,7 @@ dependencies = [
 
 [[package]]
 name = "strom-mcp-server"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "reqwest 0.13.4",
@@ -6721,7 +6721,7 @@ dependencies = [
 
 [[package]]
 name = "strom-types"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "garde",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["types", "backend", "frontend", "mcp-server"]
 default-members = ["backend"]
 
 [workspace.package]
-version = "0.6.3"
+version = "0.6.4"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Per Enstedt <per.enstedt@eyevinn.se>"]

--- a/backend/src/gst/shaders/glsl/look_old_film.glsl
+++ b/backend/src/gst/shaders/glsl/look_old_film.glsl
@@ -5,7 +5,12 @@ uniform float u_intensity;
 
 void main() {
     vec2 uv = v_texcoord;
-    float t = floor(time * 24.0) / 24.0;
+    // Bound the timebase before deriving the hash seed: absolute `time` grows
+    // unbounded, and after ~a day of uptime float32 ULP exceeds the per-frame
+    // step so the grain/flicker freezes. A look has no take-relative anchor
+    // (no u_start), so wrap instead — the ~68 min period is imperceptible for
+    // random damage. (See master_glitch for the precision rationale.)
+    float t = floor(mod(time, 4096.0) * 24.0) / 24.0;
     vec4 src = texture2D(tex, uv);
     float y = luma(src.rgb);
     vec3 warm = vec3(y * 1.05, y * 0.95, y * 0.78);

--- a/backend/src/gst/shaders/glsl/look_vhs.glsl
+++ b/backend/src/gst/shaders/glsl/look_vhs.glsl
@@ -4,11 +4,18 @@ uniform float u_intensity;
 
 void main() {
     vec2 uv = v_texcoord;
+    // Bound the timebase before it seeds a hash: absolute `time` grows
+    // unbounded and after ~a day of uptime float32 ULP swamps the per-line
+    // hash step, collapsing jitter/tear into a frozen pattern. A look has no
+    // take-relative anchor, so wrap (~68 min period, imperceptible for tape
+    // damage). The fract(time) noise below is already bounded. (See
+    // master_glitch for the precision rationale.)
+    float bt = mod(time, 4096.0);
     // Per-line horizontal jitter, re-rolled ~15x per second.
-    float jitter = (hash12(vec2(floor(uv.y * height), floor(time * 15.0))) - 0.5)
+    float jitter = (hash12(vec2(floor(uv.y * height), floor(bt * 15.0))) - 0.5)
         * 0.003 * u_intensity;
     // Occasional wider tear band.
-    float band = step(0.985, hash12(vec2(floor(time * 7.0), floor(uv.y * 30.0))))
+    float band = step(0.985, hash12(vec2(floor(bt * 7.0), floor(uv.y * 30.0))))
         * 0.02 * u_intensity;
     uv.x += jitter + band;
     // Chroma shift: sample R and B slightly apart.

--- a/backend/src/gst/shaders/glsl/master_glitch.glsl
+++ b/backend/src/gst/shaders/glsl/master_glitch.glsl
@@ -7,7 +7,14 @@ void main() {
     // Widened envelope: ramps up fast, holds near peak around the cut.
     float e = pow(envelope(), 0.4) * u_intensity;
     vec2 uv = v_texcoord;
-    float t = floor(time * 30.0);
+    // Frame counter for the per-band hashes. MUST be take-relative, not
+    // absolute `time`: with absolute PTS the argument to the sin()-based
+    // hash grows to ~1e8 after a day of runtime, where float32 ULP (~32)
+    // exceeds the per-band step (~13). Adjacent bands then collapse to the
+    // same hash and all displacement freezes into a uniform (invisible)
+    // shift — leaving only the hash-free RGB split. `time - u_start` stays
+    // in 0..duration, so the hash is well-conditioned for any uptime.
+    float t = floor((time - u_start) * 30.0);
     // Horizontal block displacement: random bands shift sideways hard.
     float band = floor(uv.y * 24.0);
     float shift = (hash12(vec2(band, t)) - 0.5) * 0.55 * e

--- a/backend/src/gst/shaders/glsl/master_punch.glsl
+++ b/backend/src/gst/shaders/glsl/master_punch.glsl
@@ -6,7 +6,10 @@ uniform float u_intensity;
 void main() {
     float e = pow(envelope(), 0.5) * u_intensity;
     float zoom = 1.0 - 0.35 * e;
-    float t = floor(time * 60.0);
+    // Take-relative frame counter: absolute `time` grows large enough over a
+    // day of uptime that float32 ULP exceeds the per-frame hash step and the
+    // shake freezes (see master_glitch for the full rationale).
+    float t = floor((time - u_start) * 60.0);
     vec2 shake = (vec2(hash12(vec2(t, 1.0)), hash12(vec2(t, 2.0))) - 0.5) * 0.04 * e;
     vec2 uv = (v_texcoord - 0.5) * zoom + 0.5 + shake;
     gl_FragColor = texture2D(tex, clamp(uv, 0.0, 1.0));

--- a/backend/src/gst/shaders/glsl/master_roll.glsl
+++ b/backend/src/gst/shaders/glsl/master_roll.glsl
@@ -1,14 +1,44 @@
-// Master TV roll: vertical sync-loss roll through the cut, with a faint
-// blanking bar at the wrap seam.
+// Master TV roll: a vertical sync-loss roll through the cut. The picture eases
+// into a slow roll, accelerates into a fast, motion-blurred smear of wrapping
+// frames that hides the delayed cut at the midpoint, then decelerates and
+// locks back to sync. A dark blanking bar and a horizontal tear ride the wrap
+// seam so the frame visibly "loses sync" rather than simply scrolling.
 uniform float u_intensity;
 
 void main() {
-    float e = envelope() * u_intensity;
-    float shift = e * 0.85;
-    float y = fract(v_texcoord.y + shift);
-    vec4 src = texture2D(tex, vec2(v_texcoord.x, y));
-    // Blanking bar around the seam.
-    float seam = min(y, 1.0 - y);
-    float bar = 1.0 - 0.7 * e * (1.0 - smoothstep(0.0, 0.04, seam));
-    gl_FragColor = vec4(src.rgb * bar, src.a);
+    float p = fx_linear_p();
+    // Monotonic roll over N whole frame-heights. smootherstep eases the roll
+    // velocity to zero at both ends (so it locks cleanly, and ends on an
+    // integer number of wraps = back in sync) while peaking at the midpoint,
+    // exactly where the delayed cut is hidden.
+    float N = 10.0;
+    float s = p * p * p * (p * (p * 6.0 - 15.0) + 10.0); // smootherstep
+    float roll = N * s;
+    // Roll speed = d/dp of N*smootherstep; drives motion blur and tearing.
+    float vel = N * 30.0 * p * p * (1.0 - p) * (1.0 - p);
+    float blur = clamp(vel * 0.015, 0.0, 0.45) * u_intensity;
+
+    // Horizontal tear riding the wrap seam, gated by roll speed. The two sides
+    // of the seam (frame top meeting frame bottom) shove opposite ways.
+    float yc = fract(v_texcoord.y + roll);
+    float seam = min(yc, 1.0 - yc);
+    float tear = (1.0 - smoothstep(0.0, 0.12, seam))
+        * clamp(vel * 0.03, 0.0, 1.0) * u_intensity;
+    float xoff = tear * 0.06 * sign(0.5 - yc);
+
+    // Vertical motion blur: average taps spread along the roll direction so the
+    // fast portion smears into an unreadable blur.
+    vec3 acc = vec3(0.0);
+    for (int i = 0; i < 7; i++) {
+        float o = (float(i) / 6.0 - 0.5) * blur;
+        float yy = fract(v_texcoord.y + roll + o);
+        acc += texture2D(tex, vec2(v_texcoord.x + xoff, yy)).rgb;
+    }
+    vec3 rgb = acc / 7.0;
+
+    // Dark blanking/retrace bar at the seam.
+    float bar = (1.0 - smoothstep(0.0, 0.05, seam)) * u_intensity;
+    rgb *= 1.0 - 0.85 * bar;
+
+    gl_FragColor = vec4(rgb, texture2D(tex, vec2(v_texcoord.x, yc)).a);
 }

--- a/backend/src/gst/shaders/glsl/wipe_heart.glsl
+++ b/backend/src/gst/shaders/glsl/wipe_heart.glsl
@@ -1,25 +1,32 @@
 // Heart iris: a heart shape grows from the center. The classic implicit
 // heart curve ((x^2+y^2-1)^3 - x^2*y^3 = 0) has no closed-form radius, so
 // the ordering value is found by bisecting the scale at which the boundary
-// passes through the pixel (monotone in scale; 10 steps is plenty).
+// passes through the pixel (monotone in scale; bisection is plenty).
 float in_heart(vec2 q, float s) {
     q /= max(s, 0.001);
     float a = q.x * q.x + q.y * q.y - 1.0;
     return q.x * q.x * q.y * q.y * q.y - a * a * a;
 }
 
-float wipe_mask(vec2 uv, float p) {
+// Pixel position in heart space. Texture y points down, so flip. The heart
+// curve is taller above the origin (lobes reach ~1.2, tip -1.0), so shift the
+// evaluation point up to drop the rendered shape onto the optical center.
+vec2 heart_q(vec2 uv) {
     vec2 q = (uv - 0.5) * vec2(width / height, 1.0) * 1.5;
-    // Texture y points down, so flip. The heart curve is taller above the
-    // origin (lobes reach ~1.2, tip -1.0), so shift the evaluation point up
-    // to drop the rendered shape onto the optical center.
     q.y = -q.y + 0.1;
+    return q;
+}
+
+// Smallest scale at which q falls inside the heart (i.e. the scale the growing
+// heart reaches the pixel). Capped at SMAX, which is generous enough to cover
+// any on-screen pixel for a normal aspect ratio.
+float heart_scale(vec2 q) {
     float lo = 0.01;
-    float hi = 1.0;
+    float hi = 3.0;
     if (in_heart(q, hi) < 0.0) {
-        return reveal(1.0, p, u_softness);
+        return hi;
     }
-    for (int i = 0; i < 10; i++) {
+    for (int i = 0; i < 14; i++) {
         float mid = 0.5 * (lo + hi);
         if (in_heart(q, mid) > 0.0) {
             hi = mid;
@@ -27,5 +34,21 @@ float wipe_mask(vec2 uv, float p) {
             lo = mid;
         }
     }
-    return reveal(hi, p, u_softness);
+    return hi;
+}
+
+float wipe_mask(vec2 uv, float p) {
+    float s = heart_scale(heart_q(uv));
+    // Normalize by the hardest-to-cover frame point so the ordering value
+    // reaches 1.0 exactly when the heart has filled the screen. Without this,
+    // every pixel beyond the max-scale heart shares one ordering value and the
+    // whole border pops in together at the end of the transition. The corners
+    // dominate (the heart narrows toward the tip, so the bottom corners need
+    // the most scale); sampling the four corners captures the maximum.
+    float smax = heart_scale(heart_q(vec2(0.0, 0.0)));
+    smax = max(smax, heart_scale(heart_q(vec2(1.0, 0.0))));
+    smax = max(smax, heart_scale(heart_q(vec2(0.0, 1.0))));
+    smax = max(smax, heart_scale(heart_q(vec2(1.0, 1.0))));
+    float d = clamp(s / max(smax, 0.001), 0.0, 1.0);
+    return reveal(d, p, u_softness);
 }

--- a/openapi.json
+++ b/openapi.json
@@ -10,7 +10,7 @@
     "license": {
       "name": "MIT OR Apache-2.0"
     },
-    "version": "0.6.3"
+    "version": "0.6.4"
   },
   "paths": {
     "/api/auth/status": {


### PR DESCRIPTION
Three vision-mixer shader FX fixes/improvements, all GPU-path, validated with `shader_validation_test` on software GL.

## 1. FX hashes freeze over long uptime (the headline bug)

The animated FX shaders seed their per-band/per-frame hashes (`fract(sin(dot(...))*K)`) from a frame counter derived from the **absolute** buffer-PTS `time` uniform. As the pipeline runs, `time` grows without bound; once the argument to `sin()` is large enough that float32 ULP exceeds the per-band/per-frame step, adjacent bands and consecutive frames collapse to the same hash value. Hash-driven motion then **freezes** while hash-free transforms (RGB split, zoom) keep working.

**Observed in the field:** a flow up 2+ days lost the glitch take's block displacement entirely (only the RGB split remained); a stop/start of the flow restored it.

- `master_glitch`, `master_punch`: seed from take-relative time (`time - u_start`), which stays in `0..duration` — the same well-behaved quantity the envelope already uses.
- `look_old_film`, `look_vhs`: looks have no take anchor, so wrap the timebase with `mod(time, 4096.0)` (~68 min period, imperceptible for random grain/jitter/tear).
- `look_night_vision` (`fract(time)`) and `look_underwater` (continuous `sin`, degrades gracefully; a `mod`-wrap would inject a visible discontinuity) are intentionally left unchanged.

Note: this fixes the **running-time-growth** case. The **absolute-PTS** case (PTP/TAI direct clock reference feeding per-input slots, where `time ≈ 1.78e9` and float32 ULP ≈ 128 s breaks the take/wipe *timing* itself) is **not** addressed here — that needs FX animation driven from a bounded Rust-supplied time uniform instead of glshader's float32 `time`. Tracked separately.

## 2. Heart wipe pops at the end

The heart wipe returned the bisected heart *scale* (capped at 1.0) directly as the ordering value. The heart at scale 1.0 never reaches the frame corners, so every pixel beyond it took the early-return `d=1.0` and the whole border revealed simultaneously near `p≈0.91–0.95` — a visible pop — after which `p→1.0` was dead. Normalize the ordering like the iris and star wipes do (extend the bisection range to cover the frame, divide by the hardest-to-cover corner) so it fills smoothly with no end pop. Shape unchanged.

## 3. Roll take is now an actual roll

The old roll just shifted the picture up to 0.85 of a frame height and back (less than one wrap) — not a roll. Replaced with a real vertical sync-loss roll: eases into a slow roll, accelerates through N whole frame-heights into a fast motion-blurred smear that hides the delayed cut at the midpoint, then decelerates and locks back to sync. Includes a blanking bar and a speed-gated horizontal tear riding the wrap seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)