### PR TITLE
fix(webrtc): refuse to build WHIP/WHEP blocks when ICE is unavailable

### DIFF
--- a/backend/src/blocks/builder.rs
+++ b/backend/src/blocks/builder.rs
@@ -39,6 +39,9 @@ pub enum BlockBuildError {
 
     #[error("Invalid configuration: {0}")]
     InvalidConfiguration(String),
+
+    #[error("{0}")]
+    MissingPlugin(String),
 }
 
 /// Function type for connecting a block-specific bus message handler.

--- a/backend/src/blocks/builtin/whep.rs
+++ b/backend/src/blocks/builtin/whep.rs
@@ -11,6 +11,7 @@
 
 use crate::blocks::{BlockBuildContext, BlockBuildError, BlockBuildResult, BlockBuilder};
 use crate::gst::gl_bridge;
+use crate::gst::ice_preflight;
 use crate::gst::whep_probe::{self, WhepProbeRegistry};
 use gstreamer as gst;
 use gstreamer::prelude::*;
@@ -37,6 +38,7 @@ impl BlockBuilder for WHEPOutputBuilder {
         ctx: &BlockBuildContext,
     ) -> Result<BlockBuildResult, BlockBuildError> {
         debug!("Building WHEP Output block instance: {}", instance_id);
+        ice_preflight::require_ice_elements("WHEP Output")?;
         build_whepserversink(instance_id, properties, ctx)
     }
 
@@ -213,6 +215,7 @@ impl BlockBuilder for WHEPInputBuilder {
         ctx: &BlockBuildContext,
     ) -> Result<BlockBuildResult, BlockBuildError> {
         debug!("Building WHEP Input block instance: {}", instance_id);
+        ice_preflight::require_ice_elements("WHEP Input")?;
 
         // Get implementation choice (default to stable whepsrc)
         let use_new = properties

--- a/backend/src/blocks/builtin/whip.rs
+++ b/backend/src/blocks/builtin/whip.rs
@@ -14,6 +14,7 @@ use crate::blocks::{
     BlockBuildContext, BlockBuildError, BlockBuildResult, BlockBuilder, APPSRC_MAX_BYTES_AUDIO,
     APPSRC_MAX_BYTES_VIDEO, APPSRC_MAX_TIME,
 };
+use crate::gst::ice_preflight;
 use crate::whip_session_manager::{SessionCleanupRequest, WhipEndpointConfig};
 use gstreamer as gst;
 use gstreamer::prelude::*;
@@ -43,6 +44,7 @@ impl BlockBuilder for WHIPOutputBuilder {
         ctx: &BlockBuildContext,
     ) -> Result<BlockBuildResult, BlockBuildError> {
         debug!("Building WHIP Output block instance: {}", instance_id);
+        ice_preflight::require_ice_elements("WHIP Output")?;
 
         // Get implementation choice (default to stable whipsink)
         let use_new = properties
@@ -72,6 +74,7 @@ impl BlockBuilder for WHIPInputBuilder {
         ctx: &BlockBuildContext,
     ) -> Result<BlockBuildResult, BlockBuildError> {
         debug!("Building WHIP Input block instance: {}", instance_id);
+        ice_preflight::require_ice_elements("WHIP Input")?;
         build_whipserversrc(instance_id, properties, ctx)
     }
 

--- a/backend/src/gst/ice_preflight.rs
+++ b/backend/src/gst/ice_preflight.rs
@@ -1,0 +1,168 @@
+//! Preflight check for the GStreamer ICE elements that WebRTC needs.
+//!
+//! `webrtcbin` cannot do ICE without the libnice elements (`nicesrc` /
+//! `nicesink`). When they are absent, upstream `webrtcsrc` calls
+//! `bin.sync_state_with_parent().unwrap()` in a context that cannot unwind, so
+//! a WHIP or WHEP session does not fail — it aborts the whole process with
+//! SIGABRT. Nothing in Strom can catch that, which leaves one option: never
+//! reach it.
+//!
+//! So every block that brings up a `webrtcbin` asks [`require_ice_elements`]
+//! first. A flow containing such a block then refuses to start with an error
+//! naming the missing package, instead of taking the server down with it.
+//!
+//! The packaging bug that motivated this is fixed, but the check is not about
+//! that one bug: any host missing the plugin fails the same way — a container
+//! image, a hand-built environment, a `minimal` install, or the next time a
+//! distribution renames the package.
+
+use gstreamer as gst;
+use tracing::{error, info};
+
+use crate::blocks::BlockBuildError;
+
+/// The element factories `webrtcbin` needs for ICE.
+const ICE_ELEMENTS: [&str; 2] = ["nicesrc", "nicesink"];
+
+/// Names of the ICE elements that are missing from this installation.
+///
+/// Empty means WebRTC can negotiate.
+pub fn missing_ice_elements() -> Vec<&'static str> {
+    ICE_ELEMENTS
+        .iter()
+        .copied()
+        .filter(|name| gst::ElementFactory::find(name).is_none())
+        .collect()
+}
+
+/// The package that ships the ICE elements on this platform.
+///
+/// Used in the operator-facing message, so it names what to install rather
+/// than what is missing.
+pub const fn ice_package_hint() -> &'static str {
+    #[cfg(target_os = "macos")]
+    {
+        "brew install libnice-gstreamer"
+    }
+    #[cfg(target_os = "windows")]
+    {
+        "the GStreamer MSI installer's full package set"
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        "gstreamer1.0-nice (Debian/Ubuntu), libnice-gstreamer1 (Fedora) or libnice (Arch)"
+    }
+}
+
+/// The message shown when a WebRTC block cannot be built.
+///
+/// Kept separate from the check itself so its wording is testable on a host
+/// where the elements are present.
+pub fn ice_missing_message(block_label: &str, missing: &[&str]) -> String {
+    format!(
+        "{} needs WebRTC ICE support, but GStreamer has no {}. \
+         webrtcbin cannot negotiate without them, and the failure would abort \
+         the server process rather than this flow. Install them with: {}",
+        block_label,
+        missing.join(" or "),
+        ice_package_hint()
+    )
+}
+
+/// Refuse to build a WebRTC block when ICE is unavailable.
+///
+/// `block_label` is the operator-facing block name, e.g. "WHIP Input".
+pub fn require_ice_elements(block_label: &str) -> Result<(), BlockBuildError> {
+    let missing = missing_ice_elements();
+    if missing.is_empty() {
+        return Ok(());
+    }
+    Err(BlockBuildError::MissingPlugin(ice_missing_message(
+        block_label,
+        &missing,
+    )))
+}
+
+/// Report ICE availability once at startup.
+///
+/// A flow that needs ICE fails cleanly on its own, but an operator setting the
+/// server up should not have to start a flow to discover this.
+pub fn log_ice_availability() {
+    let missing = missing_ice_elements();
+    if missing.is_empty() {
+        info!("WebRTC ICE available (nicesrc, nicesink)");
+    } else {
+        error!(
+            "WebRTC ICE unavailable: GStreamer has no {}. WHIP and WHEP blocks will refuse to start. Install them with: {}",
+            missing.join(" or "),
+            ice_package_hint()
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The message has to tell an operator what to install, not just what
+    /// broke — that is the whole point of the check.
+    #[test]
+    fn message_names_the_block_the_elements_and_the_remedy() {
+        let msg = ice_missing_message("WHIP Input", &["nicesrc", "nicesink"]);
+        assert!(msg.contains("WHIP Input"), "{}", msg);
+        assert!(msg.contains("nicesrc"), "{}", msg);
+        assert!(msg.contains("nicesink"), "{}", msg);
+        assert!(msg.contains(ice_package_hint()), "{}", msg);
+    }
+
+    #[test]
+    fn message_explains_why_it_is_refused_rather_than_attempted() {
+        let msg = ice_missing_message("WHEP Output", &["nicesrc"]);
+        assert!(msg.contains("abort"), "{}", msg);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_hint_names_the_plugin_formula_not_the_library() {
+        let hint = ice_package_hint();
+        assert!(hint.contains("libnice-gstreamer"), "{}", hint);
+        // `libnice` alone is the library without the GStreamer plugin — the
+        // exact mistake that made every WHIP session abort.
+        assert_ne!(hint, "brew install libnice");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_hint_covers_the_supported_distributions() {
+        let hint = ice_package_hint();
+        for pkg in ["gstreamer1.0-nice", "libnice-gstreamer1", "libnice"] {
+            assert!(hint.contains(pkg), "{} missing from {}", pkg, hint);
+        }
+    }
+
+    /// The guard and the probe must agree, or a block could be refused on a
+    /// host that can actually do ICE (or worse, allowed on one that cannot).
+    /// Passes whether or not the elements are installed, so it is meaningful
+    /// in CI as well as on a developer machine.
+    #[test]
+    fn the_guard_agrees_with_the_probe() {
+        let _ = gst::init();
+        let available = missing_ice_elements().is_empty();
+        assert_eq!(require_ice_elements("Block").is_ok(), available);
+    }
+
+    #[test]
+    fn a_present_installation_reports_nothing_missing() {
+        let _ = gst::init();
+        if gst::ElementFactory::find("nicesrc").is_some()
+            && gst::ElementFactory::find("nicesink").is_some()
+        {
+            assert!(missing_ice_elements().is_empty());
+            assert!(require_ice_elements("WHIP Input").is_ok());
+        } else {
+            // No ICE here (this is the CI Linux image, among others): the
+            // probe must say so and name both elements.
+            assert_eq!(missing_ice_elements().len(), 2);
+        }
+    }
+}

--- a/backend/src/gst/mod.rs
+++ b/backend/src/gst/mod.rs
@@ -6,6 +6,7 @@ pub(crate) mod control_bindings;
 pub(crate) mod crop;
 pub mod discovery;
 pub mod gl_bridge;
+pub mod ice_preflight;
 pub mod pipeline;
 pub mod pipeline_monitor;
 pub mod shaders;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -420,6 +420,10 @@ fn run_with_gui(
         // This tests CUDA-GL interop to determine if autovideoconvert works
         strom::gpu::detect_gpu_capabilities();
 
+        // Report WebRTC ICE availability. WHIP/WHEP blocks refuse to build
+        // without it, so say so at startup rather than at first flow start.
+        strom::gst::ice_preflight::log_ice_availability();
+
         // Start GLib main loop in background thread for bus watch callbacks
         start_glib_main_loop();
         info!("GLib main loop started in background thread");
@@ -574,6 +578,10 @@ async fn run_headless(
     // Detect GPU capabilities for video conversion mode selection
     // This tests CUDA-GL interop to determine if autovideoconvert works
     strom::gpu::detect_gpu_capabilities();
+
+    // Report WebRTC ICE availability. WHIP/WHEP blocks refuse to build
+    // without it, so say so at startup rather than at first flow start.
+    strom::gst::ice_preflight::log_ice_availability();
 
     // Start GLib main loop in background thread for bus watch callbacks
     start_glib_main_loop();

--- a/backend/tests/ice_preflight_test.rs
+++ b/backend/tests/ice_preflight_test.rs
@@ -1,0 +1,91 @@
+//! A flow that needs WebRTC ICE must refuse to start when the libnice
+//! elements are absent — not abort the server process.
+//!
+//! Without `nicesrc` / `nicesink`, upstream `webrtcsrc` panics inside a
+//! function that cannot unwind and the process dies with SIGABRT, taking every
+//! other running flow with it. Strom cannot catch that, so the only defence is
+//! to never build the block. This test removes the ICE elements from the
+//! GStreamer registry and asserts each WebRTC block builder refuses.
+//!
+//! It is meaningful in both environments: on a developer machine the elements
+//! are present and get removed here; in CI they are absent to begin with and
+//! the removal is a no-op. Either way the builders must refuse.
+
+use gstreamer as gst;
+use std::collections::HashMap;
+use strom::blocks::{builtin, BlockBuildContext};
+
+const WEBRTC_BLOCKS: [&str; 4] = [
+    "builtin.whip_input",
+    "builtin.whip_output",
+    "builtin.whep_input",
+    "builtin.whep_output",
+];
+
+/// Remove the ICE elements from this process's registry, so the rest of the
+/// test runs as if the libnice plugin were never installed.
+fn remove_ice_elements() {
+    let registry = gst::Registry::get();
+    for name in ["nicesrc", "nicesink"] {
+        if let Some(factory) = gst::ElementFactory::find(name) {
+            registry.remove_feature(&factory);
+        }
+    }
+    assert!(
+        gst::ElementFactory::find("nicesrc").is_none(),
+        "nicesrc should be gone from the registry"
+    );
+    assert!(
+        gst::ElementFactory::find("nicesink").is_none(),
+        "nicesink should be gone from the registry"
+    );
+}
+
+#[test]
+fn webrtc_blocks_refuse_to_build_without_ice_elements() {
+    gst::init().expect("gstreamer init");
+    remove_ice_elements();
+
+    let ctx = BlockBuildContext::new(vec![], "all".to_string());
+
+    for definition_id in WEBRTC_BLOCKS {
+        let builder = builtin::get_builder(definition_id)
+            .unwrap_or_else(|| panic!("no builder for {}", definition_id));
+
+        let properties: HashMap<String, strom_types::PropertyValue> = HashMap::new();
+        let result = builder.build("test_block", &properties, &ctx);
+
+        let err = match result {
+            Err(e) => e.to_string(),
+            Ok(_) => panic!(
+                "{} built a pipeline without ICE elements — a live session would abort the process",
+                definition_id
+            ),
+        };
+
+        // The message has to be actionable: what is missing, and what to
+        // install. An operator reads this in a failed flow start, not a log.
+        assert!(
+            err.contains("nicesrc") && err.contains("nicesink"),
+            "{}: message should name the missing elements, got: {}",
+            definition_id,
+            err
+        );
+        assert!(
+            err.contains(strom::gst::ice_preflight::ice_package_hint()),
+            "{}: message should name the package to install, got: {}",
+            definition_id,
+            err
+        );
+    }
+}
+
+#[test]
+fn the_probe_reports_both_elements_missing() {
+    gst::init().expect("gstreamer init");
+    remove_ice_elements();
+
+    let missing = strom::gst::ice_preflight::missing_ice_elements();
+    assert_eq!(missing.len(), 2, "got {:?}", missing);
+    assert!(strom::gst::ice_preflight::require_ice_elements("WHIP Input").is_err());
+}


### PR DESCRIPTION
## Description

This is the remaining half of #683. #686 fixed the packaging bug that caused it on macOS; this makes the failure mode legible no matter what causes it.

Without the libnice elements (`nicesrc` / `nicesink`), `webrtcbin` cannot negotiate, and upstream `webrtcsrc` does:

```rust
bin.sync_state_with_parent().unwrap()   // webrtcsrc/imp.rs:2099
```

inside a function that cannot unwind. A WHIP or WHEP session therefore does not *fail* — the process aborts with SIGABRT, taking every other running flow with it. Strom cannot catch that, so the only defence is to never get there.

Three parts:

1. **`backend/src/gst/ice_preflight.rs`** — probes the two factories, and builds an operator-facing message naming what is missing and what to install for the platform (`brew install libnice-gstreamer` on macOS; `gstreamer1.0-nice` / `libnice-gstreamer1` / `libnice` on Linux; the full MSI package set on Windows).
2. **The four WebRTC builders** — WHIP Input, WHIP Output, WHEP Input, WHEP Output — call `require_ice_elements()` before building anything. `BlockBuildError` becomes `PipelineError::InvalidFlow` on flow start (`block_expansion.rs:120-127`), which is a path the API and UI already surface, so no new plumbing was needed.
3. **Startup** — one line reporting ICE availability, in both the GUI and headless paths, so an operator setting the server up does not have to start a flow to discover this.

### What is deliberately not guarded

`get_external_pads()` is untouched. The flow editor must keep listing WHIP/WHEP pads on a host that cannot run them — otherwise the block becomes impossible to *edit* rather than merely impossible to start, and a flow authored on a working host could not be opened on a broken one.

### Why this is not only about the macOS formula

Any host missing the plugin fails identically: a container image, a hand-built environment, a `GSTREAMER_INSTALL_TYPE=minimal` install (which still omits the ICE package on both macOS and Linux — see the review on #686), or the next time a distribution renames it. `docs/CHANGELOG.md:297` records "Correct the Fedora libnice package name" as an earlier, separate instance of exactly that drift. The per-platform package lists have now been wrong twice with nothing to catch the next one.

## Related Issue

Closes #683

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have run `cargo fmt --all`
- [x] I have run `cargo clippy --workspace --all-targets -- -D warnings` (`--package strom --all-targets` is clean; the workspace-wide run still trips the pre-existing `frontend/src/themes.rs` failure on `main`)
- [x] I have run `cargo test --workspace`
- [ ] I have updated documentation as needed (not applicable — no operator-facing doc describes this; the message is the documentation)
- [x] I have added tests for new functionality

### Tests, and what they actually prove

`backend/tests/ice_preflight_test.rs` is a real guard, not a demonstration. It removes `nicesrc` and `nicesink` from the process's GStreamer registry (`Registry::remove_feature`) and then asserts that each of the four builders refuses, with a message that names both elements and the package to install.

**Verified by reverting:** with the four `require_ice_elements()` calls commented out, the test fails, and on the right thing:

```
test webrtc_blocks_refuse_to_build_without_ice_elements ... FAILED
panicked at backend/tests/ice_preflight_test.rs:60:22:
builtin.whip_input built a pipeline without ICE elements — a live session would abort the process
```

Guards restored, it passes again.

**It is meaningful in CI as well.** The CI Linux image has no libnice package (`.github/workflows/ci.yml:89`), so the elements are absent to begin with and the removal is a no-op — but the assertions are unchanged and still run. The test does not skip on a missing element, so it guards something in both environments. That also means this PR needs no CI package change.

Five unit tests in `ice_preflight` cover the message wording (names the block, both elements, and the remedy), the per-platform hint (the macOS one asserts `libnice-gstreamer`, explicitly not bare `libnice` — the exact mistake behind #683), and that the guard and the probe agree.

Test runs on this machine, where ICE *is* installed: `cargo test --package strom` — 516 lib tests plus every integration test pass, including `ice_preflight_test` (2) and `pipeline_lifecycle_test` (3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)