### PR TITLE
ci: make sccache cache non-blocking via a backend preflight

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
       # Package list must stay identical to build-linux-x86_64 so both jobs
       # share one apt cache entry (the action keys by package list + arch).
       - name: Cache apt packages
-        uses: awalsh128/cache-apt-pkgs-action@v1
+        uses: awalsh128/cache-apt-pkgs-action@v1.6.1
         with:
           packages: libunwind-dev libssl-dev libcairo2-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-bad1.0-dev gstreamer1.0-plugins-base gstreamer1.0-plugins-good pkg-config cmake libclang-dev
           version: 1.5
@@ -280,7 +280,7 @@ jobs:
       # check-linux so both x86_64 jobs share one apt cache entry; arm64 gets
       # its own entry automatically (the action keys by list + runner arch).
       - name: Install GStreamer (cached)
-        uses: awalsh128/cache-apt-pkgs-action@v1
+        uses: awalsh128/cache-apt-pkgs-action@v1.6.1
         with:
           packages: libunwind-dev libssl-dev libcairo2-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-bad1.0-dev gstreamer1.0-plugins-base gstreamer1.0-plugins-good pkg-config cmake libclang-dev
           version: 1.5
@@ -390,7 +390,7 @@ jobs:
       # check-linux so both x86_64 jobs share one apt cache entry; arm64 gets
       # its own entry automatically (the action keys by list + runner arch).
       - name: Install GStreamer (cached)
-        uses: awalsh128/cache-apt-pkgs-action@v1
+        uses: awalsh128/cache-apt-pkgs-action@v1.6.1
         with:
           packages: libunwind-dev libssl-dev libcairo2-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-bad1.0-dev gstreamer1.0-plugins-base gstreamer1.0-plugins-good pkg-config cmake libclang-dev
           version: 1.5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,17 +24,49 @@ env:
   SCCACHE_S3_USE_SSL: "true"
   AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_S3_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_S3_SECRET_ACCESS_KEY }}
-  # Dependabot- and fork-triggered runs don't receive Actions secrets, and
-  # sccache hard-fails on empty S3 credentials. Fall back to building without
-  # the compile cache instead (cargo ignores an empty RUSTC_WRAPPER).
-  RUSTC_WRAPPER: ${{ secrets.SCCACHE_S3_ACCESS_KEY_ID != '' && 'sccache' || '' }}
+  # RUSTC_WRAPPER is NOT set globally. sccache treats its configured cache as a
+  # hard requirement: a missing bucket or unreachable endpoint makes every cargo
+  # invocation fail instead of compiling normally. The `preflight` job probes the
+  # backend once and each build job sets RUSTC_WRAPPER=sccache only when
+  # preflight reports it healthy (and credentials are present — forks and
+  # dependabot get none). The cache is an optimization, never a dependency.
 
 jobs:
+  # Probe the sccache S3 backend once so a broken cache degrades to an uncached
+  # build instead of failing CI. Exposes cache_ok consumed by every build job.
+  preflight:
+    name: sccache preflight
+    runs-on: ubuntu-latest
+    outputs:
+      cache_ok: ${{ steps.probe.outputs.cache_ok }}
+    steps:
+      - name: Probe sccache S3 backend
+        id: probe
+        run: |
+          if [ -z "$AWS_ACCESS_KEY_ID" ]; then
+            echo "No sccache credentials (fork or dependabot run) - cache disabled"
+            echo "cache_ok=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # list-objects-v2 needs only s3:ListBucket, which the scoped service
+          # account has. NoSuchBucket / unreachable endpoint -> non-zero -> off.
+          if timeout 25 aws --endpoint-url "$SCCACHE_ENDPOINT" --region "$SCCACHE_REGION" \
+               --cli-connect-timeout 8 --cli-read-timeout 8 \
+               s3api list-objects-v2 --bucket "$SCCACHE_BUCKET" --max-keys 1 >/dev/null 2>&1; then
+            echo "sccache backend reachable - cache enabled"
+            echo "cache_ok=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::sccache backend unreachable or bucket missing - building WITHOUT compile cache"
+            echo "cache_ok=false" >> "$GITHUB_OUTPUT"
+          fi
   # Fast checks on Linux: fmt + clippy + test
   check-linux:
     name: Check (Linux)
+    needs: preflight
     runs-on: ubuntu-24.04
     timeout-minutes: 25
+    env:
+      RUSTC_WRAPPER: ${{ needs.preflight.outputs.cache_ok == 'true' && 'sccache' || '' }}
     steps:
       - uses: actions/checkout@v6
 
@@ -63,7 +95,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Setup sccache
-        if: env.AWS_ACCESS_KEY_ID != ''
+        if: needs.preflight.outputs.cache_ok == 'true'
         uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: Check formatting
@@ -84,7 +116,10 @@ jobs:
   # WASM: clippy + build frontend
   check-wasm:
     name: Check & Build (WASM)
+    needs: preflight
     runs-on: ubuntu-latest
+    env:
+      RUSTC_WRAPPER: ${{ needs.preflight.outputs.cache_ok == 'true' && 'sccache' || '' }}
     steps:
       - uses: actions/checkout@v6
 
@@ -115,7 +150,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Setup sccache
-        if: env.AWS_ACCESS_KEY_ID != ''
+        if: needs.preflight.outputs.cache_ok == 'true'
         uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: Run Clippy on frontend
@@ -165,9 +200,11 @@ jobs:
   # Linux x86_64 build
   build-linux-x86_64:
     name: Build (Linux x86_64)
-    needs: check-wasm
+    needs: [check-wasm, preflight]
     runs-on: ubuntu-24.04
     timeout-minutes: 30
+    env:
+      RUSTC_WRAPPER: ${{ needs.preflight.outputs.cache_ok == 'true' && 'sccache' || '' }}
     steps:
       - uses: actions/checkout@v6
 
@@ -181,7 +218,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Setup sccache
-        if: env.AWS_ACCESS_KEY_ID != ''
+        if: needs.preflight.outputs.cache_ok == 'true'
         uses: mozilla-actions/sccache-action@v0.0.10
 
       # Must NOT share a key with check-linux: rust-cache saves only once per
@@ -280,9 +317,11 @@ jobs:
   # Linux ARM64 build (build only - no native clippy/test)
   build-linux-arm64:
     name: Build (Linux ARM64)
-    needs: check-wasm
+    needs: [check-wasm, preflight]
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 30
+    env:
+      RUSTC_WRAPPER: ${{ needs.preflight.outputs.cache_ok == 'true' && 'sccache' || '' }}
     steps:
       - uses: actions/checkout@v6
 
@@ -296,7 +335,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Setup sccache
-        if: env.AWS_ACCESS_KEY_ID != ''
+        if: needs.preflight.outputs.cache_ok == 'true'
         uses: mozilla-actions/sccache-action@v0.0.10
 
       # save-if main: see check-linux.
@@ -390,9 +429,11 @@ jobs:
   build-windows:
     name: Build (Windows)
     if: github.event_name == 'workflow_dispatch'
-    needs: check-wasm
+    needs: [check-wasm, preflight]
     runs-on: windows-latest
     timeout-minutes: 45
+    env:
+      RUSTC_WRAPPER: ${{ needs.preflight.outputs.cache_ok == 'true' && 'sccache' || '' }}
     steps:
       - uses: actions/checkout@v6
 
@@ -440,7 +481,7 @@ jobs:
       # stale or evicted by the next manual run. sccache via MinIO covers
       # recompiles instead.
       - name: Setup sccache
-        if: env.AWS_ACCESS_KEY_ID != ''
+        if: needs.preflight.outputs.cache_ok == 'true'
         uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: Run Clippy
@@ -479,9 +520,11 @@ jobs:
   build-macos:
     name: Build (macOS)
     if: github.event_name == 'workflow_dispatch'
-    needs: check-wasm
+    needs: [check-wasm, preflight]
     runs-on: macos-latest
     timeout-minutes: 30
+    env:
+      RUSTC_WRAPPER: ${{ needs.preflight.outputs.cache_ok == 'true' && 'sccache' || '' }}
     steps:
       - uses: actions/checkout@v6
 
@@ -510,7 +553,7 @@ jobs:
 
       # No rust-cache here: workflow_dispatch-only, see the Windows job.
       - name: Setup sccache
-        if: env.AWS_ACCESS_KEY_ID != ''
+        if: needs.preflight.outputs.cache_ok == 'true'
         uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: Run Clippy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,40 @@ env:
   AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_S3_SECRET_ACCESS_KEY }}
 
 jobs:
+  # Probe the sccache S3 backend once so a broken cache degrades to an uncached
+  # build instead of failing the release. sccache treats its configured cache as
+  # a hard requirement (a missing bucket or unreachable endpoint fails every
+  # cargo invocation), so jobs set RUSTC_WRAPPER=sccache only when this reports
+  # the backend healthy. The cache is an optimization, never a dependency.
+  preflight:
+    name: sccache preflight
+    runs-on: ubuntu-latest
+    outputs:
+      cache_ok: ${{ steps.probe.outputs.cache_ok }}
+    steps:
+      - name: Probe sccache S3 backend
+        id: probe
+        run: |
+          if [ -z "$AWS_ACCESS_KEY_ID" ]; then
+            echo "No sccache credentials - cache disabled"
+            echo "cache_ok=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # list-objects-v2 needs only s3:ListBucket, which the scoped service
+          # account has. NoSuchBucket / unreachable endpoint -> non-zero -> off.
+          if timeout 25 aws --endpoint-url "$SCCACHE_ENDPOINT" --region "$SCCACHE_REGION" \
+               --cli-connect-timeout 8 --cli-read-timeout 8 \
+               s3api list-objects-v2 --bucket "$SCCACHE_BUCKET" --max-keys 1 >/dev/null 2>&1; then
+            echo "sccache backend reachable - cache enabled"
+            echo "cache_ok=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::sccache backend unreachable or bucket missing - building WITHOUT compile cache"
+            echo "cache_ok=false" >> "$GITHUB_OUTPUT"
+          fi
+
   build-frontend:
     name: Build Frontend (WASM)
+    needs: preflight
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -49,6 +81,7 @@ jobs:
           wget -qO- https://github.com/trunk-rs/trunk/releases/download/v${{ env.TRUNK_VERSION }}/trunk-x86_64-unknown-linux-gnu.tar.gz | tar -xzf- -C ~/.cargo/bin
 
       - name: Setup sccache
+        if: needs.preflight.outputs.cache_ok == 'true'
         uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: Build frontend
@@ -56,7 +89,7 @@ jobs:
           cd frontend
           trunk build --release
         env:
-          RUSTC_WRAPPER: sccache
+          RUSTC_WRAPPER: ${{ needs.preflight.outputs.cache_ok == 'true' && 'sccache' || '' }}
 
       - name: Upload frontend dist
         uses: actions/upload-artifact@v7
@@ -67,7 +100,7 @@ jobs:
 
   build:
     name: Build ${{ matrix.platform }}
-    needs: build-frontend
+    needs: [build-frontend, preflight]
     runs-on: ${{ matrix.os }}
     timeout-minutes: ${{ matrix.platform == 'macos' && 60 || 45 }}
     strategy:
@@ -113,6 +146,7 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Setup sccache
+        if: needs.preflight.outputs.cache_ok == 'true'
         uses: mozilla-actions/sccache-action@v0.0.10
 
       # Linux: Install Zig and cargo-zigbuild for glibc 2.31 compatibility
@@ -246,7 +280,7 @@ jobs:
         if: startsWith(matrix.platform, 'linux')
         env:
           RUSTFLAGS: "-L /usr/lib/${{ matrix.target == 'aarch64-unknown-linux-gnu' && 'aarch64-linux-gnu' || 'x86_64-linux-gnu' }}"
-          RUSTC_WRAPPER: sccache
+          RUSTC_WRAPPER: ${{ needs.preflight.outputs.cache_ok == 'true' && 'sccache' || '' }}
         run: |
           set -e
           FEATURES="${{ matrix.features }}"
@@ -262,7 +296,7 @@ jobs:
         if: ${{ !startsWith(matrix.platform, 'linux') }}
         shell: bash
         env:
-          RUSTC_WRAPPER: sccache
+          RUSTC_WRAPPER: ${{ needs.preflight.outputs.cache_ok == 'true' && 'sccache' || '' }}
         run: |
           set -e
           FEATURES="${{ matrix.features }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,13 +45,21 @@ ENV SCCACHE_BUCKET=sccache \
 COPY . .
 
 # Build frontend (WASM is platform-independent).
-# sccache is enabled only when the AWS credential secrets are present.
+# sccache is enabled only when the credential secrets are present AND the cache
+# backend is reachable. sccache validates its bucket on server start (fast
+# non-zero exit if the bucket is missing or the endpoint is unreachable), so we
+# probe with `sccache --start-server` and wrap rustc only on success. A broken
+# cache degrades to an uncached build instead of failing the image build.
 RUN --mount=type=secret,id=aws_access_key_id \
     --mount=type=secret,id=aws_secret_access_key \
     if [ -s /run/secrets/aws_access_key_id ]; then \
         export AWS_ACCESS_KEY_ID="$(cat /run/secrets/aws_access_key_id)" && \
         export AWS_SECRET_ACCESS_KEY="$(cat /run/secrets/aws_secret_access_key)" && \
-        export RUSTC_WRAPPER=sccache; \
+        if timeout 30 sccache --start-server >/dev/null 2>&1; then \
+            export RUSTC_WRAPPER=sccache; \
+        else \
+            echo "==> sccache backend unreachable - building without compile cache"; \
+        fi; \
     fi && \
     cd frontend && trunk build --release && \
     { command -v sccache >/dev/null && [ -n "$RUSTC_WRAPPER" ] && sccache --show-stats || true; }
@@ -184,12 +192,18 @@ ENV RUST_BACKTRACE=1
 
 # Cross-compilation: Use cargo-zigbuild with glibc 2.36 targeting (Raspberry Pi compatible)
 # Native compilation: Use regular cargo build
+# sccache: see the frontend stage — probe the backend and only wrap rustc when
+# the cache is healthy, so a broken cache never fails the build.
 RUN --mount=type=secret,id=aws_access_key_id \
     --mount=type=secret,id=aws_secret_access_key \
     if [ -s /run/secrets/aws_access_key_id ]; then \
         export AWS_ACCESS_KEY_ID="$(cat /run/secrets/aws_access_key_id)" && \
         export AWS_SECRET_ACCESS_KEY="$(cat /run/secrets/aws_secret_access_key)" && \
-        export RUSTC_WRAPPER=sccache; \
+        if timeout 30 sccache --start-server >/dev/null 2>&1; then \
+            export RUSTC_WRAPPER=sccache; \
+        else \
+            echo "==> sccache backend unreachable - building without compile cache"; \
+        fi; \
     fi && \
     if [ "$BUILDPLATFORM" != "$TARGETPLATFORM" ] && [ "$TARGETARCH" = "arm64" ]; then \
     echo "==> Cross-compiling backend with Zig (targeting glibc 2.36)"; \


### PR DESCRIPTION
## Why

When the sccache S3 backend broke during the recent migration (missing bucket / unreachable endpoint), **CI broke with it** — exactly what a cache should never do. sccache treats its configured cache as a hard requirement: once credentials were present, every `cargo` invocation went through sccache and failed when the backend was gone. The cache is an optimization, not a dependency.

## Verified failure mode

I reproduced it against the live instance. `sccache --start-server` validates the bucket on startup (it writes/reads `.sccache_check`) and **fails fast** when the backend is broken:

- healthy bucket → `start-server` exit 0 in ~0s
- missing bucket → `start-server` exit 2 in ~1s: `Server startup failed: ... NoSuchBucket`

It does *not* hang on a missing bucket, so a cheap preflight probe is reliable. (`SCCACHE_IGNORE_SERVER_IO_ERROR` does not help — it only covers client↔server read errors mid-compile, not backend init.)

## What changed

**`ci.yml` / `release.yml`**
- New `preflight` job probes the backend once with an authenticated `aws s3api list-objects-v2 --max-keys 1` (needs only `s3:ListBucket`, which the scoped service account has; bounded by `timeout`) and outputs `cache_ok`.
- Every build job sets `RUSTC_WRAPPER=sccache` **only** when `needs.preflight.outputs.cache_ok == 'true'`, and gates the `sccache-action` install on the same condition (so the action's own server start can't fail a step either). This replaces the old "are credentials present?" gate — forks/dependabot still get no cache (no creds → `cache_ok=false`).

**`Dockerfile`**
- Both builder stages probe with `timeout 30 sccache --start-server` and wrap rustc only on success, else build uncached.

## Net effect

A missing or unreachable cache now degrades to a normal (slower) **uncached build with a `::warning::`**, instead of failing or hanging CI. When the backend is healthy, behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)