### PR TITLE
docs: correct the X11/Docker-only claim for HTML rendering on macOS

### DIFF
--- a/docs/HTML_RENDER.md
+++ b/docs/HTML_RENDER.md
@@ -3,7 +3,7 @@
 > **Code is the source of truth.** This guide describes intended behaviour and may have
 > drifted from the current implementation. When in doubt, read the code and check the in-app UI.
 
-Strom supports rendering HTML content as video sources using the `cefsrc` GStreamer element from [gstcefsrc](https://github.com/AioCef/gstcefsrc). This enables:
+Strom supports rendering HTML content as video sources using the `cefsrc` GStreamer element from [gstcefsrc](https://github.com/centricular/gstcefsrc). This enables:
 
 - Dynamic HTML/CSS/JavaScript overlays
 - Web-based graphics and animations
@@ -240,12 +240,14 @@ The build uses Ubuntu Questing to match the strom base image's glibc version.
 
 ## Limitations
 
-- **Docker only**: CEF requires X11, which the strom-full image provides via Xvfb
+- **`strom-full` image only**: `cefsrc` comes from the gstcefsrc plugin, which Strom ships only in the `strom-full` image. The plain `strom` image and the native release builds (Linux, macOS, Windows) do not include it.
+- **Linux: X11 required**: CEF needs an X server on Linux, which the strom-full image provides via Xvfb. This is why `strom-full` is the supported way to run HTML sources.
+- **macOS: no native support yet**: CEF renders offscreen through its own macOS path, so Xvfb is not involved and the X11 requirement above does not apply. Native macOS support is tracked in [centricular/gstcefsrc#110](https://github.com/centricular/gstcefsrc/pull/110) (macOS build fixes) and [Eyevinn/strom#669](https://github.com/Eyevinn/strom/pull/669) (a Cocoa run loop on the main thread, needed in headless mode). CEF on macOS also refuses to initialise unless the host process is inside an `.app` bundle, and the macOS release ships a bare executable rather than a bundle.
 - **Software rendering by default**: CEF uses CPU rendering; opt in to GPU with `STROM_CEF_GPU=1` (see above)
 - **Memory usage**: CEF spawns multiple processes (browser, renderer, GPU process)
 - **No audio by default**: Use `cefbin` or `cefdemux` if you need audio from web content
 
 ## References
 
-- [gstcefsrc GitHub](https://github.com/AioCef/gstcefsrc) - GStreamer CEF plugin
-- [CEF Project](https://bitbucket.org/AioCef/cef/overview) - Chromium Embedded Framework
+- [gstcefsrc GitHub](https://github.com/centricular/gstcefsrc) - GStreamer CEF plugin
+- [CEF Project](https://bitbucket.org/chromiumembedded/cef) - Chromium Embedded Framework


### PR DESCRIPTION
## Description

`docs/HTML_RENDER.md` currently says, under Limitations:

> **Docker only**: CEF requires X11, which the strom-full image provides via Xvfb

The X11 requirement is Linux-specific. CEF on macOS renders offscreen through its own path and never touches X11 or Xvfb, so the stated reason doesn't hold there.

This splits the bullet per platform:

- **Linux** — keeps the existing (correct) rationale: CEF needs an X server, `strom-full` provides Xvfb, which is why it's the supported path for HTML sources.
- **macOS** — states the real situation. Native macOS is still not supported, but for different reasons, and they're worth naming: gstcefsrc needs macOS build fixes ([centricular/gstcefsrc#110](https://github.com/centricular/gstcefsrc/pull/110)), headless needs a Cocoa run loop on the main thread (#669), and CEF refuses to initialise unless the host process is inside an `.app` bundle.

That last point is the one worth documenting: an unbundled process doesn't error, it hangs silently at PAUSED with no diagnostic. It's easy to lose an afternoon to.

I deliberately did **not** claim macOS is supported — neither prerequisite has merged. The goal is only that the stated *reason* is correct, so someone on macOS isn't sent looking for an X server they don't need.

Docs-only; no behaviour change.

## Related Issue

None. Companion to #669.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Checklist

- [x] I have run `cargo fmt --all` — clean (no code changed)
- [ ] I have run `cargo clippy --workspace --all-targets -- -D warnings` — fails on `main` independently of this change (pre-existing `float-literal-f32-fallback` errors in `frontend/*.rs` on Rust 1.97.1, addressed by #664). No code changed here.
- [x] I have run `cargo test --workspace` — passes
- [x] I have updated documentation as needed — this *is* the documentation update; navigational per CONTRIBUTING, not code-describing
- [x] I have added tests for new functionality — n/a, docs only

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
