### PR TITLE
fix(install): install libnice-gstreamer on macOS so webrtcbin has ICE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -547,7 +547,7 @@ jobs:
 
       - name: Install GStreamer
         run: |
-          brew install gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly gst-libav
+          brew install gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly gst-libav libnice-gstreamer
           echo "PKG_CONFIG_PATH=$(brew --prefix)/lib/pkgconfig:$(brew --prefix gstreamer)/lib/pkgconfig:$(brew --prefix glib)/lib/pkgconfig" >> $GITHUB_ENV
           echo "LIBRARY_PATH=$(brew --prefix)/lib" >> $GITHUB_ENV
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -24,8 +24,10 @@ Make sure you have the following installed:
    # Fedora
    sudo dnf install gstreamer1-devel gstreamer1-plugins-base-devel
 
-   # macOS
-   brew install gstreamer gst-plugins-base libnice-gstreamer
+   # macOS (libnice-gstreamer, not libnice — it provides the nicesrc/nicesink
+   # elements webrtcbin needs for ICE; without them WHIP/WHEP aborts the process)
+   brew install gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad \
+     gst-plugins-ugly gst-libav libnice-gstreamer cairo graphviz
    ```
 
 3. **WebAssembly target** (for frontend)

--- a/install.sh
+++ b/install.sh
@@ -169,7 +169,7 @@ is_gstreamer_installed() {
             if command -v brew >/dev/null 2>&1; then
                 local required_packages=(gstreamer gst-plugins-base gst-plugins-good)
                 if [ "$install_type" = "full" ]; then
-                    required_packages+=(gst-plugins-bad gst-plugins-ugly)
+                    required_packages+=(gst-plugins-bad gst-plugins-ugly libnice-gstreamer)
                 fi
                 for pkg in "${required_packages[@]}"; do
                     if ! brew list "$pkg" >/dev/null 2>&1; then
@@ -385,8 +385,12 @@ install_gstreamer() {
             if command -v brew >/dev/null 2>&1; then
                 local packages=(gstreamer gst-plugins-base gst-plugins-good)
 
+                # libnice-gstreamer provides the nicesrc/nicesink elements that
+                # webrtcbin needs for ICE. The plain libnice formula installs
+                # only the library, leaving webrtcbin without ICE, which aborts
+                # every WHIP/WHEP session. libnice-gstreamer depends on libnice.
                 if [ "$install_type" = "full" ]; then
-                    packages+=(gst-plugins-bad gst-plugins-ugly gst-libav libnice)
+                    packages+=(gst-plugins-bad gst-plugins-ugly gst-libav libnice-gstreamer)
                 fi
 
                 brew install "${packages[@]}"


### PR DESCRIPTION
## Description

On macOS `install.sh` installed the `libnice` formula, which ships only the library. The GStreamer plugin that provides `nicesrc`/`nicesink` lives in the separate `libnice-gstreamer` formula. On a machine set up by the installer, `webrtcbin` therefore had no ICE implementation at all, and every WHIP/WHEP session aborted the whole process inside `webrtcsrc`:

```
webrtcsrc/imp.rs:2099  bin.sync_state_with_parent().unwrap()
  -> Err("Failed to sync state with parent") -> panic in a function that cannot unwind
  -> SIGABRT (exit 134)
```

Two changes:

- `install_gstreamer` (macOS): `libnice` -> `libnice-gstreamer`. The plugin formula depends on `libnice`, so nothing is lost by the swap.
- `is_gstreamer_installed` (macOS): require `libnice-gstreamer` for a `full` install. Without this a host that has GStreamer but no ICE plugin is reported as already installed and is never repaired, which is how the broken state survives a re-run of the installer.

Docs: `docs/DEVELOPMENT.md` already named `libnice-gstreamer` but omitted `gst-plugins-good/bad/ugly` and `gst-libav` from the macOS line. Completed it and noted why the formula choice matters.

The macOS CI job runs `cargo test --package strom`, so it gets the same formula added to its `brew install` line — otherwise any future test that brings up a WHIP/WHEP session aborts the test process rather than failing.

Linux is unaffected — Debian (`gstreamer1.0-nice`), Fedora (`libnice-gstreamer1`) and Arch (`libnice`, which bundles the plugin) already name the right package.

## Related Issue

Refs #683 (package half; the runtime `nicesrc`/`nicesink` preflight suggested in that issue is not included here)

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Checklist

- [ ] I have run `cargo fmt --all` (not applicable — no Rust changed)
- [ ] I have run `cargo clippy --workspace --all-targets -- -D warnings` (not applicable — no Rust changed)
- [ ] I have run `cargo test --workspace` (not applicable — no Rust changed)
- [x] I have updated documentation as needed
- [ ] I have added tests for new functionality (not applicable — no test harness exists for `install.sh`)

### What was actually verified

- `bash -n install.sh` passes.
- All eight brew formulas named in the macOS path exist and resolve: `gstreamer`, `gst-plugins-base`, `gst-plugins-good`, `gst-plugins-bad`, `gst-plugins-ugly`, `gst-libav`, `libnice`, `libnice-gstreamer`.
- `brew info libnice-gstreamer` confirms `libnice` is among its dependencies.
- Confirmed on the affected machine that installing `libnice-gstreamer` restores `nicesrc`/`nicesink` and stops the SIGABRT.
- **Not run:** `install.sh` end to end on a clean macOS host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
