### PR TITLE
fix(whip): proactively retry keyframe (PLI) request on video pad connect

### DIFF
--- a/backend/src/blocks/builtin/whip.rs
+++ b/backend/src/blocks/builtin/whip.rs
@@ -831,6 +831,41 @@ pub fn create_whipserversrc_for_session(
                     pad_name, stream_num, slot, media_type
                 );
 
+                if media_type == "video" {
+                    // Proactively request a keyframe as soon as the video pad
+                    // connects, and keep retrying for a few seconds. Without
+                    // this, if the publisher's initial keyframe is
+                    // incomplete/lost before decodebin has a decoder element
+                    // to install the existing DISCONT-triggered recovery
+                    // probe on, decodebin waits forever for a keyframe that
+                    // never arrives — a chicken-and-egg stall that's
+                    // otherwise invisible (packets keep flowing, just never a
+                    // usable one). If retransmission is disabled/unavailable,
+                    // the keyframe response itself can also be lost with no
+                    // recovery, so a single request isn't reliable — retry a
+                    // few times, spaced out, until decode has had a fair
+                    // chance to succeed.
+                    let retry_pad = pad.clone();
+                    let retry_slot = slot;
+                    std::thread::Builder::new()
+                        .name(format!("whip-keyframe-retry-{}", retry_slot))
+                        .spawn(move || {
+                            for attempt in 0..5 {
+                                let fku = gst_video::UpstreamForceKeyUnitEvent::builder()
+                                    .all_headers(true)
+                                    .build();
+                                retry_pad.send_event(fku);
+                                info!(
+                                    "WHIP Input: Requested keyframe (PLI) on video pad for slot {} (attempt {})",
+                                    retry_slot,
+                                    attempt + 1
+                                );
+                                std::thread::sleep(std::time::Duration::from_millis(800));
+                            }
+                        })
+                        .ok();
+                }
+
                 let ts_offset = shared_ts_offset.clone();
                 let main_pipeline_for_ts = main_pipeline_weak.clone();
                 let media_for_log = media_type.to_string();


### PR DESCRIPTION
## Summary
- WHIP Input's existing keyframe-recovery mechanism (a DISCONT-triggered PLI request) only installs once a decoder element exists downstream of `decodebin`. If the publisher's very first keyframe is incomplete or lost before that decoder exists, `decodebin` waits forever for a keyframe that never arrives — a chicken-and-egg stall that's otherwise invisible, since packets keep flowing normally, just never a usable one.
- Fixes this by proactively sending an `UpstreamForceKeyUnitEvent` (PLI) on the video pad as soon as it connects, retried 5 times spaced 800ms apart on a dedicated background thread. A single request isn't reliable either — if retransmission is disabled or unavailable, the keyframe response itself can be lost with no recovery — so retrying gives decode a fair chance to succeed.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo build`
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` on the changed file (no new warnings introduced)
- [ ] No unit test is feasible for this change — it's runtime GStreamer pad/thread behavior, and no pipeline-construction test harness exists in this codebase for WHIP/WHEP. Verified via manual `GST_DEBUG`/pad-caps inspection during live diagnosis of a WHIP Input -> WHEP Output flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)