### PR TITLE
feat(aes67): expose RTP payload type as a property on AES67 Output

### DIFF
--- a/backend/src/blocks/builtin/aes67.rs
+++ b/backend/src/blocks/builtin/aes67.rs
@@ -1297,4 +1297,51 @@ mod tests {
             "16-bit should allow longer ptime than 24-bit"
         );
     }
+
+    /// The builder must reject an RTP payload type outside the 7-bit range
+    /// (0-127) before it creates a single GStreamer element.
+    ///
+    /// This guards more than a malformed SDP. With the check removed, the build
+    /// walks on to `.property("pt", payload_type as u32)` on the payloader and
+    /// glib panics there — "property 'pt' of type 'GstRtpL24Pay' can't be set
+    /// from given value" — so the range check is what stops a stored
+    /// out-of-range value from taking the process down. GStreamer does not
+    /// clamp it.
+    ///
+    /// The variant and message are asserted rather than just `is_err()`, so a
+    /// rejection from a later check (packet size, bit depth) cannot stand in
+    /// for this one. `gst::init` is called because the panic above only
+    /// reproduces with GStreamer initialised; otherwise element creation aborts
+    /// on the uninitialised library first, which depends on whether another
+    /// test in this binary happened to initialise it.
+    #[test]
+    fn test_aes67_output_rejects_out_of_range_payload_type() {
+        let _ = gst::init();
+
+        let builder = AES67OutputBuilder;
+        let ctx = BlockBuildContext::new(Vec::new(), "all".to_string());
+
+        for pt in [-1, 128, 200] {
+            let mut properties = HashMap::new();
+            properties.insert("payload_type".to_string(), PropertyValue::Int(pt));
+
+            let result = builder.build("aes67-out-test", &properties, &ctx);
+
+            match result {
+                Err(BlockBuildError::InvalidConfiguration(msg)) => {
+                    assert!(
+                        msg.contains("payload type") && msg.contains(&pt.to_string()),
+                        "payload type {} was rejected, but not by the range check: {}",
+                        pt,
+                        msg
+                    );
+                }
+                Err(other) => panic!(
+                    "payload type {} was rejected by the wrong check: {:?}",
+                    pt, other
+                ),
+                Ok(_) => panic!("payload type {} was accepted", pt),
+            }
+        }
+    }
 }

--- a/backend/src/blocks/builtin/aes67.rs
+++ b/backend/src/blocks/builtin/aes67.rs
@@ -19,6 +19,8 @@ const AES67_INPUT_DEFAULT_BUFFER_DURATION_MS: i64 =
 // AES67 Output defaults
 const AES67_OUTPUT_DEFAULT_TTL: i64 = 32;
 const AES67_OUTPUT_DEFAULT_QOS_DSCP: &str = "0x2E"; // DSCP EF (Expedited Forwarding) per AES67 standard
+const AES67_OUTPUT_DEFAULT_PAYLOAD_TYPE: i64 =
+    strom_types::block::DEFAULT_AES67_OUTPUT_PAYLOAD_TYPE;
 
 /// Parse DSCP value from string (hex like "0x2E" or "disabled")
 /// Returns the integer value for udpsink qos-dscp property
@@ -663,6 +665,30 @@ impl BlockBuilder for AES67OutputBuilder {
             })
             .unwrap_or_else(|| parse_dscp_value(AES67_OUTPUT_DEFAULT_QOS_DSCP));
 
+        let payload_type = properties
+            .get("payload_type")
+            .and_then(|v| match v {
+                PropertyValue::Int(i) => Some(*i),
+                PropertyValue::String(s) => s.parse::<i64>().ok(),
+                _ => None,
+            })
+            .unwrap_or(AES67_OUTPUT_DEFAULT_PAYLOAD_TYPE);
+
+        if !(0..=127).contains(&payload_type) {
+            return Err(BlockBuildError::InvalidConfiguration(format!(
+                "Invalid RTP payload type: {}. Must be between 0 and 127.",
+                payload_type
+            )));
+        }
+
+        if !(96..=127).contains(&payload_type) {
+            warn!(
+                "AES67 Output [{}]: Payload type {} is outside the dynamic range (96-127). \
+                 AES67 requires a dynamic payload type for L16/L24 streams; receivers may reject the stream.",
+                instance_id, payload_type
+            );
+        }
+
         // Validate packet size fits within AES67/Ethernet MTU constraints
         // RTP payload must fit in ~1440 bytes (1500 MTU - 20 IP - 8 UDP - 12 RTP - ~20 safety margin)
         // Payload size = framecount × channels × bytes_per_sample
@@ -730,6 +756,7 @@ impl BlockBuilder for AES67OutputBuilder {
         let payloader = gst::ElementFactory::make(payloader_type)
             .name(&payloader_id)
             .property("timestamp-offset", 0u32)
+            .property("pt", payload_type as u32)
             .property("min-ptime", ptime_ns)
             .property("max-ptime", ptime_ns)
             .build()
@@ -762,8 +789,8 @@ impl BlockBuilder for AES67OutputBuilder {
         }
 
         debug!(
-            "AES67 Output [{}]: Multicast TTL={}, QoS DSCP={}",
-            instance_id, ttl, qos_dscp
+            "AES67 Output [{}]: Multicast TTL={}, QoS DSCP={}, payload type={}",
+            instance_id, ttl, qos_dscp, payload_type
         );
 
         let udpsink = udpsink_builder
@@ -1023,6 +1050,20 @@ fn aes67_output_definition() -> BlockDefinition {
                 mapping: PropertyMapping {
                     element_id: "_block".to_string(),
                     property_name: "ptime".to_string(),
+                    transform: None,
+                },
+                live: false,
+                persist: None,
+            },
+            ExposedProperty {
+                name: "payload_type".to_string(),
+                label: "Payload Type".to_string(),
+                description: "RTP payload type used in the packets and announced in the SDP. Must be in the dynamic range 96-127 for AES67.".to_string(),
+                property_type: PropertyType::Int,
+                default_value: Some(PropertyValue::Int(AES67_OUTPUT_DEFAULT_PAYLOAD_TYPE)),
+                mapping: PropertyMapping {
+                    element_id: "_block".to_string(),
+                    property_name: "payload_type".to_string(),
                     transform: None,
                 },
                 live: false,

--- a/backend/src/blocks/sdp.rs
+++ b/backend/src/blocks/sdp.rs
@@ -257,7 +257,18 @@ pub fn generate_aes67_output_sdp(
     // Use provided values or fall back to AES67 defaults: 48kHz, 2 channels
     let sample_rate = sample_rate.unwrap_or(48000);
     let channels = channels.unwrap_or(2);
-    let payload_type = 96; // Dynamic payload type
+
+    // RTP payload type - must match the "pt" property set on the payloader
+    let payload_type = block
+        .properties
+        .get("payload_type")
+        .and_then(|v| match v {
+            PropertyValue::Int(i) => Some(*i),
+            PropertyValue::String(s) => s.parse::<i64>().ok(),
+            _ => None,
+        })
+        .filter(|pt| (0..=127).contains(pt))
+        .unwrap_or(strom_types::block::DEFAULT_AES67_OUTPUT_PAYLOAD_TYPE);
 
     // Determine encoding name based on bit depth
     let encoding = match bit_depth {
@@ -429,6 +440,50 @@ mod tests {
         assert!(sdp.contains("a=mediaclk:sender"));
         // Multicast should have source-filter with default origin IP
         assert!(sdp.contains("a=source-filter: incl IN IP4 239.69.1.1 0.0.0.0"));
+    }
+
+    #[test]
+    fn test_generate_sdp_custom_payload_type() {
+        let mut properties = HashMap::new();
+        properties.insert("payload_type".to_string(), PropertyValue::Int(98));
+
+        let block = BlockInstance {
+            id: "block_0".to_string(),
+            block_definition_id: "builtin.aes67_output".to_string(),
+            name: None,
+            properties,
+            position: strom_types::block::Position { x: 0.0, y: 0.0 },
+            runtime_data: None,
+            computed_external_pads: None,
+        };
+
+        let sdp =
+            generate_aes67_output_sdp(&block, "Test Stream", None, None, None, None, None, false);
+
+        assert!(sdp.contains("m=audio 5004 RTP/AVP 98"));
+        assert!(sdp.contains("a=rtpmap:98 L24/48000/2"));
+    }
+
+    #[test]
+    fn test_generate_sdp_out_of_range_payload_type_falls_back() {
+        let mut properties = HashMap::new();
+        properties.insert("payload_type".to_string(), PropertyValue::Int(200));
+
+        let block = BlockInstance {
+            id: "block_0".to_string(),
+            block_definition_id: "builtin.aes67_output".to_string(),
+            name: None,
+            properties,
+            position: strom_types::block::Position { x: 0.0, y: 0.0 },
+            runtime_data: None,
+            computed_external_pads: None,
+        };
+
+        let sdp =
+            generate_aes67_output_sdp(&block, "Test Stream", None, None, None, None, None, false);
+
+        assert!(sdp.contains("m=audio 5004 RTP/AVP 96"));
+        assert!(sdp.contains("a=rtpmap:96 L24/48000/2"));
     }
 
     #[test]

--- a/types/src/block.rs
+++ b/types/src/block.rs
@@ -415,6 +415,11 @@ pub const DEFAULT_EFP_HOL_TIMEOUT: u32 = 5;
 /// downstream wakeups and context switches.
 pub const DEFAULT_AES67_INPUT_BUFFER_DURATION_MS: i64 = 20;
 
+/// Default RTP payload type for AES67 output.
+/// 96 is the first dynamic payload type (RFC 3551), which AES67 requires for
+/// L16/L24 streams that are not covered by a static payload type assignment.
+pub const DEFAULT_AES67_OUTPUT_PAYLOAD_TYPE: i64 = 96;
+
 /// Default Opus encoder complexity (0-10). GStreamer defaults to 10 (max CPU).
 /// 5 is a good balance between quality and CPU for real-time use cases.
 pub const DEFAULT_OPUS_COMPLEXITY: i32 = 5;


### PR DESCRIPTION
## Summary

The RTP payload type for AES67 Output was hardcoded to `96` in two places: the `pt` value implicitly used by the payloader, and the `m=`/`a=rtpmap:` lines in the generated SDP. This exposes it as a configurable block property so a stream can be matched against receivers that expect a specific dynamic payload type.

## Changes

- **`strom-types`**: new shared constant `DEFAULT_AES67_OUTPUT_PAYLOAD_TYPE` (96).
- **AES67 Output block definition**: new `payload_type` exposed property (Int, default 96), placed after `ptime`. Renders automatically in the properties panel.
- **Builder**: reads the property and sets `pt` on `rtpL16pay`/`rtpL24pay`. Values outside 0-127 are rejected with `InvalidConfiguration`; values outside the dynamic range 96-127 are accepted but log a warning, since AES67 receivers may reject a non-dynamic payload type for L16/L24.
- **SDP generation**: reads the same property for the `m=audio ... RTP/AVP <pt>` and `a=rtpmap:<pt> ...` lines, falling back to 96 for out-of-range values so the SDP is never malformed.
- Two unit tests for the SDP side: a custom payload type (98), and the out-of-range fallback.

Note: the property is `live: false`, so a change requires a flow restart to take effect — consistent with the other AES67 Output properties.

## Test plan

- `cargo check` passes; pre-commit `cargo fmt` + `clippy` pass.
- Unit tests were **not** run locally (skipped at the author's request) — CI covers them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)