### PR TITLE
chore(ci): move sccache cache to olivedev MinIO instance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ env:
   # ceiling with the docker buildkit blobs. The same backend is reused by the
   # release workflow and the Dockerfile builder, where rust-cache cannot reach.
   # Requires repo secrets SCCACHE_S3_ACCESS_KEY_ID / SCCACHE_S3_SECRET_ACCESS_KEY
-  # (a service account scoped to the strom bucket, no admin).
-  SCCACHE_BUCKET: strom
-  SCCACHE_ENDPOINT: https://eyevinnlab-rustcache.minio-minio.auto.prod.osaas.io
+  # (a service account scoped to the sccache bucket, no admin).
+  SCCACHE_BUCKET: sccache
+  SCCACHE_ENDPOINT: https://olivedev-rustcache.minio-minio.auto.prod-se.osaas.io
   SCCACHE_REGION: us-east-1
   SCCACHE_S3_USE_SSL: "true"
   AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_S3_ACCESS_KEY_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,8 @@ env:
   # NO Swatinem/rust-cache steps: saving ~5-7 GB of one-shot caches per tag
   # only evicted the CI workflow's hot caches. sccache is the persistent cache.
   # Requires repo secrets SCCACHE_S3_ACCESS_KEY_ID / SCCACHE_S3_SECRET_ACCESS_KEY.
-  SCCACHE_BUCKET: strom
-  SCCACHE_ENDPOINT: https://eyevinnlab-rustcache.minio-minio.auto.prod.osaas.io
+  SCCACHE_BUCKET: sccache
+  SCCACHE_ENDPOINT: https://olivedev-rustcache.minio-minio.auto.prod-se.osaas.io
   SCCACHE_REGION: us-east-1
   SCCACHE_S3_USE_SSL: "true"
   AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_S3_ACCESS_KEY_ID }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,8 @@ RUN ARCH="$(uname -m)" && \
       | tar -xz -C /tmp && \
     install -m0755 "/tmp/sccache-v${SCCACHE_VERSION}-${ARCH}-unknown-linux-musl/sccache" /usr/local/bin/sccache && \
     rm -rf /tmp/sccache-*
-ENV SCCACHE_BUCKET=strom \
-    SCCACHE_ENDPOINT=https://eyevinnlab-rustcache.minio-minio.auto.prod.osaas.io \
+ENV SCCACHE_BUCKET=sccache \
+    SCCACHE_ENDPOINT=https://olivedev-rustcache.minio-minio.auto.prod-se.osaas.io \
     SCCACHE_REGION=us-east-1 \
     SCCACHE_S3_USE_SSL=true
 
@@ -91,8 +91,8 @@ RUN ARCH="$(uname -m)" && \
       | tar -xz -C /tmp && \
     install -m0755 "/tmp/sccache-v${SCCACHE_VERSION}-${ARCH}-unknown-linux-musl/sccache" /usr/local/bin/sccache && \
     rm -rf /tmp/sccache-*
-ENV SCCACHE_BUCKET=strom \
-    SCCACHE_ENDPOINT=https://eyevinnlab-rustcache.minio-minio.auto.prod.osaas.io \
+ENV SCCACHE_BUCKET=sccache \
+    SCCACHE_ENDPOINT=https://olivedev-rustcache.minio-minio.auto.prod-se.osaas.io \
     SCCACHE_REGION=us-east-1 \
     SCCACHE_S3_USE_SSL=true
 


### PR DESCRIPTION
## Why

The `eyevinnlab/rustcache` MinIO instance backing the self-hosted sccache S3 cache lost its data **and** its bucket during the hyperscaler migration (the volume came back freshly formatted, no bucket). sccache was failing on every job.

While fixing it we also moved the service to the **olivedev** tenant.

## What changed

Repointed the sccache S3 backend in all four locations:

- `ci.yml` and `release.yml` env blocks
- both `Dockerfile` builder-stage `ENV` blocks

| Param | Old | New |
|---|---|---|
| `SCCACHE_BUCKET` | `strom` | `sccache` |
| `SCCACHE_ENDPOINT` | `eyevinnlab-rustcache…auto.prod.osaas.io` | `olivedev-rustcache…auto.prod-se.osaas.io` |
| `SCCACHE_REGION` | `us-east-1` | unchanged |
| `SCCACHE_S3_USE_SSL` | `true` | unchanged |

## Out-of-band (already done)

- New `minio-minio` instance `rustcache` provisioned in `olivedev`, `sccache` bucket created.
- A bucket-scoped service account (Get/Put/List on `sccache` only, no admin) was created and verified (put/get/list OK, delete + admin denied).
- Repo secrets `SCCACHE_S3_ACCESS_KEY_ID` / `SCCACHE_S3_SECRET_ACCESS_KEY` rotated to the new service account.

Credential-less runs (forks, dependabot) still fall back to building without the cache — `RUSTC_WRAPPER` stays empty when the access-key secret is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)