### PR TITLE
feat(vision-mixer): make multiview PVW/PGM positions swappable

### DIFF
--- a/backend/src/blocks/builtin/vision_mixer/builder/mod.rs
+++ b/backend/src/blocks/builtin/vision_mixer/builder/mod.rs
@@ -148,6 +148,8 @@ impl BlockBuilder for VisionMixerBuilder {
             properties::parse_bool(props, "gl_download", vision_mixer::DEFAULT_GL_DOWNLOAD);
         let show_vu_meters = properties::parse_show_vu_meters(props);
         let enable_fx = properties::parse_bool(props, "enable_fx", vision_mixer::DEFAULT_ENABLE_FX);
+        let swap_pvw_pgm =
+            properties::parse_bool(props, "swap_pvw_pgm", vision_mixer::DEFAULT_SWAP_PVW_PGM);
 
         let pref = props
             .get("compositor_preference")
@@ -190,6 +192,7 @@ impl BlockBuilder for VisionMixerBuilder {
             gl_download,
             show_vu_meters,
             enable_fx,
+            swap_pvw_pgm,
         };
 
         match backend {
@@ -226,6 +229,8 @@ pub(super) struct PipelineParams<'a> {
     pub(super) show_vu_meters: bool,
     /// Build shader FX slots (GPU pipeline only; the CPU builder ignores it).
     pub(super) enable_fx: bool,
+    /// Mirror the multiview layout (PGM left, PVW right).
+    pub(super) swap_pvw_pgm: bool,
 }
 
 impl<'a> PipelineParams<'a> {

--- a/backend/src/blocks/builtin/vision_mixer/builder/pipeline_cpu.rs
+++ b/backend/src/blocks/builtin/vision_mixer/builder/pipeline_cpu.rs
@@ -39,7 +39,14 @@ pub(super) fn build_cpu_pipeline(
     } else {
         16.0 / 9.0
     };
-    let mv_layout = layout::compute_layout(p.mv_w, p.mv_h, p.num_inputs, p.num_pips, source_aspect);
+    let mv_layout = layout::compute_layout(
+        p.mv_w,
+        p.mv_h,
+        p.num_inputs,
+        p.num_pips,
+        source_aspect,
+        p.swap_pvw_pgm,
+    );
 
     // --- Distribution output chain: mixer → capsfilter_dist → tee_pgm → queue_dist_out ---
     // DSK inputs are composited on the main mixer (same as GPU path).

--- a/backend/src/blocks/builtin/vision_mixer/builder/pipeline_gpu.rs
+++ b/backend/src/blocks/builtin/vision_mixer/builder/pipeline_gpu.rs
@@ -40,7 +40,14 @@ pub(super) fn build_gpu_pipeline(
     } else {
         16.0 / 9.0
     };
-    let mv_layout = layout::compute_layout(p.mv_w, p.mv_h, p.num_inputs, p.num_pips, source_aspect);
+    let mv_layout = layout::compute_layout(
+        p.mv_w,
+        p.mv_h,
+        p.num_inputs,
+        p.num_pips,
+        source_aspect,
+        p.swap_pvw_pgm,
+    );
 
     // --- Distribution output chain ---
     // queue_post_dist decouples the compositor from downstream processing.

--- a/backend/src/blocks/builtin/vision_mixer/definition.rs
+++ b/backend/src/blocks/builtin/vision_mixer/definition.rs
@@ -237,6 +237,25 @@ fn vision_mixer_definition() -> BlockDefinition {
             live: false,
             persist: None,
         },
+        // Swap PVW/PGM positions in the multiview layout
+        ExposedProperty {
+            name: "swap_pvw_pgm".to_string(),
+            label: "Swap PVW/PGM Positions".to_string(),
+            description:
+                "Mirror the multiview layout so PGM is on the left and PVW on the right."
+                    .to_string(),
+            property_type: PropertyType::Bool,
+            default_value: Some(PropertyValue::Bool(
+                strom_types::vision_mixer::DEFAULT_SWAP_PVW_PGM,
+            )),
+            mapping: PropertyMapping {
+                element_id: "_block".to_string(),
+                property_name: "swap_pvw_pgm".to_string(),
+                transform: None,
+            },
+            live: false,
+            persist: None,
+        },
         // Output pixel format
         ExposedProperty {
             name: "output_format".to_string(),

--- a/backend/src/blocks/builtin/vision_mixer/layout.rs
+++ b/backend/src/blocks/builtin/vision_mixer/layout.rs
@@ -183,6 +183,7 @@ pub fn compute_layout(
     num_inputs: usize,
     num_pips: usize,
     source_aspect: f64,
+    swap_pvw_pgm: bool,
 ) -> OverlayLayout {
     let cw = canvas_width as f64;
     let ch = canvas_height as f64;
@@ -202,8 +203,16 @@ pub fn compute_layout(
     let (big_w, big_h) = fit_to_aspect(half_w_box, top_h_box, source_aspect);
     let big_pad_left = ((half_w_box - big_w) / 2.0).max(0.0);
     let big_pad_top = ((top_h_box - big_h) / 2.0).max(0.0);
-    let pvw_x = gap + big_pad_left;
-    let pgm_x = gap * 2.0 + half_w_box + big_pad_left;
+    // PVW occupies the left half and PGM the right by default; swap_pvw_pgm
+    // mirrors them. The label positions, borders and compositor pads all
+    // derive from these rects, so swapping the x coords flips everything.
+    let left_x = gap + big_pad_left;
+    let right_x = gap * 2.0 + half_w_box + big_pad_left;
+    let (pvw_x, pgm_x) = if swap_pvw_pgm {
+        (right_x, left_x)
+    } else {
+        (left_x, right_x)
+    };
     let big_y = gap + big_pad_top;
     let pvw_rect = Rect::new(pvw_x, big_y, big_w, big_h);
     let pgm_rect = Rect::new(pgm_x, big_y, big_w, big_h);

--- a/backend/src/blocks/builtin/vision_mixer/tests.rs
+++ b/backend/src/blocks/builtin/vision_mixer/tests.rs
@@ -73,7 +73,7 @@ const ASPECT_16_9: f64 = 16.0 / 9.0;
 
 #[test]
 fn test_layout_compute_basic() {
-    let l = layout::compute_layout(1920, 1080, 4, 0, ASPECT_16_9);
+    let l = layout::compute_layout(1920, 1080, 4, 0, ASPECT_16_9, false);
     assert_eq!(l.num_inputs, 4);
     assert_eq!(l.thumbnail_rects.len(), 4);
     assert_eq!(l.label_positions.len(), 4);
@@ -98,10 +98,23 @@ fn test_layout_compute_basic() {
 }
 
 #[test]
+fn test_layout_swap_pvw_pgm() {
+    let normal = layout::compute_layout(1920, 1080, 4, 0, ASPECT_16_9, false);
+    let swapped = layout::compute_layout(1920, 1080, 4, 0, ASPECT_16_9, true);
+    // Swap mirrors the two big rects: PGM is now on the left, PVW on the right.
+    assert!(swapped.pgm_rect.x < swapped.pvw_rect.x);
+    // The geometry is exactly mirrored — swapped PVW sits where PGM was.
+    assert_eq!(swapped.pvw_rect.x as i32, normal.pgm_rect.x as i32);
+    assert_eq!(swapped.pgm_rect.x as i32, normal.pvw_rect.x as i32);
+    // Labels follow their rects, so they swap sides too.
+    assert!(swapped.pgm_label_pos.x < swapped.pvw_label_pos.x);
+}
+
+#[test]
 fn test_layout_compute_10_inputs() {
     // 10 slots → (5, 2) grid (cell aspect ≈ 1.43, zero empty cells beats
     // any alternative on the combined aspect+empty cost).
-    let l = layout::compute_layout(1920, 1080, 10, 0, ASPECT_16_9);
+    let l = layout::compute_layout(1920, 1080, 10, 0, ASPECT_16_9, false);
     assert_eq!(l.thumbnail_rects.len(), 10);
     // First 5 in row 1, next 5 in row 2
     let row1_y = l.thumbnail_rects[0].y;
@@ -122,7 +135,7 @@ fn test_layout_compute_with_pip_tile() {
     // 4 inputs + 1 PiP tile = 5 slots → (3, 2) grid: 3 in row 1, 2 in row 2.
     // PiP is slot 4 → row 1 (second row), col 1. Last input is slot 3 →
     // row 1, col 0. Same row, PiP to the right of last input.
-    let l = layout::compute_layout(1920, 1080, 4, 1, ASPECT_16_9);
+    let l = layout::compute_layout(1920, 1080, 4, 1, ASPECT_16_9, false);
     assert_eq!(l.num_inputs, 4);
     assert_eq!(l.num_pips, 1);
     assert_eq!(l.thumbnail_rects.len(), 4);
@@ -157,7 +170,7 @@ fn test_layout_compute_with_pip_tile() {
 
 #[test]
 fn test_pip_overlay_rects_tile_within_bg() {
-    let l = layout::compute_layout(1920, 1080, 4, 1, ASPECT_16_9);
+    let l = layout::compute_layout(1920, 1080, 4, 1, ASPECT_16_9, false);
     let (bx, by, bw, bh) = layout::pip_bg_pad_position(&l, 0);
 
     // Two overlays → side-by-side aspect-preserving cells within the PiP tile.
@@ -281,7 +294,7 @@ fn overlay_registries_round_trip() {
 
     let block_id = "test-vm-overlay-cleanup-block-id";
 
-    let lo = layout::compute_layout(1280, 720, 4, 0, ASPECT_16_9);
+    let lo = layout::compute_layout(1280, 720, 4, 0, ASPECT_16_9, false);
     let state = Arc::new(VisionMixerOverlayState::new(
         4,
         0,

--- a/types/src/vision_mixer.rs
+++ b/types/src/vision_mixer.rs
@@ -145,6 +145,11 @@ pub const DEFAULT_GL_DOWNLOAD: bool = false;
 /// GPU pipeline. GPU path only — the CPU compositor has no FX engine.
 pub const DEFAULT_ENABLE_FX: bool = true;
 
+/// Whether to swap the PVW and PGM positions in the multiview layout. When
+/// false (default) PVW is on the left and PGM on the right; when true they
+/// are mirrored.
+pub const DEFAULT_SWAP_PVW_PGM: bool = false;
+
 // --- Z-order constants for compositor pads ---
 
 /// Z-order for thumbnail pads on the multiview compositor.


### PR DESCRIPTION
## What

Adds a `swap_pvw_pgm` block property to the vision mixer (default `false`) that mirrors the multiview layout so **PGM is on the left and PVW on the right**.

## Why

Operators may prefer PGM on a particular side depending on their setup/habits. Until now the layout was fixed: PVW left, PGM right.

## How

The multiview layout is fully driven by two rects, `pvw_rect` and `pgm_rect`, in `compute_layout`. The label text ("PVW"/"PGM"), borders, VU meters and compositor pad positions all derive from those rects — so swapping the rect x-coordinates flips everything consistently. Video routing is unchanged; only the on-screen positions move.

- New constant `DEFAULT_SWAP_PVW_PGM` in `strom-types`
- New `Bool` block property `swap_pvw_pgm` (`live: false` — applies on pipeline build), rendered automatically as a checkbox in the GUI like `gl_download`/`enable_fx`
- Threaded through `PipelineParams` into both the GPU and CPU pipeline builders

## Testing

- New unit test `test_layout_swap_pvw_pgm` verifies both rects and labels mirror
- All existing layout tests pass; OpenAPI snapshot unaffected (block properties aren't part of the schema)

🤖 Generated with [Claude Code](https://claude.com/claude-code)