### PR TITLE
chore: release v0.6.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6550,7 +6550,7 @@ dependencies = [
 
 [[package]]
 name = "strom"
-version = "0.6.6-dev"
+version = "0.6.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6627,7 +6627,7 @@ dependencies = [
 
 [[package]]
 name = "strom-frontend"
-version = "0.6.6-dev"
+version = "0.6.6"
 dependencies = [
  "base64",
  "chrono",
@@ -6663,7 +6663,7 @@ dependencies = [
 
 [[package]]
 name = "strom-mcp-server"
-version = "0.6.6-dev"
+version = "0.6.6"
 dependencies = [
  "anyhow",
  "reqwest 0.13.4",
@@ -6677,7 +6677,7 @@ dependencies = [
 
 [[package]]
 name = "strom-types"
-version = "0.6.6-dev"
+version = "0.6.6"
 dependencies = [
  "garde",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["types", "backend", "frontend", "mcp-server"]
 default-members = ["backend"]
 
 [workspace.package]
-version = "0.6.6-dev"
+version = "0.6.6"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Per Enstedt <per.enstedt@eyevinn.se>"]


### PR DESCRIPTION
Bump workspace version from `0.6.6-dev` to `0.6.6` for release.

- Drops the `-dev` suffix in the workspace `Cargo.toml`
- `Cargo.lock` updated accordingly
- `cargo check` passes; pre-commit clippy/fmt/secret checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)