### PR TITLE
fix(api): return a JSON 404 for unmatched /api/* paths

### DIFF
--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -19,3 +19,28 @@ pub mod vision_mixer_page;
 pub mod websocket;
 pub mod whep_player;
 pub mod whip_ingest;
+
+use axum::{
+    extract::OriginalUri,
+    http::{Method, StatusCode},
+    Json,
+};
+use strom_types::api::ErrorResponse;
+
+/// Fallback for unmatched `/api/*` paths.
+///
+/// Without this the top-level SPA fallback answers with `200 OK` and the frontend
+/// HTML document, which makes a missing route look like a successful call to any
+/// client that only checks the status code.
+pub async fn not_found(
+    method: Method,
+    OriginalUri(uri): OriginalUri,
+) -> (StatusCode, Json<ErrorResponse>) {
+    (
+        StatusCode::NOT_FOUND,
+        Json(ErrorResponse::with_details(
+            "API endpoint not found",
+            format!("No API route matches {} {}", method, uri.path()),
+        )),
+    )
+}

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -459,9 +459,13 @@ pub async fn create_app_with_config(
     let mcp_sessions = mcp::McpSessionManager::new();
 
     // Combine routers with auth config and MCP session manager extensions
+    // The API router carries its own fallback so that unmatched /api/* paths get a
+    // JSON 404 instead of inheriting the outer SPA fallback (which would answer 200
+    // with the frontend HTML).
     let api_router = Router::new()
         .merge(public_api_router)
         .merge(protected_api_router)
+        .fallback(api::not_found)
         .layer(Extension(auth_config.clone()))
         .layer(Extension(mcp_sessions));
 

--- a/backend/tests/api_not_found_test.rs
+++ b/backend/tests/api_not_found_test.rs
@@ -1,0 +1,100 @@
+//! Regression test for issue #692.
+//!
+//! Unmatched `/api/*` paths used to fall through to the SPA catch-all and answer
+//! `200 OK` with the frontend HTML document, so an API client that only checks the
+//! status code recorded a success for a route that does not exist in the running
+//! build. They must return a JSON 404 instead, while non-`/api/` paths keep being
+//! served by the SPA fallback so deep links continue to work.
+
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+    Router,
+};
+use strom_types::api::ErrorResponse;
+use tower::ServiceExt; // for `oneshot`
+
+async fn create_test_app() -> Router {
+    use strom::create_app;
+
+    gstreamer::init().unwrap();
+    create_app().await
+}
+
+#[tokio::test]
+async fn unmatched_api_path_returns_json_404() {
+    let app = create_test_app().await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/this/route/does/not/exist")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+    let content_type = response
+        .headers()
+        .get(axum::http::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default()
+        .to_string();
+    assert!(
+        content_type.starts_with("application/json"),
+        "expected a JSON body, got content-type {content_type}"
+    );
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let error: ErrorResponse =
+        serde_json::from_slice(&body).expect("body must be an ErrorResponse");
+    assert!(!error.error.is_empty());
+    // The details carry the full path, not the prefix-stripped one the nested
+    // router sees internally.
+    assert!(
+        error
+            .details
+            .as_deref()
+            .unwrap_or_default()
+            .contains("/api/this/route/does/not/exist"),
+        "details should name the requested path, got {:?}",
+        error.details
+    );
+}
+
+#[tokio::test]
+async fn unmatched_non_api_path_still_serves_the_spa() {
+    let app = create_test_app().await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/some/deep/spa/link")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // The frontend bundle is only embedded when `backend/dist/` has been built, so
+    // accept either the SPA document or the plain 404 from an unbuilt frontend.
+    // What must never happen is this path being answered by the API 404 handler.
+    let status = response.status();
+    let content_type = response
+        .headers()
+        .get(axum::http::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default()
+        .to_string();
+
+    assert!(
+        !content_type.starts_with("application/json"),
+        "non-API deep links must not be answered by the API 404 handler (status {status}, \
+         content-type {content_type})"
+    );
+}


### PR DESCRIPTION
Fixes #692.

## Problem

`GET /api/system/clock` on a build without that route returned `200 OK` and the
frontend HTML document: `.nest("/api", api_router)` had no fallback of its own, so
unmatched `/api/*` paths inherited the outer `.fallback(assets::serve_static)`, which
serves `index.html` at 200 for any path it cannot resolve to an embedded asset. A
client that checks the status code saw success for a route that does not exist.

## Change

- `api::not_found` — a fallback handler returning 404 with the existing `ErrorResponse`
  shape. It uses `OriginalUri` so the details name the full path (`/api/...`) rather
  than the prefix-stripped path the nested router sees internally.
- `api_router` gets `.fallback(api::not_found)`. Per axum's documented nesting rules, a
  nested router with its own fallback does not inherit the outer one, so only
  non-`/api/` paths now reach the SPA handler.

Option 1 from the issue. The static-asset handler stays unaware of the `/api` routing
convention, and 404 handling lives in the API layer where `ErrorResponse` already does.

## Behaviour change

Clients that today tolerate 200 + HTML for a route missing from their target build will
start seeing 404. That is the point of the fix, but it is a real difference — monitoring
probes and integration tests asserting on status alone are the ones affected.

## Tests

New `backend/tests/api_not_found_test.rs`, both tests run locally and pass:

- `unmatched_api_path_returns_json_404` — `GET /api/this/route/does/not/exist` is 404,
  `application/json`, deserializes as `ErrorResponse`, details contain the full path.
  Verified as a guard: with `.fallback(api::not_found)` removed it fails with 200 vs 404.
- `unmatched_non_api_path_still_serves_the_spa` — an unmatched deep link is not answered
  by the API 404 handler, which is what stops an overcorrection from breaking SPA routing.
  It asserts on content-type rather than a 200, because `backend/dist/` is not always
  built in a test environment.

Also ran `cargo test --test api_tests --test openapi_test` (all pass), `cargo fmt --check`
and `cargo clippy --all-targets` (clean). The rest of the suite was not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)