### PR TITLE
fix(whip,whep): expose do-retransmission as a block property

### DIFF
--- a/backend/src/blocks/builtin/whep.rs
+++ b/backend/src/blocks/builtin/whep.rs
@@ -2359,7 +2359,7 @@ fn whep_output_definition() -> BlockDefinition {
             ExposedProperty {
                 name: "do_retransmission".to_string(),
                 label: "Retransmission (RTX)".to_string(),
-                description: "Resend lost packets to viewers on request (NACK-based). Disable only to cap the outgoing bitrate — without it, packet loss forces a full keyframe request instead of a cheap resend.".to_string(),
+                description: "Resend lost packets to viewers on request (NACK-based). Without it, packet loss forces a full keyframe request instead of a cheap resend.".to_string(),
                 property_type: PropertyType::Bool,
                 default_value: Some(PropertyValue::Bool(true)),
                 mapping: PropertyMapping {

--- a/backend/src/blocks/builtin/whep.rs
+++ b/backend/src/blocks/builtin/whep.rs
@@ -167,6 +167,19 @@ fn explicit_track_count(properties: &HashMap<String, PropertyValue>, name: &str)
     })
 }
 
+/// Parse do_retransmission from properties (default: true).
+///
+/// `whepserversink` is send-only, so this is a bandwidth/quality tunable only.
+fn parse_do_retransmission(properties: &HashMap<String, PropertyValue>) -> bool {
+    properties
+        .get("do_retransmission")
+        .and_then(|v| match v {
+            PropertyValue::Bool(b) => Some(*b),
+            _ => None,
+        })
+        .unwrap_or(true)
+}
+
 /// Migrate a legacy `mode` property on a WHEP Output block to explicit
 /// `num_audio_tracks` / `num_video_tracks` counts, and drop `mode`.
 ///
@@ -951,6 +964,8 @@ fn build_whepserversink(
         num_audio_tracks, num_video_tracks
     );
 
+    let do_retransmission = parse_do_retransmission(properties);
+
     // Timestamp offset in milliseconds. A negative value shifts playout earlier,
     // reducing end-to-end latency for this output while maintaining A/V sync.
     // Applied as ts-offset on clocksync and appsink inside whepserversink.
@@ -1021,7 +1036,7 @@ fn build_whepserversink(
         whepserversink.set_property("turn-servers", turn_servers);
     }
 
-    // Disable FEC but keep RTX (retransmission) enabled.
+    // Disable FEC; RTX (retransmission) is configurable, default on.
     // - FEC adds proactive redundancy packets on every stream (~50% constant
     //   overhead, near-double bandwidth for pre-encoded high-bitrate video),
     //   so it stays off.
@@ -1030,7 +1045,7 @@ fn build_whepserversink(
     //   escalates to PLI -> forced keyframe, which is far more expensive and
     //   leaves the picture broken until the keyframe arrives.
     whepserversink.set_property("do-fec", false);
-    whepserversink.set_property("do-retransmission", true);
+    whepserversink.set_property("do-retransmission", do_retransmission);
 
     // Access the signaller child and set its properties
     // Bind to localhost only - axum will proxy external requests
@@ -2341,6 +2356,20 @@ fn whep_output_definition() -> BlockDefinition {
                 live: false,
                 persist: None,
             },
+            ExposedProperty {
+                name: "do_retransmission".to_string(),
+                label: "Retransmission (RTX)".to_string(),
+                description: "Resend lost packets to viewers on request (NACK-based). Disable only to cap the outgoing bitrate — without it, packet loss forces a full keyframe request instead of a cheap resend.".to_string(),
+                property_type: PropertyType::Bool,
+                default_value: Some(PropertyValue::Bool(true)),
+                mapping: PropertyMapping {
+                    element_id: "_block".to_string(),
+                    property_name: "do_retransmission".to_string(),
+                    transform: None,
+                },
+                live: false,
+                persist: None,
+            },
         ],
         // Note: external_pads here are the static defaults (1 video + 1 audio).
         // The actual pads are determined dynamically by WHEPOutputBuilder::get_external_pads()
@@ -2378,6 +2407,13 @@ fn whep_output_definition() -> BlockDefinition {
 mod tests {
     use super::*;
 
+    /// `whepserversink` comes from the `gst-plugin-webrtc` crate, which is only
+    /// registered by the binary. Tests must register it themselves.
+    fn init_gst() {
+        let _ = gst::init();
+        let _ = gstrswebrtc::plugin_register_static();
+    }
+
     /// Build a property map. `legacy_mode` populates the old "mode" enum
     /// (`Some("audio")` etc.) to exercise the migration path; pass `None` for
     /// new flows. Count values pass through `num_audio_tracks` /
@@ -2414,6 +2450,59 @@ mod tests {
             .filter(|p| matches!(p.media_type, MediaType::Video))
             .map(|p| p.name.clone())
             .collect()
+    }
+
+    /// Build a property map from explicit key/value pairs.
+    fn raw_props(entries: &[(&str, PropertyValue)]) -> HashMap<String, PropertyValue> {
+        entries
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.clone()))
+            .collect()
+    }
+
+    #[test]
+    fn do_retransmission_defaults_to_true() {
+        assert!(parse_do_retransmission(&raw_props(&[])));
+    }
+
+    #[test]
+    fn do_retransmission_respects_explicit_true() {
+        assert!(parse_do_retransmission(&raw_props(&[(
+            "do_retransmission",
+            PropertyValue::Bool(true)
+        )])));
+    }
+
+    #[test]
+    fn do_retransmission_respects_explicit_false() {
+        assert!(!parse_do_retransmission(&raw_props(&[(
+            "do_retransmission",
+            PropertyValue::Bool(false)
+        )])));
+    }
+
+    /// The block property must land on the `whepserversink` element itself.
+    /// Hardcoding `do-retransmission` back to a literal fails the `false` case.
+    #[test]
+    fn do_retransmission_reaches_whepserversink() {
+        init_gst();
+
+        for expected in [true, false] {
+            let ctx = BlockBuildContext::new(Vec::new(), "all".to_string());
+            let result = build_whepserversink(
+                "whep-rtx-test",
+                &raw_props(&[("do_retransmission", PropertyValue::Bool(expected))]),
+                &ctx,
+            )
+            .expect("build_whepserversink failed");
+
+            let (_, sink) = result
+                .elements
+                .iter()
+                .find(|(id, _)| id == "whep-rtx-test:whepserversink")
+                .expect("whepserversink missing from build result");
+            assert_eq!(sink.property::<bool>("do-retransmission"), expected);
+        }
     }
 
     #[test]

--- a/backend/src/blocks/builtin/whip.rs
+++ b/backend/src/blocks/builtin/whip.rs
@@ -150,6 +150,17 @@ fn parse_jitterbuffer_latency_ms(properties: &HashMap<String, PropertyValue>) ->
         .unwrap_or(400)
 }
 
+/// Parse do_retransmission from properties (default: true).
+fn parse_do_retransmission(properties: &HashMap<String, PropertyValue>) -> bool {
+    properties
+        .get("do_retransmission")
+        .and_then(|v| match v {
+            PropertyValue::Bool(b) => Some(*b),
+            _ => None,
+        })
+        .unwrap_or(true)
+}
+
 /// Build WHIP Input per-slot output chains.
 ///
 /// At build time, per-slot chains are created in the main pipeline:
@@ -199,6 +210,7 @@ fn build_whipserversrc(
     // causing the whole video stream to stall (never reaching decodebin)
     // even though the packets arrived fine over the network.
     let jitterbuffer_latency_ms = parse_jitterbuffer_latency_ms(properties);
+    let do_retransmission = parse_do_retransmission(properties);
 
     let max_video_bitrate_kbps = properties
         .get("max_video_bitrate")
@@ -434,8 +446,8 @@ fn build_whipserversrc(
     let turn_server = ctx.turn_server();
 
     info!(
-        "WHIP Input configured: endpoint_id='{}', stun={:?}, turn={:?}, mode={:?}, decode={}, max_sessions={} (whipserversrc created per-session)",
-        endpoint_id, stun_server, turn_server, mode, decode, max_sessions
+        "WHIP Input configured: endpoint_id='{}', stun={:?}, turn={:?}, mode={:?}, decode={}, do_retransmission={}, max_sessions={} (whipserversrc created per-session)",
+        endpoint_id, stun_server, turn_server, mode, decode, do_retransmission, max_sessions
     );
 
     // Register WHIP endpoint with the build context (port=0 placeholder, sessions get their own ports)
@@ -456,6 +468,7 @@ fn build_whipserversrc(
             pipeline_weak: gst::glib::WeakRef::new(),
             decode,
             jitterbuffer_latency_ms,
+            do_retransmission,
             dynamic_webrtcbin_store: ctx.dynamic_webrtcbin_store(),
             max_video_bitrate_kbps,
             max_sessions,
@@ -530,6 +543,8 @@ pub fn create_whipserversrc_for_session(
     // Set signaller host-addr
     let signaller = whipserversrc.property::<gst::glib::Object>("signaller");
     signaller.set_property("host-addr", &host_addr);
+
+    whipserversrc.set_property("do-retransmission", config.do_retransmission);
 
     // Configure codec negotiation based on mode
     if config.mode.has_audio() {
@@ -1488,6 +1503,20 @@ fn whip_input_definition() -> BlockDefinition {
                 persist: None,
             },
             ExposedProperty {
+                name: "do_retransmission".to_string(),
+                label: "Retransmission (RTX)".to_string(),
+                description: "Request retransmission of lost packets from the publisher (NACK-based). Without it, any packet loss forces a full keyframe request instead of a cheap resend. Disabling it is an unconfirmed workaround for the intermittent GStreamer depayloader crash on this ingest path.".to_string(),
+                property_type: PropertyType::Bool,
+                default_value: Some(PropertyValue::Bool(true)),
+                mapping: PropertyMapping {
+                    element_id: "_block".to_string(),
+                    property_name: "do_retransmission".to_string(),
+                    transform: None,
+                },
+                live: false,
+                persist: None,
+            },
+            ExposedProperty {
                 name: "max_video_bitrate".to_string(),
                 label: "Max Video Bitrate (kbps)".to_string(),
                 description: "Maximum video bitrate hint sent to the browser via SDP. The browser's encoder will ramp up to this value.".to_string(),
@@ -1705,5 +1734,48 @@ mod tests {
             )])),
             0
         );
+    }
+
+    #[test]
+    fn do_retransmission_defaults_to_true() {
+        assert!(parse_do_retransmission(&props(&[])));
+    }
+
+    #[test]
+    fn do_retransmission_respects_explicit_true() {
+        assert!(parse_do_retransmission(&props(&[(
+            "do_retransmission",
+            PropertyValue::Bool(true)
+        )])));
+    }
+
+    #[test]
+    fn do_retransmission_respects_explicit_false() {
+        assert!(!parse_do_retransmission(&props(&[(
+            "do_retransmission",
+            PropertyValue::Bool(false)
+        )])));
+    }
+
+    /// The block property must reach the `WhipEndpointConfig` handed to the
+    /// session manager, which is the value `create_whipserversrc_for_session`
+    /// applies to `whipserversrc`.
+    #[test]
+    fn do_retransmission_reaches_whip_endpoint_config() {
+        let _ = gst::init();
+
+        for expected in [true, false] {
+            let ctx = BlockBuildContext::new(Vec::new(), "all".to_string());
+            build_whipserversrc(
+                "whip-rtx-test",
+                &props(&[("do_retransmission", PropertyValue::Bool(expected))]),
+                &ctx,
+            )
+            .expect("build_whipserversrc failed");
+
+            let configs = ctx.take_whip_endpoint_configs();
+            assert_eq!(configs.len(), 1, "expected exactly one endpoint config");
+            assert_eq!(configs[0].1.do_retransmission, expected);
+        }
     }
 }

--- a/backend/src/blocks/builtin/whip.rs
+++ b/backend/src/blocks/builtin/whip.rs
@@ -1505,7 +1505,7 @@ fn whip_input_definition() -> BlockDefinition {
             ExposedProperty {
                 name: "do_retransmission".to_string(),
                 label: "Retransmission (RTX)".to_string(),
-                description: "Request retransmission of lost packets from the publisher (NACK-based). Without it, any packet loss forces a full keyframe request instead of a cheap resend. Disabling it is an unconfirmed workaround for the intermittent GStreamer depayloader crash on this ingest path.".to_string(),
+                description: "Request retransmission of lost packets from the publisher (NACK-based). Without it, any packet loss forces a full keyframe request instead of a cheap resend.".to_string(),
                 property_type: PropertyType::Bool,
                 default_value: Some(PropertyValue::Bool(true)),
                 mapping: PropertyMapping {

--- a/backend/src/whip_session_manager.rs
+++ b/backend/src/whip_session_manager.rs
@@ -34,6 +34,9 @@ pub struct WhipEndpointConfig {
     pub decode: bool,
     /// Jitterbuffer latency in milliseconds for the per-session webrtcbin.
     pub jitterbuffer_latency_ms: u32,
+    /// Whether whipserversrc should request retransmission (NACK) of lost
+    /// packets from the publisher.
+    pub do_retransmission: bool,
     /// Shared dynamic webrtcbin store for ICE policy tracking
     pub dynamic_webrtcbin_store: DynamicWebrtcbinStore,
     /// Maximum video bitrate hint for Chrome (kbps). Injected into the SDP


### PR DESCRIPTION
## Description

RTX was not configurable on either WebRTC block: `whipserversrc` (WHIP Input) relied on the element default and `whepserversink` (WHEP Output) hardcoded `do-retransmission` to `true`. This PR exposes `do_retransmission` as a block property on both, defaulting to `true` so existing behaviour is unchanged.

**On WHIP Input** this is the receive leg. RTX feeds retransmitted and reordered packets into the `rtph264depay` that Strom's `decodebin` autoplugs downstream, and that depayloader is where the process aborts on the hdrext assertion in `gst_rtp_base_depayload_handle_buffer` (#685). The property gives operators a switch to try when they hit it.

To be clear about what this does and does not claim: **turning RTX off has not been observed to stop the assertion.** The crash is intermittent and a clean baseline run stopped reproducing it, so the causal link is unproven. The default therefore stays `true`, and this ships as an escape hatch, not a verified mitigation. Defaulting it off would impose a certain quality cost (every lost packet becomes a full keyframe request instead of a cheap resend) for an unconfirmed benefit.

**On WHEP Output** the property cannot affect that crash at all: `whepserversink` is send-only and instantiates no depayloader. It is exposed there purely as a bandwidth/quality tunable, and the PR should not be read as claiming otherwise.

## Related Issue

#685 — Process aborts on `gst_rtp_base_depayload` hdrext assertion when video enters WHIP Input.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

Tests were added that cover the plumbing, not just the parser:

- `do_retransmission_reaches_whepserversink` — builds the block and reads `do-retransmission` back off the `whepserversink` element itself.
- `do_retransmission_reaches_whip_endpoint_config` — reads the value back off the `WhipEndpointConfig` handed to the session manager.

Both were confirmed to **fail** when `do-retransmission` is hardcoded back to a literal on either block. Under that same revert all six of the original parser tests still passed, so those six are unit coverage of the parse helper rather than regression guards, and are retained on that basis. Neither new test needs a skip guard: `gst-plugin-webrtc` is a Cargo dependency registered via `plugin_register_static()`, so both elements exist in CI without any additional system package.

One hop is deliberately not covered: `WhipEndpointConfig` -> `set_property` inside `create_whipserversrc_for_session`. Exercising it requires calling a function that sets a session pipeline to PLAYING and blocks up to five seconds on the state change, which is unsuitable for a unit test. The WHIP test stops at the config boundary.

**What was actually run:** `cargo test --lib do_retransmission` (8 passed), `cargo fmt --check` (clean), `cargo clippy --workspace --all-targets` (clean, zero lints). **Not run:** the full `cargo test --workspace` suite. The change is additive and workspace-wide clippy is clean, but no broader regression check than the above is being claimed.

## Checklist

- [x] I have run `cargo fmt --all`
- [x] I have run `cargo clippy --workspace --all-targets` — clean, zero lints (the previously noted `frontend/src/themes.rs` failure no longer reproduces)
- [ ] I have run `cargo test --workspace` — **not run**; see Testing above for what was
- [ ] I have updated documentation as needed (not applicable — internal implementation detail, no navigational docs affected)
- [x] I have added tests for new functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)
