### PR TITLE
fix(whep): download GL-memory video before it reaches whepserversink

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,11 @@
 ## GStreamer Queues
 - Leave `queue`, `queue2`, and `multiqueue` elements with default property values unless there is a documented latency requirement that justifies overriding them.
 
+## GStreamer Memory Formats
+- A block emits the memory type it naturally produces (system, GL, CUDA, ...). The **consuming** block adapts its own input. A producer does not know its consumer, so any producer-side download is wrong for half the graph and costs a GPU round trip per frame in the other half.
+- Adapt at build time where the input is known (`glupload` on a GL consumer's inputs). Where it depends on what `decodebin` autoplugged upstream, decide from the negotiated caps — `gst::gl_bridge` does this for GL memory.
+- Beware sinks that advertise GPU memory features they cannot actually process: `whepserversink` accepts `video/x-raw(memory:GLMemory)` and then fails encoder discovery. A successful link is not proof the consumer can use the frames.
+
 ## Code Organization
 - When working in or near a file that exceeds 1500 lines, proactively suggest splitting it into focused sub-modules (following the pattern used for `pipeline.rs` and `app.rs`)
 - Each sub-module should have a single clear responsibility (e.g. construction, lifecycle, linking, properties)

--- a/backend/src/blocks/builtin/whep.rs
+++ b/backend/src/blocks/builtin/whep.rs
@@ -10,6 +10,7 @@
 //! Handles dynamic pad creation by linking new audio streams to a liveadder mixer.
 
 use crate::blocks::{BlockBuildContext, BlockBuildError, BlockBuildResult, BlockBuilder};
+use crate::gst::gl_bridge;
 use crate::gst::whep_probe::{self, WhepProbeRegistry};
 use gstreamer as gst;
 use gstreamer::prelude::*;
@@ -1709,6 +1710,21 @@ fn build_whepserversink(
                 }
                 gst::PadProbeReturn::Ok
             });
+
+            // Consumer-side GPU-memory adaptation.
+            //
+            // whepserversink advertises video/x-raw(memory:GLMemory) on its
+            // video request pads, so GL frames negotiate all the way to the
+            // sink — and webrtcsink's encoder discovery then finds no encoder
+            // that can take them. Video goes missing while audio, on a
+            // non-GL path, keeps working. On macOS this is the normal case:
+            // decodebin autoplugs vtdec_hw, which outputs GL memory.
+            //
+            // The producer cannot decide this for us (a GL vision mixer
+            // feeding a GL consumer must stay on the GPU), and neither can
+            // this block at build time, since the upstream decoder is
+            // autoplugged. So the decision is made from the negotiated caps.
+            gl_bridge::install_gl_download_bridge(&queue_src_pad, &video_queue_id);
 
             // Video link: queue -> whepserversink (video_<slot> request pad)
             internal_links.push((

--- a/backend/src/gst/gl_bridge.rs
+++ b/backend/src/gst/gl_bridge.rs
@@ -1,0 +1,210 @@
+//! Consumer-side GPU-memory adaptation for video inputs.
+//!
+//! The convention is that a block emits the memory type it naturally produces
+//! and the *consuming* block adapts its own input, so a GPU-to-GPU flow is
+//! never forced through a download and re-upload. Most consumers can pick
+//! their input front at build time. This module covers the case where they
+//! cannot: whether frames arriving on a pad live in GL memory depends on which
+//! decoder `decodebin` autoplugged upstream, which is only known once caps are
+//! negotiated.
+//!
+//! [`install_gl_download_bridge`] watches an already-linked source pad and, on
+//! the first CAPS event that carries `memory:GLMemory`, splices a `gldownload`
+//! between that pad and its peer. Relinking from inside a push-event probe is
+//! a supported pattern: `gst_pad_push_event_unchecked` resolves the peer and
+//! rechecks pending sticky events *after* running its probes, so the event that
+//! triggered the splice lands on the newly inserted element.
+//!
+//! Only GL memory is bridged. CUDA, NVMM, D3D11 and VA memory are left in
+//! place — the consumers that advertise those memory types really do encode
+//! them, and downloading would cost a full round trip per frame.
+
+use gstreamer as gst;
+use gstreamer::prelude::*;
+use tracing::{info, warn};
+
+/// The caps feature that marks a buffer as living in GL memory.
+const GL_MEMORY_FEATURE: &str = "memory:GLMemory";
+
+/// True when `caps` describe raw video in GL memory.
+///
+/// Encoded video (`video/x-h264` and friends) is never a candidate: there is
+/// nothing to download, and `gldownload` would not even link. Other GPU memory
+/// types are not candidates either — see the module docs.
+pub fn needs_gl_download(caps: &gst::CapsRef) -> bool {
+    let Some(structure) = caps.structure(0) else {
+        return false;
+    };
+    if structure.name() != "video/x-raw" {
+        return false;
+    }
+    caps.features(0)
+        .is_some_and(|features| features.contains(GL_MEMORY_FEATURE))
+}
+
+/// Watch `src_pad` and insert a `gldownload` in front of its peer if the
+/// negotiated caps turn out to carry GL memory.
+///
+/// The probe is one-shot: it removes itself as soon as the first CAPS event has
+/// been classified, whichever way it went, so nothing is left behind on the
+/// data path. `name_prefix` names the inserted element and is only used for
+/// logging and debugging.
+pub fn install_gl_download_bridge(src_pad: &gst::Pad, name_prefix: &str) {
+    let name_prefix = name_prefix.to_string();
+
+    // EVENT_DOWNSTREAM, not BLOCK/BUFFER: this fires per event, not per buffer.
+    src_pad.add_probe(gst::PadProbeType::EVENT_DOWNSTREAM, move |pad, info| {
+        let Some(gst::PadProbeData::Event(ref event)) = info.data else {
+            return gst::PadProbeReturn::Ok;
+        };
+        let gst::EventView::Caps(caps_event) = event.view() else {
+            return gst::PadProbeReturn::Ok;
+        };
+
+        if !needs_gl_download(caps_event.caps()) {
+            // System memory, another GPU memory type, or already-encoded video:
+            // nothing to do, and nothing to keep watching for.
+            return gst::PadProbeReturn::Remove;
+        }
+
+        // Remove the probe on every path from here on: the splice either
+        // succeeds, or it failed for a reason that retrying will not fix.
+        if let Err(e) = splice_gl_download(pad, &name_prefix) {
+            warn!(
+                "{}: GL-memory input could not be bridged ({}), leaving it in GL memory — a downstream encoder may not accept it",
+                name_prefix, e
+            );
+        }
+        gst::PadProbeReturn::Remove
+    });
+}
+
+/// Insert a `gldownload` between `src_pad` and its current peer.
+fn splice_gl_download(src_pad: &gst::Pad, name_prefix: &str) -> Result<(), String> {
+    let peer = src_pad
+        .peer()
+        .ok_or_else(|| "source pad has no peer".to_string())?;
+
+    // Strong references stay local to this function — never captured in a
+    // closure, so no reference cycle can outlive the pipeline.
+    let bin = src_pad
+        .parent_element()
+        .and_then(|element| element.parent())
+        .and_then(|parent| parent.downcast::<gst::Bin>().ok())
+        .ok_or_else(|| "source pad's element has no parent bin".to_string())?;
+
+    let name = format!("{}_gldownload", name_prefix);
+    let gldownload = gst::ElementFactory::make("gldownload")
+        .name(&name)
+        .build()
+        .map_err(|e| format!("gldownload could not be created: {}", e))?;
+
+    bin.add(&gldownload)
+        .map_err(|e| format!("gldownload could not be added to {}: {}", bin.name(), e))?;
+
+    let sink = gldownload
+        .static_pad("sink")
+        .ok_or_else(|| "gldownload has no sink pad".to_string())?;
+    let src = gldownload
+        .static_pad("src")
+        .ok_or_else(|| "gldownload has no src pad".to_string())?;
+
+    // Unlink before linking: the peer accepts one upstream link only.
+    src_pad.unlink(&peer).map_err(|e| {
+        format!(
+            "could not unlink {} from {}: {}",
+            src_pad.name(),
+            peer.name(),
+            e
+        )
+    })?;
+    src.link(&peer)
+        .map_err(|e| format!("could not link gldownload to {}: {}", peer.name(), e))?;
+    src_pad
+        .link(&sink)
+        .map_err(|e| format!("could not link {} to gldownload: {}", src_pad.name(), e))?;
+
+    // State last, so the element negotiates against a complete topology.
+    gldownload
+        .sync_state_with_parent()
+        .map_err(|e| format!("gldownload could not reach the pipeline state: {}", e))?;
+
+    info!(
+        "{}: input carries GL memory, inserted {} in front of {}",
+        name_prefix,
+        name,
+        peer.name()
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    fn caps(s: &str) -> gst::Caps {
+        // Caps parsing needs the type system registered.
+        let _ = gst::init();
+        gst::Caps::from_str(s).expect("valid caps")
+    }
+
+    #[test]
+    fn gl_memory_raw_video_needs_a_download() {
+        assert!(needs_gl_download(&caps(
+            "video/x-raw(memory:GLMemory), format=NV12, width=1280, height=720"
+        )));
+    }
+
+    #[test]
+    fn system_memory_raw_video_does_not() {
+        assert!(!needs_gl_download(&caps(
+            "video/x-raw, format=NV12, width=1280, height=720"
+        )));
+    }
+
+    /// The consumers that advertise these memory types encode them directly.
+    /// Downloading would cost a GPU round trip per frame for nothing.
+    #[test]
+    fn other_gpu_memory_types_are_left_alone() {
+        for feature in [
+            "memory:CUDAMemory",
+            "memory:NVMM",
+            "memory:D3D11Memory",
+            "memory:VAMemory",
+            "memory:DMABuf",
+        ] {
+            let c = caps(&format!("video/x-raw({}), format=NV12", feature));
+            assert!(
+                !needs_gl_download(&c),
+                "{} should not be downloaded",
+                feature
+            );
+        }
+    }
+
+    /// WHEP Output also takes pre-encoded video. gldownload cannot even link
+    /// to it, so it must never be spliced in.
+    #[test]
+    fn encoded_video_is_not_a_candidate() {
+        for c in [
+            "video/x-h264, stream-format=avc, alignment=au",
+            "video/x-h265",
+            "video/x-vp9",
+            "video/x-av1",
+        ] {
+            assert!(
+                !needs_gl_download(&caps(c)),
+                "{} should be passed through",
+                c
+            );
+        }
+    }
+
+    #[test]
+    fn audio_and_capsless_caps_are_not_candidates() {
+        assert!(!needs_gl_download(&caps("audio/x-raw, rate=48000")));
+        assert!(!needs_gl_download(&caps("ANY")));
+        assert!(!needs_gl_download(&caps("EMPTY")));
+    }
+}

--- a/backend/src/gst/mod.rs
+++ b/backend/src/gst/mod.rs
@@ -5,6 +5,7 @@ pub mod buffer_age_probe;
 pub(crate) mod control_bindings;
 pub(crate) mod crop;
 pub mod discovery;
+pub mod gl_bridge;
 pub mod pipeline;
 pub mod pipeline_monitor;
 pub mod shaders;


### PR DESCRIPTION
## Description

A WHIP Input -> WHEP Output flow on macOS produces an audio-only session. `whepserversink` advertises `video/x-raw(memory:GLMemory)` on its `video_%u` request pads, so GL frames negotiate all the way to the sink; webrtcsink's encoder discovery then finds no encoder that can take them. The only symptom is one `no codec present that can handle the stream's type` line and a missing video payloader — the link itself succeeds, so nothing looks wrong. On macOS this is the normal path: `decodebin` autoplugs `vtdec_hw`, which outputs GL memory.

**Neither side can decide this statically.** The producer does not know its consumer — WHIP Input feeding a GL vision mixer must stay on the GPU — and the consuming block cannot know at build time which decoder `decodebin` will autoplug upstream. So the decision is made from the negotiated caps.

`gst::gl_bridge` watches the video queue's src pad and, on the first CAPS event carrying `memory:GLMemory`, splices a `gldownload` between that pad and the sink. Relinking from inside a push-event probe is a supported pattern: `gst_pad_push_event_unchecked` resolves the peer and rechecks pending sticky events *after* running its probes, so the triggering event lands on the newly inserted element.

Scope of the adaptation:

- **GL memory** is bridged.
- **CUDA / NVMM / D3D11 / VA memory** is left in place. Those consumers really do encode those memory types, and downloading would cost a GPU round trip per frame.
- **Encoded input** (`video/x-h264` and friends, which WHEP Output also accepts and detects) is never a candidate — `gldownload` could not link to it.
- The probe is `EVENT_DOWNSTREAM`, not a buffer probe, and removes itself once the first CAPS event has been classified either way.

The convention this follows is written down in `CLAUDE.md` under **GStreamer Memory Formats**, which is step 1 of #682.

## Measurements

Same machine, same flow, same publisher (`whipclientsink` with `videotestsrc` + `audiotestsrc`, software H.264 forced), only the build differs. Full A/B, not a spot check:

| Build | `no codec present` | video payloaders | audio payloaders | caps at `whepserversink:video_0` |
|---|---|---|---|---|
| `main` | 1 | 0 | 1 | `video/x-raw(memory:GLMemory), NV12` |
| this PR | 0 | 5 | 1 | `video/x-raw, NV12` |
| this PR, software decode forced on the server (`vtdec_hw:0,vtdec:0`) | 0 | 5 | 1 | `video/x-raw, I420` — no bridge inserted |

The negotiated chain with the fix, from `/api/flows/{id}/pad-caps`:

```
whep1:video_queue:src                video/x-raw(memory:GLMemory), NV12
whep1:video_queue_gldownload:sink    video/x-raw(memory:GLMemory), NV12
whep1:video_queue_gldownload:src     video/x-raw, NV12
whep1:whepserversink:video_0         video/x-raw, NV12
```

The third row is the regression check in the other direction: with a non-GL decoder the probe classifies the caps, inserts nothing, and removes itself. Audio negotiates in all three runs, so the video path change does not disturb it.

## Related Issue

Fixes #684. Implements the WHEP Output part of #682 and adds the convention section that issue asks for.

Supersedes #667, which fixed the same bug on the producer side (`gldownload` inside WHIP Input). Its diagnosis was right and this PR is built on it, but a producer-side download is wrong for any GL-to-GL flow and does not help the other GL producers that can feed WHEP Output.

Not addressed by #668 either: `autovideoconvert` does bridge GL to system memory when downstream demands it (verified: `gltestsrc ! autovideoconvert ! video/x-raw,format=NV12 ! fakesink` negotiates, plain `videoconvert` fails to link), but `whepserversink` *advertises* GL memory, so nothing downstream ever demands system memory and no auto-converter has a reason to download. WHEP Output does not use `video_convert_mode()` at all.


## Verified in a browser

Confirmed end to end on macOS by the maintainer: publish from `/player/whip-ingest`, view on `/player/whep`. Video plays. Repeated WHIP connect / WHEP connect cycles, no errors and no crashes.

From that session's log — 6 real (non-discovery) consumer sessions, every one of them with an H.264 video payloader alongside Opus:

```
consumer sessions:               6
consumers with a video payloader: 6
"no codec present":              0
hdrext assertion:                0
NOT_NEGOTIATED:                  0
gldownload insertions:           1
```

The bridge is spliced once, when the first CAPS event arrives on the main pipeline, and then serves every consumer session that follows — it does not re-run per viewer.

The negotiated chain with a real browser publisher (H.264 payload 102, hardware `vtdec_hw`):

```
vtdechw0:src                       video/x-raw(memory:GLMemory), NV12, 1280x720
whip1:decodebin_video_0:src_0      video/x-raw(memory:GLMemory), NV12
whep1:video_queue:src              video/x-raw(memory:GLMemory), NV12
whep1:video_queue_gldownload:sink  video/x-raw(memory:GLMemory), NV12
whep1:video_queue_gldownload:src   video/x-raw, NV12
whep1:whepserversink:video_0       video/x-raw, NV12
```

This closes the gap left open above: the earlier measurements were server-side only. A viewer now actually gets the picture.

Incidentally, #685 (the intermittent `gst_rtp_base_depayload` hdrext assertion) did not fire in any of these browser sessions. That is not evidence it is fixed — it was always intermittent, and nothing in this diff touches the depayloader — just a note that it did not interfere with the verification.

## Which flows this affects

The bridge only fires on *raw* GL video, so it matters exactly where WHEP Output is fed raw frames and lets webrtcsink do the encoding:

- **WHIP Input -> WHEP Output on macOS.** The reported case. `decodebin` autoplugs `vtdec_hw`, which emits GL memory. Fixed and verified here.
- **A GL vision mixer -> WHEP Output directly, on a GL host.** The vision mixer defaults to emitting GL memory (`DEFAULT_GL_DOWNLOAD = false`), so this hits the same dead end. Same code path and same caps feature, but **not tested by me** — it needs a Linux host with hardware GL.

It does **not** affect the common `vision mixer -> video encoder -> WHEP Output` shape: WHEP Output then receives `video/x-h264`, the predicate classifies it as not a candidate, and the probe removes itself without touching the pipeline.

That path has a separate problem, outside this PR's scope. `videoenc` fronts its input with `video_convert_mode().element_name()`, and `gpu.rs` falls back to plain `videoconvert` whenever NVENC is absent (`if !has_nvenc`). Measured:

```
GL RGBA -> videoconvert         -> x264enc   FAIL  ("could not link videoconvert0 to x264enc0")
GL RGBA -> autovideoconvert     -> x264enc   OK
GL RGBA -> gldownload ! videoconvert -> x264enc   OK
```

Since the vision mixer picks its GPU backend from `glvideomixerelement` + `has_hardware_gl()` and not from NVENC, an AMD or Intel Linux host with hardware GL emits GL memory into an encoder fronted by plain `videoconvert` — and negotiation dies there. On NVIDIA hosts the global flag happens to select `autovideoconvert` and it works. That is #682 item 2, and `gl_bridge` is directly reusable for it.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have run `cargo fmt --all`
- [x] I have run `cargo clippy --workspace --all-targets -- -D warnings` (`--package strom --all-targets` is clean; the workspace-wide run still trips the pre-existing `frontend/src/themes.rs` failure on `main`)
- [x] I have run `cargo test --workspace`
- [x] I have updated documentation as needed (`CLAUDE.md` convention section)
- [x] I have added tests for new functionality

### What the tests actually cover

Five unit tests in `gl_bridge` cover the classification: GL raw memory is a candidate; system memory is not; CUDA/NVMM/D3D11/VA/DMABuf are not; encoded H.264/H.265/VP9/AV1 are not; audio and ANY/EMPTY caps are not. Reverting the predicate breaks them.

**The splice itself is not covered by an automated test, and this is a deliberate gap.** A test would need real GL buffers, and `gltestsrc`/`gldownload` come from `gstreamer1.0-gl`, which is not in the CI package list — a test needing it would skip green in CI and guard nothing. Adding GL to CI is a bigger change than this fix and belongs with the construction-level harness #682 proposes. The splice is instead verified by the A/B measurements above.

Test runs: `cargo test --package strom` (511 unit + all integration tests pass), `cargo test --package strom --test pipeline_lifecycle_test` (3 pass — the probe captures no element or pipeline reference, only a `String`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

