### PR TITLE
fix(recorder): request splitmuxsink pads for connected tracks only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,17 @@ jobs:
           packages: libunwind-dev libssl-dev libcairo2-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-bad1.0-dev gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-libav pkg-config cmake libclang-dev
           version: 1.5
 
+      # cache-apt-pkgs-action restores package files but does not run postinst,
+      # so update-alternatives links such as /usr/lib/*/libblas.so.3 never get
+      # created. gst-libav then fails to load ("libblas.so.3: cannot open shared
+      # object file"), avenc_aac goes missing, and every test requiring it skips
+      # green. Reinstalling runs postinst; ldconfig then picks the links up.
+      - name: Repair alternatives for cached libraries
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --reinstall libblas3 liblapack3
+          sudo ldconfig
+
       # save-if main: PR runs restore the main-branch cache (GHA cache scoping
       # falls back to the base branch) but don't save their own per-branch
       # copy — that copy doubled every rust-cache entry against the 10 GB
@@ -115,6 +126,9 @@ jobs:
 
       - name: Run tests on backend
         run: cargo test --package strom --features efp,nvidia
+        env:
+          # Turn a missing-element skip into a failure — see plugins_available().
+          STROM_REQUIRE_GST_PLUGINS: 1
 
       - name: Run tests on MCP server
         run: cargo test --package strom-mcp-server
@@ -291,6 +305,17 @@ jobs:
           packages: libunwind-dev libssl-dev libcairo2-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-bad1.0-dev gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-libav pkg-config cmake libclang-dev
           version: 1.5
 
+      # cache-apt-pkgs-action restores package files but does not run postinst,
+      # so update-alternatives links such as /usr/lib/*/libblas.so.3 never get
+      # created. gst-libav then fails to load ("libblas.so.3: cannot open shared
+      # object file"), avenc_aac goes missing, and every test requiring it skips
+      # green. Reinstalling runs postinst; ldconfig then picks the links up.
+      - name: Repair alternatives for cached libraries
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --reinstall libblas3 liblapack3
+          sudo ldconfig
+
       - name: Download frontend dist
         uses: actions/download-artifact@v8
         with:
@@ -400,6 +425,17 @@ jobs:
         with:
           packages: libunwind-dev libssl-dev libcairo2-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-bad1.0-dev gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-libav pkg-config cmake libclang-dev
           version: 1.5
+
+      # cache-apt-pkgs-action restores package files but does not run postinst,
+      # so update-alternatives links such as /usr/lib/*/libblas.so.3 never get
+      # created. gst-libav then fails to load ("libblas.so.3: cannot open shared
+      # object file"), avenc_aac goes missing, and every test requiring it skips
+      # green. Reinstalling runs postinst; ldconfig then picks the links up.
+      - name: Repair alternatives for cached libraries
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --reinstall libblas3 liblapack3
+          sudo ldconfig
 
       - name: Download frontend dist
         uses: actions/download-artifact@v8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,7 @@ jobs:
       # created. gst-libav then fails to load ("libblas.so.3: cannot open shared
       # object file"), avenc_aac goes missing, and every test requiring it skips
       # green. Reinstalling runs postinst; ldconfig then picks the links up.
+      # Only needed here: the build jobs never load a plugin.
       - name: Repair alternatives for cached libraries
         run: |
           sudo apt-get update -qq
@@ -305,17 +306,6 @@ jobs:
           packages: libunwind-dev libssl-dev libcairo2-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-bad1.0-dev gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-libav pkg-config cmake libclang-dev
           version: 1.5
 
-      # cache-apt-pkgs-action restores package files but does not run postinst,
-      # so update-alternatives links such as /usr/lib/*/libblas.so.3 never get
-      # created. gst-libav then fails to load ("libblas.so.3: cannot open shared
-      # object file"), avenc_aac goes missing, and every test requiring it skips
-      # green. Reinstalling runs postinst; ldconfig then picks the links up.
-      - name: Repair alternatives for cached libraries
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y --reinstall libblas3 liblapack3
-          sudo ldconfig
-
       - name: Download frontend dist
         uses: actions/download-artifact@v8
         with:
@@ -426,17 +416,6 @@ jobs:
           packages: libunwind-dev libssl-dev libcairo2-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-bad1.0-dev gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-libav pkg-config cmake libclang-dev
           version: 1.5
 
-      # cache-apt-pkgs-action restores package files but does not run postinst,
-      # so update-alternatives links such as /usr/lib/*/libblas.so.3 never get
-      # created. gst-libav then fails to load ("libblas.so.3: cannot open shared
-      # object file"), avenc_aac goes missing, and every test requiring it skips
-      # green. Reinstalling runs postinst; ldconfig then picks the links up.
-      - name: Repair alternatives for cached libraries
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y --reinstall libblas3 liblapack3
-          sudo ldconfig
-
       - name: Download frontend dist
         uses: actions/download-artifact@v8
         with:
@@ -535,6 +514,9 @@ jobs:
         run: |
           cargo test --package strom --features nvidia
           cargo test --package strom-mcp-server
+        env:
+          # Turn a missing-element skip into a failure — see plugins_available().
+          STROM_REQUIRE_GST_PLUGINS: 1
 
       - name: Build
         run: |
@@ -607,6 +589,9 @@ jobs:
         run: |
           cargo test --package strom --features efp,nvidia
           cargo test --package strom-mcp-server
+        env:
+          # Turn a missing-element skip into a failure — see plugins_available().
+          STROM_REQUIRE_GST_PLUGINS: 1
 
       - name: Build
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -514,9 +514,6 @@ jobs:
         run: |
           cargo test --package strom --features nvidia
           cargo test --package strom-mcp-server
-        env:
-          # Turn a missing-element skip into a failure — see plugins_available().
-          STROM_REQUIRE_GST_PLUGINS: 1
 
       - name: Build
         run: |

--- a/backend/src/blocks/builder.rs
+++ b/backend/src/blocks/builder.rs
@@ -324,6 +324,10 @@ impl BlockBuildContext {
     /// Use this to connect GLib signals on elements that need the event broadcaster
     /// (e.g., splitmuxsink's format-location signal for recording status).
     /// The GStreamer element(s) should be captured in the closure during build time.
+    ///
+    /// Runs after construction has linked every block and before the pipeline leaves
+    /// NULL. Recorder requests its splitmuxsink pads here and needs both halves of that
+    /// window; moving this call breaks it silently.
     pub fn register_element_setup(&self, setup: ElementSetupFn) {
         self.element_setups.borrow_mut().push(setup);
     }

--- a/backend/src/blocks/builtin/recorder.rs
+++ b/backend/src/blocks/builtin/recorder.rs
@@ -17,6 +17,10 @@
 //! audio_in_N (identity) --[pad probe]--> [parser chain] --> splitmuxsink:audio_0..N
 //! ```
 //!
+//! splitmuxsink stalls forever on a pad that is never fed, so sink pads are requested at
+//! pipeline start for connected tracks only — not for every configured track, and not
+//! lazily from the pad probes.
+//!
 //! Output files are written to: {media_path}/{output_dir}/{filename_prefix}_%05d.{ext}
 
 use crate::blocks::{BlockBuildContext, BlockBuildError, BlockBuildResult, BlockBuilder};
@@ -26,7 +30,7 @@ use gstreamer as gst;
 use gstreamer::prelude::*;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use strom_types::{
     block::{EnumValue, *},
     PropertyValue, *,
@@ -344,76 +348,29 @@ impl BlockBuilder for RecorderBuilder {
         let mut elements: Vec<(String, gst::Element)> =
             vec![(sink_id.clone(), splitmuxsink.clone())];
 
-        // --- Request pads from splitmuxsink ---
-        // All splitmuxsink sink pads are "On request". Pads must be requested before
-        // the pipeline starts; splitmuxsink manages them across file segments internally.
+        // --- splitmuxsink sink pads: requested at pipeline start, connected tracks only ---
         //
-        // splitmuxsink pad templates:
-        //   video           -> first video track (request_pad_simple)
-        //   video_aux_%u    -> additional video tracks (request_pad via template)
-        //   audio_%u        -> audio tracks (request_pad via template)
-        let video_aux_template = if num_video_tracks > 1 {
-            Some(splitmuxsink.pad_template("video_aux_%u").ok_or_else(|| {
-                BlockBuildError::ElementCreation(
-                    "splitmuxsink: no video_aux_%u pad template".to_string(),
-                )
-            })?)
-        } else {
-            None
-        };
+        // splitmuxsink releases a GOP only once every requested pad has reached the next
+        // GOP, so a pad that is never fed stalls the recording. An unconnected track must
+        // not get one.
+        //
+        // The element-setup hook at the end of this function requests them: it runs after
+        // the flow has linked every block but before the pipeline leaves NULL, so
+        // connectivity is known and the muxer has not started. Requesting from the caps
+        // probes instead loses a race — the muxer starts on the first track's data, after
+        // which mp4mux refuses the second pad and matroskamux drops its data. Requesting
+        // up front also keeps the reference stream on the primary video pad.
+        //
+        // Templates: video (first connected video), video_aux_%u (the rest), audio_%u.
 
-        let video_sink_pad_names: Vec<String> = (0..num_video_tracks)
-            .map(|i| {
-                let pad = if i == 0 {
-                    splitmuxsink.request_pad_simple("video").ok_or_else(|| {
-                        BlockBuildError::ElementCreation(
-                            "splitmuxsink: failed to request video pad".to_string(),
-                        )
-                    })?
-                } else {
-                    let tmpl = video_aux_template.as_ref().unwrap();
-                    splitmuxsink.request_pad(tmpl, None, None).ok_or_else(|| {
-                        BlockBuildError::ElementCreation(format!(
-                            "splitmuxsink: failed to request video_aux pad for track {}",
-                            i
-                        ))
-                    })?
-                };
-                debug!(
-                    "Recorder {}: requested splitmuxsink pad: {}",
-                    instance_id,
-                    pad.name()
-                );
-                Ok::<String, BlockBuildError>(pad.name().to_string())
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-
-        let audio_template = splitmuxsink.pad_template("audio_%u").ok_or_else(|| {
-            BlockBuildError::ElementCreation("splitmuxsink: no audio_%u pad template".to_string())
-        })?;
-
-        let audio_sink_pad_names: Vec<String> = (0..num_audio_tracks)
-            .map(|_| {
-                splitmuxsink
-                    .request_pad(&audio_template, None, None)
-                    .ok_or_else(|| {
-                        BlockBuildError::ElementCreation(
-                            "splitmuxsink: failed to request audio pad".to_string(),
-                        )
-                    })
-                    .map(|p| {
-                        debug!(
-                            "Recorder {}: requested splitmuxsink audio pad: {}",
-                            instance_id,
-                            p.name()
-                        );
-                        p.name().to_string()
-                    })
-            })
-            .collect::<Result<Vec<_>, _>>()?;
+        // Pad name per track, filled in by that hook. Empty means unconnected, no pad.
+        let mut video_pad_cells: Vec<Arc<OnceLock<String>>> = Vec::new();
+        let mut audio_pad_cells: Vec<Arc<OnceLock<String>>> = Vec::new();
+        let mut video_input_weaks: Vec<gst::glib::WeakRef<gst::Element>> = Vec::new();
+        let mut audio_input_weaks: Vec<gst::glib::WeakRef<gst::Element>> = Vec::new();
 
         // --- Create video input chains ---
-        for (vi, video_sink_pad_name_for_chain) in video_sink_pad_names.iter().enumerate() {
+        for vi in 0..num_video_tracks {
             let video_input_id = format!("{}:video_input_{}", instance_id, vi);
             let video_input = gst::ElementFactory::make("identity")
                 .name(&video_input_id)
@@ -425,7 +382,10 @@ impl BlockBuilder for RecorderBuilder {
             let parser_inserted = Arc::new(AtomicBool::new(false));
             let splitmuxsink_weak = splitmuxsink.downgrade();
             let instance_id_clone = instance_id.to_string();
-            let video_sink_pad_name_clone = video_sink_pad_name_for_chain.clone();
+
+            let pad_name_cell: Arc<OnceLock<String>> = Arc::new(OnceLock::new());
+            video_pad_cells.push(Arc::clone(&pad_name_cell));
+            video_input_weaks.push(video_input.downgrade());
 
             // Use a pad probe on the identity src pad to detect caps and insert parser
             let src_pad = video_input.static_pad("src").ok_or_else(|| {
@@ -464,6 +424,30 @@ impl BlockBuilder for RecorderBuilder {
                     let caps_name = structure.name().to_string();
                     debug!("Recorder {}: video caps detected: {}", instance_id_clone, caps_name);
 
+                    let splitmuxsink = match splitmuxsink_weak.upgrade() {
+                        Some(e) => e,
+                        None => {
+                            error!("Recorder {}: splitmuxsink element no longer exists", instance_id_clone);
+                            return gst::PadProbeReturn::Ok;
+                        }
+                    };
+
+                    // Empty cell: this track was unconnected at build time, so it has no pad.
+                    let sink_pad = match pad_name_cell.get().and_then(|n| splitmuxsink.static_pad(n)) {
+                        Some(p) => p,
+                        None => {
+                            warn!(
+                                "Recorder {}: video track {} is carrying data but was not connected when the pipeline was built, so it has no splitmuxsink pad and will not be recorded",
+                                instance_id_clone, vi
+                            );
+                            return gst::PadProbeReturn::Ok;
+                        }
+                    };
+
+                    // Every path that gives up below must hand the pad back, or splitmuxsink
+                    // waits on it forever and the recording stalls.
+                    let give_pad_back = || splitmuxsink.release_request_pad(&sink_pad);
+
                     let (parser_factory, config_interval) = if caps_name == "video/x-h264" {
                         ("h264parse", -1i32)
                     } else if caps_name == "video/x-h265" {
@@ -473,27 +457,22 @@ impl BlockBuilder for RecorderBuilder {
                             "Recorder {}: received raw video — recorder only accepts pre-encoded video. Add an encoder block before the recorder.",
                             instance_id_clone
                         );
+                        give_pad_back();
                         return gst::PadProbeReturn::Ok;
                     } else {
                         warn!(
                             "Recorder {}: unsupported video codec: {} (supported: H.264, H.265)",
                             instance_id_clone, caps_name
                         );
+                        give_pad_back();
                         return gst::PadProbeReturn::Ok;
-                    };
-
-                    let splitmuxsink = match splitmuxsink_weak.upgrade() {
-                        Some(e) => e,
-                        None => {
-                            error!("Recorder {}: splitmuxsink element no longer exists", instance_id_clone);
-                            return gst::PadProbeReturn::Ok;
-                        }
                     };
 
                     let bin = match splitmuxsink.parent().and_then(|p| p.downcast::<gst::Bin>().ok()) {
                         Some(b) => b,
                         None => {
                             error!("Recorder {}: splitmuxsink has no Bin parent", instance_id_clone);
+                            give_pad_back();
                             return gst::PadProbeReturn::Ok;
                         }
                     };
@@ -506,6 +485,7 @@ impl BlockBuilder for RecorderBuilder {
                         Ok(p) => p,
                         Err(e) => {
                             error!("Recorder {}: failed to create {}: {}", instance_id_clone, parser_factory, e);
+                            give_pad_back();
                             return gst::PadProbeReturn::Ok;
                         }
                     };
@@ -517,10 +497,12 @@ impl BlockBuilder for RecorderBuilder {
 
                     if let Err(e) = bin.add(&parser) {
                         error!("Recorder {}: failed to add parser to bin: {}", instance_id_clone, e);
+                        give_pad_back();
                         return gst::PadProbeReturn::Ok;
                     }
                     if let Err(e) = parser.sync_state_with_parent() {
                         error!("Recorder {}: failed to sync parser state: {}", instance_id_clone, e);
+                        give_pad_back();
                         return gst::PadProbeReturn::Ok;
                     }
 
@@ -528,6 +510,7 @@ impl BlockBuilder for RecorderBuilder {
                         Some(p) => p,
                         None => {
                             error!("Recorder {}: parser has no sink pad", instance_id_clone);
+                            give_pad_back();
                             return gst::PadProbeReturn::Ok;
                         }
                     };
@@ -535,15 +518,7 @@ impl BlockBuilder for RecorderBuilder {
                         Some(p) => p,
                         None => {
                             error!("Recorder {}: parser has no src pad", instance_id_clone);
-                            return gst::PadProbeReturn::Ok;
-                        }
-                    };
-
-                    // Get the pre-requested video sink pad from splitmuxsink
-                    let sink_pad = match splitmuxsink.static_pad(&video_sink_pad_name_clone) {
-                        Some(p) => p,
-                        None => {
-                            error!("Recorder {}: could not find pad {} on splitmuxsink", instance_id_clone, video_sink_pad_name_clone);
+                            give_pad_back();
                             return gst::PadProbeReturn::Ok;
                         }
                     };
@@ -559,23 +534,27 @@ impl BlockBuilder for RecorderBuilder {
                         Ok(q) => q,
                         Err(e) => {
                             error!("Recorder {}: failed to create video queue: {}", instance_id_clone, e);
+                            give_pad_back();
                             return gst::PadProbeReturn::Ok;
                         }
                     };
                     if let Err(e) = bin.add(&queue) {
                         error!("Recorder {}: failed to add video queue to bin: {}", instance_id_clone, e);
+                        give_pad_back();
                         return gst::PadProbeReturn::Ok;
                     }
                     // Linked from a pad probe while the pipeline is already running, so the new
                     // element's state has to be synced explicitly.
                     if let Err(e) = queue.sync_state_with_parent() {
                         error!("Recorder {}: failed to sync video queue state: {}", instance_id_clone, e);
+                        give_pad_back();
                         return gst::PadProbeReturn::Ok;
                     }
                     let queue_sink = match queue.static_pad("sink") {
                         Some(p) => p,
                         None => {
                             error!("Recorder {}: video queue has no sink pad", instance_id_clone);
+                            give_pad_back();
                             return gst::PadProbeReturn::Ok;
                         }
                     };
@@ -583,20 +562,24 @@ impl BlockBuilder for RecorderBuilder {
                         Some(p) => p,
                         None => {
                             error!("Recorder {}: video queue has no src pad", instance_id_clone);
+                            give_pad_back();
                             return gst::PadProbeReturn::Ok;
                         }
                     };
 
                     if let Err(e) = pad.link(&parser_sink) {
                         error!("Recorder {}: failed to link identity to parser: {:?}", instance_id_clone, e);
+                        give_pad_back();
                         return gst::PadProbeReturn::Ok;
                     }
                     if let Err(e) = parser_src.link(&queue_sink) {
                         error!("Recorder {}: failed to link parser to video queue: {:?}", instance_id_clone, e);
+                        give_pad_back();
                         return gst::PadProbeReturn::Ok;
                     }
                     if let Err(e) = queue_src.link(&sink_pad) {
                         error!("Recorder {}: failed to link video queue to splitmuxsink: {:?}", instance_id_clone, e);
+                        give_pad_back();
                         return gst::PadProbeReturn::Ok;
                     }
 
@@ -609,8 +592,7 @@ impl BlockBuilder for RecorderBuilder {
         }
 
         // --- Create audio input chains ---
-        for (i, audio_sink_pad_name) in audio_sink_pad_names.iter().enumerate() {
-            let audio_sink_pad_name = audio_sink_pad_name.clone();
+        for i in 0..num_audio_tracks {
             let audio_input_id = format!("{}:audio_input_{}", instance_id, i);
             let audio_input = gst::ElementFactory::make("identity")
                 .name(&audio_input_id)
@@ -622,6 +604,10 @@ impl BlockBuilder for RecorderBuilder {
             let parser_inserted = Arc::new(AtomicBool::new(false));
             let splitmuxsink_weak = splitmuxsink.downgrade();
             let instance_id_clone = instance_id.to_string();
+
+            let pad_name_cell: Arc<OnceLock<String>> = Arc::new(OnceLock::new());
+            audio_pad_cells.push(Arc::clone(&pad_name_cell));
+            audio_input_weaks.push(audio_input.downgrade());
 
             let src_pad = audio_input.static_pad("src").ok_or_else(|| {
                 BlockBuildError::ElementCreation(format!("audio_{} identity has no src pad", i))
@@ -668,21 +654,21 @@ impl BlockBuilder for RecorderBuilder {
                         }
                     };
 
-                    let bin = match splitmuxsink.parent().and_then(|p| p.downcast::<gst::Bin>().ok()) {
-                        Some(b) => b,
+                    // Empty cell: this track was unconnected at build time, so it has no pad.
+                    let sink_pad = match pad_name_cell.get().and_then(|n| splitmuxsink.static_pad(n)) {
+                        Some(p) => p,
                         None => {
-                            error!("Recorder {}: splitmuxsink has no Bin parent", instance_id_clone);
+                            warn!(
+                                "Recorder {}: audio track {} is carrying data but was not connected when the pipeline was built, so it has no splitmuxsink pad and will not be recorded",
+                                instance_id_clone, i
+                            );
                             return gst::PadProbeReturn::Ok;
                         }
                     };
 
-                    let sink_pad = match splitmuxsink.static_pad(&audio_sink_pad_name) {
-                        Some(p) => p,
-                        None => {
-                            error!("Recorder {}: could not find {} on splitmuxsink", instance_id_clone, audio_sink_pad_name);
-                            return gst::PadProbeReturn::Ok;
-                        }
-                    };
+                    // Every path that gives up below must hand the pad back, or splitmuxsink
+                    // waits on it forever and the recording stalls.
+                    let give_pad_back = || splitmuxsink.release_request_pad(&sink_pad);
 
                     // Only accept pre-encoded audio. Raw audio requires an encoder before the recorder.
                     if caps_name == "audio/x-raw" {
@@ -690,6 +676,7 @@ impl BlockBuilder for RecorderBuilder {
                             "Recorder {}: received raw audio — recorder only accepts pre-encoded audio. Add an encoder block before the recorder.",
                             instance_id_clone
                         );
+                        give_pad_back();
                         return gst::PadProbeReturn::Ok;
                     }
 
@@ -705,6 +692,16 @@ impl BlockBuilder for RecorderBuilder {
                                 "Recorder {}: unsupported audio codec: {} (supported: AAC, MP3, AC3, DTS, Opus)",
                                 instance_id_clone, other
                             );
+                            give_pad_back();
+                            return gst::PadProbeReturn::Ok;
+                        }
+                    };
+
+                    let bin = match splitmuxsink.parent().and_then(|p| p.downcast::<gst::Bin>().ok()) {
+                        Some(b) => b,
+                        None => {
+                            error!("Recorder {}: splitmuxsink has no Bin parent", instance_id_clone);
+                            give_pad_back();
                             return gst::PadProbeReturn::Ok;
                         }
                     };
@@ -719,22 +716,26 @@ impl BlockBuilder for RecorderBuilder {
                         Ok(p) => p,
                         Err(e) => {
                             error!("Recorder {}: failed to create {}: {}", instance_id_clone, factory, e);
+                            give_pad_back();
                             return gst::PadProbeReturn::Ok;
                         }
                     };
 
                     if let Err(e) = bin.add(&parser) {
                         error!("Recorder {}: failed to add audio parser: {}", instance_id_clone, e);
+                        give_pad_back();
                         return gst::PadProbeReturn::Ok;
                     }
                     if let Err(e) = parser.sync_state_with_parent() {
                         error!("Recorder {}: failed to sync audio parser state: {}", instance_id_clone, e);
+                        give_pad_back();
                         return gst::PadProbeReturn::Ok;
                     }
                     let parser_sink = match parser.static_pad("sink") {
                         Some(p) => p,
                         None => {
                             error!("Recorder {}: audio parser has no sink pad", instance_id_clone);
+                            give_pad_back();
                             return gst::PadProbeReturn::Ok;
                         }
                     };
@@ -742,6 +743,7 @@ impl BlockBuilder for RecorderBuilder {
                         Some(p) => p,
                         None => {
                             error!("Recorder {}: audio parser has no src pad", instance_id_clone);
+                            give_pad_back();
                             return gst::PadProbeReturn::Ok;
                         }
                     };
@@ -753,23 +755,27 @@ impl BlockBuilder for RecorderBuilder {
                         Ok(q) => q,
                         Err(e) => {
                             error!("Recorder {}: failed to create audio queue: {}", instance_id_clone, e);
+                            give_pad_back();
                             return gst::PadProbeReturn::Ok;
                         }
                     };
                     if let Err(e) = bin.add(&queue) {
                         error!("Recorder {}: failed to add audio queue to bin: {}", instance_id_clone, e);
+                        give_pad_back();
                         return gst::PadProbeReturn::Ok;
                     }
                     // Linked from a pad probe while the pipeline is already running, so the new
                     // element's state has to be synced explicitly.
                     if let Err(e) = queue.sync_state_with_parent() {
                         error!("Recorder {}: failed to sync audio queue state: {}", instance_id_clone, e);
+                        give_pad_back();
                         return gst::PadProbeReturn::Ok;
                     }
                     let queue_sink = match queue.static_pad("sink") {
                         Some(p) => p,
                         None => {
                             error!("Recorder {}: audio queue has no sink pad", instance_id_clone);
+                            give_pad_back();
                             return gst::PadProbeReturn::Ok;
                         }
                     };
@@ -777,23 +783,28 @@ impl BlockBuilder for RecorderBuilder {
                         Some(p) => p,
                         None => {
                             error!("Recorder {}: audio queue has no src pad", instance_id_clone);
+                            give_pad_back();
                             return gst::PadProbeReturn::Ok;
                         }
                     };
 
                     if let Err(e) = pad.link(&parser_sink) {
                         error!("Recorder {}: failed to link identity to audio parser: {:?}", instance_id_clone, e);
+                        give_pad_back();
                         return gst::PadProbeReturn::Ok;
                     }
                     if let Err(e) = parser_src.link(&queue_sink) {
                         error!("Recorder {}: failed to link audio parser to audio queue: {:?}", instance_id_clone, e);
+                        give_pad_back();
                         return gst::PadProbeReturn::Ok;
                     }
                     if let Err(e) = queue_src.link(&sink_pad) {
                         error!("Recorder {}: failed to link audio queue to splitmuxsink: {:?}", instance_id_clone, e);
+                        give_pad_back();
                         return gst::PadProbeReturn::Ok;
                     }
-                    info!("Recorder {}: audio_{} chain linked: identity -> {} -> queue -> splitmuxsink", instance_id_clone, i, factory);
+
+                    info!("Recorder {}: audio_{} chain linked: identity -> parser -> queue -> splitmuxsink", instance_id_clone, i);
 
                     gst::PadProbeReturn::Ok
                 },
@@ -806,6 +817,93 @@ impl BlockBuilder for RecorderBuilder {
             "Recorder {}: built with {} video track(s), {} audio track(s), container: {}",
             instance_id, num_video_tracks, num_audio_tracks, container
         );
+
+        // Request the sink pads — see the note above the input chains.
+        {
+            let splitmuxsink_weak = splitmuxsink.downgrade();
+            let block_id = instance_id.to_string();
+            ctx.register_element_setup(Box::new(move |_flow_id, _events| {
+                let Some(splitmuxsink) = splitmuxsink_weak.upgrade() else {
+                    return;
+                };
+
+                // First connected video track takes the primary pad, so splitmuxsink splits
+                // on its keyframes; the rest take video_aux. splitmuxsink names video pads
+                // itself, so record what it handed back, not what we asked for.
+                let mut have_primary_video = false;
+                for (vi, (input, cell)) in video_input_weaks
+                    .iter()
+                    .zip(video_pad_cells.iter())
+                    .enumerate()
+                {
+                    if !input_is_connected(input) {
+                        info!(
+                            "Recorder {}: video track {} is not connected — requesting no splitmuxsink pad for it",
+                            block_id, vi
+                        );
+                        continue;
+                    }
+                    let requested = if !have_primary_video {
+                        splitmuxsink.request_pad_simple("video")
+                    } else {
+                        splitmuxsink
+                            .pad_template("video_aux_%u")
+                            .and_then(|tmpl| splitmuxsink.request_pad(&tmpl, None, None))
+                    };
+                    match requested {
+                        Some(pad) => {
+                            have_primary_video = true;
+                            debug!(
+                                "Recorder {}: requested splitmuxsink pad {} for video track {}",
+                                block_id,
+                                pad.name(),
+                                vi
+                            );
+                            let _ = cell.set(pad.name().to_string());
+                        }
+                        None => error!(
+                            "Recorder {}: splitmuxsink refused a sink pad for video track {} — that track will not be recorded",
+                            block_id, vi
+                        ),
+                    }
+                }
+
+                for (i, (input, cell)) in audio_input_weaks
+                    .iter()
+                    .zip(audio_pad_cells.iter())
+                    .enumerate()
+                {
+                    if !input_is_connected(input) {
+                        info!(
+                            "Recorder {}: audio track {} is not connected — requesting no splitmuxsink pad for it",
+                            block_id, i
+                        );
+                        continue;
+                    }
+                    // audio_N keeps track order on the input index. mp4mux and matroskamux
+                    // honour the name; mpegtsmux falls back to sink_%d.
+                    let requested_name = format!("audio_{}", i);
+                    let requested = splitmuxsink.pad_template("audio_%u").and_then(|tmpl| {
+                        splitmuxsink.request_pad(&tmpl, Some(requested_name.as_str()), None)
+                    });
+                    match requested {
+                        Some(pad) => {
+                            debug!(
+                                "Recorder {}: requested splitmuxsink pad {} for audio track {}",
+                                block_id,
+                                pad.name(),
+                                i
+                            );
+                            let _ = cell.set(pad.name().to_string());
+                        }
+                        None => error!(
+                            "Recorder {}: splitmuxsink refused a sink pad for audio track {} — that track will not be recorded",
+                            block_id, i
+                        ),
+                    }
+                }
+            }));
+        }
 
         // Register element setup to connect format-location signal at pipeline start.
         // The signal fires each time splitmuxsink opens a new file, giving us the actual filename.
@@ -867,6 +965,18 @@ impl BlockBuilder for RecorderBuilder {
             pad_properties: HashMap::new(),
         })
     }
+}
+
+/// Whether a recorder input identity has something linked to its sink pad.
+///
+/// Called after the flow has linked every block, so unlinked means the track will never
+/// carry data and must not be given a splitmuxsink pad.
+fn input_is_connected(input: &gst::glib::WeakRef<gst::Element>) -> bool {
+    input
+        .upgrade()
+        .and_then(|e| e.static_pad("sink"))
+        .map(|p| p.is_linked())
+        .unwrap_or(false)
 }
 
 /// Build a TS passthrough pipeline: identity -> multifilesink.

--- a/backend/src/blocks/builtin/recorder.rs
+++ b/backend/src/blocks/builtin/recorder.rs
@@ -969,8 +969,10 @@ impl BlockBuilder for RecorderBuilder {
 
 /// Whether a recorder input identity has something linked to its sink pad.
 ///
-/// Called after the flow has linked every block, so unlinked means the track will never
-/// carry data and must not be given a splitmuxsink pad.
+/// Runs after construction's linking pass, so this is exact for links resolved there —
+/// every link into a recorder today, since recorder inputs take encoded media and so are
+/// fed by encoder src pads. A link deferred to `pending_links` resolves after this and
+/// would read as unconnected, losing that track. Nothing enforces that none can be.
 fn input_is_connected(input: &gst::glib::WeakRef<gst::Element>) -> bool {
     input
         .upgrade()

--- a/backend/tests/recorder_splitmux_threading_test.rs
+++ b/backend/tests/recorder_splitmux_threading_test.rs
@@ -41,11 +41,18 @@ const REQUIRED_ELEMENTS: &[&str] = &[
     "splitmuxsink",
 ];
 
+/// Skipping on a missing element passes green and guards nothing, so CI sets
+/// `STROM_REQUIRE_GST_PLUGINS=1` to turn a skip into a failure.
 fn missing_element() -> Option<&'static str> {
-    REQUIRED_ELEMENTS
+    let missing = REQUIRED_ELEMENTS
         .iter()
         .copied()
-        .find(|e| gst::ElementFactory::find(e).is_none())
+        .find(|e| gst::ElementFactory::find(e).is_none())?;
+    assert!(
+        std::env::var("STROM_REQUIRE_GST_PLUGINS").is_err(),
+        "STROM_REQUIRE_GST_PLUGINS is set but this element is missing: {missing}"
+    );
+    Some(missing)
 }
 
 /// Run a pipeline to EOS, returning an error on bus error or if `RUN_TIMEOUT`

--- a/backend/tests/recorder_unfed_track_test.rs
+++ b/backend/tests/recorder_unfed_track_test.rs
@@ -37,10 +37,23 @@ const REQUIRED: &[&str] = &[
     "tsdemux",
 ];
 
+/// Skipping on a missing element passes green and guards nothing, so CI sets
+/// `STROM_REQUIRE_GST_PLUGINS=1` to turn a skip into a failure.
 fn plugins_available() -> bool {
-    REQUIRED
+    let missing: Vec<&str> = REQUIRED
         .iter()
-        .all(|e| gst::ElementFactory::find(e).is_some())
+        .copied()
+        .filter(|e| gst::ElementFactory::find(e).is_none())
+        .collect();
+    if missing.is_empty() {
+        return true;
+    }
+    assert!(
+        std::env::var("STROM_REQUIRE_GST_PLUGINS").is_err(),
+        "STROM_REQUIRE_GST_PLUGINS is set but these elements are missing: {}",
+        missing.join(", ")
+    );
+    false
 }
 
 fn container_available(container: &str) -> bool {

--- a/backend/tests/recorder_unfed_track_test.rs
+++ b/backend/tests/recorder_unfed_track_test.rs
@@ -13,8 +13,9 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use strom::blocks::builtin::recorder::RecorderBuilder;
-use strom::blocks::{BlockBuildContext, BlockBuilder};
+use strom::blocks::{BlockBuildContext, BlockBuilder, BlockRegistry};
 use strom::events::EventBroadcaster;
+use strom::gst::pipeline::PipelineManager;
 use strom_types::PropertyValue;
 
 use gstreamer as gst;
@@ -277,13 +278,24 @@ fn stream_kinds(path: &Path, container: &str) -> (bool, bool) {
         let _ = pad.link(&sink_pad);
     });
 
+    // no-more-pads means all streams are known. EOS would mean playing the file
+    // through, and does not reliably arrive for every recording these tests produce.
+    let all_pads_seen = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let all_pads_seen_for_cb = std::sync::Arc::clone(&all_pads_seen);
+    demux.connect_no_more_pads(move |_| {
+        all_pads_seen_for_cb.store(true, std::sync::atomic::Ordering::SeqCst);
+    });
+
     pipeline
         .set_state(gst::State::Playing)
         .expect("demux plays");
     let bus = pipeline.bus().expect("demux bus");
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
     while std::time::Instant::now() < deadline {
-        let Some(msg) = bus.timed_pop(gst::ClockTime::from_seconds(1)) else {
+        if all_pads_seen.load(std::sync::atomic::Ordering::SeqCst) {
+            break;
+        }
+        let Some(msg) = bus.timed_pop(gst::ClockTime::from_mseconds(100)) else {
             continue;
         };
         match msg.view() {
@@ -418,4 +430,178 @@ fn both_tracks_fed_records_both_streams() {
             );
         }
     }
+}
+
+/// Drive a recorder through the real `PipelineManager` start path.
+///
+/// The tests above run the hook themselves, so they would still pass if `start()`
+/// stopped running it at the right moment. This one does not.
+///
+/// Measured by making each change and rerunning: moving the hook before the linking
+/// pass fails this deterministically; moving it after `set_state(Playing)` does not,
+/// because `set_state` returns before the encoders negotiate caps. Nothing guards
+/// that second direction.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn recorder_records_when_driven_through_pipeline_start() {
+    gst::init().unwrap();
+    if !plugins_available() {
+        eprintln!("skipping: required GStreamer elements not installed");
+        return;
+    }
+    if !container_available("mp4") {
+        eprintln!("skipping: mp4mux not installed");
+        return;
+    }
+
+    let media_root = tempfile::tempdir().expect("tempdir");
+    let registry_file = tempfile::NamedTempFile::new().expect("registry file");
+    let registry = BlockRegistry::new(registry_file.path());
+
+    let mut props: HashMap<String, PropertyValue> = HashMap::new();
+    props.insert(
+        "container".to_string(),
+        PropertyValue::String("mp4".to_string()),
+    );
+    props.insert("num_video_tracks".to_string(), PropertyValue::UInt(1));
+    props.insert("num_audio_tracks".to_string(), PropertyValue::UInt(1));
+    props.insert(
+        "output_dir".to_string(),
+        PropertyValue::String("recordings".to_string()),
+    );
+    props.insert(
+        "filename_prefix".to_string(),
+        PropertyValue::String("viaflow".to_string()),
+    );
+
+    let mut flow = strom_types::Flow::new("recorder_start_path");
+
+    flow.elements.push(strom_types::Element {
+        id: "vsrc".to_string(),
+        element_type: "videotestsrc".to_string(),
+        properties: {
+            let mut p = HashMap::new();
+            p.insert("num-buffers".to_string(), PropertyValue::Int(30));
+            p
+        },
+        position: [100.0, 100.0].into(),
+        pad_properties: HashMap::new(),
+    });
+    flow.elements.push(strom_types::Element {
+        id: "venc".to_string(),
+        element_type: "x264enc".to_string(),
+        properties: {
+            let mut p = HashMap::new();
+            p.insert("key-int-max".to_string(), PropertyValue::UInt(10));
+            p
+        },
+        position: [250.0, 100.0].into(),
+        pad_properties: HashMap::new(),
+    });
+
+    flow.blocks.push(strom_types::BlockInstance {
+        id: "rec".to_string(),
+        block_definition_id: "builtin.recorder".to_string(),
+        name: None,
+        properties: props.clone(),
+        position: strom_types::block::Position { x: 400.0, y: 100.0 },
+        runtime_data: None,
+        // From the builder, so the links below do not depend on registry state.
+        computed_external_pads: RecorderBuilder.get_external_pads(&props),
+    });
+
+    // Both tracks connected: the configuration that loses the caps race if pads are late.
+    flow.elements.push(strom_types::Element {
+        id: "asrc".to_string(),
+        element_type: "audiotestsrc".to_string(),
+        properties: {
+            let mut p = HashMap::new();
+            p.insert("num-buffers".to_string(), PropertyValue::Int(50));
+            p
+        },
+        position: [100.0, 250.0].into(),
+        pad_properties: HashMap::new(),
+    });
+    flow.elements.push(strom_types::Element {
+        id: "aenc".to_string(),
+        element_type: "avenc_aac".to_string(),
+        properties: HashMap::new(),
+        position: [250.0, 250.0].into(),
+        pad_properties: HashMap::new(),
+    });
+
+    flow.links.push(strom_types::Link {
+        from: "vsrc:src".to_string(),
+        to: "venc:sink".to_string(),
+    });
+    flow.links.push(strom_types::Link {
+        from: "venc:src".to_string(),
+        to: "rec:video_in_0".to_string(),
+    });
+    flow.links.push(strom_types::Link {
+        from: "asrc:src".to_string(),
+        to: "aenc:sink".to_string(),
+    });
+    flow.links.push(strom_types::Link {
+        from: "aenc:src".to_string(),
+        to: "rec:audio_in_0".to_string(),
+    });
+
+    // The bus watch is a glib signal watch, so it only dispatches while a main loop
+    // runs. The real app has one; a test does not.
+    let main_loop = gst::glib::MainLoop::new(None, false);
+    let main_loop_thread = {
+        let ml = main_loop.clone();
+        std::thread::spawn(move || ml.run())
+    };
+
+    let events = EventBroadcaster::new(16);
+    let mut event_rx = events.subscribe();
+
+    let mut manager = PipelineManager::new(
+        &flow,
+        events,
+        &registry,
+        vec![],
+        "all".to_string(),
+        None,
+        media_root.path().to_path_buf(),
+        std::sync::Arc::new(std::sync::Mutex::new(HashMap::new())),
+    )
+    .expect("PipelineManager builds");
+
+    manager.start().expect("pipeline starts");
+
+    // Both sources have num-buffers, so the flow ends on its own. splitmuxsink only
+    // finalizes the file on EOS, and an unfinalized mp4 has no moov to demux.
+    tokio::time::timeout(std::time::Duration::from_secs(30), async {
+        loop {
+            match event_rx.recv().await {
+                Ok(strom_types::StromEvent::PipelineEos { .. }) => break,
+                Ok(_) => continue,
+                Err(e) => panic!("event stream ended before EOS: {e}"),
+            }
+        }
+    })
+    .await
+    .expect("pipeline reached EOS within 30s — a splitmuxsink pad for a connected track was not requested in time");
+
+    // Shut down before reading the file back.
+    manager.stop().expect("pipeline stops");
+    main_loop.quit();
+    main_loop_thread.join().expect("main loop thread joins");
+
+    let dir = media_root.path().join("recordings");
+    let mut files: Vec<PathBuf> = std::fs::read_dir(&dir)
+        .expect("recordings directory exists")
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.is_file())
+        .collect();
+    files.sort();
+    let recorded = files.into_iter().next();
+
+    let recorded = recorded.expect("splitmuxsink wrote no file at all");
+    let (has_video, has_audio) = stream_kinds(&recorded, "mp4");
+    assert!(has_video, "recording has no video stream");
+    assert!(has_audio, "recording has no audio stream");
 }

--- a/backend/tests/recorder_unfed_track_test.rs
+++ b/backend/tests/recorder_unfed_track_test.rs
@@ -1,0 +1,408 @@
+//! Regression tests for how the recorder hands out `splitmuxsink` sink pads.
+//!
+//! `splitmuxsink` releases a GOP only once every requested pad has reached the
+//! next GOP, so a pad that is never fed makes it write nothing at all. An
+//! unconnected track must not get one — but every connected track must, before
+//! any data flows. Requesting lazily from the caps probes fails that second way:
+//! the muxer starts on the first track's data, after which mp4mux refuses the
+//! second pad and matroskamux grants it but drops the data.
+//!
+//! These tests assert on the streams inside the file, not its size: a dropped
+//! track still leaves a large, valid, single-stream recording.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use strom::blocks::builtin::recorder::RecorderBuilder;
+use strom::blocks::{BlockBuildContext, BlockBuilder};
+use strom::events::EventBroadcaster;
+use strom_types::PropertyValue;
+
+use gstreamer as gst;
+use gstreamer::prelude::*;
+
+/// Elements this test needs beyond core GStreamer. Missing on a bare CI image.
+const REQUIRED: &[&str] = &[
+    "splitmuxsink",
+    "x264enc",
+    "h264parse",
+    "avenc_aac",
+    "aacparse",
+    "videotestsrc",
+    "audiotestsrc",
+    // Used to read the recordings back and check which streams they contain.
+    "filesrc",
+    "fakesink",
+    "qtdemux",
+    "matroskademux",
+    "tsdemux",
+];
+
+fn plugins_available() -> bool {
+    REQUIRED
+        .iter()
+        .all(|e| gst::ElementFactory::find(e).is_some())
+}
+
+fn container_available(container: &str) -> bool {
+    let muxer = match container {
+        "mkv" => "matroskamux",
+        "mpegts" => "mpegtsmux",
+        _ => "mp4mux",
+    };
+    gst::ElementFactory::find(muxer).is_some()
+}
+
+/// Which inputs the test actually connects to the recorder.
+#[derive(Clone, Copy, PartialEq)]
+enum Feed {
+    VideoOnly,
+    AudioOnly,
+    Both,
+}
+
+/// Build a recorder block configured for one video and one audio track, wire up
+/// only the inputs named by `feed`, run until EOS, and return the files written.
+///
+/// Both tracks are always configured — the point of the test is that configuring
+/// a track the flow never connects must not stop the other track from recording.
+fn run_recorder(container: &str, feed: Feed, media_root: &Path) -> Vec<PathBuf> {
+    let instance_id = "rec";
+
+    let mut props: HashMap<String, PropertyValue> = HashMap::new();
+    props.insert(
+        "container".to_string(),
+        PropertyValue::String(container.to_string()),
+    );
+    props.insert("num_video_tracks".to_string(), PropertyValue::UInt(1));
+    props.insert("num_audio_tracks".to_string(), PropertyValue::UInt(1));
+    props.insert(
+        "output_dir".to_string(),
+        PropertyValue::String("recordings".to_string()),
+    );
+    props.insert(
+        "filename_prefix".to_string(),
+        PropertyValue::String("test".to_string()),
+    );
+    props.insert(
+        "_media_path".to_string(),
+        PropertyValue::String(media_root.to_string_lossy().to_string()),
+    );
+
+    let ctx = BlockBuildContext::new(vec![], "all".to_string());
+    let built = RecorderBuilder
+        .build(instance_id, &props, &ctx)
+        .expect("recorder block builds");
+
+    let pipeline = gst::Pipeline::new();
+    let mut by_id: HashMap<String, gst::Element> = HashMap::new();
+    for (id, element) in &built.elements {
+        pipeline.add(element).expect("add block element");
+        by_id.insert(id.clone(), element.clone());
+    }
+
+    // Short, deterministic sources. 30 buffers at 30fps = 1s of video, which is
+    // several GOPs at key-int-max=10 — enough for splitmuxsink to complete and
+    // release at least one GOP if it is not stalled.
+    if feed == Feed::VideoOnly || feed == Feed::Both {
+        let src = gst::ElementFactory::make("videotestsrc")
+            .property("num-buffers", 30i32)
+            .property_from_str("pattern", "smpte")
+            .build()
+            .expect("videotestsrc");
+        let caps = gst::ElementFactory::make("capsfilter")
+            .property(
+                "caps",
+                gst::Caps::builder("video/x-raw")
+                    .field("width", 320i32)
+                    .field("height", 240i32)
+                    .field("framerate", gst::Fraction::new(30, 1))
+                    .build(),
+            )
+            .build()
+            .expect("capsfilter");
+        let enc = gst::ElementFactory::make("x264enc")
+            .property("key-int-max", 10u32)
+            .property_from_str("tune", "zerolatency")
+            .build()
+            .expect("x264enc");
+
+        pipeline.add_many([&src, &caps, &enc]).unwrap();
+        gst::Element::link_many([&src, &caps, &enc]).unwrap();
+
+        let target = by_id
+            .get(&format!("{}:video_input_0", instance_id))
+            .expect("recorder exposes video_input_0");
+        enc.link(target).expect("link video into recorder");
+    }
+
+    if feed == Feed::AudioOnly || feed == Feed::Both {
+        let src = gst::ElementFactory::make("audiotestsrc")
+            .property("num-buffers", 50i32)
+            .build()
+            .expect("audiotestsrc");
+        let conv = gst::ElementFactory::make("audioconvert").build().unwrap();
+        let resample = gst::ElementFactory::make("audioresample").build().unwrap();
+        let enc = gst::ElementFactory::make("avenc_aac")
+            .build()
+            .expect("avenc_aac");
+
+        pipeline.add_many([&src, &conv, &resample, &enc]).unwrap();
+        gst::Element::link_many([&src, &conv, &resample, &enc]).unwrap();
+
+        let target = by_id
+            .get(&format!("{}:audio_input_0", instance_id))
+            .expect("recorder exposes audio_input_0");
+        enc.link(target).expect("link audio into recorder");
+    }
+
+    // The pipeline manager runs these after linking, before PLAYING. The hook is what
+    // decides which tracks are connected, so skipping it would exercise nothing.
+    for setup in ctx.take_element_setups() {
+        setup(uuid::Uuid::new_v4(), EventBroadcaster::new(16));
+    }
+
+    pipeline
+        .set_state(gst::State::Playing)
+        .expect("pipeline goes to PLAYING");
+
+    let bus = pipeline.bus().expect("pipeline has a bus");
+    let mut reached_eos = false;
+    // 30 s is generous for ~1 s of content; a stalled splitmuxsink burns all of it.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+    while std::time::Instant::now() < deadline {
+        let Some(msg) = bus.timed_pop(gst::ClockTime::from_seconds(1)) else {
+            continue;
+        };
+        match msg.view() {
+            gst::MessageView::Eos(_) => {
+                reached_eos = true;
+                break;
+            }
+            gst::MessageView::Error(err) => {
+                panic!(
+                    "pipeline error from {:?}: {} ({:?})",
+                    err.src().map(|s| s.path_string()),
+                    err.error(),
+                    err.debug()
+                );
+            }
+            _ => {}
+        }
+    }
+
+    pipeline.set_state(gst::State::Null).unwrap();
+    assert!(
+        reached_eos,
+        "pipeline never reached EOS within 30s (container={}, feed connected={})",
+        container,
+        match feed {
+            Feed::VideoOnly => "video only",
+            Feed::AudioOnly => "audio only",
+            Feed::Both => "video + audio",
+        }
+    );
+
+    let dir = media_root.join("recordings");
+    let mut files: Vec<PathBuf> = std::fs::read_dir(&dir)
+        .map(|rd| {
+            rd.filter_map(|e| e.ok())
+                .map(|e| e.path())
+                .filter(|p| p.is_file())
+                .collect()
+        })
+        .unwrap_or_default();
+    files.sort();
+    files
+}
+
+/// Demux a recording and report which media kinds it contains, as
+/// `(has_video, has_audio)`.
+fn stream_kinds(path: &Path, container: &str) -> (bool, bool) {
+    let demux_factory = match container {
+        "mkv" => "matroskademux",
+        "mpegts" => "tsdemux",
+        _ => "qtdemux",
+    };
+
+    let pipeline = gst::Pipeline::new();
+    let src = gst::ElementFactory::make("filesrc")
+        .property("location", path.to_string_lossy().to_string())
+        .build()
+        .expect("filesrc");
+    let demux = gst::ElementFactory::make(demux_factory)
+        .build()
+        .unwrap_or_else(|_| panic!("{} available", demux_factory));
+    pipeline.add_many([&src, &demux]).unwrap();
+    src.link(&demux).expect("filesrc -> demux");
+
+    let found = std::sync::Arc::new(std::sync::Mutex::new((false, false)));
+    let found_for_cb = std::sync::Arc::clone(&found);
+    let pipeline_weak = pipeline.downgrade();
+    demux.connect_pad_added(move |_, pad| {
+        let Some(pipeline) = pipeline_weak.upgrade() else {
+            return;
+        };
+        let media = pad
+            .current_caps()
+            .and_then(|c| c.structure(0).map(|s| s.name().to_string()))
+            .unwrap_or_default();
+        {
+            let mut f = found_for_cb.lock().unwrap();
+            if media.starts_with("video/") {
+                f.0 = true;
+            } else if media.starts_with("audio/") {
+                f.1 = true;
+            }
+        }
+        // Drain the branch so the file plays through to EOS.
+        let sink = gst::ElementFactory::make("fakesink")
+            .build()
+            .expect("fakesink");
+        pipeline.add(&sink).expect("add fakesink");
+        sink.sync_state_with_parent().expect("sync fakesink");
+        let sink_pad = sink.static_pad("sink").expect("fakesink sink pad");
+        let _ = pad.link(&sink_pad);
+    });
+
+    pipeline
+        .set_state(gst::State::Playing)
+        .expect("demux plays");
+    let bus = pipeline.bus().expect("demux bus");
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+    while std::time::Instant::now() < deadline {
+        let Some(msg) = bus.timed_pop(gst::ClockTime::from_seconds(1)) else {
+            continue;
+        };
+        match msg.view() {
+            gst::MessageView::Eos(_) => break,
+            gst::MessageView::Error(err) => {
+                panic!("demuxing {} failed: {}", path.display(), err.error());
+            }
+            _ => {}
+        }
+    }
+    pipeline.set_state(gst::State::Null).unwrap();
+
+    let f = *found.lock().unwrap();
+    f
+}
+
+/// Assert the recording exists, is non-empty, and contains exactly the streams the
+/// connected inputs should have produced.
+fn assert_recorded(container: &str, feed: Feed, label: &str) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let files = run_recorder(container, feed, tmp.path());
+
+    assert!(
+        !files.is_empty(),
+        "{} / {}: splitmuxsink wrote no file at all",
+        container,
+        label
+    );
+    for f in &files {
+        let len = std::fs::metadata(f).expect("stat recording").len();
+        assert!(
+            len > 0,
+            "{} / {}: recording {} is empty",
+            container,
+            label,
+            f.display()
+        );
+    }
+
+    let expect_video = feed == Feed::VideoOnly || feed == Feed::Both;
+    let expect_audio = feed == Feed::AudioOnly || feed == Feed::Both;
+    let (has_video, has_audio) = stream_kinds(&files[0], container);
+
+    assert_eq!(
+        has_video,
+        expect_video,
+        "{} / {}: recording {} video stream (file has video={}, audio={})",
+        container,
+        label,
+        if expect_video {
+            "is missing its"
+        } else {
+            "has an unexpected"
+        },
+        has_video,
+        has_audio
+    );
+    assert_eq!(
+        has_audio,
+        expect_audio,
+        "{} / {}: recording {} audio stream (file has video={}, audio={})",
+        container,
+        label,
+        if expect_audio {
+            "is missing its"
+        } else {
+            "has an unexpected"
+        },
+        has_video,
+        has_audio
+    );
+}
+
+/// The regression: an audio track is configured but the flow connects only video.
+/// Before the fix, splitmuxsink waited forever on the unfed audio pad and no file
+/// was ever written.
+#[test]
+fn video_only_feed_records_despite_configured_audio_track() {
+    gst::init().unwrap();
+    if !plugins_available() {
+        eprintln!("skipping: required GStreamer elements not installed");
+        return;
+    }
+    for container in ["mp4", "mkv", "mpegts"] {
+        if !container_available(container) {
+            eprintln!("skipping container {}: muxer not installed", container);
+            continue;
+        }
+        assert_recorded(container, Feed::VideoOnly, "video only");
+    }
+}
+
+/// The mirror case: a video track is configured but the flow connects only audio.
+#[test]
+fn audio_only_feed_records_despite_configured_video_track() {
+    gst::init().unwrap();
+    if !plugins_available() {
+        eprintln!("skipping: required GStreamer elements not installed");
+        return;
+    }
+    for container in ["mp4", "mkv", "mpegts"] {
+        if !container_available(container) {
+            eprintln!("skipping container {}: muxer not installed", container);
+            continue;
+        }
+        assert_recorded(container, Feed::AudioOnly, "audio only");
+    }
+}
+
+/// Both tracks connected, so both must end up in the file.
+///
+/// Catches pads requested too late: `avenc_aac` negotiates caps before `x264enc`, so
+/// a recorder that requests on the caps event loses the video track. Repeated because
+/// that failure is a race — 11 of 12 runs for mp4, so one green run proves nothing.
+#[test]
+fn both_tracks_fed_records_both_streams() {
+    gst::init().unwrap();
+    if !plugins_available() {
+        eprintln!("skipping: required GStreamer elements not installed");
+        return;
+    }
+    for container in ["mp4", "mkv", "mpegts"] {
+        if !container_available(container) {
+            eprintln!("skipping container {}: muxer not installed", container);
+            continue;
+        }
+        for attempt in 1..=3 {
+            assert_recorded(
+                container,
+                Feed::Both,
+                &format!("video + audio, run {}", attempt),
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`splitmuxsink` releases a GOP only once every requested sink pad has reached the next GOP. A pad that is never fed keeps its running time at `GST_CLOCK_STIME_NONE` forever, so the sink waits on it indefinitely.

A recorder configured with one video and one audio track, where the flow connects only video, therefore recorded nothing at all — not a video-only file, an empty one.

## What changed

Pads used to be requested per *configured* track at build time. They are now requested from an element-setup hook, for *connected* tracks only.

That hook runs after the flow has linked every block but before the pipeline leaves NULL. It is the first point where connectivity is knowable — an input identity's sink pad being linked answers "will this track ever carry data?" exactly — and still early enough to request pads before any data flows.

## Why not request them from the caps probes

That is the obvious alternative, and it was tried here first. It fixes the stall and breaks the ordinary case instead: the muxer starts on the first track's data, so whichever track negotiates caps second loses the race. mp4mux refuses the pad (`Not providing request pad after stream start`); matroskamux grants it and drops the data.

Measured against a harness mirroring this block's chain and muxer config (`muxer` element instance, `use-robust-muxing`, 12 h reserved moov):

| | |
|---|---|
| `avenc_aac` caps before `x264enc` | 12 of 12 runs, by 5–29 ms |
| mp4, both tracks connected, video lost | 11 of 12 runs |
| …with the per-leg queues from #675 | 12 of 12 |
| …with robust muxing disabled | 6 of 8 |

A refused pad leaves its leg dead-ended, which takes the pipeline down with `Internal data stream error … not-linked`.

Requesting up front also keeps splitmuxsink's reference stream on the primary video pad, instead of a late `video` pad demoting a live reference mid-stream.

## Failure paths

A connected track that turns out to carry raw or unsupported media hands its pad back from the caps probe, as does any failure while wiring the leg up. Either would otherwise stall the recording — the same bug in a different disguise.

## Tests

`backend/tests/recorder_unfed_track_test.rs`, three arms × three containers (mp4, mkv, mpegts): video connected only, audio connected only, and both — the last repeated 3× per container because the failure it guards is a race.

The tests demux the recording and assert on the streams inside it, not on file size; a dropped track still leaves a large, valid, single-stream file. They also run the element-setup hook the way the pipeline manager does, since that hook is what decides connectivity.

Reverting the fix breaks them: removing the connectivity check makes both unfed-track arms fail with `pipeline never reached EOS within 30s`, the original stall.

Ran locally on macOS: `cargo test --workspace` (506 unit tests plus all integration tests, including `pipeline_lifecycle_test` and `recorder_splitmux_threading_test`) green, and `cargo clippy --workspace --all-targets` clean. The three recorder arms genuinely executed there — `avenc_aac` is present, and they take ~800 ms rather than the ~11 ms of a skip.

They did *not* run in CI before this branch. `gst-libav` failed to load with `libblas.so.3: cannot open shared object file`, so `avenc_aac` was missing and all three tests returned early through `plugins_available()` — "passing" in 11 ms. `libblas3` was already in the package list and being restored; `cache-apt-pkgs-action` just does not run postinst, so the `update-alternatives` link for `libblas.so.3` was never created. `ldconfig` alone does not help — there is no link for it to find.

The second commit reinstalls `libblas3`/`liblapack3` so postinst runs, and sets `STROM_REQUIRE_GST_PLUGINS=1` for the Linux test step so a missing element fails and names itself instead of skipping green. On the latest run both now execute for real: `recorder_unfed_track_test` 3 passed in 0.92 s and the pre-existing `recorder_splitmux_threading_test` 1 passed in 0.39 s, against 0.01 s each before.

## On the earlier review

Both points still hold. The caps probe cannot re-fire after teardown — `parser_inserted.swap(true, SeqCst)` runs the body at most once per chain, and the `WeakRef` upgrade returns `None` once the pipeline is gone. Releasing a partially-configured pad is still the mechanism for unsupported codecs and wiring failures, now on paths reached before the leg carries data.

## Known limitation

A track that negotiates caps and then produces no buffers — a parser that never syncs, an ingest that goes silent right after connecting — still stalls the recording, as before. Connectivity is knowable at build time; "will this connected track actually produce data?" is not.
