### PR TITLE
fix(whip): ask the publisher for a keyframe when video does not start

### DIFF
--- a/backend/src/blocks/builtin/whip.rs
+++ b/backend/src/blocks/builtin/whip.rs
@@ -15,6 +15,7 @@ use crate::blocks::{
     APPSRC_MAX_BYTES_VIDEO, APPSRC_MAX_TIME,
 };
 use crate::gst::ice_preflight;
+use crate::gst::keyframe_request;
 use crate::whip_session_manager::{SessionCleanupRequest, WhipEndpointConfig};
 use gstreamer as gst;
 use gstreamer::prelude::*;
@@ -238,6 +239,11 @@ fn build_whipserversrc(
     let mut slot_audio_appsrcs: Vec<gst_app::AppSrc> = Vec::new();
     let mut slot_video_appsrcs: Vec<gst_app::AppSrc> = Vec::new();
 
+    // One flag per slot, set when decodebin exposes that slot's video pad.
+    // A session stops asking the publisher for keyframes once its flag flips.
+    let video_decoding: Arc<Vec<AtomicBool>> =
+        Arc::new((0..max_sessions).map(|_| AtomicBool::new(false)).collect());
+
     for slot in 0..max_sessions {
         // Audio chain for this slot
         if mode.has_audio() {
@@ -392,9 +398,15 @@ fn build_whipserversrc(
 
                 // decodebin has dynamic pads — connect pad-added to link to videoconvert
                 let videoconvert_weak = videoconvert.downgrade();
+                let video_decoding_for_pad = video_decoding.clone();
                 decodebin.connect_pad_added(move |_dec, src_pad| {
                     if src_pad.direction() != gst::PadDirection::Src {
                         return;
+                    }
+                    // Video is decoding: whoever is asking for keyframes on
+                    // this slot can stop.
+                    if let Some(flag) = video_decoding_for_pad.get(slot) {
+                        flag.store(true, Ordering::Relaxed);
                     }
                     if let Some(vc) = videoconvert_weak.upgrade() {
                         let sink = vc.static_pad("sink").unwrap();
@@ -458,6 +470,7 @@ fn build_whipserversrc(
             ice_transport_policy: ctx.ice_transport_policy().to_string(),
             pipeline_weak: gst::glib::WeakRef::new(),
             decode,
+            video_decoding,
             jitterbuffer_latency_ms,
             dynamic_webrtcbin_store: ctx.dynamic_webrtcbin_store(),
             max_video_bitrate_kbps,
@@ -570,16 +583,12 @@ pub fn create_whipserversrc_for_session(
             // see comment in whep.rs build_whepsrc iterate_recurse for details.
             if element_name.starts_with("rtpbin") && element.has_property("drop-on-latency") {
                 element.set_property("drop-on-latency", true);
-                info!(
-                    "WHIP Input: Set drop-on-latency=true on {}",
-                    element_name
-                );
+                info!("WHIP Input: Set drop-on-latency=true on {}", element_name);
             }
 
             if element_name.starts_with("webrtcbin") {
                 if element.has_property("ice-transport-policy") {
-                    element
-                        .set_property_from_str("ice-transport-policy", &ice_transport_policy);
+                    element.set_property_from_str("ice-transport-policy", &ice_transport_policy);
                     info!(
                         "WHIP Input: Set ice-transport-policy={} on webrtcbin {}",
                         ice_transport_policy, element_name
@@ -631,10 +640,8 @@ pub fn create_whipserversrc_for_session(
                             .unwrap_or_else(|| "unknown".to_string())
                     };
 
-                    let is_dead = matches!(
-                        state_name.as_str(),
-                        "failed" | "disconnected" | "closed"
-                    );
+                    let is_dead =
+                        matches!(state_name.as_str(), "failed" | "disconnected" | "closed");
 
                     info!(
                         "WHIP Input: [SERVER] {} ice-connection-state = {}",
@@ -643,10 +650,7 @@ pub fn create_whipserversrc_for_session(
 
                     if is_dead && !cleanup_sent.swap(true, Ordering::SeqCst) {
                         let reason = format!("ICE {}", state_name);
-                        let _ = cleanup_tx.send(SessionCleanupRequest {
-                            port,
-                            reason,
-                        });
+                        let _ = cleanup_tx.send(SessionCleanupRequest { port, reason });
                     }
                 });
             }
@@ -667,47 +671,14 @@ pub fn create_whipserversrc_for_session(
                 }
             }
 
-            let element_klass = element
-                .factory()
-                .and_then(|f| f.metadata("klass").map(|s| s.to_string()))
-                .unwrap_or_default();
-            if element_klass.contains("Decoder") && element_klass.contains("Video") {
-                let decoder_name = element_name.to_string();
-                let decoder_weak = element.downgrade();
-                let fku_epoch = Instant::now();
-                let last_fku_ms = Arc::new(AtomicU64::new(0));
-                let block_id = block_id_for_callback.clone();
-
-                if let Some(sink_pad) = element.static_pad("sink") {
-                    sink_pad.add_probe(gst::PadProbeType::BUFFER, move |_pad, info| {
-                        if let Some(gst::PadProbeData::Buffer(ref buffer)) = info.data {
-                            if buffer.flags().contains(gst::BufferFlags::DISCONT) {
-                                let now_ms = fku_epoch.elapsed().as_millis() as u64;
-                                let last = last_fku_ms.load(Ordering::Relaxed);
-                                if now_ms.saturating_sub(last) >= 1000 {
-                                    last_fku_ms.store(now_ms, Ordering::Relaxed);
-                                    if let Some(decoder) = decoder_weak.upgrade() {
-                                        debug!(
-                                            "WHIP Input [{}]: Discontinuity on {} sink, requesting keyframe (PLI)",
-                                            block_id, decoder_name
-                                        );
-                                        let fku =
-                                            gst_video::UpstreamForceKeyUnitEvent::builder()
-                                                .all_headers(true)
-                                                .build();
-                                        decoder.send_event(fku);
-                                    }
-                                }
-                            }
-                        }
-                        gst::PadProbeReturn::Ok
-                    });
-                    info!(
-                        "WHIP Input: Installed keyframe recovery probe on {} sink pad",
-                        element_name
-                    );
-                }
-            }
+            // NOTE: a DISCONT-triggered keyframe request used to live here, on
+            // the decoder's sink pad. It never ran, and could not have worked:
+            // the decoder lives in the *main* pipeline, not in this session
+            // pipeline, so the branch was never reached — and an upstream
+            // force-key-unit sent from there dies at the main pipeline's
+            // `appsrc` instead of crossing into the WebRTC source. Keyframe
+            // requests are made from the session side instead, where they
+            // reach the publisher. See `gst::keyframe_request`.
             None
         });
     }
@@ -715,6 +686,13 @@ pub fn create_whipserversrc_for_session(
     // Get the slot's appsrc refs — these are the targets in the main pipeline
     let slot_audio_appsrc: Option<gst_app::AppSrc> = config.slot_audio_appsrcs.get(slot).cloned();
     let slot_video_appsrc: Option<gst_app::AppSrc> = config.slot_video_appsrcs.get(slot).cloned();
+
+    // Re-arm the slot: this session has to prove for itself that video decodes.
+    // A previous session on the same slot left the flag set.
+    let video_decoding = config.video_decoding.clone();
+    if let Some(flag) = video_decoding.get(slot) {
+        flag.store(false, Ordering::Relaxed);
+    }
 
     // Shared timestamp offset for A/V sync across audio and video appsrcs.
     // Computed from the first buffer on either stream:
@@ -862,6 +840,60 @@ pub fn create_whipserversrc_for_session(
                     "WHIP Input: Pad {} (stream {}) → appsink → slot {} appsrc ({})",
                     pad_name, stream_num, slot, media_type
                 );
+
+                if media_type == "video" {
+                    // A browser sends H.264 parameter sets only alongside a
+                    // keyframe. If this session's first keyframe never arrives,
+                    // the depayloader gets nothing but non-reference slices and
+                    // can never output an access unit — decodebin exposes no
+                    // pad and the flow's pipeline never leaves PAUSED, so WHEP
+                    // viewers get nothing while audio plays fine.
+                    //
+                    // Ask for one. The event has to be sent here, on the WebRTC
+                    // source's pad, because this is the only side of the
+                    // appsink/appsrc boundary from which it reaches the
+                    // publisher. It stops as soon as video decodes, so a
+                    // healthy session is normally never asked at all.
+                    let request_pad = pad.clone();
+                    let request_flag = video_decoding.clone();
+                    let request_slot = slot;
+                    if let Err(e) = std::thread::Builder::new()
+                        .name(format!("whip-keyframe-{}", request_slot))
+                        .spawn(move || {
+                            let policy = keyframe_request::KeyframeRequestPolicy::default();
+                            let Some(flag) = request_flag.get(request_slot) else {
+                                return;
+                            };
+                            let sent = keyframe_request::request_until_decoding(
+                                policy,
+                                flag,
+                                std::thread::sleep,
+                                |attempt| {
+                                    debug!(
+                                        "WHIP Input: video not decoding on slot {}, requesting keyframe (PLI) attempt {}/{}",
+                                        request_slot, attempt, policy.attempts
+                                    );
+                                    request_pad.send_event(
+                                        gst_video::UpstreamForceKeyUnitEvent::builder()
+                                            .all_headers(true)
+                                            .build(),
+                                    );
+                                },
+                            );
+                            if sent > 0 {
+                                info!(
+                                    "WHIP Input: requested a keyframe {} time(s) on slot {} (video had not started decoding)",
+                                    sent, request_slot
+                                );
+                            }
+                        })
+                    {
+                        warn!(
+                            "WHIP Input: could not spawn keyframe requester for slot {}: {}",
+                            slot, e
+                        );
+                    }
+                }
 
                 let ts_offset = shared_ts_offset.clone();
                 let main_pipeline_for_ts = main_pipeline_weak.clone();

--- a/backend/src/gst/keyframe_request.rs
+++ b/backend/src/gst/keyframe_request.rs
@@ -1,0 +1,164 @@
+//! Asking a WHIP publisher for a keyframe, and knowing when to stop.
+//!
+//! A browser sends H.264 parameter sets (SPS/PPS, as a STAP-A packet) only
+//! alongside a keyframe. If a session's first keyframe does not arrive — the
+//! publisher was already running, the burst was dropped, the receiver came up
+//! a moment late — then `rtph264depay` receives nothing but fragmented
+//! non-reference slices. It can reassemble them (the FU-A start/end bits pair
+//! up fine) but without parameter sets it cannot set caps, so it never outputs
+//! an access unit, `decodebin` never exposes a pad, and the flow's pipeline
+//! never leaves PAUSED. Audio is unaffected, which is why the symptom reads as
+//! "audio works, video doesn't".
+//!
+//! Measured on a real session: 14830 FU-A fragments, 1987 complete fragmented
+//! NAL units, zero STAP-A packets, zero completed access units. Every session
+//! that worked had at least one STAP-A.
+//!
+//! The remedy is to ask: an upstream force-key-unit event on the WHIP source
+//! pad becomes a PLI to the publisher, which answers with a keyframe and the
+//! parameter sets that travel with it.
+//!
+//! This module is the part worth testing: *when* to ask, and when to stop.
+//! Asking is cheap but not free — a forced keyframe is a bitrate spike — so a
+//! healthy session should never be asked at all, and a stalled one should be
+//! asked a bounded number of times and then left alone.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+/// How persistently to ask for a keyframe before giving up.
+#[derive(Debug, Clone, Copy)]
+pub struct KeyframeRequestPolicy {
+    /// Maximum number of requests to send.
+    pub attempts: u32,
+    /// Delay before the first request, and between subsequent ones.
+    pub interval: Duration,
+}
+
+impl Default for KeyframeRequestPolicy {
+    fn default() -> Self {
+        Self {
+            // A PLI is answered in well under a second on a working connection.
+            // Five tries over 2.5s covers a stalled start without turning into
+            // a keyframe generator if the publisher never answers.
+            attempts: 5,
+            interval: Duration::from_millis(500),
+        }
+    }
+}
+
+/// Ask for a keyframe until video is decoding, or until the attempts run out.
+///
+/// Waits *before* each request rather than after, so a session that starts
+/// normally is never asked: on a healthy connect the decoder appears within a
+/// few hundred milliseconds and the first check already sees it.
+///
+/// `wait` and `send` are injected so the policy can be tested without sleeping
+/// and without a pipeline. Returns the number of requests actually sent.
+pub fn request_until_decoding(
+    policy: KeyframeRequestPolicy,
+    decoding: &AtomicBool,
+    mut wait: impl FnMut(Duration),
+    mut send: impl FnMut(u32),
+) -> u32 {
+    let mut sent = 0;
+    for attempt in 1..=policy.attempts {
+        wait(policy.interval);
+        if decoding.load(Ordering::Relaxed) {
+            break;
+        }
+        send(attempt);
+        sent += 1;
+    }
+    sent
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn policy(attempts: u32) -> KeyframeRequestPolicy {
+        KeyframeRequestPolicy {
+            attempts,
+            interval: Duration::from_millis(500),
+        }
+    }
+
+    /// The common case. A session that starts normally must not be asked for a
+    /// keyframe at all — every request is a bitrate spike on a stream that is
+    /// already fine.
+    #[test]
+    fn a_healthy_session_is_never_asked() {
+        let decoding = AtomicBool::new(true);
+        let sent = request_until_decoding(policy(5), &decoding, |_| {}, |_| panic!("asked anyway"));
+        assert_eq!(sent, 0);
+    }
+
+    /// Video starts during the first wait: exactly one check, no request.
+    #[test]
+    fn video_arriving_during_the_first_wait_stops_it() {
+        let decoding = AtomicBool::new(false);
+        let sent = request_until_decoding(
+            policy(5),
+            &decoding,
+            |_| decoding.store(true, Ordering::Relaxed),
+            |_| panic!("asked after video started"),
+        );
+        assert_eq!(sent, 0);
+    }
+
+    /// The request worked: stop after it, do not keep asking.
+    #[test]
+    fn it_stops_as_soon_as_video_decodes() {
+        let decoding = AtomicBool::new(false);
+        let mut waits = 0;
+        let sent = request_until_decoding(
+            policy(5),
+            &decoding,
+            |_| waits += 1,
+            |_| decoding.store(true, Ordering::Relaxed),
+        );
+        assert_eq!(sent, 1, "one request should have been enough");
+        assert_eq!(
+            waits, 2,
+            "one wait before the request, one before giving up"
+        );
+    }
+
+    /// An unresponsive publisher must not be asked forever.
+    #[test]
+    fn it_gives_up_after_the_configured_attempts() {
+        let decoding = AtomicBool::new(false);
+        let mut attempts_seen = Vec::new();
+        let sent = request_until_decoding(
+            policy(5),
+            &decoding,
+            |_| {},
+            |attempt| attempts_seen.push(attempt),
+        );
+        assert_eq!(sent, 5);
+        assert_eq!(attempts_seen, vec![1, 2, 3, 4, 5]);
+    }
+
+    /// One wait per attempt and no trailing wait after the last request — the
+    /// loop must not keep a thread alive doing nothing.
+    #[test]
+    fn it_waits_once_per_attempt_and_not_after_the_last() {
+        let decoding = AtomicBool::new(false);
+        let mut waits = 0;
+        request_until_decoding(policy(3), &decoding, |_| waits += 1, |_| {});
+        assert_eq!(waits, 3);
+    }
+
+    #[test]
+    fn the_default_policy_is_bounded_and_short() {
+        let p = KeyframeRequestPolicy::default();
+        assert!(p.attempts >= 1 && p.attempts <= 10, "{:?}", p);
+        let total = p.interval * p.attempts;
+        assert!(
+            total <= Duration::from_secs(5),
+            "a stalled start should be resolved or abandoned quickly, not {:?}",
+            total
+        );
+    }
+}

--- a/backend/src/gst/mod.rs
+++ b/backend/src/gst/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod crop;
 pub mod discovery;
 pub mod gl_bridge;
 pub mod ice_preflight;
+pub mod keyframe_request;
 pub mod pipeline;
 pub mod pipeline_monitor;
 pub mod shaders;

--- a/backend/src/whip_session_manager.rs
+++ b/backend/src/whip_session_manager.rs
@@ -12,6 +12,7 @@ use gstreamer as gst;
 use gstreamer::prelude::*;
 use gstreamer_app as gst_app;
 use std::collections::{HashMap, HashSet};
+use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex, RwLock};
 use strom_types::block::StreamMode;
 use tokio::sync::mpsc;
@@ -32,6 +33,13 @@ pub struct WhipEndpointConfig {
     pub pipeline_weak: gst::glib::WeakRef<gst::Pipeline>,
     /// Whether to decode RTP to raw media (true) or pass through RTP (false)
     pub decode: bool,
+    /// Per-slot flag, set once the main pipeline's `decodebin` has exposed a
+    /// video pad for that slot — i.e. video is genuinely being decoded.
+    ///
+    /// A session asks the publisher for a keyframe until this flips, because
+    /// without the parameter sets that travel with a keyframe the depayloader
+    /// can never produce an access unit. See `gst::keyframe_request`.
+    pub video_decoding: Arc<Vec<AtomicBool>>,
     /// Jitterbuffer latency in milliseconds for the per-session webrtcbin.
     pub jitterbuffer_latency_ms: u32,
     /// Shared dynamic webrtcbin store for ICE policy tracking


### PR DESCRIPTION
## Description

A WHIP Input -> WHEP Output flow sometimes comes up with audio only, and WHEP viewers get `502 Bad Gateway`. Traced end to end:

A browser sends H.264 parameter sets (SPS/PPS, as a STAP-A packet) only alongside a keyframe. When a session's first keyframe does not arrive, `rtph264depay` receives nothing but fragmented non-reference slices. It reassembles them correctly — the FU-A start/end bits pair up — but without parameter sets it cannot set caps, so it never outputs an access unit. `decodebin` therefore never exposes a pad, the flow's pipeline never leaves PAUSED, `whepserversink` never reaches PLAYING, its signalling server never binds, and the WHEP proxy has nothing to forward to. Audio is unaffected the whole way, which is why the symptom reads as "audio works, video doesn't".

Measured with `GST_DEBUG=rtph264depay:5` on a stalled session versus working ones:

| depayloader | Type 1 | Type 24 (STAP-A) | Type 28 (FU-A) | completed access units |
|---|---|---|---|---|
| depay0 | 7 | 1 | 15862 | 1370 |
| depay1 | 3 | 1 | 1824 | 165 |
| depay2 | 3 | 1 | 909 | 102 |
| depay3 | 8 | 2 | 17926 | 1434 |
| **depay4 (stalled)** | 4 | **0** | 14830 | **0** |

Every session that worked received at least one STAP-A. The stalled one received none, while 1987 complete fragmented NAL units arrived — so this is not packet loss, it is a stream with no parameter sets in it.

**So ask for a keyframe.** An upstream force-key-unit on the WebRTC source's pad becomes a PLI, and the publisher answers with a keyframe and the parameter sets that travel with it.

The request has to be sent from the session side. That is the only side of the appsink/appsrc boundary from which the event can reach the publisher at all — an upstream event sent from the main pipeline dies at its `appsrc`.

Asking is not free: a forced keyframe is a bitrate spike. So the policy waits *before* asking rather than after, and stops the moment the main pipeline's `decodebin` exposes a video pad for that slot. A session that starts normally is never asked at all. An unresponsive publisher is asked five times over 2.5s and then left alone.

### Also removes dead code

The DISCONT-triggered keyframe request on the decoder's sink pad is deleted. It never ran — the decoder lives in the main pipeline, not the session pipeline, so the branch was unreachable (`grep -c "Installed keyframe recovery probe"` over a full session log returns 0). And it could not have worked if it had, for the boundary reason above. It was also a BUFFER probe — the hottest path in the pipeline — doing nothing.

## Related Issue

Relates to #666, which identified this stall independently and proposed the same mechanism. The difference here is cancellation: #666 sends five requests 800ms apart unconditionally, on every session, with no way to stop once video starts, from a detached thread that keeps firing after teardown. This one asks only when video has not started and stops as soon as it does.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have run `cargo fmt --all`
- [x] I have run `cargo clippy --workspace --all-targets -- -D warnings` (`--package strom --all-targets` clean; the workspace-wide run still trips the pre-existing `frontend/src/themes.rs` failure on `main`)
- [x] I have run `cargo test --workspace`
- [ ] I have updated documentation as needed (not applicable)
- [x] I have added tests for new functionality

### What is verified, and what is not

**Verified by tests.** Six unit tests on the policy in `gst::keyframe_request`, which is deliberately written to be testable without a pipeline (`wait` and `send` are injected): a healthy session is never asked; video arriving during the first wait stops it before any request; one successful request stops the loop; an unresponsive publisher gets exactly the configured number of attempts; there is one wait per attempt and none after the last. `cargo test --package strom`: 522 unit tests and all integration tests pass, including `pipeline_lifecycle_test`.

**Verified on a real publish.** A `whipclientsink` publish on macOS: zero keyframe requests sent, video pad linked, pipeline PLAYING, GL bridge active, no codec errors. This is the important negative check — the healthy path is untouched and pays nothing.

**Verified manually by the maintainer.** Repeated browser publish/view cycles, all behaving as expected.

**Not verified.** In one instrumented run, four sessions that lived 20–30 seconds were asked five times and video never started. Those are unexplained: `pad.send_event()`'s return value is not logged, so it is not known whether the force-key-unit reached something that turns it into a PLI, or whether the publisher ignored it. Worth knowing before treating this as a complete fix for every instance of the stall. Relevant detail found while diagnosing: `webrtcsrc`'s own `CustomUpstream` handling forwards such events over a gst-plugins-rs control data channel, which a browser does not speak — the PLI, if it happens, comes from the event continuing upstream into `webrtcbin`'s `rtpsession`, which was not confirmed at the protocol level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)