### PR TITLE
ci(macos): raise the job timeout from 30 to 45 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -528,7 +528,12 @@ jobs:
     if: github.event_name == 'workflow_dispatch' && contains(fromJSON('["both","macos"]'), inputs.platforms)
     needs: [check-wasm, preflight]
     runs-on: macos-latest
-    timeout-minutes: 30
+    # 30 was not enough: the job is workflow_dispatch-only, so it runs rarely
+    # and sccache's Rust cache is cold almost every time (measured 0.00% Rust
+    # hit rate on a fresh branch), which means clippy, the test build and the
+    # release build each compile the tree from scratch. Matches the Windows
+    # job, which is dispatch-only for the same reason and already sits at 45.
+    timeout-minutes: 45
     env:
       RUSTC_WRAPPER: ${{ needs.preflight.outputs.cache_ok == 'true' && 'sccache' || '' }}
     steps:


### PR DESCRIPTION
## Description

The `build-macos` job ends as `cancelled` on the first dispatch against any branch. It is not a manual cancel and not a build failure — it is the job's own `timeout-minutes: 30`:

```
job started                          07:47:20
##[error]The operation was canceled.  08:17:32     <- 30 min + 12 s
```

The `Build` step was still compiling (`bcrypt`, `strom-frontend`) when the clock ran out.

### Why it does not fit in 30 minutes

sccache returns no Rust cache hits at all on a fresh branch:

```
Cache hits rate (Rust)        0.00 %   (1974 misses)
Cache hits rate (C/C++)      48.28 %
Cache hits rate (Assembler)  45.88 %
```

The job is `workflow_dispatch`-only, so it runs rarely enough that its Rust artifacts are effectively never warm. With no Rust cache, clippy, the test build and the release build each compile the tree from scratch:

```
Install GStreamer   0m35s
Run Clippy          6m54s
Run tests          10m59s
Build (release)    11m28s   <- killed here
```

### The pattern in the history

Every `workflow_dispatch` run of this workflow:

```
fix/whep-gl-memory-input   cancelled   (the run above)
feat/vision-mixer-fx…      success
ci/sccache-minio-s3        success     <- second attempt
ci/sccache-minio-s3        cancelled   <- first
feat/efp-macos             success     <- third attempt
feat/efp-macos             cancelled   <- second
feat/efp-macos             failure     <- first
```

The first dispatch on a branch dies; a re-run succeeds because the timed-out run still populated the cache before it was killed. Maintainers have been paying for that re-run by hand each time.

### Why 45

It is what the Windows job already uses (`.github/workflows/ci.yml:440`), and Windows is `workflow_dispatch`-only for the same cost reason, so it faces the same cold cache. The measured run needed 30 minutes plus a partially finished release build, which fits inside 45 with margin. Nothing about the steps changes, so a warm run still finishes in its usual ~20 minutes and costs nothing extra — `timeout-minutes` is a ceiling, not a reservation.

The alternative — dropping `--release` from dispatch runs that only want a test signal — would be a bigger behavioural change and would stop producing the artifacts the job uploads. Not done here.

## Related Issue

N/A — found while getting a macOS signal for #687, whose dispatch run is the one quoted above.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have run `cargo fmt --all` (not applicable — no Rust changed)
- [ ] I have run `cargo clippy --workspace --all-targets -- -D warnings` (not applicable — no Rust changed)
- [ ] I have run `cargo test --workspace` (not applicable — no Rust changed)
- [ ] I have updated documentation as needed (not applicable)
- [ ] I have added tests for new functionality (not applicable — a workflow timeout value has nothing to assert against)

### What was actually verified

- The diff is one value plus a comment; the surrounding job is untouched.
- The timing and cache numbers above are read from the log of run 32702896751, job `Build (macOS)` (97358495795), not estimated.
- **Not verified:** that 45 minutes is sufficient for every cold macOS run. It covers the one measured run with margin. If a cold run ever needs more, the log will say so the same way this one did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)