### PR TITLE
fix(efpsrt): expose EFP's embedded-data channel as block pads

### DIFF
--- a/backend/src/blocks/builtin/efpsrt.rs
+++ b/backend/src/blocks/builtin/efpsrt.rs
@@ -7,6 +7,7 @@
 //! - Dynamic parser insertion for video (h264parse/h265parse with config-interval=1)
 //! - Dynamic audio chain: supports raw audio (encodes to Opus) and encoded formats
 //! - Configurable inputs: 1 video input + 1-32 audio inputs (default: 1 audio)
+//! - Optional embedded-data inputs carried on EFP's `embed_%u` pads (default: 0)
 //! - SRT with auto-reconnect and configurable latency
 //! - Configurable MTU for EFP fragmentation
 //!
@@ -61,6 +62,15 @@ impl BlockBuilder for EfpSrtOutputBuilder {
             })
             .unwrap_or(1);
 
+        let num_data_tracks = properties
+            .get("num_data_tracks")
+            .and_then(|v| match v {
+                PropertyValue::UInt(u) => Some(*u as usize),
+                PropertyValue::Int(i) => Some(*i as usize),
+                _ => None,
+            })
+            .unwrap_or(0);
+
         let mut inputs = Vec::new();
 
         for i in 0..num_video_tracks {
@@ -87,6 +97,16 @@ impl BlockBuilder for EfpSrtOutputBuilder {
                 name: format!("audio_in_{}", i),
                 media_type: MediaType::Audio,
                 internal_element_id: format!("audio_input_{}", i),
+                internal_pad_name: "sink".to_string(),
+            });
+        }
+
+        for i in 0..num_data_tracks {
+            inputs.push(ExternalPad {
+                label: Some(format!("D{}", i)),
+                name: format!("data_in_{}", i),
+                media_type: MediaType::Generic,
+                internal_element_id: format!("data_input_{}", i),
                 internal_pad_name: "sink".to_string(),
             });
         }
@@ -173,6 +193,15 @@ impl BlockBuilder for EfpSrtOutputBuilder {
             })
             .unwrap_or(1);
 
+        let num_data_tracks = properties
+            .get("num_data_tracks")
+            .and_then(|v| match v {
+                PropertyValue::UInt(u) => Some(*u as usize),
+                PropertyValue::Int(i) => Some(*i as usize),
+                _ => None,
+            })
+            .unwrap_or(0);
+
         // Create efpmux
         let mux_id = format!("{}:efpmux", instance_id);
         let mux = gst::ElementFactory::make("efpmux")
@@ -218,9 +247,64 @@ impl BlockBuilder for EfpSrtOutputBuilder {
             );
         }
 
+        // Embedded-data inputs. Unlike video and audio these need no codec
+        // detection, so the embed pad is requested up front instead of from a
+        // caps probe. Addressing is caps-driven: efpmux takes `stream-id` and
+        // `data-type` from the caps on this pad, so the caller sends
+        // application/x-efp-embedded caps carrying both. Embedded data is
+        // prepended to the next frame of the media stream with the same
+        // `stream-id`, so data addressed to a stream that carries no media
+        // never leaves the muxer.
+        let mut data_elements = Vec::new();
+        for i in 0..num_data_tracks {
+            let data_input_id = format!("{}:data_input_{}", instance_id, i);
+            let data_input = gst::ElementFactory::make("identity")
+                .name(&data_input_id)
+                .build()
+                .map_err(|e| {
+                    BlockBuildError::ElementCreation(format!("data identity {}: {}", i, e))
+                })?;
+
+            let pad_template = mux.pad_template("embed_%u").ok_or_else(|| {
+                BlockBuildError::ElementCreation(
+                    "efpmux has no embed_%u pad template (requires gst-plugin-efp >= 0.3.0)"
+                        .to_string(),
+                )
+            })?;
+
+            // Name the pad explicitly: efpmux's default name is derived from the
+            // caps stream-id, which is still 0 at request time, so every track
+            // would ask for embed_0 and the second request would fail.
+            let embed_pad = mux
+                .request_pad(&pad_template, Some(&format!("embed_{}", i)), None)
+                .ok_or_else(|| {
+                    BlockBuildError::ElementCreation(format!(
+                        "failed to request embed pad {} from efpmux",
+                        i
+                    ))
+                })?;
+
+            let data_src = data_input.static_pad("src").ok_or_else(|| {
+                BlockBuildError::ElementCreation(format!("data identity {} has no src pad", i))
+            })?;
+
+            data_src.link(&embed_pad).map_err(|e| {
+                BlockBuildError::LinkError(format!("data input {} -> efpmux: {:?}", i, e))
+            })?;
+
+            info!(
+                "EFP data input {}: linked to efpmux ({})",
+                i,
+                embed_pad.name()
+            );
+
+            data_elements.push((data_input_id, data_input));
+        }
+
         let mut internal_links = vec![];
         let mux_weak = mux.downgrade();
         let mut elements = vec![(mux_id.clone(), mux), (sink_id.clone(), srtsink)];
+        elements.extend(data_elements);
 
         // Create video input chains with dynamic parser insertion
         if num_video_tracks > 0 {
@@ -549,8 +633,8 @@ impl BlockBuilder for EfpSrtOutputBuilder {
         ));
 
         info!(
-            "Created EFP/SRT block with {} video track(s) and {} audio chain(s)",
-            num_video_tracks, num_audio_tracks
+            "Created EFP/SRT block with {} video track(s), {} audio chain(s) and {} data track(s)",
+            num_video_tracks, num_audio_tracks, num_data_tracks
         );
 
         Ok(BlockBuildResult {
@@ -775,6 +859,20 @@ fn efpsrt_output_definition() -> BlockDefinition {
                 mapping: PropertyMapping {
                     element_id: "_block".to_string(),
                     property_name: "num_audio_tracks".to_string(),
+                    transform: None,
+                },
+                live: false,
+                persist: None,
+            },
+            ExposedProperty {
+                name: "num_data_tracks".to_string(),
+                label: "Number of Data Tracks".to_string(),
+                description: "Number of EFP embedded-data input tracks (default: 0). Each track maps to an efpmux 'embed_%u' pad. The connected source must send 'application/x-efp-embedded' caps carrying 'data-type' and 'stream-id'; data is delivered alongside the media stream with the matching stream-id.".to_string(),
+                property_type: PropertyType::UInt,
+                default_value: Some(PropertyValue::UInt(0)),
+                mapping: PropertyMapping {
+                    element_id: "_block".to_string(),
+                    property_name: "num_data_tracks".to_string(),
                     transform: None,
                 },
                 live: false,

--- a/backend/src/blocks/builtin/efpsrt.rs
+++ b/backend/src/blocks/builtin/efpsrt.rs
@@ -36,6 +36,20 @@ use std::sync::Arc;
 use strom_types::{block::*, element::ElementPadRef, PropertyValue, *};
 use tracing::{debug, error, info, warn};
 
+/// Read a track-count property, returning `None` when it is absent, not a
+/// number, or negative, so the caller applies its own default.
+///
+/// `usize::try_from` rather than `as usize`: every track count feeds a
+/// `for i in 0..n` loop that allocates an element per iteration, and a negative
+/// `Int` cast with `as` becomes `usize::MAX`.
+pub fn track_count(properties: &HashMap<String, PropertyValue>, name: &str) -> Option<usize> {
+    properties.get(name).and_then(|v| match v {
+        PropertyValue::UInt(u) => usize::try_from(*u).ok(),
+        PropertyValue::Int(i) => usize::try_from(*i).ok(),
+        _ => None,
+    })
+}
+
 /// EFP/SRT Output block builder.
 pub struct EfpSrtOutputBuilder;
 
@@ -44,32 +58,11 @@ impl BlockBuilder for EfpSrtOutputBuilder {
         &self,
         properties: &HashMap<String, PropertyValue>,
     ) -> Option<ExternalPads> {
-        let num_video_tracks = properties
-            .get("num_video_tracks")
-            .and_then(|v| match v {
-                PropertyValue::UInt(u) => Some(*u as usize),
-                PropertyValue::Int(i) => Some(*i as usize),
-                _ => None,
-            })
-            .unwrap_or(1);
+        let num_video_tracks = track_count(properties, "num_video_tracks").unwrap_or(1);
 
-        let num_audio_tracks = properties
-            .get("num_audio_tracks")
-            .and_then(|v| match v {
-                PropertyValue::UInt(u) => Some(*u as usize),
-                PropertyValue::Int(i) => Some(*i as usize),
-                _ => None,
-            })
-            .unwrap_or(1);
+        let num_audio_tracks = track_count(properties, "num_audio_tracks").unwrap_or(1);
 
-        let num_data_tracks = properties
-            .get("num_data_tracks")
-            .and_then(|v| match v {
-                PropertyValue::UInt(u) => Some(*u as usize),
-                PropertyValue::Int(i) => Some(*i as usize),
-                _ => None,
-            })
-            .unwrap_or(0);
+        let num_data_tracks = track_count(properties, "num_data_tracks").unwrap_or(0);
 
         let mut inputs = Vec::new();
 
@@ -175,32 +168,11 @@ impl BlockBuilder for EfpSrtOutputBuilder {
             })
             .unwrap_or(DEFAULT_EFP_MTU);
 
-        let num_video_tracks = properties
-            .get("num_video_tracks")
-            .and_then(|v| match v {
-                PropertyValue::UInt(u) => Some(*u as usize),
-                PropertyValue::Int(i) => Some(*i as usize),
-                _ => None,
-            })
-            .unwrap_or(1);
+        let num_video_tracks = track_count(properties, "num_video_tracks").unwrap_or(1);
 
-        let num_audio_tracks = properties
-            .get("num_audio_tracks")
-            .and_then(|v| match v {
-                PropertyValue::UInt(u) => Some(*u as usize),
-                PropertyValue::Int(i) => Some(*i as usize),
-                _ => None,
-            })
-            .unwrap_or(1);
+        let num_audio_tracks = track_count(properties, "num_audio_tracks").unwrap_or(1);
 
-        let num_data_tracks = properties
-            .get("num_data_tracks")
-            .and_then(|v| match v {
-                PropertyValue::UInt(u) => Some(*u as usize),
-                PropertyValue::Int(i) => Some(*i as usize),
-                _ => None,
-            })
-            .unwrap_or(0);
+        let num_data_tracks = track_count(properties, "num_data_tracks").unwrap_or(0);
 
         // Create efpmux
         let mux_id = format!("{}:efpmux", instance_id);
@@ -867,7 +839,7 @@ fn efpsrt_output_definition() -> BlockDefinition {
             ExposedProperty {
                 name: "num_data_tracks".to_string(),
                 label: "Number of Data Tracks".to_string(),
-                description: "Number of EFP embedded-data input tracks (default: 0). Each track maps to an efpmux 'embed_%u' pad. The connected source must send 'application/x-efp-embedded' caps carrying 'data-type' and 'stream-id'; data is delivered alongside the media stream with the matching stream-id.".to_string(),
+                description: "Number of EFP embedded-data input tracks (default: 0). Each track maps to an efpmux 'embed_%u' pad. The connected source must send 'application/x-efp-embedded' caps carrying 'data-type' and 'stream-id'. Both fields default to 0 when omitted rather than failing, and stream-id 0 is reserved: data addressed to it, or to any stream-id that carries no media, is buffered by the muxer and never sent. Media stream-ids are allocated from 1 in pad order, so the video track is 1 and audio tracks follow.".to_string(),
                 property_type: PropertyType::UInt,
                 default_value: Some(PropertyValue::UInt(0)),
                 mapping: PropertyMapping {

--- a/backend/src/blocks/builtin/efpsrt_input.rs
+++ b/backend/src/blocks/builtin/efpsrt_input.rs
@@ -1,7 +1,8 @@
 //! EFP over SRT input block builder.
 //!
 //! This block receives an SRT stream carrying EFP (Elastic Frame Protocol) and demuxes
-//! it into separate video and audio output pads.
+//! it into separate video and audio output pads, plus an optional embedded-data
+//! output carrying efpdemux's `embedded` pad (default: 0 data tracks).
 //!
 //! Pipeline structure (decode=true, default):
 //! ```text
@@ -32,6 +33,9 @@ use std::sync::Arc;
 use strom_types::{block::*, element::ElementPadRef, FlowId, PropertyValue, *};
 use tracing::{debug, error, warn};
 
+/// Caps name of `efpdemux`'s embedded-data src pad.
+const EFP_EMBEDDED_CAPS_NAME: &str = "application/x-efp-embedded";
+
 /// EFP/SRT Input block builder.
 pub struct EfpSrtInputBuilder;
 
@@ -57,6 +61,15 @@ impl BlockBuilder for EfpSrtInputBuilder {
                 _ => None,
             })
             .unwrap_or(1);
+
+        let num_data_tracks = properties
+            .get("num_data_tracks")
+            .and_then(|v| match v {
+                PropertyValue::UInt(u) => Some(*u as usize),
+                PropertyValue::Int(i) => Some(*i as usize),
+                _ => None,
+            })
+            .unwrap_or(0);
 
         let mut outputs = Vec::new();
 
@@ -84,6 +97,16 @@ impl BlockBuilder for EfpSrtInputBuilder {
                 name: format!("audio_out_{}", i),
                 media_type: MediaType::Audio,
                 internal_element_id: format!("audio_output_{}", i),
+                internal_pad_name: "src".to_string(),
+            });
+        }
+
+        for i in 0..num_data_tracks {
+            outputs.push(ExternalPad {
+                label: Some(format!("D{}", i)),
+                name: format!("data_out_{}", i),
+                media_type: MediaType::Generic,
+                internal_element_id: format!("data_output_{}", i),
                 internal_pad_name: "src".to_string(),
             });
         }
@@ -179,6 +202,15 @@ impl BlockBuilder for EfpSrtInputBuilder {
                 _ => None,
             })
             .unwrap_or(1);
+
+        let num_data_tracks = properties
+            .get("num_data_tracks")
+            .and_then(|v| match v {
+                PropertyValue::UInt(u) => Some(*u as usize),
+                PropertyValue::Int(i) => Some(*i as usize),
+                _ => None,
+            })
+            .unwrap_or(0);
 
         // Create srtsrc
         let src_id = format!("{}:srtsrc", instance_id);
@@ -294,6 +326,23 @@ impl BlockBuilder for EfpSrtInputBuilder {
             elements.push((element_id, identity));
         }
 
+        // Create embedded-data output identity elements. efpdemux exposes a
+        // single `embedded` src pad for all data types, so only the first of
+        // these is ever linked.
+        let mut data_guards = Vec::new();
+        for i in 0..num_data_tracks {
+            let element_id = format!("{}:data_output_{}", instance_id, i);
+            let identity = gst::ElementFactory::make("identity")
+                .name(&element_id)
+                .build()
+                .map_err(|e| {
+                    BlockBuildError::ElementCreation(format!("data identity {}: {}", i, e))
+                })?;
+            let guard = Arc::new(AtomicBool::new(false));
+            data_guards.push((identity.downgrade(), guard));
+            elements.push((element_id, identity));
+        }
+
         // Setup dynamic pad linking on efpdemux pad-added.
         // - decode mode: video via h264parse + decoder, audio via opusdec + audioconvert + audioresample.
         // - passthrough mode: video via h264parse, audio linked directly.
@@ -325,6 +374,10 @@ impl BlockBuilder for EfpSrtInputBuilder {
             let is_audio = caps_name
                 .as_ref()
                 .map(|n| n.starts_with("audio/"))
+                .unwrap_or(false);
+            let is_data = caps_name
+                .as_deref()
+                .map(|n| n == EFP_EMBEDDED_CAPS_NAME)
                 .unwrap_or(false);
 
             debug!(
@@ -424,6 +477,43 @@ impl BlockBuilder for EfpSrtInputBuilder {
                 }
                 warn!(
                     "EFPSRT Input {}: No available audio output for pad {}",
+                    instance_id_clone, pad_name
+                );
+            } else if is_data {
+                // Embedded data is opaque bytes — nothing to parse or decode in
+                // either mode, so it is always linked straight through.
+                for (weak_identity, guard) in &data_guards {
+                    if guard.swap(true, Ordering::SeqCst) {
+                        continue;
+                    }
+
+                    if let Some(identity) = weak_identity.upgrade() {
+                        let sink_pad = match identity.static_pad("sink") {
+                            Some(p) => p,
+                            None => {
+                                guard.store(false, Ordering::SeqCst);
+                                continue;
+                            }
+                        };
+                        if let Err(e) = pad.link(&sink_pad) {
+                            error!(
+                                "EFPSRT Input {}: Failed to link embedded-data pad {}: {:?}",
+                                instance_id_clone, pad_name, e
+                            );
+                            guard.store(false, Ordering::SeqCst);
+                            continue;
+                        }
+                        debug!(
+                            "EFPSRT Input {}: Linked embedded-data pad {} -> {}",
+                            instance_id_clone,
+                            pad_name,
+                            identity.name()
+                        );
+                        return;
+                    }
+                }
+                warn!(
+                    "EFPSRT Input {}: No available data output for pad {}",
                     instance_id_clone, pad_name
                 );
             } else {
@@ -784,7 +874,22 @@ fn efpsrt_input_definition() -> BlockDefinition {
                 },
                 live: false,
                 persist: None,
-            },            ExposedProperty {
+            },
+            ExposedProperty {
+                name: "num_data_tracks".to_string(),
+                label: "Number of Data Tracks".to_string(),
+                description: "Number of EFP embedded-data output tracks (default: 0). efpdemux exposes a single 'embedded' pad carrying every data type, so only the first track is ever linked.".to_string(),
+                property_type: PropertyType::UInt,
+                default_value: Some(PropertyValue::UInt(0)),
+                mapping: PropertyMapping {
+                    element_id: "_block".to_string(),
+                    property_name: "num_data_tracks".to_string(),
+                    transform: None,
+                },
+                live: false,
+                persist: None,
+            },
+            ExposedProperty {
                 name: "srt_uri".to_string(),
                 label: "SRT URI".to_string(),
                 description: "SRT URI (e.g., 'srt://:4000?mode=listener' or 'srt://192.0.2.1:4000?mode=caller')".to_string(),

--- a/backend/src/blocks/builtin/efpsrt_input.rs
+++ b/backend/src/blocks/builtin/efpsrt_input.rs
@@ -23,6 +23,7 @@
 //! No videoconvert is inserted in the decoded video path to preserve GPU memory
 //! (e.g. CUDAMemory from nvh264dec) for downstream elements.
 
+use crate::blocks::builtin::efpsrt::track_count;
 use crate::blocks::{BlockBuildContext, BlockBuildError, BlockBuildResult, BlockBuilder};
 use crate::events::EventBroadcaster;
 use gstreamer as gst;
@@ -36,6 +37,16 @@ use tracing::{debug, error, warn};
 /// Caps name of `efpdemux`'s embedded-data src pad.
 const EFP_EMBEDDED_CAPS_NAME: &str = "application/x-efp-embedded";
 
+/// Data tracks this block can actually reach.
+///
+/// `efpdemux` caches a single `embedded` src pad and returns it for every data
+/// type, so a second data track would publish an output pad that can never
+/// carry a buffer. `build` rejects anything above this rather than clamping
+/// silently: a flow configured for two tracks behaving as one is the same
+/// surprise in a quieter voice. Raising the limit is the compatible direction,
+/// so this can be relaxed once `efpdemux` demultiplexes by stream ID.
+const MAX_DATA_TRACKS: usize = 1;
+
 /// EFP/SRT Input block builder.
 pub struct EfpSrtInputBuilder;
 
@@ -44,32 +55,11 @@ impl BlockBuilder for EfpSrtInputBuilder {
         &self,
         properties: &HashMap<String, PropertyValue>,
     ) -> Option<ExternalPads> {
-        let num_video_tracks = properties
-            .get("num_video_tracks")
-            .and_then(|v| match v {
-                PropertyValue::UInt(u) => Some(*u as usize),
-                PropertyValue::Int(i) => Some(*i as usize),
-                _ => None,
-            })
-            .unwrap_or(1);
+        let num_video_tracks = track_count(properties, "num_video_tracks").unwrap_or(1);
 
-        let num_audio_tracks = properties
-            .get("num_audio_tracks")
-            .and_then(|v| match v {
-                PropertyValue::UInt(u) => Some(*u as usize),
-                PropertyValue::Int(i) => Some(*i as usize),
-                _ => None,
-            })
-            .unwrap_or(1);
+        let num_audio_tracks = track_count(properties, "num_audio_tracks").unwrap_or(1);
 
-        let num_data_tracks = properties
-            .get("num_data_tracks")
-            .and_then(|v| match v {
-                PropertyValue::UInt(u) => Some(*u as usize),
-                PropertyValue::Int(i) => Some(*i as usize),
-                _ => None,
-            })
-            .unwrap_or(0);
+        let num_data_tracks = track_count(properties, "num_data_tracks").unwrap_or(0);
 
         let mut outputs = Vec::new();
 
@@ -101,7 +91,10 @@ impl BlockBuilder for EfpSrtInputBuilder {
             });
         }
 
-        for i in 0..num_data_tracks {
+        // Never advertise a data output the demuxer cannot feed. This signature
+        // cannot report an error, so an over-configured block shows only the
+        // pads that work here and is rejected in `build`.
+        for i in 0..num_data_tracks.min(MAX_DATA_TRACKS) {
             outputs.push(ExternalPad {
                 label: Some(format!("D{}", i)),
                 name: format!("data_out_{}", i),
@@ -185,32 +178,21 @@ impl BlockBuilder for EfpSrtInputBuilder {
             )));
         }
 
-        let num_video_tracks = properties
-            .get("num_video_tracks")
-            .and_then(|v| match v {
-                PropertyValue::UInt(u) => Some(*u as usize),
-                PropertyValue::Int(i) => Some(*i as usize),
-                _ => None,
-            })
-            .unwrap_or(1);
+        let num_video_tracks = track_count(properties, "num_video_tracks").unwrap_or(1);
 
-        let num_audio_tracks = properties
-            .get("num_audio_tracks")
-            .and_then(|v| match v {
-                PropertyValue::UInt(u) => Some(*u as usize),
-                PropertyValue::Int(i) => Some(*i as usize),
-                _ => None,
-            })
-            .unwrap_or(1);
+        let num_audio_tracks = track_count(properties, "num_audio_tracks").unwrap_or(1);
 
-        let num_data_tracks = properties
-            .get("num_data_tracks")
-            .and_then(|v| match v {
-                PropertyValue::UInt(u) => Some(*u as usize),
-                PropertyValue::Int(i) => Some(*i as usize),
-                _ => None,
-            })
-            .unwrap_or(0);
+        let num_data_tracks = track_count(properties, "num_data_tracks").unwrap_or(0);
+
+        if num_data_tracks > MAX_DATA_TRACKS {
+            return Err(BlockBuildError::InvalidConfiguration(format!(
+                "num_data_tracks is {}, but the EFP demuxer exposes a single embedded-data \
+                 pad shared by every data type, so at most {} data track can be received. \
+                 Split the streams across separate EFP inputs, or address several data types \
+                 over the one track.",
+                num_data_tracks, MAX_DATA_TRACKS
+            )));
+        }
 
         // Create srtsrc
         let src_id = format!("{}:srtsrc", instance_id);
@@ -326,9 +308,9 @@ impl BlockBuilder for EfpSrtInputBuilder {
             elements.push((element_id, identity));
         }
 
-        // Create embedded-data output identity elements. efpdemux exposes a
-        // single `embedded` src pad for all data types, so only the first of
-        // these is ever linked.
+        // Create embedded-data output identity elements. Capped at
+        // MAX_DATA_TRACKS above, so this builds at most one; the loop is kept
+        // so it needs no reshaping when efpdemux can demultiplex by stream ID.
         let mut data_guards = Vec::new();
         for i in 0..num_data_tracks {
             let element_id = format!("{}:data_output_{}", instance_id, i);
@@ -878,7 +860,7 @@ fn efpsrt_input_definition() -> BlockDefinition {
             ExposedProperty {
                 name: "num_data_tracks".to_string(),
                 label: "Number of Data Tracks".to_string(),
-                description: "Number of EFP embedded-data output tracks (default: 0). efpdemux exposes a single 'embedded' pad carrying every data type, so only the first track is ever linked.".to_string(),
+                description: "Number of EFP embedded-data output tracks: 0 or 1 (default: 0). efpdemux exposes a single 'embedded' pad carrying every data type, so a value above 1 is rejected rather than silently reduced.".to_string(),
                 property_type: PropertyType::UInt,
                 default_value: Some(PropertyValue::UInt(0)),
                 mapping: PropertyMapping {

--- a/backend/tests/efpsrt_embedded_data_test.rs
+++ b/backend/tests/efpsrt_embedded_data_test.rs
@@ -1,0 +1,233 @@
+//! Regression test for #691: EFP's embedded-data channel was unreachable from a flow.
+//!
+//! `efpmux` declares an `embed_%u` request sink pad and `efpdemux` a matching
+//! `embedded` src pad, but `builtin.efpsrt_output` / `builtin.efpsrt_input` only
+//! ever built video and audio pads, so neither end of that channel could be
+//! addressed.
+//!
+//! These tests drive the real block builders rather than reconstructing the
+//! topology inline. Without the fix `num_data_tracks` is ignored: no
+//! `data_input_*` / `data_output_*` element is created, no external data pad is
+//! reported and `efpmux` carries no `embed_%u` pad, so every assertion below
+//! fails.
+
+#![cfg(feature = "efp")]
+
+use gstreamer as gst;
+use gstreamer::prelude::*;
+use std::collections::HashMap;
+use strom::blocks::builtin::efpsrt::EfpSrtOutputBuilder;
+use strom::blocks::builtin::efpsrt_input::EfpSrtInputBuilder;
+use strom::blocks::{BlockBuildContext, BlockBuildResult, BlockBuilder};
+use strom_types::{MediaType, PropertyValue};
+
+const EMBED_TEMPLATE: &str = "embed_%u";
+
+fn init() {
+    let _ = gst::init();
+    let _ = gst_plugin_efp::plugin_register_static();
+}
+
+/// Fail loudly rather than skip: a test that silently skips on a missing element
+/// passes green and guards nothing.
+fn require_elements(names: &[&str]) {
+    for name in names {
+        assert!(
+            gst::ElementFactory::find(name).is_some(),
+            "GStreamer element '{}' is not available; the CI image needs the package that provides it",
+            name
+        );
+    }
+}
+
+fn context() -> BlockBuildContext {
+    BlockBuildContext::new(Vec::new(), "all".to_string())
+}
+
+fn properties(pairs: &[(&str, u64)]) -> HashMap<String, PropertyValue> {
+    pairs
+        .iter()
+        .map(|(k, v)| (k.to_string(), PropertyValue::UInt(*v)))
+        .collect()
+}
+
+fn element<'a>(result: &'a BlockBuildResult, id: &str) -> Option<&'a gst::Element> {
+    result
+        .elements
+        .iter()
+        .find(|(element_id, _)| element_id == id)
+        .map(|(_, element)| element)
+}
+
+fn embed_pads(mux: &gst::Element) -> Vec<gst::Pad> {
+    mux.pads()
+        .into_iter()
+        .filter(|pad| {
+            pad.pad_template()
+                .map(|templ| templ.name_template() == EMBED_TEMPLATE)
+                .unwrap_or(false)
+        })
+        .collect()
+}
+
+#[test]
+fn output_block_exposes_a_data_input_per_data_track() {
+    init();
+
+    let props = properties(&[("num_data_tracks", 2)]);
+    let pads = EfpSrtOutputBuilder
+        .get_external_pads(&props)
+        .expect("efpsrt_output should report external pads");
+
+    for i in 0..2 {
+        let name = format!("data_in_{}", i);
+        let pad = pads
+            .inputs
+            .iter()
+            .find(|pad| pad.name == name)
+            .unwrap_or_else(|| {
+                panic!(
+                    "expected external input pad '{}', got {:?}",
+                    name,
+                    pads.inputs.iter().map(|p| &p.name).collect::<Vec<_>>()
+                )
+            });
+
+        assert_eq!(
+            pad.media_type,
+            MediaType::Generic,
+            "embedded-data pads carry neither audio nor video"
+        );
+        assert_eq!(pad.internal_element_id, format!("data_input_{}", i));
+        assert_eq!(pad.internal_pad_name, "sink");
+    }
+}
+
+#[test]
+fn output_block_requests_and_links_an_embed_pad_per_data_track() {
+    init();
+    require_elements(&["efpmux", "srtsink", "identity"]);
+
+    let props = properties(&[
+        ("num_video_tracks", 0),
+        ("num_audio_tracks", 0),
+        ("num_data_tracks", 2),
+    ]);
+    let result = EfpSrtOutputBuilder
+        .build("blk", &props, &context())
+        .expect("efpsrt_output should build");
+
+    let mux = element(&result, "blk:efpmux").expect("block should contain an efpmux element");
+    let pads = embed_pads(mux);
+    assert_eq!(
+        pads.len(),
+        2,
+        "expected one '{}' pad per data track, got {:?}",
+        EMBED_TEMPLATE,
+        pads.iter()
+            .map(|p| p.name().to_string())
+            .collect::<Vec<_>>()
+    );
+
+    for i in 0..2 {
+        let id = format!("blk:data_input_{}", i);
+        let identity = element(&result, &id)
+            .unwrap_or_else(|| panic!("block should contain a '{}' element", id));
+
+        let src = identity
+            .static_pad("src")
+            .unwrap_or_else(|| panic!("'{}' should have a src pad", id));
+        let peer = src
+            .peer()
+            .unwrap_or_else(|| panic!("'{}' src pad should be linked to efpmux", id));
+
+        assert!(
+            pads.iter().any(|pad| pad == &peer),
+            "'{}' should link to an '{}' pad, but links to '{}'",
+            id,
+            EMBED_TEMPLATE,
+            peer.name()
+        );
+    }
+}
+
+#[test]
+fn output_block_requests_no_embed_pad_by_default() {
+    init();
+    require_elements(&["efpmux", "srtsink", "identity"]);
+
+    let result = EfpSrtOutputBuilder
+        .build("blk", &HashMap::new(), &context())
+        .expect("efpsrt_output should build with default properties");
+
+    let mux = element(&result, "blk:efpmux").expect("block should contain an efpmux element");
+    assert!(
+        embed_pads(mux).is_empty(),
+        "num_data_tracks defaults to 0, so an existing flow must be unchanged"
+    );
+    assert!(
+        element(&result, "blk:data_input_0").is_none(),
+        "num_data_tracks defaults to 0, so no data input element must be created"
+    );
+}
+
+#[test]
+fn input_block_exposes_a_data_output_per_data_track() {
+    init();
+
+    let props = properties(&[("num_data_tracks", 1)]);
+    let pads = EfpSrtInputBuilder
+        .get_external_pads(&props)
+        .expect("efpsrt_input should report external pads");
+
+    let pad = pads
+        .outputs
+        .iter()
+        .find(|pad| pad.name == "data_out_0")
+        .unwrap_or_else(|| {
+            panic!(
+                "expected external output pad 'data_out_0', got {:?}",
+                pads.outputs.iter().map(|p| &p.name).collect::<Vec<_>>()
+            )
+        });
+
+    assert_eq!(pad.media_type, MediaType::Generic);
+    assert_eq!(pad.internal_element_id, "data_output_0");
+    assert_eq!(pad.internal_pad_name, "src");
+}
+
+#[test]
+fn input_block_builds_a_data_output_element_per_data_track() {
+    init();
+    require_elements(&["efpdemux", "srtsrc", "identity"]);
+
+    let props = properties(&[
+        ("num_video_tracks", 0),
+        ("num_audio_tracks", 0),
+        ("num_data_tracks", 1),
+    ]);
+    let result = EfpSrtInputBuilder
+        .build("blk", &props, &context())
+        .expect("efpsrt_input should build");
+
+    assert!(
+        element(&result, "blk:data_output_0").is_some(),
+        "block should contain a 'blk:data_output_0' element, got {:?}",
+        result.elements.iter().map(|(id, _)| id).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn input_block_builds_no_data_output_by_default() {
+    init();
+    require_elements(&["efpdemux", "srtsrc", "identity"]);
+
+    let result = EfpSrtInputBuilder
+        .build("blk", &HashMap::new(), &context())
+        .expect("efpsrt_input should build with default properties");
+
+    assert!(
+        element(&result, "blk:data_output_0").is_none(),
+        "num_data_tracks defaults to 0, so no data output element must be created"
+    );
+}

--- a/backend/tests/efpsrt_embedded_data_test.rs
+++ b/backend/tests/efpsrt_embedded_data_test.rs
@@ -231,3 +231,68 @@ fn input_block_builds_no_data_output_by_default() {
         "num_data_tracks defaults to 0, so no data output element must be created"
     );
 }
+
+#[test]
+fn input_block_rejects_more_data_tracks_than_the_demuxer_can_reach() {
+    init();
+    require_elements(&["efpdemux", "srtsrc", "identity"]);
+
+    let props = properties(&[
+        ("num_video_tracks", 0),
+        ("num_audio_tracks", 0),
+        ("num_data_tracks", 2),
+    ]);
+    // `BlockBuildResult` is not `Debug`, so unwrap the error by hand.
+    let message = match EfpSrtInputBuilder.build("blk", &props, &context()) {
+        Ok(_) => panic!("efpdemux has one embedded pad, so two data tracks must not build"),
+        Err(e) => e.to_string(),
+    };
+    assert!(
+        message.contains("num_data_tracks"),
+        "the error must name the property the operator set, got: {}",
+        message
+    );
+}
+
+#[test]
+fn input_block_never_advertises_an_unreachable_data_output() {
+    init();
+
+    let props = properties(&[("num_data_tracks", 2)]);
+    let pads = EfpSrtInputBuilder
+        .get_external_pads(&props)
+        .expect("efpsrt_input should report external pads");
+
+    let data_pads = pads
+        .outputs
+        .iter()
+        .filter(|pad| pad.name.starts_with("data_out_"))
+        .map(|pad| pad.name.clone())
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        data_pads,
+        vec!["data_out_0".to_string()],
+        "a data output the demuxer can never feed must not appear in the flow graph"
+    );
+}
+
+/// Guards the `usize::try_from` conversion. Read with `as usize`, a negative
+/// `Int` becomes `usize::MAX` and drives the pad loops, so this asserts the
+/// value is discarded and the default applies instead.
+#[test]
+fn a_negative_track_count_falls_back_to_the_default() {
+    init();
+
+    for name in ["num_video_tracks", "num_audio_tracks", "num_data_tracks"] {
+        let props: HashMap<String, PropertyValue> =
+            [(name.to_string(), PropertyValue::Int(-1))].into();
+
+        assert_eq!(
+            strom::blocks::builtin::efpsrt::track_count(&props, name),
+            None,
+            "a negative {} must be discarded, not wrapped to usize::MAX",
+            name
+        );
+    }
+}


### PR DESCRIPTION
Class A — the test below fails without this fix.

Fixes #691

## Problem

EFP carries arbitrary non-audio, non-video data alongside the media, but neither EFP block
could address that channel.

Output side, `backend/src/blocks/builtin/efpsrt.rs:64` — `get_external_pads` builds its pad
list from the video and audio counts only, and nothing in `build()` ever asks `efpmux` for a
pad from its third template:

```rust
        let mut inputs = Vec::new();
```

Input side, `backend/src/blocks/builtin/efpsrt_input.rs:429` — the `pad-added` handler
classifies a demuxer pad by caps prefix (`video/`, `audio/`) and drops anything else. The
`embedded` pad's caps are `application/x-efp-embedded`, so it lands here and is discarded:

```rust
            } else {
                debug!(
                    "EFPSRT Input {}: Ignoring pad {} with caps {}",
```

The plugin side already exists. Re-read at the pinned tag (`backend/Cargo.toml:66` pins
`gst-plugin-efp` to `v0.3.0` = `fbb24bb`):

- `gst-plugin-efp/src/efpmux/imp.rs:316-327` declares an `embed_%u` **request sink** pad with
  caps `application/x-efp-embedded, data-type=[0,255], stream-id=[0,255]`.
- `gst-plugin-efp/src/efpdemux/imp.rs:298-309` declares a matching `embedded` **sometimes src**
  pad, created on demand by `get_or_create_embedded_pad` when data arrives.

## Change

`num_data_tracks` (default 0) on both blocks, per the design approved on the issue.

- **Output** — each track gets a `data_input_{i}` identity whose src pad is linked to an
  `embed_%u` pad requested from `efpmux`. External pad `data_in_{i}`, `MediaType::Generic`.
- **Input** — each track gets a `data_output_{i}` identity; the `pad-added` handler now also
  matches `application/x-efp-embedded` and links it straight through. External pad
  `data_out_{i}`, `MediaType::Generic`.

Two implementation points worth review:

1. **The embed pad is requested eagerly in `build()`**, not from a caps probe like the video and
   audio chains. Those probes exist to pick a parser from the negotiated codec; embedded data is
   opaque bytes, so there is nothing to detect and the graph can stay static.
2. **The pad is named explicitly** (`embed_{i}`). `efpmux`'s `request_embed_pad`
   (`efpmux/imp.rs:648`) defaults the name to `embed_{stream_id}`, and `stream_id` is still 0 at
   request time, so a second track would collide on `embed_0` and `add_pad` would fail.

Addressing is caps-driven, which is what the issue asked for ("the caller-set `data-type` and
`stream-id` on the pad caps"): `efpmux` updates the pad's `stream_id`/`data_type` from each Caps
event (`efpmux/imp.rs:660-670`), and the template declares both as `[0,255]` ranges
(`efpmux/imp.rs:316-318`).

**Correction (2026-08-26):** an earlier version of this body claimed the template makes both
fields *mandatory* so a caller "cannot leave them unset". That is weaker than stated: `efpmux`
reads both with `unwrap_or(0)` (`efpmux/imp.rs:640-644` and `:665-670`), so caps omitting a
field silently address `stream-id`/`data-type` 0 rather than failing. The recommendation is
unchanged (caps, not per-track properties) but the reason is narrower. **Open question for the maintainer:** the issue text also suggested
per-track `data-type`/`stream-id` *properties*. I did not add them — caps alone give the same
addressing without inventing a property-per-track scheme — but say the word and I will.

`MediaType::Generic` is used rather than a new `MediaType::Data` variant, as decided on the issue.

Option 2 from the triage (routing this through the existing `application/x-efp-private` essence
path) was rejected there: that path is the fallback for audio `efpmux` cannot encode to Opus, and
it gives neither `data-type` nor `stream-id` addressing.

## Evidence

`backend/tests/efpsrt_embedded_data_test.rs` drives the real builders — it calls
`EfpSrtOutputBuilder`/`EfpSrtInputBuilder` rather than reconstructing the topology inline, so it
fails if the wiring is reverted. It compiles against both commits, so the failure at commit 1 is a
failing assertion, not a build error.

The branch is deliberately two commits, and **the red check on commit 1 is the point** — it is
what proves the test guards the fix, not a broken PR:

| | commit | CI | result |
|---|---|---|---|
| 1 | `b85d5f3` test only | [32847244613](https://github.com/Eyevinn/strom/actions/runs/32847244613) | **failure** — `test result: FAILED. 2 passed; 4 failed` |
| 2 | `b7ed6eb` fix | [32847252378](https://github.com/Eyevinn/strom/actions/runs/32847252378) | **success** — `test result: ok. 6 passed; 0 failed` |

On commit 1 the only failing step is `Run tests on backend`; formatting, Clippy, the WASM build
and both Linux builds pass. The four failures are the assertions this PR is about, for example:

```
thread 'output_block_exposes_a_data_input_per_data_track' panicked at
backend/tests/efpsrt_embedded_data_test.rs:89:17:
expected external input pad 'data_in_0', got ["video_in", "audio_in_0"]
```

The two tests that pass at commit 1 are the default-value guards
(`*_no_embed_pad_by_default`, `*_no_data_output_by_default`) — they must pass on both commits,
since their job is to show an existing flow is unaffected.

On commit 2 all six pass:

```
running 6 tests
test input_block_exposes_a_data_output_per_data_track ... ok
test output_block_exposes_a_data_input_per_data_track ... ok
test input_block_builds_a_data_output_element_per_data_track ... ok
test output_block_requests_no_embed_pad_by_default ... ok
test output_block_requests_and_links_an_embed_pad_per_data_track ... ok
test input_block_builds_no_data_output_by_default ... ok
test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

Reproduce locally:

```
git checkout b85d5f3 && cargo test --features efp --test efpsrt_embedded_data_test   # fails
git checkout agent/fix-691-efp-embedded-data && cargo test --features efp --test efpsrt_embedded_data_test   # passes
```

Note on history: this branch was force-pushed twice. The earlier runs on `a46f8f7`/`c90c77d` and
`88988ef`/`81fcec0` are red for mistakes of mine in the test file — a `rustfmt` violation, then
`str::as_str()`, which is still unstable — not for anything about the change itself. Both are
fixed in the commits above. The commit contents are otherwise identical to the first push.

## Not verified

**I could not build or run anything in this run** — the agent runner has no `cargo` and no
GStreamer development environment (`cargo --version` and `pkg-config --modversion gstreamer-1.0`
both fail). Everything above rests on reading the code and the pinned plugin source; the CI runs
linked above are the only execution evidence, and every quoted line comes from those logs.

Specifically not covered:

- **No wire round trip.** Nothing here proves bytes pushed at `data_in_0` come back out of
  `data_out_0` on a real EFP stream. The tests assert graph structure (pads requested, elements
  created, links made), not data flow. Proving flow needs two pipelines joined over SRT, which is
  the manual check below.
- **Caps negotiation.** No test sends `application/x-efp-embedded` caps into the pad, so the
  claim that the template caps force `data-type`/`stream-id` to be set is read from the plugin
  source, not observed.
- **`stream-id` pairing.** `efpmux` buffers embedded data in `pending_embeds[stream_id]` and
  flushes it onto the next frame of the media stream with that id (`efpmux/imp.rs:504-511`).
  Sink pads are allocated ids from 1 upward. So data addressed to a `stream-id` that carries no
  media never leaves the muxer — untested, and a likely first thing to get wrong in practice.
- **Only one data output can ever link, now confirmed at the pinned tag rather than assumed.**
  `efpdemux` stores `embedded_pad: Mutex<Option<gst::Pad>>` (`efpdemux/imp.rs:144`) — a single
  `Option`, not a map — and `get_or_create_embedded_pad` (`:676-686`) returns that one pad,
  hard-named `"embedded"`, for every `data_type`. So `num_data_tracks > 1` on the **input** block
  publishes `data_out_1..data_out_{N-1}` that can never carry data, and the linking loop is dead
  past its first iteration. Reported by @borisasadanin in review and confirmed; **it needs a
  maintainer choice** between clamping the input side to 0/1 with an error above that, or renaming
  the input property so the asymmetry is visible in the API. Demuxing by `stream-id` into N pads
  is not available at `v0.3.0` and would need an `efpdemux` change. Not fixed in this PR.
- Two further `efpdemux` behaviours found in the same read: the `embedded` pad's caps are frozen
  at the first `data_type` seen (`:678-681` early-returns before `:696-699` could restamp), and
  the demux-side caps carry no `stream-id` field at all. Both are plugin behaviours, not
  introduced or fixable here.
- Frontend rendering of the new pads, `num_data_tracks > 2`, and non-zero data tracks combined
  with live video/audio traffic.
- macOS and Windows. Only the Linux CI job builds with `--features efp`.

Manual check that would settle the round trip:

```
efpsrt_output(num_data_tracks=1) --srt--> efpsrt_input(num_data_tracks=1)
```

with at least one video or audio track connected, feeding the data input caps
`application/x-efp-embedded, data-type=(int)7, stream-id=(int)1` and watching `data_out_0`.

## Blast radius

`get_external_pads` has exactly one production caller: `backend/src/api/flows.rs:222`, which
recomputes `computed_external_pads` for every block on `POST /api/flows` and then prunes links
pointing at pads that no longer exist. An existing stored flow has no `num_data_tracks` property,
so it reads as 0, no new pads appear and no links are pruned.

`build()` is called from the pipeline builder for `builtin.efpsrt_output` /
`builtin.efpsrt_input` only (`backend/src/blocks/builtin/mod.rs:161-163`, both behind
`#[cfg(feature = "efp")]`). With `num_data_tracks: 0` the new loops do not execute and the
element list, `internal_links` and every existing log line are unchanged.

The block definitions grow one `ExposedProperty` each, which shows up in `GET /api/blocks`
payload data. No schema type changed, so `openapi.json` is untouched. No `StromEvent`, no
`strom-types` addition, no dependency or feature change.

Configurations that change behaviour: only flows that explicitly set `num_data_tracks > 0`.

<!-- strom-agent protocol=v3 kind=fix issue=691 class=A -->

