### PR TITLE
chore: bump to 0.6.6-dev, document 0.6.3–0.6.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6545,7 +6545,7 @@ dependencies = [
 
 [[package]]
 name = "strom"
-version = "0.6.5"
+version = "0.6.6-dev"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6621,7 +6621,7 @@ dependencies = [
 
 [[package]]
 name = "strom-frontend"
-version = "0.6.5"
+version = "0.6.6-dev"
 dependencies = [
  "base64",
  "chrono",
@@ -6657,7 +6657,7 @@ dependencies = [
 
 [[package]]
 name = "strom-mcp-server"
-version = "0.6.5"
+version = "0.6.6-dev"
 dependencies = [
  "anyhow",
  "reqwest 0.13.4",
@@ -6671,7 +6671,7 @@ dependencies = [
 
 [[package]]
 name = "strom-types"
-version = "0.6.5"
+version = "0.6.6-dev"
 dependencies = [
  "garde",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["types", "backend", "frontend", "mcp-server"]
 default-members = ["backend"]
 
 [workspace.package]
-version = "0.6.5"
+version = "0.6.6-dev"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Per Enstedt <per.enstedt@eyevinn.se>"]

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 All notable changes to the Strom GStreamer Flow Engine project.
 
+## [0.6.5] - 2026-06-12
+
+### Added
+- Vision Mixer: ColorCorrect look — primary correction (brightness, contrast, gamma, saturation) plus white balance (temperature, tint) and hue rotation, computed in YCbCr; a strict superset of `glcolorbalance` for camera matching. Neutral at every default, so an untouched correction is an identity pass. (#639)
+- Vision Mixer: swappable multiview PVW/PGM positions via the `swap_pvw_pgm` block property (#637)
+
+### Changed
+- Vision Mixer: dithered looks — ~1 LSB TPDF dither on color-correct, blur, duotone and thermal to kill 8-bit banding; 24-tap Vogel-spiral blur with aspect-corrected circular bokeh; fixed-raster CRT scanlines and aperture grille; blur radius cap raised to 40 px (#639)
+- Vision Mixer: FX look parameters laid out in a 4-column grid (#639)
+
+### Fixed
+- Vision Mixer: glitch, roll and punch transitions left driver-dependent residual artifacts after completion — transition envelopes now settle to an exact identity pass (#639)
+- Frontend: keep `wgpu` out of the WASM build after the eframe 0.34.2 default-feature regression (#639)
+
+---
+
+## [0.6.4] - 2026-06-08
+
+### Fixed
+- Vision Mixer: shader FX time-precision freeze over long uptime, heart wipe pop, real TV roll (#636)
+- Video encoder: tame VideoToolbox burst behavior (#635)
+- Vision Mixer: FX shader crash on macOS core-profile GL (#634)
+- Pipeline: skip missing pad properties instead of panicking (#633)
+
+---
+
+## [0.6.3] - 2026-06-05
+
+### Fixed
+- Video encoder: cap VBR excursions and bound frame sizes via VBV (#631)
+- Server: harden the HTTP(S) accept path against fd exhaustion (#630)
+- WHEP: re-enable RTX retransmission, keep FEC disabled (#629)
+
+### Documentation
+- Add 0.6.1 and 0.6.2 release notes (#628)
+
+---
+
 ## [0.6.2] - 2026-06-05
 
 ### Added

--- a/docs/VISION_MIXER_OPERATOR_GUIDE.md
+++ b/docs/VISION_MIXER_OPERATOR_GUIDE.md
@@ -185,10 +185,16 @@ With the GPU backend and the **Shader FX** block property enabled
 - **Shader transitions** — the wipe and master-FX takes in §3.1. Pick
   them with the WIPE / FX buttons on the operator page.
 - **Looks** — persistent per-source effects applied wherever the source
-  appears (PGM, PVW, thumbnails, PiPs): chroma key, pixelate, blur,
-  duotone, vignette, VHS, old film, edge glow, CRT, halftone, thermal,
-  night vision, posterize, underwater. A look can also sit on the
-  **PGM master** output. Open with the LOOKS button.
+  appears (PGM, PVW, thumbnails, PiPs): color correct, chroma key,
+  pixelate, blur, duotone, vignette, VHS, old film, edge glow, CRT,
+  halftone, thermal, night vision, posterize, underwater. A look can also
+  sit on the **PGM master** output. Open with the LOOKS button.
+  - **Color Correct** is the camera-matching tool: brightness, contrast,
+    gamma, saturation, hue, plus white balance (temperature and tint).
+    Every control is neutral at its default, so a freshly added Color
+    Correct does nothing until you move a slider — reach for it to match
+    a mismatched camera or set a white point, on a single source or on
+    the PGM master.
 
 Looks are runtime state (like DSK toggles): they reset when the flow
 restarts. Looks and master-FX takes run on independent slots, so a take
@@ -407,8 +413,8 @@ The multiview is the operator's monitor. Default resolution 1280×720 @
 
 | Element | Where | Notes |
 |---|---|---|
-| **PVW big display** | Top-left of canvas | Shows the current preview source (Input or PiP). |
-| **PGM big display** | Top-right of canvas | Shows the live program. |
+| **PVW big display** | Top-left of canvas | Shows the current preview source (Input or PiP). Moves to the top-right when PVW/PGM positions are swapped. |
+| **PGM big display** | Top-right of canvas | Shows the live program. Moves to the top-left when PVW/PGM positions are swapped. |
 | **Thumbnail grid** | Bottom half | One tile per input, then one tile per configured PiP. Grid columns/rows are chosen automatically based on slot count and source aspect (16:9). |
 | **PVW border** | Around the PVW display **and** around the source tile currently routed to PVW | **Green.** |
 | **PGM border** | Around the PGM display **and** around the source tile currently routed to PGM | **Red.** |
@@ -419,6 +425,12 @@ The multiview is the operator's monitor. Default resolution 1280×720 @
 | **VU meters** | Thin vertical bar bottom-left of each thumbnail, plus one on PVW and one on PGM | See §6.2. Can be globally disabled with the **Show VU Meters** block property. |
 | **FTB badge** | Centered on PGM display | Appears when Fade-to-Black is engaged. |
 | **Multiview overlay alpha** | Whole overlay | A live operator control fades the entire overlay (borders, labels, clock, VU meters) from 0.0 → 1.0. Useful for clean screenshots / OB cleanfeeds when the multiview is doubling as a confidence monitor. |
+
+By default PVW sits on the left and PGM on the right. The **Swap PVW/PGM
+positions** block property mirrors the layout (PGM left, PVW right) —
+labels, borders, VU meters and big-display positions all follow. It only
+changes the on-screen layout, never the video routing, and applies when
+the pipeline is built (not live).
 
 ### 6.2 VU meter colors
 
@@ -489,6 +501,7 @@ WebSocket event so multiple operator panels stay in sync in real time.
 | Show VU meters on multiview | **On** |
 | Initial PGM input | Input 0 |
 | Initial PVW input | Input 1 |
+| Swap PVW/PGM positions on multiview | Off (PVW left, PGM right) |
 | Compositor latency | 20 ms |
 | Min upstream latency | 20 ms |
 


### PR DESCRIPTION
Post-release housekeeping for v0.6.5.

### Version
- Bump workspace version `0.6.5` → `0.6.6-dev` so ongoing work sits on a dev version, not the release tag.

### Changelog
The changelog had fallen behind at 0.6.2. Adds reconstructed release notes for:
- **0.6.5** — ColorCorrect look, swappable multiview PVW/PGM, dithered looks / Vogel blur / fixed-raster CRT, transition residual fixes, WASM wgpu fix (#637, #639)
- **0.6.4** — shader FX time-precision freeze, VideoToolbox burst, macOS GL crash, pad-property panic (#633–#636)
- **0.6.3** — VBV frame bounding, fd-exhaustion hardening, WHEP RTX (#629–#631)

### Vision Mixer guide
- Document the **ColorCorrect** look (camera matching / white balance) in the looks list.
- Document the **Swap PVW/PGM positions** block property in §6 and the defaults reference.

README reviewed — no change needed; its feature list already covers the FX engine at the right altitude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)