### PR TITLE
fix(frontend): pin ambiguous float literals to f32 for new rustc lint

### DIFF
--- a/frontend/src/app/dialogs.rs
+++ b/frontend/src/app/dialogs.rs
@@ -147,7 +147,7 @@ impl StromApp {
                                                 flow_label.rect.left_bottom(),
                                                 flow_label.rect.right_bottom(),
                                             ],
-                                            egui::Stroke::new(1.0, Color32::GRAY),
+                                            egui::Stroke::new(1.0_f32, Color32::GRAY),
                                         );
                                     }
                                     if flow_label.clicked() {
@@ -174,7 +174,7 @@ impl StromApp {
                                                 source_label.rect.right_bottom(),
                                             ],
                                             egui::Stroke::new(
-                                                1.0,
+                                                1.0_f32,
                                                 Color32::from_rgb(150, 150, 255),
                                             ),
                                         );

--- a/frontend/src/audioanalyzer.rs
+++ b/frontend/src/audioanalyzer.rs
@@ -233,13 +233,21 @@ pub fn show_full(ui: &mut Ui, data: &AudioAnalyzerData) {
             plot_ui.set_plot_bounds_y(-amp..=amp);
             plot_ui.set_plot_bounds_x(0.0..=bin_visible);
 
-            plot_ui.hline(HLine::new("", 0.0).color(COLOR_REF).width(0.5));
+            plot_ui.hline(HLine::new("", 0.0).color(COLOR_REF).width(0.5_f32));
 
-            plot_ui.line(Line::new("L", l_max_points).color(COLOR_L).width(1.0));
-            plot_ui.line(Line::new("L min", l_min_points).color(COLOR_L).width(1.0));
+            plot_ui.line(Line::new("L", l_max_points).color(COLOR_L).width(1.0_f32));
+            plot_ui.line(
+                Line::new("L min", l_min_points)
+                    .color(COLOR_L)
+                    .width(1.0_f32),
+            );
 
-            plot_ui.line(Line::new("R", r_max_points).color(COLOR_R).width(1.0));
-            plot_ui.line(Line::new("R min", r_min_points).color(COLOR_R).width(1.0));
+            plot_ui.line(Line::new("R", r_max_points).color(COLOR_R).width(1.0_f32));
+            plot_ui.line(
+                Line::new("R min", r_min_points)
+                    .color(COLOR_R)
+                    .width(1.0_f32),
+            );
         });
 
     ui.add_space(8.0);
@@ -287,23 +295,27 @@ pub fn show_full(ui: &mut Ui, data: &AudioAnalyzerData) {
             plot_ui.set_plot_bounds_x(-vs_scale..=vs_scale);
             plot_ui.set_plot_bounds_y(-vs_scale..=vs_scale);
 
-            plot_ui.hline(HLine::new("", 0.0).color(COLOR_REF).width(0.5));
-            plot_ui.vline(VLine::new("", 0.0).color(COLOR_REF).width(0.5));
+            plot_ui.hline(HLine::new("", 0.0).color(COLOR_REF).width(0.5_f32));
+            plot_ui.vline(VLine::new("", 0.0).color(COLOR_REF).width(0.5_f32));
 
             // +45deg (mono) diagonal
             plot_ui.line(
                 Line::new("", PlotPoints::new(vec![[-1.0, -1.0], [1.0, 1.0]]))
                     .color(Color32::from_rgb(40, 40, 50))
-                    .width(0.5),
+                    .width(0.5_f32),
             );
             // -45deg (phase inversion) diagonal
             plot_ui.line(
                 Line::new("", PlotPoints::new(vec![[-1.0, 1.0], [1.0, -1.0]]))
                     .color(Color32::from_rgb(40, 40, 50))
-                    .width(0.5),
+                    .width(0.5_f32),
             );
 
-            plot_ui.points(Points::new("L/R", scatter).color(COLOR_VECTOR).radius(1.5));
+            plot_ui.points(
+                Points::new("L/R", scatter)
+                    .color(COLOR_VECTOR)
+                    .radius(1.5_f32),
+            );
         });
 }
 
@@ -344,7 +356,7 @@ fn draw_waveform(painter: &egui::Painter, rect: Rect, data: &AudioAnalyzerData) 
         rect,
         1.0,
         Color32::from_rgb(15, 15, 20),
-        Stroke::new(1.0, Color32::from_gray(50)),
+        Stroke::new(1.0_f32, Color32::from_gray(50)),
         egui::epaint::StrokeKind::Inside,
     );
 
@@ -365,14 +377,14 @@ fn draw_waveform(painter: &egui::Painter, rect: Rect, data: &AudioAnalyzerData) 
             egui::pos2(rect.min.x, l_center_y),
             egui::pos2(rect.max.x, l_center_y),
         ],
-        Stroke::new(0.5, COLOR_REF),
+        Stroke::new(0.5_f32, COLOR_REF),
     );
     painter.line_segment(
         [
             egui::pos2(rect.min.x, r_center_y),
             egui::pos2(rect.max.x, r_center_y),
         ],
-        Stroke::new(0.5, COLOR_REF),
+        Stroke::new(0.5_f32, COLOR_REF),
     );
 
     // Divider between L and R
@@ -381,7 +393,7 @@ fn draw_waveform(painter: &egui::Painter, rect: Rect, data: &AudioAnalyzerData) 
             egui::pos2(rect.min.x, rect.min.y + half_h),
             egui::pos2(rect.max.x, rect.min.y + half_h),
         ],
-        Stroke::new(0.5, COLOR_REF),
+        Stroke::new(0.5_f32, COLOR_REF),
     );
 
     // Draw L waveform
@@ -457,13 +469,13 @@ fn draw_channel_waveform(
         // Vertical min/max bar
         painter.line_segment(
             [egui::pos2(x, y_top), egui::pos2(x, y_bot)],
-            Stroke::new(1.0, color),
+            Stroke::new(1.0_f32, color),
         );
 
         // Connect midpoints of adjacent columns to fill gaps
         let mid = egui::pos2(x, (y_top + y_bot) / 2.0);
         if let Some(prev) = prev_mid {
-            painter.line_segment([prev, mid], Stroke::new(1.0, color));
+            painter.line_segment([prev, mid], Stroke::new(1.0_f32, color));
         }
         prev_mid = Some(mid);
     }
@@ -476,7 +488,7 @@ fn draw_vectorscope(painter: &egui::Painter, rect: Rect, data: &AudioAnalyzerDat
         rect,
         1.0,
         Color32::from_rgb(15, 15, 20),
-        Stroke::new(1.0, Color32::from_gray(50)),
+        Stroke::new(1.0_f32, Color32::from_gray(50)),
         egui::epaint::StrokeKind::Inside,
     );
 
@@ -489,14 +501,14 @@ fn draw_vectorscope(painter: &egui::Painter, rect: Rect, data: &AudioAnalyzerDat
             egui::pos2(rect.min.x, center.y),
             egui::pos2(rect.max.x, center.y),
         ],
-        Stroke::new(0.5, COLOR_REF),
+        Stroke::new(0.5_f32, COLOR_REF),
     );
     painter.line_segment(
         [
             egui::pos2(center.x, rect.min.y),
             egui::pos2(center.x, rect.max.y),
         ],
-        Stroke::new(0.5, COLOR_REF),
+        Stroke::new(0.5_f32, COLOR_REF),
     );
 
     // Reference lines: +45deg (mono) and -45deg (phase inversion)
@@ -506,14 +518,14 @@ fn draw_vectorscope(painter: &egui::Painter, rect: Rect, data: &AudioAnalyzerDat
             egui::pos2(center.x - diag_len, center.y - diag_len),
             egui::pos2(center.x + diag_len, center.y + diag_len),
         ],
-        Stroke::new(0.5, Color32::from_rgb(40, 40, 50)),
+        Stroke::new(0.5_f32, Color32::from_rgb(40, 40, 50)),
     );
     painter.line_segment(
         [
             egui::pos2(center.x - diag_len, center.y + diag_len),
             egui::pos2(center.x + diag_len, center.y - diag_len),
         ],
-        Stroke::new(0.5, Color32::from_rgb(40, 40, 50)),
+        Stroke::new(0.5_f32, Color32::from_rgb(40, 40, 50)),
     );
 
     // Draw points: X = L, Y = R (standard vectorscope convention)

--- a/frontend/src/clocks.rs
+++ b/frontend/src/clocks.rs
@@ -773,7 +773,7 @@ fn draw_large_graph(
         let y = rect.min.y + (i as f32 / 4.0) * rect.height();
         painter.line_segment(
             [Pos2::new(rect.min.x, y), Pos2::new(rect.max.x, y)],
-            Stroke::new(0.5, Color32::from_gray(40)),
+            Stroke::new(0.5_f32, Color32::from_gray(40)),
         );
     }
 
@@ -785,7 +785,7 @@ fn draw_large_graph(
                 Pos2::new(rect.min.x, y_center),
                 Pos2::new(rect.max.x, y_center),
             ],
-            Stroke::new(1.0, Color32::from_gray(80)),
+            Stroke::new(1.0_f32, Color32::from_gray(80)),
         );
     }
 
@@ -804,14 +804,14 @@ fn draw_large_graph(
         .collect();
 
     if points.len() >= 2 {
-        painter.add(egui::Shape::line(points, Stroke::new(2.0, color)));
+        painter.add(egui::Shape::line(points, Stroke::new(2.0_f32, color)));
     }
 
     // Draw border
     painter.rect_stroke(
         rect,
         4.0,
-        Stroke::new(1.0, Color32::from_gray(80)),
+        Stroke::new(1.0_f32, Color32::from_gray(80)),
         egui::StrokeKind::Outside,
     );
 
@@ -847,7 +847,7 @@ fn draw_large_graph_fixed(
         let y = rect.min.y + (i as f32 / 4.0) * rect.height();
         painter.line_segment(
             [Pos2::new(rect.min.x, y), Pos2::new(rect.max.x, y)],
-            Stroke::new(0.5, Color32::from_gray(40)),
+            Stroke::new(0.5_f32, Color32::from_gray(40)),
         );
     }
 
@@ -877,14 +877,14 @@ fn draw_large_graph_fixed(
         .collect();
 
     if points.len() >= 2 {
-        painter.add(egui::Shape::line(points, Stroke::new(2.0, color)));
+        painter.add(egui::Shape::line(points, Stroke::new(2.0_f32, color)));
     }
 
     // Draw border
     painter.rect_stroke(
         rect,
         4.0,
-        Stroke::new(1.0, Color32::from_gray(80)),
+        Stroke::new(1.0_f32, Color32::from_gray(80)),
         egui::StrokeKind::Outside,
     );
 

--- a/frontend/src/compositor_editor/canvas.rs
+++ b/frontend/src/compositor_editor/canvas.rs
@@ -50,7 +50,7 @@ impl CompositorEditor {
         painter.rect_stroke(
             screen_output_rect,
             0.0,
-            Stroke::new(2.0, Color32::from_gray(100)),
+            Stroke::new(2.0_f32, Color32::from_gray(100)),
             StrokeKind::Inside,
         );
 
@@ -59,12 +59,12 @@ impl CompositorEditor {
             for x in (0..self.output_width).step_by(self.grid_size as usize) {
                 let p1 = to_screen(Pos2::new(x as f32, 0.0));
                 let p2 = to_screen(Pos2::new(x as f32, self.output_height as f32));
-                painter.line_segment([p1, p2], Stroke::new(1.0, Color32::from_gray(40)));
+                painter.line_segment([p1, p2], Stroke::new(1.0_f32, Color32::from_gray(40)));
             }
             for y in (0..self.output_height).step_by(self.grid_size as usize) {
                 let p1 = to_screen(Pos2::new(0.0, y as f32));
                 let p2 = to_screen(Pos2::new(self.output_width as f32, y as f32));
-                painter.line_segment([p1, p2], Stroke::new(1.0, Color32::from_gray(40)));
+                painter.line_segment([p1, p2], Stroke::new(1.0_f32, Color32::from_gray(40)));
             }
         }
 
@@ -126,7 +126,7 @@ impl CompositorEditor {
                 painter.rect_filled(screen_rect, 0.0, color);
             }
 
-            let border_width = if input.selected { 3.0 } else { 1.0 };
+            let border_width = if input.selected { 3.0_f32 } else { 1.0_f32 };
             let border_color = if input.selected {
                 Color32::WHITE
             } else if dimmed {
@@ -191,7 +191,7 @@ impl CompositorEditor {
                     painter.rect_stroke(
                         screen_handle_rect,
                         2.0,
-                        Stroke::new(1.0, Color32::BLACK),
+                        Stroke::new(1.0_f32, Color32::BLACK),
                         StrokeKind::Inside,
                     );
                 }

--- a/frontend/src/graph/interaction.rs
+++ b/frontend/src/graph/interaction.rs
@@ -33,11 +33,11 @@ impl GraphEditor {
 
             // Determine color and width based on state
             let (color, width) = if is_selected {
-                (Color32::from_rgb(100, 150, 255), 3.0) // Blue and thicker when selected
+                (Color32::from_rgb(100, 150, 255), 3.0_f32) // Blue and thicker when selected
             } else if is_hovered {
-                (Color32::from_rgb(200, 200, 200), 2.5) // Brighter when hovered
+                (Color32::from_rgb(200, 200, 200), 2.5_f32) // Brighter when hovered
             } else {
-                (Color32::from_rgb(150, 150, 150), 2.0) // Default gray
+                (Color32::from_rgb(150, 150, 150), 2.0_f32) // Default gray
             };
 
             painter.add(egui::epaint::CubicBezierShape::from_points_stroke(

--- a/frontend/src/graph/rendering.rs
+++ b/frontend/src/graph/rendering.rs
@@ -680,7 +680,7 @@ impl GraphEditor {
                     [from_screen_pos, control1, control2, to_pos],
                     false,
                     Color32::TRANSPARENT,
-                    Stroke::new(2.0, Color32::from_rgb(100, 150, 255)),
+                    Stroke::new(2.0_f32, Color32::from_rgb(100, 150, 255)),
                 ));
             }
 
@@ -742,7 +742,7 @@ impl GraphEditor {
         while x < rect.max.x {
             painter.line_segment(
                 [pos2(x, rect.min.y), pos2(x, rect.max.y)],
-                Stroke::new(1.0, color),
+                Stroke::new(1.0_f32, color),
             );
             x += grid_spacing;
         }
@@ -752,7 +752,7 @@ impl GraphEditor {
         while y < rect.max.y {
             painter.line_segment(
                 [pos2(rect.min.x, y), pos2(rect.max.x, y)],
-                Stroke::new(1.0, color),
+                Stroke::new(1.0_f32, color),
             );
             y += grid_spacing;
         }
@@ -799,13 +799,13 @@ impl GraphEditor {
         };
 
         let stroke_width = if has_qos_issues {
-            3.0 // Thicker border for QoS issues
+            3.0_f32 // Thicker border for QoS issues
         } else if is_selected {
-            2.5
+            2.5_f32
         } else if is_hovered {
-            1.5
+            1.5_f32
         } else {
-            1.0
+            1.0_f32
         };
 
         let fill_color = if ui.visuals().dark_mode {
@@ -1279,13 +1279,13 @@ impl GraphEditor {
         };
 
         let stroke_width = if has_qos_issues {
-            3.0 // Thicker border for QoS issues
+            3.0_f32 // Thicker border for QoS issues
         } else if is_selected {
-            2.0
+            2.0_f32
         } else if is_hovered {
-            1.5
+            1.5_f32
         } else {
-            1.0
+            1.0_f32
         };
 
         let fill_color = if let Some(color) = custom_fill {

--- a/frontend/src/info_page.rs
+++ b/frontend/src/info_page.rs
@@ -1063,7 +1063,7 @@ fn render_box(ui: &mut Ui, title: &str, width: f32, content: impl FnOnce(&mut Ui
     egui::Frame::new()
         .fill(fill_color)
         .corner_radius(8.0)
-        .stroke(Stroke::new(1.0, stroke_color))
+        .stroke(Stroke::new(1.0_f32, stroke_color))
         .inner_margin(BOX_INNER_MARGIN)
         .show(ui, |ui| {
             ui.set_width(width);
@@ -1095,7 +1095,7 @@ fn draw_graph(
         let y = rect.min.y + (i as f32 / 4.0) * rect.height();
         painter.line_segment(
             [Pos2::new(rect.min.x, y), Pos2::new(rect.max.x, y)],
-            Stroke::new(0.5, grid_color),
+            Stroke::new(0.5_f32, grid_color),
         );
     }
 
@@ -1115,14 +1115,14 @@ fn draw_graph(
         .collect();
 
     if points.len() >= 2 {
-        painter.add(egui::Shape::line(points, Stroke::new(2.0, color)));
+        painter.add(egui::Shape::line(points, Stroke::new(2.0_f32, color)));
     }
 
     // Draw border
     painter.rect_stroke(
         rect,
         4.0,
-        Stroke::new(1.0, stroke_color),
+        Stroke::new(1.0_f32, stroke_color),
         egui::StrokeKind::Outside,
     );
 }

--- a/frontend/src/interactive_overlay.rs
+++ b/frontend/src/interactive_overlay.rs
@@ -200,7 +200,7 @@ impl OverlayState {
                 painter.rect_stroke(
                     grid_rect,
                     4.0,
-                    egui::Stroke::new(2.0, Color32::from_rgb(60, 60, 80)),
+                    egui::Stroke::new(2.0_f32, Color32::from_rgb(60, 60, 80)),
                     StrokeKind::Inside,
                 );
 
@@ -208,8 +208,10 @@ impl OverlayState {
                 for i in 1..GRID_SIZE {
                     let x = grid_origin.x + i as f32 * cell_size;
                     let y = grid_origin.y + i as f32 * cell_size;
-                    let grid_line =
-                        egui::Stroke::new(0.5, Color32::from_rgba_premultiplied(40, 40, 60, 80));
+                    let grid_line = egui::Stroke::new(
+                        0.5_f32,
+                        Color32::from_rgba_premultiplied(40, 40, 60, 80),
+                    );
                     painter.line_segment(
                         [
                             Pos2::new(x, grid_origin.y),

--- a/frontend/src/latency.rs
+++ b/frontend/src/latency.rs
@@ -153,7 +153,7 @@ pub fn show_compact(ui: &mut Ui, latency_data: &LatencyData) {
         rect,
         2.0,
         Color32::from_gray(30),
-        Stroke::new(1.0, Color32::from_gray(60)),
+        Stroke::new(1.0_f32, Color32::from_gray(60)),
         egui::epaint::StrokeKind::Inside,
     );
 
@@ -202,7 +202,7 @@ pub fn show_compact(ui: &mut Ui, latency_data: &LatencyData) {
                 egui::pos2(marker_x, bar_rect.min.y),
                 egui::pos2(marker_x, bar_rect.max.y),
             ],
-            Stroke::new(2.0, Color32::WHITE),
+            Stroke::new(2.0_f32, Color32::WHITE),
         );
     }
 
@@ -331,7 +331,7 @@ pub fn show_full(ui: &mut Ui, element_id: &str, latency_data: &LatencyData) {
                 egui::pos2(marker_x, rect.min.y),
                 egui::pos2(marker_x, rect.max.y),
             ],
-            Stroke::new(2.0, Color32::WHITE),
+            Stroke::new(2.0_f32, Color32::WHITE),
         );
     }
 
@@ -340,7 +340,7 @@ pub fn show_full(ui: &mut Ui, element_id: &str, latency_data: &LatencyData) {
         rect,
         2.0,
         Color32::TRANSPARENT,
-        Stroke::new(1.0, Color32::from_gray(100)),
+        Stroke::new(1.0_f32, Color32::from_gray(100)),
         egui::epaint::StrokeKind::Inside,
     );
 

--- a/frontend/src/loudness.rs
+++ b/frontend/src/loudness.rs
@@ -320,7 +320,7 @@ pub fn show_compact(ui: &mut Ui, data: &LoudnessData) {
                 bar_rect,
                 radius,
                 Color32::TRANSPARENT,
-                Stroke::new(1.0, Color32::from_gray(80)),
+                Stroke::new(1.0_f32, Color32::from_gray(80)),
                 egui::epaint::StrokeKind::Inside,
             );
         }
@@ -441,7 +441,7 @@ pub fn show_full(ui: &mut Ui, data: &LoudnessData) {
             m_rect,
             2.0,
             Color32::TRANSPARENT,
-            Stroke::new(1.0, Color32::from_gray(100)),
+            Stroke::new(1.0_f32, Color32::from_gray(100)),
             egui::epaint::StrokeKind::Inside,
         );
 
@@ -458,7 +458,7 @@ pub fn show_full(ui: &mut Ui, data: &LoudnessData) {
             s_rect,
             2.0,
             Color32::TRANSPARENT,
-            Stroke::new(1.0, Color32::from_gray(100)),
+            Stroke::new(1.0_f32, Color32::from_gray(100)),
             egui::epaint::StrokeKind::Inside,
         );
 
@@ -471,7 +471,7 @@ pub fn show_full(ui: &mut Ui, data: &LoudnessData) {
                     egui::pos2(rect.min.x - 2.0, i_y),
                     egui::pos2(rect.min.x + total_width + 2.0, i_y),
                 ],
-                Stroke::new(2.0, Color32::WHITE),
+                Stroke::new(2.0_f32, Color32::WHITE),
             );
         }
 
@@ -492,7 +492,7 @@ pub fn show_full(ui: &mut Ui, data: &LoudnessData) {
                         egui::pos2(bracket_x, top_y),
                         egui::pos2(bracket_x, bottom_y),
                     ],
-                    Stroke::new(1.5, bracket_color),
+                    Stroke::new(1.5_f32, bracket_color),
                 );
                 // Top cap
                 painter.line_segment(
@@ -500,7 +500,7 @@ pub fn show_full(ui: &mut Ui, data: &LoudnessData) {
                         egui::pos2(bracket_x - 3.0, top_y),
                         egui::pos2(bracket_x + 3.0, top_y),
                     ],
-                    Stroke::new(1.5, bracket_color),
+                    Stroke::new(1.5_f32, bracket_color),
                 );
                 // Bottom cap
                 painter.line_segment(
@@ -508,7 +508,7 @@ pub fn show_full(ui: &mut Ui, data: &LoudnessData) {
                         egui::pos2(bracket_x - 3.0, bottom_y),
                         egui::pos2(bracket_x + 3.0, bottom_y),
                     ],
-                    Stroke::new(1.5, bracket_color),
+                    Stroke::new(1.5_f32, bracket_color),
                 );
             }
         }
@@ -554,7 +554,7 @@ pub fn show_full(ui: &mut Ui, data: &LoudnessData) {
                     rect,
                     2.0,
                     Color32::from_gray(40),
-                    Stroke::new(1.0, Color32::from_gray(80)),
+                    Stroke::new(1.0_f32, Color32::from_gray(80)),
                     egui::epaint::StrokeKind::Inside,
                 );
                 if tp_level > 0.0 {

--- a/frontend/src/mediaplayer.rs
+++ b/frontend/src/mediaplayer.rs
@@ -379,7 +379,7 @@ pub fn show_compact(ui: &mut Ui, player_data: &MediaPlayerData) -> Option<(Strin
                 rect,
                 CornerRadius::same(2),
                 Color32::TRANSPARENT,
-                Stroke::new(1.0, Color32::from_gray(80)),
+                Stroke::new(1.0_f32, Color32::from_gray(80)),
                 egui::epaint::StrokeKind::Inside,
             );
 
@@ -709,7 +709,7 @@ impl PlaylistEditor {
                                         };
                                         ui.painter().line_segment(
                                             [rect.center_top(), rect.center_bottom()],
-                                            egui::Stroke::new(1.0, color),
+                                            egui::Stroke::new(1.0_f32, color),
                                         );
                                         if resp.dragged() {
                                             if let Some(pos) = ui.ctx().pointer_interact_pos() {

--- a/frontend/src/meter.rs
+++ b/frontend/src/meter.rs
@@ -412,7 +412,7 @@ pub fn show_compact(ui: &mut Ui, meter_data: &MeterData) {
                     egui::pos2(decay_x, bar_rect.min.y),
                     egui::pos2(decay_x, bar_rect.max.y),
                 ],
-                Stroke::new(2.0, Color32::WHITE),
+                Stroke::new(2.0_f32, Color32::WHITE),
             );
         }
 
@@ -422,7 +422,7 @@ pub fn show_compact(ui: &mut Ui, meter_data: &MeterData) {
                 bar_rect,
                 radius,
                 Color32::TRANSPARENT,
-                Stroke::new(1.0, Color32::from_gray(80)),
+                Stroke::new(1.0_f32, Color32::from_gray(80)),
                 egui::epaint::StrokeKind::Inside,
             );
         }
@@ -529,7 +529,7 @@ pub fn show_full(ui: &mut Ui, meter_data: &MeterData) {
                             egui::pos2(rect.min.x, decay_y),
                             egui::pos2(rect.max.x, decay_y),
                         ],
-                        Stroke::new(2.0, Color32::WHITE),
+                        Stroke::new(2.0_f32, Color32::WHITE),
                     );
                 }
 
@@ -538,7 +538,7 @@ pub fn show_full(ui: &mut Ui, meter_data: &MeterData) {
                     rect,
                     2.0,
                     Color32::TRANSPARENT,
-                    Stroke::new(1.0, Color32::from_gray(100)),
+                    Stroke::new(1.0_f32, Color32::from_gray(100)),
                     egui::epaint::StrokeKind::Inside,
                 );
 

--- a/frontend/src/mixer/detail.rs
+++ b/frontend/src/mixer/detail.rs
@@ -14,11 +14,11 @@ fn section_frame(color: Color32, enabled: bool) -> egui::Frame {
                 25 + color.g() / 5,
                 30 + color.b() / 5,
             ))
-            .stroke(egui::Stroke::new(1.0, color.gamma_multiply(0.6)))
+            .stroke(egui::Stroke::new(1.0_f32, color.gamma_multiply(0.6)))
     } else {
         egui::Frame::NONE
             .fill(Color32::from_rgb(25, 25, 28))
-            .stroke(egui::Stroke::new(1.0, Color32::from_rgb(40, 40, 44)))
+            .stroke(egui::Stroke::new(1.0_f32, Color32::from_rgb(40, 40, 44)))
     };
     base.corner_radius(4.0).inner_margin(6.0)
 }

--- a/frontend/src/mixer/rendering.rs
+++ b/frontend/src/mixer/rendering.rs
@@ -792,7 +792,7 @@ impl MixerEditor {
                                     egui::pos2(handle_rect.left() + 2.0, handle_y),
                                     egui::pos2(handle_rect.right() - 2.0, handle_y),
                                 ],
-                                Stroke::new(1.5, Color32::from_gray(40)),
+                                Stroke::new(1.5_f32, Color32::from_gray(40)),
                             );
                         },
                     );
@@ -979,7 +979,7 @@ impl MixerEditor {
                                     egui::pos2(handle_rect.left() + 2.0, handle_y),
                                     egui::pos2(handle_rect.right() - 2.0, handle_y),
                                 ],
-                                Stroke::new(1.5, Color32::from_gray(40)),
+                                Stroke::new(1.5_f32, Color32::from_gray(40)),
                             );
                         },
                     );

--- a/frontend/src/mixer/widgets.rs
+++ b/frontend/src/mixer/widgets.rs
@@ -55,7 +55,7 @@ impl MixerEditor {
                 egui::pos2(handle_rect.left() + 2.0, handle_y),
                 egui::pos2(handle_rect.right() - 2.0, handle_y),
             ],
-            Stroke::new(1.5, Color32::from_gray(40)),
+            Stroke::new(1.5_f32, Color32::from_gray(40)),
         );
 
         response
@@ -111,7 +111,7 @@ impl MixerEditor {
                 egui::pos2(handle_rect.left() + 2.0, handle_y),
                 egui::pos2(handle_rect.right() - 2.0, handle_y),
             ],
-            Stroke::new(1.5, Color32::from_gray(40)),
+            Stroke::new(1.5_f32, Color32::from_gray(40)),
         );
 
         response
@@ -167,7 +167,7 @@ impl MixerEditor {
                 egui::pos2(handle_rect.left() + 2.0, handle_y),
                 egui::pos2(handle_rect.right() - 2.0, handle_y),
             ],
-            Stroke::new(1.5, Color32::from_gray(40)),
+            Stroke::new(1.5_f32, Color32::from_gray(40)),
         );
 
         response
@@ -231,7 +231,7 @@ impl MixerEditor {
                         egui::pos2(center.x - a0.cos() * arc_r, center.y - a0.sin() * arc_r),
                         egui::pos2(center.x - a1.cos() * arc_r, center.y - a1.sin() * arc_r),
                     ],
-                    Stroke::new(2.5, arc_color),
+                    Stroke::new(2.5_f32, arc_color),
                 );
             }
         }
@@ -251,7 +251,7 @@ impl MixerEditor {
                     center.y - center_angle.sin() * tick_outer,
                 ),
             ],
-            Stroke::new(1.0, Color32::from_gray(90)),
+            Stroke::new(1.0_f32, Color32::from_gray(90)),
         );
 
         // Pointer line
@@ -270,7 +270,7 @@ impl MixerEditor {
                     center.y - pointer_angle.sin() * outer_r,
                 ),
             ],
-            Stroke::new(1.5, pointer_color),
+            Stroke::new(1.5_f32, pointer_color),
         );
 
         // Border
@@ -279,7 +279,7 @@ impl MixerEditor {
         } else {
             Color32::from_gray(55)
         };
-        painter.circle_stroke(center, radius, Stroke::new(1.0, border_color));
+        painter.circle_stroke(center, radius, Stroke::new(1.0_f32, border_color));
 
         // Tooltip
         let resp = response.on_hover_text(format!("Pan: {}", format_pan(pan)));
@@ -294,7 +294,7 @@ impl MixerEditor {
         painter.rect_stroke(
             rect,
             CornerRadius::same(2),
-            Stroke::new(1.0, Color32::from_rgb(45, 50, 55)),
+            Stroke::new(1.0_f32, Color32::from_rgb(45, 50, 55)),
             egui::epaint::StrokeKind::Inside,
         );
         painter.text(
@@ -367,7 +367,7 @@ impl MixerEditor {
                         egui::pos2(center.x - a0.cos() * arc_r, center.y - a0.sin() * arc_r),
                         egui::pos2(center.x - a1.cos() * arc_r, center.y - a1.sin() * arc_r),
                     ],
-                    Stroke::new(2.5, arc_color),
+                    Stroke::new(2.5_f32, arc_color),
                 );
             }
         }
@@ -387,7 +387,7 @@ impl MixerEditor {
                     center.y - unity_angle.sin() * tick_outer,
                 ),
             ],
-            Stroke::new(1.0, Color32::from_gray(90)),
+            Stroke::new(1.0_f32, Color32::from_gray(90)),
         );
 
         // Pointer indicator line
@@ -410,7 +410,7 @@ impl MixerEditor {
                     center.y - pointer_angle.sin() * outer_r,
                 ),
             ],
-            Stroke::new(1.5, pointer_color),
+            Stroke::new(1.5_f32, pointer_color),
         );
 
         // Border
@@ -419,7 +419,7 @@ impl MixerEditor {
         } else {
             Color32::from_gray(55)
         };
-        painter.circle_stroke(center, radius, Stroke::new(1.0, border_color));
+        painter.circle_stroke(center, radius, Stroke::new(1.0_f32, border_color));
 
         // Hover tooltip
         let db_str = if level > 0.001 {
@@ -495,7 +495,7 @@ impl MixerEditor {
                         egui::pos2(left_rect.min.x, left_decay_y),
                         egui::pos2(left_rect.max.x, left_decay_y),
                     ],
-                    Stroke::new(1.0, Color32::WHITE),
+                    Stroke::new(1.0_f32, Color32::WHITE),
                 );
 
                 let right_decay_y = db_to_y(data.decay[1] as f32, rect.min.y, rect.max.y);
@@ -504,7 +504,7 @@ impl MixerEditor {
                         egui::pos2(right_rect.min.x, right_decay_y),
                         egui::pos2(right_rect.max.x, right_decay_y),
                     ],
-                    Stroke::new(1.0, Color32::WHITE),
+                    Stroke::new(1.0_f32, Color32::WHITE),
                 );
             }
         }
@@ -513,13 +513,13 @@ impl MixerEditor {
         painter.rect_stroke(
             left_rect,
             CornerRadius::same(2),
-            Stroke::new(1.0, Color32::from_gray(60)),
+            Stroke::new(1.0_f32, Color32::from_gray(60)),
             egui::epaint::StrokeKind::Inside,
         );
         painter.rect_stroke(
             right_rect,
             CornerRadius::same(2),
-            Stroke::new(1.0, Color32::from_gray(60)),
+            Stroke::new(1.0_f32, Color32::from_gray(60)),
             egui::epaint::StrokeKind::Inside,
         );
     }
@@ -546,7 +546,7 @@ impl MixerEditor {
 
             painter.line_segment(
                 [egui::pos2(rect.max.x - 3.0, y), egui::pos2(rect.max.x, y)],
-                Stroke::new(1.0, Color32::from_gray(100)),
+                Stroke::new(1.0_f32, Color32::from_gray(100)),
             );
 
             painter.text(

--- a/frontend/src/spectrum.rs
+++ b/frontend/src/spectrum.rs
@@ -231,7 +231,7 @@ pub fn show_compact(ui: &mut Ui, spectrum_data: &SpectrumData) {
         rect,
         1.0,
         Color32::TRANSPARENT,
-        Stroke::new(1.0, Color32::from_gray(60)),
+        Stroke::new(1.0_f32, Color32::from_gray(60)),
         egui::epaint::StrokeKind::Inside,
     );
 }
@@ -280,7 +280,7 @@ pub fn show_full(ui: &mut Ui, spectrum_data: &SpectrumData) {
             rect,
             2.0,
             Color32::from_rgb(15, 15, 15),
-            Stroke::new(1.0, Color32::from_gray(80)),
+            Stroke::new(1.0_f32, Color32::from_gray(80)),
             egui::epaint::StrokeKind::Inside,
         );
 
@@ -298,7 +298,7 @@ pub fn show_full(ui: &mut Ui, spectrum_data: &SpectrumData) {
                 let y = inner_bottom - inner_height * level;
                 painter.line_segment(
                     [egui::pos2(rect.min.x, y), egui::pos2(rect.max.x, y)],
-                    Stroke::new(0.5, Color32::from_gray(40)),
+                    Stroke::new(0.5_f32, Color32::from_gray(40)),
                 );
                 painter.text(
                     egui::pos2(rect.max.x - 28.0, y - 6.0),

--- a/frontend/src/system_monitor.rs
+++ b/frontend/src/system_monitor.rs
@@ -204,7 +204,7 @@ impl<'a> Widget for CompactSystemMonitor<'a> {
             painter.rect_stroke(
                 rect,
                 2.0,
-                Stroke::new(1.0, ui.visuals().widgets.noninteractive.bg_stroke.color),
+                Stroke::new(1.0_f32, ui.visuals().widgets.noninteractive.bg_stroke.color),
                 egui::StrokeKind::Outside,
             );
         }
@@ -230,7 +230,7 @@ fn draw_mini_graph(painter: &egui::Painter, rect: Rect, data: &VecDeque<f32>, co
         .collect();
 
     if points.len() >= 2 {
-        painter.add(egui::Shape::line(points, Stroke::new(1.5, color)));
+        painter.add(egui::Shape::line(points, Stroke::new(1.5_f32, color)));
     }
 }
 
@@ -679,7 +679,7 @@ fn draw_large_graph(
         let y = rect.min.y + (i as f32 / 4.0) * rect.height();
         painter.line_segment(
             [Pos2::new(rect.min.x, y), Pos2::new(rect.max.x, y)],
-            Stroke::new(0.5, grid_color),
+            Stroke::new(0.5_f32, grid_color),
         );
     }
 
@@ -699,14 +699,14 @@ fn draw_large_graph(
         .collect();
 
     if points.len() >= 2 {
-        painter.add(egui::Shape::line(points, Stroke::new(2.0, color)));
+        painter.add(egui::Shape::line(points, Stroke::new(2.0_f32, color)));
     }
 
     // Draw border
     painter.rect_stroke(
         rect,
         2.0,
-        Stroke::new(1.0, stroke_color),
+        Stroke::new(1.0_f32, stroke_color),
         egui::StrokeKind::Outside,
     );
 }

--- a/frontend/src/themes.rs
+++ b/frontend/src/themes.rs
@@ -99,7 +99,7 @@ pub fn nord_dark() -> Visuals {
 
     // Selection
     visuals.selection.bg_fill = nord::NORD3;
-    visuals.selection.stroke = Stroke::new(1.0, nord::NORD8);
+    visuals.selection.stroke = Stroke::new(1.0_f32, nord::NORD8);
 
     // Hyperlinks
     visuals.hyperlink_color = nord::NORD8;
@@ -111,31 +111,31 @@ pub fn nord_dark() -> Visuals {
     // Widget colors
     visuals.widgets.noninteractive.bg_fill = nord::NORD1;
     visuals.widgets.noninteractive.weak_bg_fill = nord::NORD1;
-    visuals.widgets.noninteractive.bg_stroke = Stroke::new(1.0, nord::NORD3);
-    visuals.widgets.noninteractive.fg_stroke = Stroke::new(1.0, nord::NORD4);
+    visuals.widgets.noninteractive.bg_stroke = Stroke::new(1.0_f32, nord::NORD3);
+    visuals.widgets.noninteractive.fg_stroke = Stroke::new(1.0_f32, nord::NORD4);
 
     visuals.widgets.inactive.bg_fill = nord::NORD2;
     visuals.widgets.inactive.weak_bg_fill = nord::NORD2;
-    visuals.widgets.inactive.bg_stroke = Stroke::new(1.0, nord::NORD3);
-    visuals.widgets.inactive.fg_stroke = Stroke::new(1.0, nord::NORD4);
+    visuals.widgets.inactive.bg_stroke = Stroke::new(1.0_f32, nord::NORD3);
+    visuals.widgets.inactive.fg_stroke = Stroke::new(1.0_f32, nord::NORD4);
 
     visuals.widgets.hovered.bg_fill = nord::NORD3;
     visuals.widgets.hovered.weak_bg_fill = nord::NORD3;
-    visuals.widgets.hovered.bg_stroke = Stroke::new(1.0, nord::NORD8);
-    visuals.widgets.hovered.fg_stroke = Stroke::new(1.0, nord::NORD6);
+    visuals.widgets.hovered.bg_stroke = Stroke::new(1.0_f32, nord::NORD8);
+    visuals.widgets.hovered.fg_stroke = Stroke::new(1.0_f32, nord::NORD6);
 
     visuals.widgets.active.bg_fill = nord::NORD9;
     visuals.widgets.active.weak_bg_fill = nord::NORD9;
-    visuals.widgets.active.bg_stroke = Stroke::new(1.0, nord::NORD8);
-    visuals.widgets.active.fg_stroke = Stroke::new(2.0, nord::NORD6);
+    visuals.widgets.active.bg_stroke = Stroke::new(1.0_f32, nord::NORD8);
+    visuals.widgets.active.fg_stroke = Stroke::new(2.0_f32, nord::NORD6);
 
     visuals.widgets.open.bg_fill = nord::NORD2;
     visuals.widgets.open.weak_bg_fill = nord::NORD2;
-    visuals.widgets.open.bg_stroke = Stroke::new(1.0, nord::NORD8);
-    visuals.widgets.open.fg_stroke = Stroke::new(1.0, nord::NORD4);
+    visuals.widgets.open.bg_stroke = Stroke::new(1.0_f32, nord::NORD8);
+    visuals.widgets.open.fg_stroke = Stroke::new(1.0_f32, nord::NORD4);
 
     // Window stroke
-    visuals.window_stroke = Stroke::new(1.0, nord::NORD3);
+    visuals.window_stroke = Stroke::new(1.0_f32, nord::NORD3);
 
     visuals
 }
@@ -155,7 +155,7 @@ pub fn nord_light() -> Visuals {
 
     // Selection
     visuals.selection.bg_fill = nord::NORD4;
-    visuals.selection.stroke = Stroke::new(1.0, nord::NORD10);
+    visuals.selection.stroke = Stroke::new(1.0_f32, nord::NORD10);
 
     // Hyperlinks
     visuals.hyperlink_color = nord::NORD10;
@@ -167,31 +167,31 @@ pub fn nord_light() -> Visuals {
     // Widget colors
     visuals.widgets.noninteractive.bg_fill = nord::NORD5;
     visuals.widgets.noninteractive.weak_bg_fill = nord::NORD5;
-    visuals.widgets.noninteractive.bg_stroke = Stroke::new(1.0, nord::NORD4);
-    visuals.widgets.noninteractive.fg_stroke = Stroke::new(1.0, nord::NORD1);
+    visuals.widgets.noninteractive.bg_stroke = Stroke::new(1.0_f32, nord::NORD4);
+    visuals.widgets.noninteractive.fg_stroke = Stroke::new(1.0_f32, nord::NORD1);
 
     visuals.widgets.inactive.bg_fill = nord::NORD5;
     visuals.widgets.inactive.weak_bg_fill = nord::NORD5;
-    visuals.widgets.inactive.bg_stroke = Stroke::new(1.0, nord::NORD4);
-    visuals.widgets.inactive.fg_stroke = Stroke::new(1.0, nord::NORD2);
+    visuals.widgets.inactive.bg_stroke = Stroke::new(1.0_f32, nord::NORD4);
+    visuals.widgets.inactive.fg_stroke = Stroke::new(1.0_f32, nord::NORD2);
 
     visuals.widgets.hovered.bg_fill = nord::NORD4;
     visuals.widgets.hovered.weak_bg_fill = nord::NORD4;
-    visuals.widgets.hovered.bg_stroke = Stroke::new(1.0, nord::NORD10);
-    visuals.widgets.hovered.fg_stroke = Stroke::new(1.0, nord::NORD0);
+    visuals.widgets.hovered.bg_stroke = Stroke::new(1.0_f32, nord::NORD10);
+    visuals.widgets.hovered.fg_stroke = Stroke::new(1.0_f32, nord::NORD0);
 
     visuals.widgets.active.bg_fill = nord::NORD9;
     visuals.widgets.active.weak_bg_fill = nord::NORD9;
-    visuals.widgets.active.bg_stroke = Stroke::new(1.0, nord::NORD10);
-    visuals.widgets.active.fg_stroke = Stroke::new(2.0, nord::NORD6);
+    visuals.widgets.active.bg_stroke = Stroke::new(1.0_f32, nord::NORD10);
+    visuals.widgets.active.fg_stroke = Stroke::new(2.0_f32, nord::NORD6);
 
     visuals.widgets.open.bg_fill = nord::NORD5;
     visuals.widgets.open.weak_bg_fill = nord::NORD5;
-    visuals.widgets.open.bg_stroke = Stroke::new(1.0, nord::NORD10);
-    visuals.widgets.open.fg_stroke = Stroke::new(1.0, nord::NORD1);
+    visuals.widgets.open.bg_stroke = Stroke::new(1.0_f32, nord::NORD10);
+    visuals.widgets.open.fg_stroke = Stroke::new(1.0_f32, nord::NORD1);
 
     // Window stroke
-    visuals.window_stroke = Stroke::new(1.0, nord::NORD4);
+    visuals.window_stroke = Stroke::new(1.0_f32, nord::NORD4);
 
     visuals
 }
@@ -211,7 +211,7 @@ pub fn tokyo_night() -> Visuals {
 
     // Selection
     visuals.selection.bg_fill = tokyo::SELECTION;
-    visuals.selection.stroke = Stroke::new(1.0, tokyo::BLUE);
+    visuals.selection.stroke = Stroke::new(1.0_f32, tokyo::BLUE);
 
     // Hyperlinks
     visuals.hyperlink_color = tokyo::CYAN;
@@ -223,31 +223,31 @@ pub fn tokyo_night() -> Visuals {
     // Widget colors
     visuals.widgets.noninteractive.bg_fill = Color32::from_rgb(0x1f, 0x20, 0x2a);
     visuals.widgets.noninteractive.weak_bg_fill = Color32::from_rgb(0x1f, 0x20, 0x2a);
-    visuals.widgets.noninteractive.bg_stroke = Stroke::new(1.0, tokyo::COMMENT);
-    visuals.widgets.noninteractive.fg_stroke = Stroke::new(1.0, tokyo::FG_DARK);
+    visuals.widgets.noninteractive.bg_stroke = Stroke::new(1.0_f32, tokyo::COMMENT);
+    visuals.widgets.noninteractive.fg_stroke = Stroke::new(1.0_f32, tokyo::FG_DARK);
 
     visuals.widgets.inactive.bg_fill = tokyo::SELECTION;
     visuals.widgets.inactive.weak_bg_fill = tokyo::SELECTION;
-    visuals.widgets.inactive.bg_stroke = Stroke::new(1.0, tokyo::COMMENT);
-    visuals.widgets.inactive.fg_stroke = Stroke::new(1.0, tokyo::FG_DARK);
+    visuals.widgets.inactive.bg_stroke = Stroke::new(1.0_f32, tokyo::COMMENT);
+    visuals.widgets.inactive.fg_stroke = Stroke::new(1.0_f32, tokyo::FG_DARK);
 
     visuals.widgets.hovered.bg_fill = Color32::from_rgb(0x32, 0x38, 0x50);
     visuals.widgets.hovered.weak_bg_fill = Color32::from_rgb(0x32, 0x38, 0x50);
-    visuals.widgets.hovered.bg_stroke = Stroke::new(1.0, tokyo::BLUE);
-    visuals.widgets.hovered.fg_stroke = Stroke::new(1.0, tokyo::FG_BRIGHT);
+    visuals.widgets.hovered.bg_stroke = Stroke::new(1.0_f32, tokyo::BLUE);
+    visuals.widgets.hovered.fg_stroke = Stroke::new(1.0_f32, tokyo::FG_BRIGHT);
 
     visuals.widgets.active.bg_fill = tokyo::BLUE;
     visuals.widgets.active.weak_bg_fill = tokyo::BLUE;
-    visuals.widgets.active.bg_stroke = Stroke::new(1.0, tokyo::CYAN);
-    visuals.widgets.active.fg_stroke = Stroke::new(2.0, tokyo::BG_NIGHT);
+    visuals.widgets.active.bg_stroke = Stroke::new(1.0_f32, tokyo::CYAN);
+    visuals.widgets.active.fg_stroke = Stroke::new(2.0_f32, tokyo::BG_NIGHT);
 
     visuals.widgets.open.bg_fill = tokyo::SELECTION;
     visuals.widgets.open.weak_bg_fill = tokyo::SELECTION;
-    visuals.widgets.open.bg_stroke = Stroke::new(1.0, tokyo::BLUE);
-    visuals.widgets.open.fg_stroke = Stroke::new(1.0, tokyo::FG_DARK);
+    visuals.widgets.open.bg_stroke = Stroke::new(1.0_f32, tokyo::BLUE);
+    visuals.widgets.open.fg_stroke = Stroke::new(1.0_f32, tokyo::FG_DARK);
 
     // Window stroke
-    visuals.window_stroke = Stroke::new(1.0, tokyo::COMMENT);
+    visuals.window_stroke = Stroke::new(1.0_f32, tokyo::COMMENT);
 
     visuals
 }
@@ -267,7 +267,7 @@ pub fn tokyo_night_storm() -> Visuals {
 
     // Selection
     visuals.selection.bg_fill = Color32::from_rgb(0x2d, 0x32, 0x4a);
-    visuals.selection.stroke = Stroke::new(1.0, tokyo::BLUE);
+    visuals.selection.stroke = Stroke::new(1.0_f32, tokyo::BLUE);
 
     // Hyperlinks
     visuals.hyperlink_color = tokyo::CYAN;
@@ -279,31 +279,31 @@ pub fn tokyo_night_storm() -> Visuals {
     // Widget colors
     visuals.widgets.noninteractive.bg_fill = Color32::from_rgb(0x29, 0x2e, 0x42);
     visuals.widgets.noninteractive.weak_bg_fill = Color32::from_rgb(0x29, 0x2e, 0x42);
-    visuals.widgets.noninteractive.bg_stroke = Stroke::new(1.0, tokyo::COMMENT);
-    visuals.widgets.noninteractive.fg_stroke = Stroke::new(1.0, tokyo::FG_BRIGHT);
+    visuals.widgets.noninteractive.bg_stroke = Stroke::new(1.0_f32, tokyo::COMMENT);
+    visuals.widgets.noninteractive.fg_stroke = Stroke::new(1.0_f32, tokyo::FG_BRIGHT);
 
     visuals.widgets.inactive.bg_fill = Color32::from_rgb(0x2d, 0x32, 0x4a);
     visuals.widgets.inactive.weak_bg_fill = Color32::from_rgb(0x2d, 0x32, 0x4a);
-    visuals.widgets.inactive.bg_stroke = Stroke::new(1.0, tokyo::COMMENT);
-    visuals.widgets.inactive.fg_stroke = Stroke::new(1.0, tokyo::FG_BRIGHT);
+    visuals.widgets.inactive.bg_stroke = Stroke::new(1.0_f32, tokyo::COMMENT);
+    visuals.widgets.inactive.fg_stroke = Stroke::new(1.0_f32, tokyo::FG_BRIGHT);
 
     visuals.widgets.hovered.bg_fill = Color32::from_rgb(0x38, 0x3e, 0x5a);
     visuals.widgets.hovered.weak_bg_fill = Color32::from_rgb(0x38, 0x3e, 0x5a);
-    visuals.widgets.hovered.bg_stroke = Stroke::new(1.0, tokyo::BLUE);
-    visuals.widgets.hovered.fg_stroke = Stroke::new(1.0, tokyo::FG_BRIGHT);
+    visuals.widgets.hovered.bg_stroke = Stroke::new(1.0_f32, tokyo::BLUE);
+    visuals.widgets.hovered.fg_stroke = Stroke::new(1.0_f32, tokyo::FG_BRIGHT);
 
     visuals.widgets.active.bg_fill = tokyo::BLUE;
     visuals.widgets.active.weak_bg_fill = tokyo::BLUE;
-    visuals.widgets.active.bg_stroke = Stroke::new(1.0, tokyo::CYAN);
-    visuals.widgets.active.fg_stroke = Stroke::new(2.0, tokyo::BG_STORM);
+    visuals.widgets.active.bg_stroke = Stroke::new(1.0_f32, tokyo::CYAN);
+    visuals.widgets.active.fg_stroke = Stroke::new(2.0_f32, tokyo::BG_STORM);
 
     visuals.widgets.open.bg_fill = Color32::from_rgb(0x2d, 0x32, 0x4a);
     visuals.widgets.open.weak_bg_fill = Color32::from_rgb(0x2d, 0x32, 0x4a);
-    visuals.widgets.open.bg_stroke = Stroke::new(1.0, tokyo::BLUE);
-    visuals.widgets.open.fg_stroke = Stroke::new(1.0, tokyo::FG_BRIGHT);
+    visuals.widgets.open.bg_stroke = Stroke::new(1.0_f32, tokyo::BLUE);
+    visuals.widgets.open.fg_stroke = Stroke::new(1.0_f32, tokyo::FG_BRIGHT);
 
     // Window stroke
-    visuals.window_stroke = Stroke::new(1.0, tokyo::COMMENT);
+    visuals.window_stroke = Stroke::new(1.0_f32, tokyo::COMMENT);
 
     visuals
 }
@@ -323,7 +323,7 @@ pub fn tokyo_night_light() -> Visuals {
 
     // Selection
     visuals.selection.bg_fill = Color32::from_rgb(0xc4, 0xc8, 0xda);
-    visuals.selection.stroke = Stroke::new(1.0, Color32::from_rgb(0x29, 0x59, 0xaa));
+    visuals.selection.stroke = Stroke::new(1.0_f32, Color32::from_rgb(0x29, 0x59, 0xaa));
 
     // Hyperlinks
     visuals.hyperlink_color = Color32::from_rgb(0x29, 0x59, 0xaa);
@@ -338,31 +338,31 @@ pub fn tokyo_night_light() -> Visuals {
     visuals.widgets.noninteractive.bg_fill = Color32::from_rgb(0xd0, 0xd1, 0xd6);
     visuals.widgets.noninteractive.weak_bg_fill = Color32::from_rgb(0xd0, 0xd1, 0xd6);
     visuals.widgets.noninteractive.bg_stroke =
-        Stroke::new(1.0, Color32::from_rgb(0xb0, 0xb1, 0xb6));
-    visuals.widgets.noninteractive.fg_stroke = Stroke::new(1.0, tokyo::FG_LIGHT);
+        Stroke::new(1.0_f32, Color32::from_rgb(0xb0, 0xb1, 0xb6));
+    visuals.widgets.noninteractive.fg_stroke = Stroke::new(1.0_f32, tokyo::FG_LIGHT);
 
     visuals.widgets.inactive.bg_fill = Color32::from_rgb(0xca, 0xcb, 0xd0);
     visuals.widgets.inactive.weak_bg_fill = Color32::from_rgb(0xca, 0xcb, 0xd0);
-    visuals.widgets.inactive.bg_stroke = Stroke::new(1.0, Color32::from_rgb(0xb0, 0xb1, 0xb6));
-    visuals.widgets.inactive.fg_stroke = Stroke::new(1.0, tokyo::FG_LIGHT);
+    visuals.widgets.inactive.bg_stroke = Stroke::new(1.0_f32, Color32::from_rgb(0xb0, 0xb1, 0xb6));
+    visuals.widgets.inactive.fg_stroke = Stroke::new(1.0_f32, tokyo::FG_LIGHT);
 
     visuals.widgets.hovered.bg_fill = Color32::from_rgb(0xc0, 0xc4, 0xd0);
     visuals.widgets.hovered.weak_bg_fill = Color32::from_rgb(0xc0, 0xc4, 0xd0);
-    visuals.widgets.hovered.bg_stroke = Stroke::new(1.0, light_accent);
-    visuals.widgets.hovered.fg_stroke = Stroke::new(1.0, tokyo::FG_LIGHT);
+    visuals.widgets.hovered.bg_stroke = Stroke::new(1.0_f32, light_accent);
+    visuals.widgets.hovered.fg_stroke = Stroke::new(1.0_f32, tokyo::FG_LIGHT);
 
     visuals.widgets.active.bg_fill = light_accent;
     visuals.widgets.active.weak_bg_fill = light_accent;
-    visuals.widgets.active.bg_stroke = Stroke::new(1.0, Color32::from_rgb(0x1e, 0x40, 0x80));
-    visuals.widgets.active.fg_stroke = Stroke::new(2.0, Color32::WHITE);
+    visuals.widgets.active.bg_stroke = Stroke::new(1.0_f32, Color32::from_rgb(0x1e, 0x40, 0x80));
+    visuals.widgets.active.fg_stroke = Stroke::new(2.0_f32, Color32::WHITE);
 
     visuals.widgets.open.bg_fill = Color32::from_rgb(0xc8, 0xcc, 0xda);
     visuals.widgets.open.weak_bg_fill = Color32::from_rgb(0xc8, 0xcc, 0xda);
-    visuals.widgets.open.bg_stroke = Stroke::new(1.0, light_accent);
-    visuals.widgets.open.fg_stroke = Stroke::new(1.0, tokyo::FG_LIGHT);
+    visuals.widgets.open.bg_stroke = Stroke::new(1.0_f32, light_accent);
+    visuals.widgets.open.fg_stroke = Stroke::new(1.0_f32, tokyo::FG_LIGHT);
 
     // Window stroke
-    visuals.window_stroke = Stroke::new(1.0, Color32::from_rgb(0xb0, 0xb1, 0xb6));
+    visuals.window_stroke = Stroke::new(1.0_f32, Color32::from_rgb(0xb0, 0xb1, 0xb6));
 
     visuals
 }
@@ -385,7 +385,7 @@ pub fn claude_dark() -> Visuals {
 
     // Selection
     visuals.selection.bg_fill = claude::BG_DARK_SURFACE;
-    visuals.selection.stroke = Stroke::new(1.0, claude::ORANGE);
+    visuals.selection.stroke = Stroke::new(1.0_f32, claude::ORANGE);
 
     // Hyperlinks
     visuals.hyperlink_color = claude::ORANGE_LIGHT;
@@ -397,31 +397,31 @@ pub fn claude_dark() -> Visuals {
     // Widget colors
     visuals.widgets.noninteractive.bg_fill = claude::BG_DARK_ELEVATED;
     visuals.widgets.noninteractive.weak_bg_fill = claude::BG_DARK_ELEVATED;
-    visuals.widgets.noninteractive.bg_stroke = Stroke::new(1.0, claude::BG_DARK_SURFACE);
-    visuals.widgets.noninteractive.fg_stroke = Stroke::new(1.0, claude::TEXT_CREAM);
+    visuals.widgets.noninteractive.bg_stroke = Stroke::new(1.0_f32, claude::BG_DARK_SURFACE);
+    visuals.widgets.noninteractive.fg_stroke = Stroke::new(1.0_f32, claude::TEXT_CREAM);
 
     visuals.widgets.inactive.bg_fill = claude::BG_DARK_ELEVATED;
     visuals.widgets.inactive.weak_bg_fill = claude::BG_DARK_ELEVATED;
-    visuals.widgets.inactive.bg_stroke = Stroke::new(1.0, claude::BG_DARK_SURFACE);
-    visuals.widgets.inactive.fg_stroke = Stroke::new(1.0, claude::TEXT_MUTED);
+    visuals.widgets.inactive.bg_stroke = Stroke::new(1.0_f32, claude::BG_DARK_SURFACE);
+    visuals.widgets.inactive.fg_stroke = Stroke::new(1.0_f32, claude::TEXT_MUTED);
 
     visuals.widgets.hovered.bg_fill = claude::BG_DARK_SURFACE;
     visuals.widgets.hovered.weak_bg_fill = claude::BG_DARK_SURFACE;
-    visuals.widgets.hovered.bg_stroke = Stroke::new(1.0, claude::TERRACOTTA);
-    visuals.widgets.hovered.fg_stroke = Stroke::new(1.0, claude::TEXT_CREAM);
+    visuals.widgets.hovered.bg_stroke = Stroke::new(1.0_f32, claude::TERRACOTTA);
+    visuals.widgets.hovered.fg_stroke = Stroke::new(1.0_f32, claude::TEXT_CREAM);
 
     visuals.widgets.active.bg_fill = claude::TERRACOTTA;
     visuals.widgets.active.weak_bg_fill = claude::TERRACOTTA;
-    visuals.widgets.active.bg_stroke = Stroke::new(1.0, claude::ORANGE);
-    visuals.widgets.active.fg_stroke = Stroke::new(2.0, claude::TEXT_CREAM);
+    visuals.widgets.active.bg_stroke = Stroke::new(1.0_f32, claude::ORANGE);
+    visuals.widgets.active.fg_stroke = Stroke::new(2.0_f32, claude::TEXT_CREAM);
 
     visuals.widgets.open.bg_fill = claude::BG_DARK_SURFACE;
     visuals.widgets.open.weak_bg_fill = claude::BG_DARK_SURFACE;
-    visuals.widgets.open.bg_stroke = Stroke::new(1.0, claude::TERRACOTTA);
-    visuals.widgets.open.fg_stroke = Stroke::new(1.0, claude::TEXT_CREAM);
+    visuals.widgets.open.bg_stroke = Stroke::new(1.0_f32, claude::TERRACOTTA);
+    visuals.widgets.open.fg_stroke = Stroke::new(1.0_f32, claude::TEXT_CREAM);
 
     // Window stroke
-    visuals.window_stroke = Stroke::new(1.0, claude::BG_DARK_SURFACE);
+    visuals.window_stroke = Stroke::new(1.0_f32, claude::BG_DARK_SURFACE);
 
     visuals
 }
@@ -444,7 +444,7 @@ pub fn claude_light() -> Visuals {
 
     // Selection
     visuals.selection.bg_fill = Color32::from_rgb(0xe8, 0xd5, 0xc4);
-    visuals.selection.stroke = Stroke::new(1.0, claude::CORAL);
+    visuals.selection.stroke = Stroke::new(1.0_f32, claude::CORAL);
 
     // Hyperlinks
     visuals.hyperlink_color = claude::CORAL;
@@ -456,31 +456,31 @@ pub fn claude_light() -> Visuals {
     // Widget colors
     visuals.widgets.noninteractive.bg_fill = claude::BG_LIGHT_ELEVATED;
     visuals.widgets.noninteractive.weak_bg_fill = claude::BG_LIGHT_ELEVATED;
-    visuals.widgets.noninteractive.bg_stroke = Stroke::new(1.0, claude::BG_LIGHT_SURFACE);
-    visuals.widgets.noninteractive.fg_stroke = Stroke::new(1.0, claude::TEXT_DARK);
+    visuals.widgets.noninteractive.bg_stroke = Stroke::new(1.0_f32, claude::BG_LIGHT_SURFACE);
+    visuals.widgets.noninteractive.fg_stroke = Stroke::new(1.0_f32, claude::TEXT_DARK);
 
     visuals.widgets.inactive.bg_fill = claude::BG_LIGHT_ELEVATED;
     visuals.widgets.inactive.weak_bg_fill = claude::BG_LIGHT_ELEVATED;
-    visuals.widgets.inactive.bg_stroke = Stroke::new(1.0, claude::BG_LIGHT_SURFACE);
-    visuals.widgets.inactive.fg_stroke = Stroke::new(1.0, claude::TEXT_DARK_MUTED);
+    visuals.widgets.inactive.bg_stroke = Stroke::new(1.0_f32, claude::BG_LIGHT_SURFACE);
+    visuals.widgets.inactive.fg_stroke = Stroke::new(1.0_f32, claude::TEXT_DARK_MUTED);
 
     visuals.widgets.hovered.bg_fill = claude::BG_LIGHT_SURFACE;
     visuals.widgets.hovered.weak_bg_fill = claude::BG_LIGHT_SURFACE;
-    visuals.widgets.hovered.bg_stroke = Stroke::new(1.0, claude::CORAL);
-    visuals.widgets.hovered.fg_stroke = Stroke::new(1.0, claude::TEXT_DARK);
+    visuals.widgets.hovered.bg_stroke = Stroke::new(1.0_f32, claude::CORAL);
+    visuals.widgets.hovered.fg_stroke = Stroke::new(1.0_f32, claude::TEXT_DARK);
 
     visuals.widgets.active.bg_fill = claude::CORAL;
     visuals.widgets.active.weak_bg_fill = claude::CORAL;
-    visuals.widgets.active.bg_stroke = Stroke::new(1.0, claude::TERRACOTTA);
-    visuals.widgets.active.fg_stroke = Stroke::new(2.0, Color32::WHITE);
+    visuals.widgets.active.bg_stroke = Stroke::new(1.0_f32, claude::TERRACOTTA);
+    visuals.widgets.active.fg_stroke = Stroke::new(2.0_f32, Color32::WHITE);
 
     visuals.widgets.open.bg_fill = claude::BG_LIGHT_SURFACE;
     visuals.widgets.open.weak_bg_fill = claude::BG_LIGHT_SURFACE;
-    visuals.widgets.open.bg_stroke = Stroke::new(1.0, claude::CORAL);
-    visuals.widgets.open.fg_stroke = Stroke::new(1.0, claude::TEXT_DARK);
+    visuals.widgets.open.bg_stroke = Stroke::new(1.0_f32, claude::CORAL);
+    visuals.widgets.open.fg_stroke = Stroke::new(1.0_f32, claude::TEXT_DARK);
 
     // Window stroke
-    visuals.window_stroke = Stroke::new(1.0, claude::BG_LIGHT_SURFACE);
+    visuals.window_stroke = Stroke::new(1.0_f32, claude::BG_LIGHT_SURFACE);
 
     visuals
 }


### PR DESCRIPTION
## Description

Stable rustc recently promoted the `float_literal_f32_fallback` lint ([rust-lang/rust#154024](https://github.com/rust-lang/rust/issues/154024)) to warn-by-default. It fires whenever an untyped float literal (e.g. `1.0`) is passed where type inference relies on an `f32: From<f64>` impl that doesn't exist, which several `egui` APIs (`Stroke::new`, `.width()`, `.radius()`, etc.) hit throughout `strom-frontend`.

This repo pins no Rust toolchain version (no `rust-toolchain.toml`, CI uses `dtolnay/rust-toolchain@stable` unpinned), so the lint newly surfaced across ~187 call sites in `strom-frontend` without any code change on our side. It's a plain warning under normal `cargo check`, but both the CI clippy jobs and the local pre-commit hook run with `-D warnings`, turning it into a hard build failure blocking clippy across the crate.

Fixed by applying the compiler's own machine-applicable suggestion (explicit `_f32` suffix, e.g. `1.0` -> `1.0_f32`) via `cargo fix` at every ambiguous site, then `cargo fmt --all`. Purely mechanical — no behavior change.

Files changed (18): `frontend/src/app/dialogs.rs`, `frontend/src/audioanalyzer.rs`, `frontend/src/clocks.rs`, `frontend/src/compositor_editor/canvas.rs`, `frontend/src/graph/interaction.rs`, `frontend/src/graph/rendering.rs`, `frontend/src/info_page.rs`, `frontend/src/interactive_overlay.rs`, `frontend/src/latency.rs`, `frontend/src/loudness.rs`, `frontend/src/mediaplayer.rs`, `frontend/src/meter.rs`, `frontend/src/mixer/detail.rs`, `frontend/src/mixer/rendering.rs`, `frontend/src/mixer/widgets.rs`, `frontend/src/spectrum.rs`, `frontend/src/system_monitor.rs`, `frontend/src/themes.rs`.

## Related Issue

None — discovered as a pre-existing lint failure blocking `cargo clippy --workspace --all-targets -- -D warnings`.

## Type of Change

- [x] Bug fix

## Checklist

- [x] I have run `cargo fmt --all`
- [x] I have run `cargo clippy --workspace --all-targets -- -D warnings`
- [x] I have run `cargo test --workspace`
- [ ] I have updated documentation as needed (n/a — no user-facing/doc changes)
- [ ] I have added tests for new functionality (n/a — mechanical lint fix, no behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)