### PR TITLE
chore(release): v0.6.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6545,7 +6545,7 @@ dependencies = [
 
 [[package]]
 name = "strom"
-version = "0.6.5-dev"
+version = "0.6.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6621,7 +6621,7 @@ dependencies = [
 
 [[package]]
 name = "strom-frontend"
-version = "0.6.5-dev"
+version = "0.6.5"
 dependencies = [
  "base64",
  "chrono",
@@ -6657,7 +6657,7 @@ dependencies = [
 
 [[package]]
 name = "strom-mcp-server"
-version = "0.6.5-dev"
+version = "0.6.5"
 dependencies = [
  "anyhow",
  "reqwest 0.13.4",
@@ -6671,7 +6671,7 @@ dependencies = [
 
 [[package]]
 name = "strom-types"
-version = "0.6.5-dev"
+version = "0.6.5"
 dependencies = [
  "garde",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["types", "backend", "frontend", "mcp-server"]
 default-members = ["backend"]
 
 [workspace.package]
-version = "0.6.5-dev"
+version = "0.6.5"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Per Enstedt <per.enstedt@eyevinn.se>"]


### PR DESCRIPTION
Cut the v0.6.5 release by dropping the `-dev` suffix from the workspace version.

This release picks up the commits landed on `main` since v0.6.4:
- ColorCorrect, dithered looks, Vogel blur, and transition fixes (#639)
- Swappable multiview PVW/PGM positions (#637)
- README link to the hosted Open Live platform (#638)

After merge, `main` will be tagged `v0.6.5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)