### PR TITLE
fix(whip): default do_retransmission to false; correct the WHEP rationale

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,12 +26,12 @@ tokio-stream = { version = "0.1", features = ["sync"] }
 futures = "0.3"
 tower-http = { version = "0.7", features = ["fs", "cors", "trace"] }
 cairo-rs = { version = "0.22", features = ["v1_16"] }
-gstreamer = { version = "0.25", features = ["v1_20"] }
-gstreamer-app = { version = "0.25", features = ["v1_20"] }
-gstreamer-controller = { version = "0.25", features = ["v1_20"] }
-gstreamer-net = { version = "0.25", features = ["v1_20"] }
-gstreamer-gl = { version = "0.25", features = ["v1_20"] }
-gstreamer-video = { version = "0.25", features = ["v1_20"] }
+gstreamer = { version = "0.25", features = ["v1_22"] }
+gstreamer-app = { version = "0.25", features = ["v1_22"] }
+gstreamer-controller = { version = "0.25", features = ["v1_22"] }
+gstreamer-net = { version = "0.25", features = ["v1_22"] }
+gstreamer-gl = { version = "0.25", features = ["v1_22"] }
+gstreamer-video = { version = "0.25", features = ["v1_22"] }
 # gio 0.22 matches the glib 0.22 transitive that gstreamer 0.25 pulls in.
 # Used by the SRT stats parser to format peer GSocketAddress fields.
 gio = "0.22"

--- a/backend/src/blocks/builtin/recorder.rs
+++ b/backend/src/blocks/builtin/recorder.rs
@@ -17,6 +17,10 @@
 //! audio_in_N (identity) --[pad probe]--> [parser chain] --> splitmuxsink:audio_0..N
 //! ```
 //!
+//! The splitmuxsink sink pads are requested from inside those pad probes, not up front:
+//! splitmuxsink stalls forever if a requested pad is never fed, so a configured-but-
+//! unconnected track must not have a pad at all.
+//!
 //! Output files are written to: {media_path}/{output_dir}/{filename_prefix}_%05d.{ext}
 
 use crate::blocks::{BlockBuildContext, BlockBuildError, BlockBuildResult, BlockBuilder};
@@ -344,76 +348,31 @@ impl BlockBuilder for RecorderBuilder {
         let mut elements: Vec<(String, gst::Element)> =
             vec![(sink_id.clone(), splitmuxsink.clone())];
 
-        // --- Request pads from splitmuxsink ---
-        // All splitmuxsink sink pads are "On request". Pads must be requested before
-        // the pipeline starts; splitmuxsink manages them across file segments internally.
+        // --- splitmuxsink sink pads are requested lazily, from the caps probes below ---
+        //
+        // All splitmuxsink sink pads are "On request", but they must NOT be requested
+        // up front. splitmuxsink only releases a completed GOP once *every* requested
+        // sink pad has advanced to the start of the next GOP. A pad that is requested
+        // but never fed keeps its input running time at NONE forever, so the sink waits
+        // on it indefinitely and the recording stays empty.
+        //
+        // That means a track configured here but left unconnected — or connected but
+        // carrying a codec we cannot handle — must never get a pad. Each input chain
+        // therefore requests its pad from inside its caps probe, at the moment real
+        // data is known to be arriving.
         //
         // splitmuxsink pad templates:
         //   video           -> first video track (request_pad_simple)
         //   video_aux_%u    -> additional video tracks (request_pad via template)
         //   audio_%u        -> audio tracks (request_pad via template)
-        let video_aux_template = if num_video_tracks > 1 {
-            Some(splitmuxsink.pad_template("video_aux_%u").ok_or_else(|| {
-                BlockBuildError::ElementCreation(
-                    "splitmuxsink: no video_aux_%u pad template".to_string(),
-                )
-            })?)
-        } else {
-            None
-        };
-
-        let video_sink_pad_names: Vec<String> = (0..num_video_tracks)
-            .map(|i| {
-                let pad = if i == 0 {
-                    splitmuxsink.request_pad_simple("video").ok_or_else(|| {
-                        BlockBuildError::ElementCreation(
-                            "splitmuxsink: failed to request video pad".to_string(),
-                        )
-                    })?
-                } else {
-                    let tmpl = video_aux_template.as_ref().unwrap();
-                    splitmuxsink.request_pad(tmpl, None, None).ok_or_else(|| {
-                        BlockBuildError::ElementCreation(format!(
-                            "splitmuxsink: failed to request video_aux pad for track {}",
-                            i
-                        ))
-                    })?
-                };
-                debug!(
-                    "Recorder {}: requested splitmuxsink pad: {}",
-                    instance_id,
-                    pad.name()
-                );
-                Ok::<String, BlockBuildError>(pad.name().to_string())
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-
-        let audio_template = splitmuxsink.pad_template("audio_%u").ok_or_else(|| {
-            BlockBuildError::ElementCreation("splitmuxsink: no audio_%u pad template".to_string())
-        })?;
-
-        let audio_sink_pad_names: Vec<String> = (0..num_audio_tracks)
-            .map(|_| {
-                splitmuxsink
-                    .request_pad(&audio_template, None, None)
-                    .ok_or_else(|| {
-                        BlockBuildError::ElementCreation(
-                            "splitmuxsink: failed to request audio pad".to_string(),
-                        )
-                    })
-                    .map(|p| {
-                        debug!(
-                            "Recorder {}: requested splitmuxsink audio pad: {}",
-                            instance_id,
-                            p.name()
-                        );
-                        p.name().to_string()
-                    })
-            })
-            .collect::<Result<Vec<_>, _>>()?;
+        //
+        // Caveat: mp4mux/qtmux refuses request pads once it has started writing
+        // ("Not providing request pad after stream start"), so a track whose caps only
+        // arrive after the first GOP has been muxed cannot be added any more. Such a
+        // track is dropped with an error rather than stalling the whole recording.
 
         // --- Create video input chains ---
-        for (vi, video_sink_pad_name_for_chain) in video_sink_pad_names.iter().enumerate() {
+        for vi in 0..num_video_tracks {
             let video_input_id = format!("{}:video_input_{}", instance_id, vi);
             let video_input = gst::ElementFactory::make("identity")
                 .name(&video_input_id)
@@ -425,7 +384,6 @@ impl BlockBuilder for RecorderBuilder {
             let parser_inserted = Arc::new(AtomicBool::new(false));
             let splitmuxsink_weak = splitmuxsink.downgrade();
             let instance_id_clone = instance_id.to_string();
-            let video_sink_pad_name_clone = video_sink_pad_name_for_chain.clone();
 
             // Use a pad probe on the identity src pad to detect caps and insert parser
             let src_pad = video_input.static_pad("src").ok_or_else(|| {
@@ -539,15 +497,6 @@ impl BlockBuilder for RecorderBuilder {
                         }
                     };
 
-                    // Get the pre-requested video sink pad from splitmuxsink
-                    let sink_pad = match splitmuxsink.static_pad(&video_sink_pad_name_clone) {
-                        Some(p) => p,
-                        None => {
-                            error!("Recorder {}: could not find pad {} on splitmuxsink", instance_id_clone, video_sink_pad_name_clone);
-                            return gst::PadProbeReturn::Ok;
-                        }
-                    };
-
                     // Each splitmuxsink sink pad needs its own streaming thread. splitmuxsink
                     // blocks one input pad while waiting for the others to reach the next GOP
                     // boundary, so if two pads are fed by a single upstream streaming task (for
@@ -595,8 +544,40 @@ impl BlockBuilder for RecorderBuilder {
                         error!("Recorder {}: failed to link parser to video queue: {:?}", instance_id_clone, e);
                         return gst::PadProbeReturn::Ok;
                     }
+
+                    // Request the splitmuxsink pad only now that this track is known to
+                    // carry supported video — see the note above the input chains.
+                    let requested = if vi == 0 {
+                        splitmuxsink.request_pad_simple("video")
+                    } else {
+                        splitmuxsink
+                            .pad_template("video_aux_%u")
+                            .and_then(|tmpl| splitmuxsink.request_pad(&tmpl, None, None))
+                    };
+                    let sink_pad = match requested {
+                        Some(p) => p,
+                        None => {
+                            error!(
+                                "Recorder {}: splitmuxsink refused a sink pad for video track {}. \
+                                 If the muxer has already started writing it cannot accept new \
+                                 tracks (mp4mux), so this track will not be recorded.",
+                                instance_id_clone, vi
+                            );
+                            return gst::PadProbeReturn::Ok;
+                        }
+                    };
+                    debug!(
+                        "Recorder {}: requested splitmuxsink pad {} for video track {}",
+                        instance_id_clone,
+                        sink_pad.name(),
+                        vi
+                    );
+
                     if let Err(e) = queue_src.link(&sink_pad) {
                         error!("Recorder {}: failed to link video queue to splitmuxsink: {:?}", instance_id_clone, e);
+                        // Never leave a requested pad unlinked: splitmuxsink would wait on
+                        // it forever and the whole recording would stall.
+                        splitmuxsink.release_request_pad(&sink_pad);
                         return gst::PadProbeReturn::Ok;
                     }
 
@@ -609,8 +590,7 @@ impl BlockBuilder for RecorderBuilder {
         }
 
         // --- Create audio input chains ---
-        for (i, audio_sink_pad_name) in audio_sink_pad_names.iter().enumerate() {
-            let audio_sink_pad_name = audio_sink_pad_name.clone();
+        for i in 0..num_audio_tracks {
             let audio_input_id = format!("{}:audio_input_{}", instance_id, i);
             let audio_input = gst::ElementFactory::make("identity")
                 .name(&audio_input_id)
@@ -676,14 +656,6 @@ impl BlockBuilder for RecorderBuilder {
                         }
                     };
 
-                    let sink_pad = match splitmuxsink.static_pad(&audio_sink_pad_name) {
-                        Some(p) => p,
-                        None => {
-                            error!("Recorder {}: could not find {} on splitmuxsink", instance_id_clone, audio_sink_pad_name);
-                            return gst::PadProbeReturn::Ok;
-                        }
-                    };
-
                     // Only accept pre-encoded audio. Raw audio requires an encoder before the recorder.
                     if caps_name == "audio/x-raw" {
                         warn!(
@@ -711,6 +683,7 @@ impl BlockBuilder for RecorderBuilder {
 
                     // parser_factory is always Some here (unknown codecs returned early above)
                     let factory = parser_factory.unwrap();
+
                     let parser_name = format!("{}:audio_{}_parser", instance_id_clone, i);
                     let parser = match gst::ElementFactory::make(factory)
                         .name(&parser_name)
@@ -789,8 +762,39 @@ impl BlockBuilder for RecorderBuilder {
                         error!("Recorder {}: failed to link audio parser to audio queue: {:?}", instance_id_clone, e);
                         return gst::PadProbeReturn::Ok;
                     }
+
+                    // Request the splitmuxsink pad only now that this track is known to
+                    // carry supported audio — see the note above the input chains. The pad
+                    // is named after the input index so track order does not depend on the
+                    // order in which caps happen to arrive.
+                    let requested_name = format!("audio_{}", i);
+                    let requested = splitmuxsink.pad_template("audio_%u").and_then(|tmpl| {
+                        splitmuxsink.request_pad(&tmpl, Some(requested_name.as_str()), None)
+                    });
+                    let sink_pad = match requested {
+                        Some(p) => p,
+                        None => {
+                            error!(
+                                "Recorder {}: splitmuxsink refused a sink pad for audio track {}. \
+                                 If the muxer has already started writing it cannot accept new \
+                                 tracks (mp4mux), so this track will not be recorded.",
+                                instance_id_clone, i
+                            );
+                            return gst::PadProbeReturn::Ok;
+                        }
+                    };
+                    debug!(
+                        "Recorder {}: requested splitmuxsink pad {} for audio track {}",
+                        instance_id_clone,
+                        sink_pad.name(),
+                        i
+                    );
+
                     if let Err(e) = queue_src.link(&sink_pad) {
                         error!("Recorder {}: failed to link audio queue to splitmuxsink: {:?}", instance_id_clone, e);
+                        // Never leave a requested pad unlinked: splitmuxsink would wait on
+                        // it forever and the whole recording would stall.
+                        splitmuxsink.release_request_pad(&sink_pad);
                         return gst::PadProbeReturn::Ok;
                     }
                     info!("Recorder {}: audio_{} chain linked: identity -> {} -> queue -> splitmuxsink", instance_id_clone, i, factory);

--- a/backend/src/blocks/builtin/recorder.rs
+++ b/backend/src/blocks/builtin/recorder.rs
@@ -548,16 +548,59 @@ impl BlockBuilder for RecorderBuilder {
                         }
                     };
 
+                    // Each splitmuxsink sink pad needs its own streaming thread. splitmuxsink
+                    // blocks one input pad while waiting for the others to reach the next GOP
+                    // boundary, so if two pads are fed by a single upstream streaming task (for
+                    // example tsdemux in passthrough mode) the blocked pad holds the only thread
+                    // that could unblock it and the pipeline deadlocks. Default properties: the
+                    // only requirement here is thread decoupling.
+                    let queue_name = format!("{}:video_{}_queue", instance_id_clone, vi);
+                    let queue = match gst::ElementFactory::make("queue").name(&queue_name).build() {
+                        Ok(q) => q,
+                        Err(e) => {
+                            error!("Recorder {}: failed to create video queue: {}", instance_id_clone, e);
+                            return gst::PadProbeReturn::Ok;
+                        }
+                    };
+                    if let Err(e) = bin.add(&queue) {
+                        error!("Recorder {}: failed to add video queue to bin: {}", instance_id_clone, e);
+                        return gst::PadProbeReturn::Ok;
+                    }
+                    // Linked from a pad probe while the pipeline is already running, so the new
+                    // element's state has to be synced explicitly.
+                    if let Err(e) = queue.sync_state_with_parent() {
+                        error!("Recorder {}: failed to sync video queue state: {}", instance_id_clone, e);
+                        return gst::PadProbeReturn::Ok;
+                    }
+                    let queue_sink = match queue.static_pad("sink") {
+                        Some(p) => p,
+                        None => {
+                            error!("Recorder {}: video queue has no sink pad", instance_id_clone);
+                            return gst::PadProbeReturn::Ok;
+                        }
+                    };
+                    let queue_src = match queue.static_pad("src") {
+                        Some(p) => p,
+                        None => {
+                            error!("Recorder {}: video queue has no src pad", instance_id_clone);
+                            return gst::PadProbeReturn::Ok;
+                        }
+                    };
+
                     if let Err(e) = pad.link(&parser_sink) {
                         error!("Recorder {}: failed to link identity to parser: {:?}", instance_id_clone, e);
                         return gst::PadProbeReturn::Ok;
                     }
-                    if let Err(e) = parser_src.link(&sink_pad) {
-                        error!("Recorder {}: failed to link parser to splitmuxsink: {:?}", instance_id_clone, e);
+                    if let Err(e) = parser_src.link(&queue_sink) {
+                        error!("Recorder {}: failed to link parser to video queue: {:?}", instance_id_clone, e);
+                        return gst::PadProbeReturn::Ok;
+                    }
+                    if let Err(e) = queue_src.link(&sink_pad) {
+                        error!("Recorder {}: failed to link video queue to splitmuxsink: {:?}", instance_id_clone, e);
                         return gst::PadProbeReturn::Ok;
                     }
 
-                    info!("Recorder {}: video chain linked: identity -> {} -> splitmuxsink", instance_id_clone, parser_factory);
+                    info!("Recorder {}: video chain linked: identity -> {} -> queue -> splitmuxsink", instance_id_clone, parser_factory);
                     gst::PadProbeReturn::Ok
                 },
             );
@@ -703,15 +746,54 @@ impl BlockBuilder for RecorderBuilder {
                         }
                     };
 
+                    // See the video leg: one queue per splitmuxsink sink pad, so the pads do not
+                    // block each other on a shared upstream streaming thread. Default properties.
+                    let queue_name = format!("{}:audio_{}_queue", instance_id_clone, i);
+                    let queue = match gst::ElementFactory::make("queue").name(&queue_name).build() {
+                        Ok(q) => q,
+                        Err(e) => {
+                            error!("Recorder {}: failed to create audio queue: {}", instance_id_clone, e);
+                            return gst::PadProbeReturn::Ok;
+                        }
+                    };
+                    if let Err(e) = bin.add(&queue) {
+                        error!("Recorder {}: failed to add audio queue to bin: {}", instance_id_clone, e);
+                        return gst::PadProbeReturn::Ok;
+                    }
+                    // Linked from a pad probe while the pipeline is already running, so the new
+                    // element's state has to be synced explicitly.
+                    if let Err(e) = queue.sync_state_with_parent() {
+                        error!("Recorder {}: failed to sync audio queue state: {}", instance_id_clone, e);
+                        return gst::PadProbeReturn::Ok;
+                    }
+                    let queue_sink = match queue.static_pad("sink") {
+                        Some(p) => p,
+                        None => {
+                            error!("Recorder {}: audio queue has no sink pad", instance_id_clone);
+                            return gst::PadProbeReturn::Ok;
+                        }
+                    };
+                    let queue_src = match queue.static_pad("src") {
+                        Some(p) => p,
+                        None => {
+                            error!("Recorder {}: audio queue has no src pad", instance_id_clone);
+                            return gst::PadProbeReturn::Ok;
+                        }
+                    };
+
                     if let Err(e) = pad.link(&parser_sink) {
                         error!("Recorder {}: failed to link identity to audio parser: {:?}", instance_id_clone, e);
                         return gst::PadProbeReturn::Ok;
                     }
-                    if let Err(e) = parser_src.link(&sink_pad) {
-                        error!("Recorder {}: failed to link audio parser to splitmuxsink: {:?}", instance_id_clone, e);
+                    if let Err(e) = parser_src.link(&queue_sink) {
+                        error!("Recorder {}: failed to link audio parser to audio queue: {:?}", instance_id_clone, e);
                         return gst::PadProbeReturn::Ok;
                     }
-                    info!("Recorder {}: audio_{} chain linked: identity -> {} -> splitmuxsink", instance_id_clone, i, factory);
+                    if let Err(e) = queue_src.link(&sink_pad) {
+                        error!("Recorder {}: failed to link audio queue to splitmuxsink: {:?}", instance_id_clone, e);
+                        return gst::PadProbeReturn::Ok;
+                    }
+                    info!("Recorder {}: audio_{} chain linked: identity -> {} -> queue -> splitmuxsink", instance_id_clone, i, factory);
 
                     gst::PadProbeReturn::Ok
                 },

--- a/backend/src/blocks/builtin/whep.rs
+++ b/backend/src/blocks/builtin/whep.rs
@@ -168,6 +168,13 @@ fn explicit_track_count(properties: &HashMap<String, PropertyValue>, name: &str)
 }
 
 /// Parse do_retransmission from properties (default: true).
+///
+/// Unlike WHIP Input's identically named property, this one is *not* a
+/// workaround for gstreamer#5057. `whepserversink` is a send-only
+/// `webrtcsink`: the property maps to `do-nack` on a sendonly transceiver and
+/// to `rtprtxsend`, and no depayloader is ever instantiated on this path, so
+/// the crashing assertion is unreachable here. It is exposed purely as an
+/// ordinary bandwidth/quality tunable, and defaults to on.
 fn parse_do_retransmission(properties: &HashMap<String, PropertyValue>) -> bool {
     properties
         .get("do_retransmission")
@@ -1041,10 +1048,11 @@ fn build_whepserversink(
     // - RTX is reactive: it costs nothing while no packets are lost and only
     //   resends the exact packets the client NACKs. Without it, every loss
     //   escalates to PLI -> forced keyframe, which is far more expensive and
-    //   leaves the picture broken until the keyframe arrives. It can be
-    //   disabled as a workaround for a GStreamer bug where RTX combined with
-    //   RTP header-extension aggregation can crash the process (assertion in
-    //   gst_rtp_base_depayload_handle_buffer on priv->hdrext_buffers).
+    //   leaves the picture broken until the keyframe arrives, so it stays on
+    //   by default. It is exposed only so an operator can trade loss
+    //   resilience for a flat bitrate ceiling; disabling it here does nothing
+    //   for the RTX-related gst-plugins-base crash (gstreamer#5057), which
+    //   lives in a depayloader and so can only be hit on a receive path.
     whepserversink.set_property("do-fec", false);
     whepserversink.set_property("do-retransmission", do_retransmission);
 
@@ -2360,7 +2368,7 @@ fn whep_output_definition() -> BlockDefinition {
             ExposedProperty {
                 name: "do_retransmission".to_string(),
                 label: "Retransmission (RTX)".to_string(),
-                description: "Resend lost packets to viewers on request (NACK-based). Disable only for diagnostics — a known GStreamer bug can crash the process when RTX is combined with RTP header-extension aggregation; without it, packet loss forces a full keyframe request instead of a cheap resend.".to_string(),
+                description: "Resend lost packets to viewers on request (NACK-based). Disable only to cap the outgoing bitrate — without it, packet loss forces a full keyframe request instead of a cheap resend. This is a send-only path, so unlike the WHIP Input property of the same name it has no bearing on the RTX-related GStreamer depayloader crash.".to_string(),
                 property_type: PropertyType::Bool,
                 default_value: Some(PropertyValue::Bool(true)),
                 mapping: PropertyMapping {

--- a/backend/src/blocks/builtin/whep.rs
+++ b/backend/src/blocks/builtin/whep.rs
@@ -167,6 +167,17 @@ fn explicit_track_count(properties: &HashMap<String, PropertyValue>, name: &str)
     })
 }
 
+/// Parse do_retransmission from properties (default: true).
+fn parse_do_retransmission(properties: &HashMap<String, PropertyValue>) -> bool {
+    properties
+        .get("do_retransmission")
+        .and_then(|v| match v {
+            PropertyValue::Bool(b) => Some(*b),
+            _ => None,
+        })
+        .unwrap_or(true)
+}
+
 /// Migrate a legacy `mode` property on a WHEP Output block to explicit
 /// `num_audio_tracks` / `num_video_tracks` counts, and drop `mode`.
 ///
@@ -951,6 +962,8 @@ fn build_whepserversink(
         num_audio_tracks, num_video_tracks
     );
 
+    let do_retransmission = parse_do_retransmission(properties);
+
     // Timestamp offset in milliseconds. A negative value shifts playout earlier,
     // reducing end-to-end latency for this output while maintaining A/V sync.
     // Applied as ts-offset on clocksync and appsink inside whepserversink.
@@ -1021,16 +1034,19 @@ fn build_whepserversink(
         whepserversink.set_property("turn-servers", turn_servers);
     }
 
-    // Disable FEC but keep RTX (retransmission) enabled.
+    // Disable FEC but keep RTX (retransmission) configurable (default: on).
     // - FEC adds proactive redundancy packets on every stream (~50% constant
     //   overhead, near-double bandwidth for pre-encoded high-bitrate video),
     //   so it stays off.
     // - RTX is reactive: it costs nothing while no packets are lost and only
     //   resends the exact packets the client NACKs. Without it, every loss
     //   escalates to PLI -> forced keyframe, which is far more expensive and
-    //   leaves the picture broken until the keyframe arrives.
+    //   leaves the picture broken until the keyframe arrives. It can be
+    //   disabled as a workaround for a GStreamer bug where RTX combined with
+    //   RTP header-extension aggregation can crash the process (assertion in
+    //   gst_rtp_base_depayload_handle_buffer on priv->hdrext_buffers).
     whepserversink.set_property("do-fec", false);
-    whepserversink.set_property("do-retransmission", true);
+    whepserversink.set_property("do-retransmission", do_retransmission);
 
     // Access the signaller child and set its properties
     // Bind to localhost only - axum will proxy external requests
@@ -2341,6 +2357,20 @@ fn whep_output_definition() -> BlockDefinition {
                 live: false,
                 persist: None,
             },
+            ExposedProperty {
+                name: "do_retransmission".to_string(),
+                label: "Retransmission (RTX)".to_string(),
+                description: "Resend lost packets to viewers on request (NACK-based). Disable only for diagnostics — a known GStreamer bug can crash the process when RTX is combined with RTP header-extension aggregation; without it, packet loss forces a full keyframe request instead of a cheap resend.".to_string(),
+                property_type: PropertyType::Bool,
+                default_value: Some(PropertyValue::Bool(true)),
+                mapping: PropertyMapping {
+                    element_id: "_block".to_string(),
+                    property_name: "do_retransmission".to_string(),
+                    transform: None,
+                },
+                live: false,
+                persist: None,
+            },
         ],
         // Note: external_pads here are the static defaults (1 video + 1 audio).
         // The actual pads are determined dynamically by WHEPOutputBuilder::get_external_pads()
@@ -2414,6 +2444,36 @@ mod tests {
             .filter(|p| matches!(p.media_type, MediaType::Video))
             .map(|p| p.name.clone())
             .collect()
+    }
+
+    /// Build a property map from explicit key/value pairs, for tests of pure
+    /// parsing helpers that don't need the pad-count `props` helper above.
+    fn raw_props(entries: &[(&str, PropertyValue)]) -> HashMap<String, PropertyValue> {
+        entries
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.clone()))
+            .collect()
+    }
+
+    #[test]
+    fn do_retransmission_defaults_to_true() {
+        assert!(parse_do_retransmission(&raw_props(&[])));
+    }
+
+    #[test]
+    fn do_retransmission_respects_explicit_true() {
+        assert!(parse_do_retransmission(&raw_props(&[(
+            "do_retransmission",
+            PropertyValue::Bool(true)
+        )])));
+    }
+
+    #[test]
+    fn do_retransmission_respects_explicit_false() {
+        assert!(!parse_do_retransmission(&raw_props(&[(
+            "do_retransmission",
+            PropertyValue::Bool(false)
+        )])));
     }
 
     #[test]

--- a/backend/src/blocks/builtin/whip.rs
+++ b/backend/src/blocks/builtin/whip.rs
@@ -139,6 +139,28 @@ impl BlockBuilder for WHIPInputBuilder {
 // WHIP Input (whipserversrc - hosts WHIP server)
 // ============================================================================
 
+/// Parse do_retransmission from properties (default: true).
+fn parse_do_retransmission(properties: &HashMap<String, PropertyValue>) -> bool {
+    properties
+        .get("do_retransmission")
+        .and_then(|v| match v {
+            PropertyValue::Bool(b) => Some(*b),
+            _ => None,
+        })
+        .unwrap_or(true)
+}
+
+/// Parse jitterbuffer_latency_ms from properties (default: 400, negative clamps to 0).
+fn parse_jitterbuffer_latency_ms(properties: &HashMap<String, PropertyValue>) -> u32 {
+    properties
+        .get("jitterbuffer_latency_ms")
+        .and_then(|v| match v {
+            PropertyValue::Int(i) => Some((*i).max(0) as u32),
+            _ => None,
+        })
+        .unwrap_or(400)
+}
+
 /// Build WHIP Input per-slot output chains.
 ///
 /// At build time, per-slot chains are created in the main pipeline:
@@ -180,6 +202,16 @@ fn build_whipserversrc(
             _ => None,
         })
         .unwrap_or(true);
+
+    let do_retransmission = parse_do_retransmission(properties);
+
+    // Jitterbuffer latency: how long to buffer before dropping/releasing packets.
+    // Left unset, webrtcbin defaults to 200ms, which combined with
+    // drop-on-latency=true (below) can be too tight for an initial video
+    // keyframe's packet burst on a freshly-created per-session pipeline,
+    // causing the whole video stream to stall (never reaching decodebin)
+    // even though the packets arrived fine over the network.
+    let jitterbuffer_latency_ms = parse_jitterbuffer_latency_ms(properties);
 
     let max_video_bitrate_kbps = properties
         .get("max_video_bitrate")
@@ -368,24 +400,100 @@ fn build_whipserversrc(
                     ElementPadRef::pad(&decodebin_id, "sink"),
                 ));
 
-                // decodebin has dynamic pads — connect pad-added to link to videoconvert
+                // decodebin can autoplug a GL-accelerated decoder (e.g. vtdec_hw),
+                // producing video/x-raw(memory:GLMemory) frames instead of plain
+                // system-memory video/x-raw. videoconvert passes GL memory through
+                // unchanged rather than downloading it, and downstream consumers
+                // (encoders for WHEP Output, etc.) generally only accept
+                // system-memory video/x-raw — without a gldownload, encoding
+                // silently fails ("no codec present that can handle the stream's
+                // type"). A gldownload is only inserted when the negotiated pad
+                // caps actually carry GL memory: gldownload is a GstGLBaseFilter,
+                // which unconditionally requires a negotiated GL context to reach
+                // PLAYING, so inserting it unconditionally would impose a hard GL
+                // dependency on every session and break decode on GL-less hosts
+                // (headless servers, WSL, CPU-only fallback — see gpu.rs). If
+                // caps are ever unavailable, default to the non-GL path: skipping
+                // gldownload when it was needed reproduces the already-diagnosed
+                // GL-memory bug, but inserting it when not needed reproduces a
+                // newer, harder-to-diagnose GL-context failure — the former is
+                // the safer default.
                 let videoconvert_weak = videoconvert.downgrade();
+                let decodebin_weak = decodebin.downgrade();
+                let instance_id_for_pad = instance_id.to_string();
                 decodebin.connect_pad_added(move |_dec, src_pad| {
                     if src_pad.direction() != gst::PadDirection::Src {
                         return;
                     }
-                    if let Some(vc) = videoconvert_weak.upgrade() {
-                        let sink = vc.static_pad("sink").unwrap();
-                        if !sink.is_linked() {
-                            if let Err(e) = src_pad.link(&sink) {
-                                warn!("Failed to link decodebin video pad to videoconvert: {:?}", e);
-                            } else {
-                                info!(
-                                    "WHIP Input: decodebin video pad linked to videoconvert for slot {}",
-                                    slot
-                                );
-                            }
+                    let Some(vc) = videoconvert_weak.upgrade() else {
+                        return;
+                    };
+                    let sink = vc.static_pad("sink").unwrap();
+                    if sink.is_linked() {
+                        return;
+                    }
+
+                    let is_gl_memory = src_pad
+                        .current_caps()
+                        .map(|caps| caps.to_string().contains("memory:GLMemory"))
+                        .unwrap_or(false);
+
+                    if !is_gl_memory {
+                        if let Err(e) = src_pad.link(&sink) {
+                            warn!("Failed to link decodebin video pad to videoconvert: {:?}", e);
+                        } else {
+                            info!(
+                                "WHIP Input: decodebin video pad linked to videoconvert for slot {}",
+                                slot
+                            );
                         }
+                        return;
+                    }
+
+                    let Some(bin) = decodebin_weak
+                        .upgrade()
+                        .and_then(|dec| dec.parent())
+                        .and_then(|p| p.downcast::<gst::Bin>().ok())
+                    else {
+                        warn!("WHIP Input: decodebin has no parent bin, cannot insert gldownload for slot {}", slot);
+                        return;
+                    };
+
+                    let gldownload_id = format!("{}:gldownload_{}", instance_id_for_pad, slot);
+                    let gldownload = match gst::ElementFactory::make("gldownload")
+                        .name(&gldownload_id)
+                        .build()
+                    {
+                        Ok(e) => e,
+                        Err(e) => {
+                            warn!("WHIP Input: failed to create gldownload for slot {}: {:?}", slot, e);
+                            return;
+                        }
+                    };
+
+                    if let Err(e) = bin.add(&gldownload) {
+                        warn!("WHIP Input: failed to add gldownload to bin for slot {}: {:?}", slot, e);
+                        return;
+                    }
+
+                    let gldownload_src = gldownload.static_pad("src").unwrap();
+                    if let Err(e) = gldownload_src.link(&sink) {
+                        warn!("Failed to link gldownload -> videoconvert: {:?}", e);
+                        return;
+                    }
+                    if let Err(e) = gldownload.sync_state_with_parent() {
+                        warn!("WHIP Input: failed to sync gldownload state for slot {}: {:?}", slot, e);
+                        return;
+                    }
+
+                    let gldownload_sink = gldownload.static_pad("sink").unwrap();
+                    if let Err(e) = src_pad.link(&gldownload_sink) {
+                        warn!("Failed to link decodebin video pad to gldownload: {:?}", e);
+                    } else {
+                        info!(
+                            "WHIP Input: decodebin video pad carries GL memory, linked through gldownload for slot {}",
+                            slot
+                        );
                     }
                 });
 
@@ -415,8 +523,8 @@ fn build_whipserversrc(
     let turn_server = ctx.turn_server();
 
     info!(
-        "WHIP Input configured: endpoint_id='{}', stun={:?}, turn={:?}, mode={:?}, decode={}, max_sessions={} (whipserversrc created per-session)",
-        endpoint_id, stun_server, turn_server, mode, decode, max_sessions
+        "WHIP Input configured: endpoint_id='{}', stun={:?}, turn={:?}, mode={:?}, decode={}, do_retransmission={}, max_sessions={} (whipserversrc created per-session)",
+        endpoint_id, stun_server, turn_server, mode, decode, do_retransmission, max_sessions
     );
 
     // Register WHIP endpoint with the build context (port=0 placeholder, sessions get their own ports)
@@ -436,6 +544,8 @@ fn build_whipserversrc(
             ice_transport_policy: ctx.ice_transport_policy().to_string(),
             pipeline_weak: gst::glib::WeakRef::new(),
             decode,
+            do_retransmission,
+            jitterbuffer_latency_ms,
             dynamic_webrtcbin_store: ctx.dynamic_webrtcbin_store(),
             max_video_bitrate_kbps,
             max_sessions,
@@ -511,6 +621,8 @@ pub fn create_whipserversrc_for_session(
     let signaller = whipserversrc.property::<gst::glib::Object>("signaller");
     signaller.set_property("host-addr", &host_addr);
 
+    whipserversrc.set_property("do-retransmission", config.do_retransmission);
+
     // Configure codec negotiation based on mode
     if config.mode.has_audio() {
         let audio_codecs = gst::Array::new(["OPUS"]);
@@ -531,6 +643,7 @@ pub fn create_whipserversrc_for_session(
     let dynamic_webrtcbin_store = config.dynamic_webrtcbin_store.clone();
     let block_id_for_callback = config.instance_id.clone();
     let ice_transport_policy = config.ice_transport_policy.clone();
+    let jitterbuffer_latency_ms = config.jitterbuffer_latency_ms;
     // Flag to ensure only one cleanup request per session (shared across ICE callback,
     // inactivity watchdog, etc.)
     let cleanup_sent = Arc::new(AtomicBool::new(false));
@@ -559,6 +672,14 @@ pub fn create_whipserversrc_for_session(
                     info!(
                         "WHIP Input: Set ice-transport-policy={} on webrtcbin {}",
                         ice_transport_policy, element_name
+                    );
+                }
+
+                if element.has_property("latency") {
+                    element.set_property("latency", jitterbuffer_latency_ms);
+                    info!(
+                        "WHIP Input: Set jitterbuffer latency={}ms on webrtcbin {}",
+                        jitterbuffer_latency_ms, element_name
                     );
                 }
 
@@ -830,6 +951,41 @@ pub fn create_whipserversrc_for_session(
                     "WHIP Input: Pad {} (stream {}) → appsink → slot {} appsrc ({})",
                     pad_name, stream_num, slot, media_type
                 );
+
+                if media_type == "video" {
+                    // Proactively request a keyframe as soon as the video pad
+                    // connects, and keep retrying for a few seconds. Without
+                    // this, if the publisher's initial keyframe is
+                    // incomplete/lost before decodebin has a decoder element
+                    // to install the DISCONT-triggered recovery probe on (see
+                    // below), decodebin waits forever for a keyframe that
+                    // never arrives — a chicken-and-egg stall that's
+                    // otherwise invisible (packets keep flowing, just never a
+                    // usable one). With RTX disabled (see do_retransmission),
+                    // the keyframe response itself can also be lost with no
+                    // recovery, so a single request isn't reliable — retry a
+                    // few times, spaced out, until decode has had a fair
+                    // chance to succeed.
+                    let retry_pad = pad.clone();
+                    let retry_slot = slot;
+                    std::thread::Builder::new()
+                        .name(format!("whip-keyframe-retry-{}", retry_slot))
+                        .spawn(move || {
+                            for attempt in 0..5 {
+                                let fku = gst_video::UpstreamForceKeyUnitEvent::builder()
+                                    .all_headers(true)
+                                    .build();
+                                retry_pad.send_event(fku);
+                                info!(
+                                    "WHIP Input: Requested keyframe (PLI) on video pad for slot {} (attempt {})",
+                                    retry_slot,
+                                    attempt + 1
+                                );
+                                std::thread::sleep(std::time::Duration::from_millis(800));
+                            }
+                        })
+                        .ok();
+                }
 
                 let ts_offset = shared_ts_offset.clone();
                 let main_pipeline_for_ts = main_pipeline_weak.clone();
@@ -1445,6 +1601,34 @@ fn whip_input_definition() -> BlockDefinition {
                 persist: None,
             },
             ExposedProperty {
+                name: "do_retransmission".to_string(),
+                label: "Retransmission (RTX)".to_string(),
+                description: "Request retransmission of lost packets from the publisher (NACK-based). Disable only for diagnostics; without it, any packet loss forces a full keyframe request instead of a cheap resend.".to_string(),
+                property_type: PropertyType::Bool,
+                default_value: Some(PropertyValue::Bool(true)),
+                mapping: PropertyMapping {
+                    element_id: "_block".to_string(),
+                    property_name: "do_retransmission".to_string(),
+                    transform: None,
+                },
+                live: false,
+                persist: None,
+            },
+            ExposedProperty {
+                name: "jitterbuffer_latency_ms".to_string(),
+                label: "Jitterbuffer Latency (ms)".to_string(),
+                description: "How long to buffer incoming RTP before releasing/dropping it. Too low can cause an initial video keyframe's packet burst to be dropped locally on connect, stalling video entirely even though packets arrived fine. Increase if video never starts.".to_string(),
+                property_type: PropertyType::Int,
+                default_value: Some(PropertyValue::Int(400)),
+                mapping: PropertyMapping {
+                    element_id: "_block".to_string(),
+                    property_name: "jitterbuffer_latency_ms".to_string(),
+                    transform: None,
+                },
+                live: false,
+                persist: None,
+            },
+            ExposedProperty {
                 name: "max_video_bitrate".to_string(),
                 label: "Max Video Bitrate (kbps)".to_string(),
                 description: "Maximum video bitrate hint sent to the browser via SDP. The browser's encoder will ramp up to this value.".to_string(),
@@ -1624,4 +1808,64 @@ fn setup_incoming_rtp_handler(
     });
 
     info!("WHIP: Incoming RTP handler installed for {}", instance_id);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn props(entries: &[(&str, PropertyValue)]) -> HashMap<String, PropertyValue> {
+        entries
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.clone()))
+            .collect()
+    }
+
+    #[test]
+    fn do_retransmission_defaults_to_true() {
+        assert!(parse_do_retransmission(&props(&[])));
+    }
+
+    #[test]
+    fn do_retransmission_respects_explicit_true() {
+        assert!(parse_do_retransmission(&props(&[(
+            "do_retransmission",
+            PropertyValue::Bool(true)
+        )])));
+    }
+
+    #[test]
+    fn do_retransmission_respects_explicit_false() {
+        assert!(!parse_do_retransmission(&props(&[(
+            "do_retransmission",
+            PropertyValue::Bool(false)
+        )])));
+    }
+
+    #[test]
+    fn jitterbuffer_latency_ms_defaults_to_400() {
+        assert_eq!(parse_jitterbuffer_latency_ms(&props(&[])), 400);
+    }
+
+    #[test]
+    fn jitterbuffer_latency_ms_respects_explicit_value() {
+        assert_eq!(
+            parse_jitterbuffer_latency_ms(&props(&[(
+                "jitterbuffer_latency_ms",
+                PropertyValue::Int(150)
+            )])),
+            150
+        );
+    }
+
+    #[test]
+    fn jitterbuffer_latency_ms_clamps_negative_to_zero() {
+        assert_eq!(
+            parse_jitterbuffer_latency_ms(&props(&[(
+                "jitterbuffer_latency_ms",
+                PropertyValue::Int(-50)
+            )])),
+            0
+        );
+    }
 }

--- a/backend/src/blocks/builtin/whip.rs
+++ b/backend/src/blocks/builtin/whip.rs
@@ -139,7 +139,15 @@ impl BlockBuilder for WHIPInputBuilder {
 // WHIP Input (whipserversrc - hosts WHIP server)
 // ============================================================================
 
-/// Parse do_retransmission from properties (default: true).
+/// Parse do_retransmission from properties.
+///
+/// Defaults to `false`, which diverges from `whipserversrc`'s own default of
+/// `true`. RTX on the receive leg feeds retransmitted and reordered packets
+/// into `rtph264depay`, which is where an unfixed gst-plugins-base bug
+/// (gstreamer#5057) aborts the whole process from a `g_assert` in
+/// `gst_rtp_base_depayload_handle_buffer`. Remote network input must not be
+/// able to kill the server, so the safe value is the default until upstream
+/// lands a fix; set this to `true` to get RTX back once it does.
 fn parse_do_retransmission(properties: &HashMap<String, PropertyValue>) -> bool {
     properties
         .get("do_retransmission")
@@ -147,7 +155,7 @@ fn parse_do_retransmission(properties: &HashMap<String, PropertyValue>) -> bool 
             PropertyValue::Bool(b) => Some(*b),
             _ => None,
         })
-        .unwrap_or(true)
+        .unwrap_or(false)
 }
 
 /// Parse jitterbuffer_latency_ms from properties (default: 400, negative clamps to 0).
@@ -621,6 +629,7 @@ pub fn create_whipserversrc_for_session(
     let signaller = whipserversrc.property::<gst::glib::Object>("signaller");
     signaller.set_property("host-addr", &host_addr);
 
+    // Defaults to false, unlike whipserversrc itself — see parse_do_retransmission.
     whipserversrc.set_property("do-retransmission", config.do_retransmission);
 
     // Configure codec negotiation based on mode
@@ -1603,9 +1612,9 @@ fn whip_input_definition() -> BlockDefinition {
             ExposedProperty {
                 name: "do_retransmission".to_string(),
                 label: "Retransmission (RTX)".to_string(),
-                description: "Request retransmission of lost packets from the publisher (NACK-based). Disable only for diagnostics; without it, any packet loss forces a full keyframe request instead of a cheap resend.".to_string(),
+                description: "Request retransmission of lost packets from the publisher (NACK-based). Off by default: RTX on the receive leg can trigger an unfixed gst-plugins-base crash (gstreamer#5057) that aborts the whole process. Enabling it restores cheap resends instead of a full keyframe request on every loss, at that risk.".to_string(),
                 property_type: PropertyType::Bool,
-                default_value: Some(PropertyValue::Bool(true)),
+                default_value: Some(PropertyValue::Bool(false)),
                 mapping: PropertyMapping {
                     element_id: "_block".to_string(),
                     property_name: "do_retransmission".to_string(),
@@ -1822,8 +1831,9 @@ mod tests {
     }
 
     #[test]
-    fn do_retransmission_defaults_to_true() {
-        assert!(parse_do_retransmission(&props(&[])));
+    fn do_retransmission_defaults_to_false() {
+        // Diverges from whipserversrc's own default; see parse_do_retransmission.
+        assert!(!parse_do_retransmission(&props(&[])));
     }
 
     #[test]

--- a/backend/src/gpu.rs
+++ b/backend/src/gpu.rs
@@ -1,10 +1,18 @@
 //! GPU capability detection and video conversion mode selection.
 //!
 //! This module detects at startup whether GPU-accelerated video conversion
-//! with CUDA-GL interop is supported. On systems where it works (native Linux
-//! with X11 and NVIDIA drivers), we use `autovideoconvert` for better performance.
-//! On systems where it fails (WSL, headless/GBM, broken interop), we fall back
-//! to software `videoconvert`.
+//! is supported, and picks between `autovideoconvert` (which auto-inserts
+//! bridge elements such as `gldownload`/`glcolorconvert` when GL-memory
+//! frames need to reach a non-GL element, e.g. an encoder) and plain
+//! `videoconvert` (software-only; cannot accept `memory:GLMemory` caps).
+//!
+//! - On macOS there is no CUDA to worry about, so `autovideoconvert` is
+//!   always used (see `detect_gpu_capabilities`).
+//! - On Linux, GPU accel additionally requires CUDA-GL interop with NVENC.
+//!   On systems where it works (native Linux with X11 and NVIDIA drivers),
+//!   we use `autovideoconvert` for better performance. On systems where it
+//!   fails (WSL, headless/GBM, broken interop), we fall back to software
+//!   `videoconvert`.
 
 use gstreamer as gst;
 use gstreamer::prelude::*;
@@ -224,6 +232,23 @@ pub fn detect_gpu_capabilities() -> VideoConvertMode {
     // Probe GL renderer info early (best-effort, independent of CUDA-GL interop)
     let gl_info = detect_gl_renderer();
     let _ = GL_RENDERER_INFO.set(gl_info);
+
+    // macOS has no CUDA/NVENC, so the interop test below (which is entirely
+    // CUDA-specific) never applies here and would always force the software
+    // fallback. But GL-memory frames still occur on macOS (e.g. from the GL
+    // video mixer) and need bridging to non-GL encoders like vtenc_h264_hw.
+    // autovideoconvert auto-inserts the needed gldownload/glcolorconvert
+    // bridge; plain videoconvert cannot accept memory:GLMemory caps at all.
+    // There's no known autovideoconvert breakage on macOS to guard against
+    // (unlike the WSL/CUDA-GL cases below), so always use it here.
+    if cfg!(target_os = "macos") {
+        info!(
+            "macOS detected - using GPU-accelerated video conversion (autovideoconvert bridges GL memory)"
+        );
+        let mode = VideoConvertMode::GpuAccelerated;
+        let _ = VIDEO_CONVERT_MODE.set(mode);
+        return mode;
+    }
 
     // Fast path: WSL has broken CUDA-GL interop, skip expensive test
     if is_wsl() {

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -299,6 +299,26 @@ fn main() -> anyhow::Result<()> {
         std::process::exit(1);
     });
 
+    // Give CEF (the `cefsrc` element behind HTML sources and DSK graphics) a
+    // per-instance cache directory. The strom-full Docker image sets
+    // GST_CEF_CACHE_LOCATION in its entrypoint, but native runs get Chromium's
+    // default, which warns
+    //
+    //   Please customize CefSettings.root_cache_path for your application. Use
+    //   of the default value may lead to unintended process singleton behavior.
+    //
+    // and makes Chromium's process singleton shared: a second Strom instance on
+    // the same machine cannot start any cefsrc element, failing in
+    // gst_base_src_start() so the flow start returns 500 "Element failed to
+    // change its state". Deriving the directory from the data directory keeps
+    // instances isolated, and gives CEF a warm on-disk profile, which also cuts
+    // repeat flow-start latency. An explicitly configured value always wins.
+    if std::env::var_os("GST_CEF_CACHE_LOCATION").is_none() {
+        if let Some(data_dir) = config.flows_path.parent() {
+            std::env::set_var("GST_CEF_CACHE_LOCATION", data_dir.join("cef-cache"));
+        }
+    }
+
     // Initialize logging with optional file output and log level
     let (log_reload_handle, default_log_filter) =
         init_logging(config.log_file.as_ref(), config.log_level.as_ref()).unwrap_or_else(|e| {

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -344,7 +344,7 @@ fn main() -> anyhow::Result<()> {
             )
         } else {
             // Headless mode: Run HTTP server on main thread
-            run_headless(
+            run_headless_entry(
                 config,
                 args.no_auto_restart,
                 log_reload_handle,
@@ -356,7 +356,7 @@ fn main() -> anyhow::Result<()> {
     #[cfg(feature = "no-gui")]
     {
         // Always headless when no-gui feature is enabled
-        run_headless(
+        run_headless_entry(
             config,
             args.no_auto_restart,
             log_reload_handle,
@@ -545,6 +545,42 @@ fn run_with_gui(
     }
 
     Ok(())
+}
+
+/// Entry point for headless mode.
+///
+/// On macOS, CEF (the `cefsrc` element used for HTML overlays) needs a Cocoa run
+/// loop on the main thread. Without one, starting a flow containing `cefsrc`
+/// blocks forever in `gst_cef_src_change_state` waiting for browser
+/// initialisation that nothing ever services. `gst_macos_main` runs a CFRunLoop
+/// on the main thread and our server on a secondary thread. GUI mode does not
+/// need this -- winit's event loop already runs a Cocoa run loop on main.
+fn run_headless_entry(
+    config: Config,
+    no_auto_restart: bool,
+    log_reload_handle: strom::state::LogReloadHandle,
+    default_log_filter: String,
+) -> anyhow::Result<()> {
+    #[cfg(target_os = "macos")]
+    {
+        gstreamer::macos_main(move || {
+            run_headless(
+                config,
+                no_auto_restart,
+                log_reload_handle,
+                default_log_filter,
+            )
+        })
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        run_headless(
+            config,
+            no_auto_restart,
+            log_reload_handle,
+            default_log_filter,
+        )
+    }
 }
 
 #[tokio::main]

--- a/backend/src/whip_session_manager.rs
+++ b/backend/src/whip_session_manager.rs
@@ -32,6 +32,11 @@ pub struct WhipEndpointConfig {
     pub pipeline_weak: gst::glib::WeakRef<gst::Pipeline>,
     /// Whether to decode RTP to raw media (true) or pass through RTP (false)
     pub decode: bool,
+    /// Whether whipserversrc should request retransmission (NACK) of lost
+    /// packets from the publisher. Matches upstream default (true).
+    pub do_retransmission: bool,
+    /// Jitterbuffer latency in milliseconds for the per-session webrtcbin.
+    pub jitterbuffer_latency_ms: u32,
     /// Shared dynamic webrtcbin store for ICE policy tracking
     pub dynamic_webrtcbin_store: DynamicWebrtcbinStore,
     /// Maximum video bitrate hint for Chrome (kbps). Injected into the SDP

--- a/backend/tests/recorder_splitmux_threading_test.rs
+++ b/backend/tests/recorder_splitmux_threading_test.rs
@@ -1,0 +1,357 @@
+//! Regression test for the recorder deadlock when one upstream streaming task
+//! feeds several `splitmuxsink` sink pads.
+//!
+//! Bug: `splitmuxsink` blocks one input pad's streaming thread while it waits for
+//! the other input pads to reach the next GOP boundary — that is how it aligns
+//! GOPs across streams. The reference pad (video) waits in `check_completed_gop`
+//! until every context reaches the next GOP start; non-reference pads (audio)
+//! wait once they catch up to `max_in_running_time`, which only the reference pad
+//! advances.
+//!
+//! That mutual blocking is only survivable when the pads are fed by different
+//! threads. With `mpegtssrt_input(decode=false) -> recorder` the recorder fed both
+//! sink pads from `tsdemux`'s single streaming task, so the pad that blocked held
+//! the only thread that could ever unblock it and recording stopped within a
+//! packet or two — 0 files, or a single fragment that never closed.
+//!
+//! Fix: a `queue` per leg between the parser and `splitmuxsink`, giving every sink
+//! pad its own streaming thread. This test reproduces that topology (a single
+//! `tsdemux` task feeding both a video and an audio `splitmuxsink` pad) and
+//! asserts that recording actually completes. Remove the queues and it stalls
+//! until the watchdog below fires.
+
+use gstreamer as gst;
+use gstreamer::prelude::*;
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+/// Long enough for a healthy run (which finishes in ~1s) to never flake, short
+/// enough that a reintroduced deadlock fails the suite promptly.
+const RUN_TIMEOUT: Duration = Duration::from_secs(30);
+
+const REQUIRED_ELEMENTS: &[&str] = &[
+    "videotestsrc",
+    "audiotestsrc",
+    "x264enc",
+    "avenc_aac",
+    "mpegtsmux",
+    "tsdemux",
+    "h264parse",
+    "aacparse",
+    "splitmuxsink",
+];
+
+fn missing_element() -> Option<&'static str> {
+    REQUIRED_ELEMENTS
+        .iter()
+        .copied()
+        .find(|e| gst::ElementFactory::find(e).is_none())
+}
+
+/// Run a pipeline to EOS, returning an error on bus error or if `RUN_TIMEOUT`
+/// elapses first. A deadlock shows up here as the timeout.
+fn run_to_eos(pipeline: &gst::Pipeline) -> Result<(), String> {
+    pipeline
+        .set_state(gst::State::Playing)
+        .map_err(|e| format!("failed to start pipeline: {e}"))?;
+
+    let bus = pipeline.bus().expect("pipeline has no bus");
+    let deadline = Instant::now() + RUN_TIMEOUT;
+    let mut result = Err("timed out waiting for EOS (deadlock?)".to_string());
+
+    while let Some(remaining) = deadline.checked_duration_since(Instant::now()) {
+        let Some(msg) = bus.timed_pop(gst::ClockTime::from_nseconds(
+            remaining.as_nanos().min(u64::MAX as u128) as u64,
+        )) else {
+            break;
+        };
+        match msg.view() {
+            gst::MessageView::Eos(_) => {
+                result = Ok(());
+                break;
+            }
+            gst::MessageView::Error(err) => {
+                result = Err(format!(
+                    "pipeline error from {:?}: {}",
+                    err.src().map(|s| s.path_string()),
+                    err.error()
+                ));
+                break;
+            }
+            _ => {}
+        }
+    }
+
+    let _ = pipeline.set_state(gst::State::Null);
+    result
+}
+
+/// Produce a short MPEG-TS file carrying both H.264 video and AAC audio.
+fn write_test_transport_stream(path: &std::path::Path) -> Result<(), String> {
+    let pipeline = gst::Pipeline::new();
+
+    let video_src = gst::ElementFactory::make("videotestsrc")
+        .property("num-buffers", 150i32) // 5s at 30fps, enough for several GOPs
+        .property_from_str("pattern", "smpte")
+        .build()
+        .map_err(|e| e.to_string())?;
+    // Short GOPs so splitmuxsink has frequent split points to align on.
+    let encoder = gst::ElementFactory::make("x264enc")
+        .property("key-int-max", 30u32)
+        .property_from_str("tune", "zerolatency")
+        .build()
+        .map_err(|e| e.to_string())?;
+    let video_parse = gst::ElementFactory::make("h264parse")
+        .build()
+        .map_err(|e| e.to_string())?;
+
+    let audio_src = gst::ElementFactory::make("audiotestsrc")
+        .property("num-buffers", 240i32) // ~5s of 1024-sample AAC frames at 48kHz
+        .build()
+        .map_err(|e| e.to_string())?;
+    let audio_convert = gst::ElementFactory::make("audioconvert")
+        .build()
+        .map_err(|e| e.to_string())?;
+    let audio_resample = gst::ElementFactory::make("audioresample")
+        .build()
+        .map_err(|e| e.to_string())?;
+    let audio_enc = gst::ElementFactory::make("avenc_aac")
+        .build()
+        .map_err(|e| e.to_string())?;
+    let audio_parse = gst::ElementFactory::make("aacparse")
+        .build()
+        .map_err(|e| e.to_string())?;
+
+    let mux = gst::ElementFactory::make("mpegtsmux")
+        .build()
+        .map_err(|e| e.to_string())?;
+    let sink = gst::ElementFactory::make("filesink")
+        .property("location", path.to_str().expect("temp path is valid UTF-8"))
+        .build()
+        .map_err(|e| e.to_string())?;
+
+    let elements = [
+        &video_src,
+        &encoder,
+        &video_parse,
+        &audio_src,
+        &audio_convert,
+        &audio_resample,
+        &audio_enc,
+        &audio_parse,
+        &mux,
+        &sink,
+    ];
+    pipeline.add_many(elements).map_err(|e| e.to_string())?;
+
+    gst::Element::link_many([&video_src, &encoder, &video_parse, &mux])
+        .map_err(|e| e.to_string())?;
+    gst::Element::link_many([
+        &audio_src,
+        &audio_convert,
+        &audio_resample,
+        &audio_enc,
+        &audio_parse,
+        &mux,
+    ])
+    .map_err(|e| e.to_string())?;
+    mux.link(&sink).map_err(|e| e.to_string())?;
+
+    run_to_eos(&pipeline)
+}
+
+/// Record `ts_path` through the recorder's topology: one `tsdemux` streaming task
+/// feeding both `splitmuxsink` sink pads, with or without the per-leg queue.
+///
+/// Returns (file count, total bytes) of the produced fragments.
+fn record_transport_stream(
+    ts_path: &std::path::Path,
+    out_dir: &std::path::Path,
+    use_queues: bool,
+) -> Result<(usize, u64), String> {
+    let pipeline = gst::Pipeline::new();
+
+    let src = gst::ElementFactory::make("filesrc")
+        .property("location", ts_path.to_str().expect("path is valid UTF-8"))
+        .build()
+        .map_err(|e| e.to_string())?;
+    let demux = gst::ElementFactory::make("tsdemux")
+        .build()
+        .map_err(|e| e.to_string())?;
+    let splitmux = gst::ElementFactory::make("splitmuxsink")
+        .property(
+            "location",
+            out_dir
+                .join("segment%05d.mp4")
+                .to_str()
+                .expect("path is valid UTF-8"),
+        )
+        // Split partway through so a healthy run yields several fragments; a run
+        // that stalls after the first GOP yields zero or one.
+        .property("max-size-time", 2_000_000_000u64)
+        .build()
+        .map_err(|e| e.to_string())?;
+
+    pipeline
+        .add_many([&src, &demux, &splitmux])
+        .map_err(|e| e.to_string())?;
+    src.link(&demux).map_err(|e| e.to_string())?;
+
+    // tsdemux exposes its streams dynamically, exactly as it does behind
+    // mpegtssrt_input in passthrough mode.
+    let (err_tx, err_rx) = mpsc::channel::<String>();
+    let pipeline_weak = pipeline.downgrade();
+    let splitmux_weak = splitmux.downgrade();
+    demux.connect_pad_added(move |_demux, pad| {
+        let Some(pipeline) = pipeline_weak.upgrade() else {
+            return;
+        };
+        let Some(splitmux) = splitmux_weak.upgrade() else {
+            return;
+        };
+
+        let report = |msg: String| {
+            let _ = err_tx.send(msg);
+        };
+
+        let Some(caps) = pad.current_caps() else {
+            report("demux pad exposed without caps".to_string());
+            return;
+        };
+        let Some(structure) = caps.structure(0) else {
+            report("demux pad caps had no structure".to_string());
+            return;
+        };
+        let media_type = structure.name();
+
+        let (parser_factory, sink_pad_name) = if media_type.starts_with("video/x-h264") {
+            ("h264parse", "video")
+        } else if media_type.starts_with("audio/mpeg") {
+            ("aacparse", "audio_%u")
+        } else {
+            // Not a stream this recorder handles.
+            return;
+        };
+
+        let parser = match gst::ElementFactory::make(parser_factory).build() {
+            Ok(p) => p,
+            Err(e) => {
+                report(format!("failed to create {parser_factory}: {e}"));
+                return;
+            }
+        };
+        if let Err(e) = pipeline.add(&parser) {
+            report(format!("failed to add {parser_factory}: {e}"));
+            return;
+        }
+        if let Err(e) = parser.sync_state_with_parent() {
+            report(format!("failed to sync {parser_factory} state: {e}"));
+            return;
+        }
+
+        // The element whose src pad feeds splitmuxsink: the parser directly, or
+        // the queue that decouples this leg onto its own streaming thread.
+        let tail = if use_queues {
+            let queue = match gst::ElementFactory::make("queue").build() {
+                Ok(q) => q,
+                Err(e) => {
+                    report(format!("failed to create queue: {e}"));
+                    return;
+                }
+            };
+            if let Err(e) = pipeline.add(&queue) {
+                report(format!("failed to add queue: {e}"));
+                return;
+            }
+            if let Err(e) = queue.sync_state_with_parent() {
+                report(format!("failed to sync queue state: {e}"));
+                return;
+            }
+            if let Err(e) = parser.link(&queue) {
+                report(format!("failed to link {parser_factory} to queue: {e}"));
+                return;
+            }
+            queue
+        } else {
+            parser.clone()
+        };
+
+        let Some(parser_sink) = parser.static_pad("sink") else {
+            report(format!("{parser_factory} has no sink pad"));
+            return;
+        };
+        if let Err(e) = pad.link(&parser_sink) {
+            report(format!("failed to link demux to {parser_factory}: {e:?}"));
+            return;
+        }
+
+        let Some(mux_pad) = splitmux.request_pad_simple(sink_pad_name) else {
+            report(format!("splitmuxsink refused a {sink_pad_name} pad"));
+            return;
+        };
+        let Some(tail_src) = tail.static_pad("src") else {
+            report("tail element has no src pad".to_string());
+            return;
+        };
+        if let Err(e) = tail_src.link(&mux_pad) {
+            report(format!("failed to link into splitmuxsink: {e:?}"));
+        }
+    });
+
+    let run_result = run_to_eos(&pipeline);
+
+    // Surface a link-time failure in preference to the resulting timeout.
+    if let Ok(link_error) = err_rx.try_recv() {
+        return Err(link_error);
+    }
+    run_result?;
+
+    let mut files = 0usize;
+    let mut bytes = 0u64;
+    for entry in std::fs::read_dir(out_dir).map_err(|e| e.to_string())? {
+        let entry = entry.map_err(|e| e.to_string())?;
+        let metadata = entry.metadata().map_err(|e| e.to_string())?;
+        if metadata.is_file() {
+            files += 1;
+            bytes += metadata.len();
+        }
+    }
+    Ok((files, bytes))
+}
+
+/// A recorder fed by a single demuxer streaming task must record both legs to
+/// completion. Without a queue per leg the two `splitmuxsink` sink pads deadlock
+/// on that shared thread and this times out.
+#[test]
+fn records_video_and_audio_from_a_single_demux_thread() {
+    gst::init().expect("failed to initialize GStreamer");
+
+    if let Some(missing) = missing_element() {
+        eprintln!("SKIP: required element '{missing}' is unavailable");
+        return;
+    }
+
+    let tmp = std::env::temp_dir().join(format!("strom-recorder-threading-{}", std::process::id()));
+    let out_dir = tmp.join("segments");
+    std::fs::create_dir_all(&out_dir).expect("failed to create temp output directory");
+    let ts_path = tmp.join("source.ts");
+
+    let result = (|| -> Result<(usize, u64), String> {
+        write_test_transport_stream(&ts_path)?;
+        record_transport_stream(&ts_path, &out_dir, true)
+    })();
+
+    let cleanup = std::fs::remove_dir_all(&tmp);
+
+    let (files, bytes) = result.unwrap_or_else(|e| {
+        panic!("recording with a queue per leg failed: {e}");
+    });
+    cleanup.expect("failed to clean up temp directory");
+
+    // A healthy 5s recording split every 2s yields multiple non-empty fragments.
+    assert!(
+        files >= 2,
+        "expected several recorded fragments, got {files}"
+    );
+    assert!(bytes > 0, "recorded fragments were empty");
+}

--- a/backend/tests/recorder_unfed_track_test.rs
+++ b/backend/tests/recorder_unfed_track_test.rs
@@ -1,0 +1,279 @@
+//! Regression test for recorder tracks that are configured but never fed.
+//!
+//! `splitmuxsink` only releases a completed GOP once *every* requested sink pad
+//! has advanced to the start of the next GOP. A pad that is requested but never
+//! receives data keeps its input running time at `GST_CLOCK_STIME_NONE`, so the
+//! sink waits on it forever and writes nothing at all.
+//!
+//! The recorder therefore must not request a splitmuxsink pad for a track that
+//! carries no data. These tests configure a recorder with both a video and an
+//! audio track, feed only one of them, and assert that a non-empty file is still
+//! written.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use strom::blocks::builtin::recorder::RecorderBuilder;
+use strom::blocks::{BlockBuildContext, BlockBuilder};
+use strom_types::PropertyValue;
+
+use gstreamer as gst;
+use gstreamer::prelude::*;
+
+/// Elements this test needs beyond core GStreamer. Missing on a bare CI image.
+const REQUIRED: &[&str] = &[
+    "splitmuxsink",
+    "x264enc",
+    "h264parse",
+    "avenc_aac",
+    "aacparse",
+    "videotestsrc",
+    "audiotestsrc",
+];
+
+fn plugins_available() -> bool {
+    REQUIRED
+        .iter()
+        .all(|e| gst::ElementFactory::find(e).is_some())
+}
+
+fn container_available(container: &str) -> bool {
+    let muxer = match container {
+        "mkv" => "matroskamux",
+        "mpegts" => "mpegtsmux",
+        _ => "mp4mux",
+    };
+    gst::ElementFactory::find(muxer).is_some()
+}
+
+/// Which inputs the test actually connects to the recorder.
+#[derive(Clone, Copy, PartialEq)]
+enum Feed {
+    VideoOnly,
+    AudioOnly,
+    Both,
+}
+
+/// Build a recorder block configured for one video and one audio track, wire up
+/// only the inputs named by `feed`, run until EOS, and return the files written.
+///
+/// Both tracks are always configured — the point of the test is that configuring
+/// a track the flow never connects must not stop the other track from recording.
+fn run_recorder(container: &str, feed: Feed, media_root: &Path) -> Vec<PathBuf> {
+    let instance_id = "rec";
+
+    let mut props: HashMap<String, PropertyValue> = HashMap::new();
+    props.insert(
+        "container".to_string(),
+        PropertyValue::String(container.to_string()),
+    );
+    props.insert("num_video_tracks".to_string(), PropertyValue::UInt(1));
+    props.insert("num_audio_tracks".to_string(), PropertyValue::UInt(1));
+    props.insert(
+        "output_dir".to_string(),
+        PropertyValue::String("recordings".to_string()),
+    );
+    props.insert(
+        "filename_prefix".to_string(),
+        PropertyValue::String("test".to_string()),
+    );
+    props.insert(
+        "_media_path".to_string(),
+        PropertyValue::String(media_root.to_string_lossy().to_string()),
+    );
+
+    let ctx = BlockBuildContext::new(vec![], "all".to_string());
+    let built = RecorderBuilder
+        .build(instance_id, &props, &ctx)
+        .expect("recorder block builds");
+
+    let pipeline = gst::Pipeline::new();
+    let mut by_id: HashMap<String, gst::Element> = HashMap::new();
+    for (id, element) in &built.elements {
+        pipeline.add(element).expect("add block element");
+        by_id.insert(id.clone(), element.clone());
+    }
+
+    // Short, deterministic sources. 30 buffers at 30fps = 1s of video, which is
+    // several GOPs at key-int-max=10 — enough for splitmuxsink to complete and
+    // release at least one GOP if it is not stalled.
+    if feed == Feed::VideoOnly || feed == Feed::Both {
+        let src = gst::ElementFactory::make("videotestsrc")
+            .property("num-buffers", 30i32)
+            .property_from_str("pattern", "smpte")
+            .build()
+            .expect("videotestsrc");
+        let caps = gst::ElementFactory::make("capsfilter")
+            .property(
+                "caps",
+                gst::Caps::builder("video/x-raw")
+                    .field("width", 320i32)
+                    .field("height", 240i32)
+                    .field("framerate", gst::Fraction::new(30, 1))
+                    .build(),
+            )
+            .build()
+            .expect("capsfilter");
+        let enc = gst::ElementFactory::make("x264enc")
+            .property("key-int-max", 10u32)
+            .property_from_str("tune", "zerolatency")
+            .build()
+            .expect("x264enc");
+
+        pipeline.add_many([&src, &caps, &enc]).unwrap();
+        gst::Element::link_many([&src, &caps, &enc]).unwrap();
+
+        let target = by_id
+            .get(&format!("{}:video_input_0", instance_id))
+            .expect("recorder exposes video_input_0");
+        enc.link(target).expect("link video into recorder");
+    }
+
+    if feed == Feed::AudioOnly || feed == Feed::Both {
+        let src = gst::ElementFactory::make("audiotestsrc")
+            .property("num-buffers", 50i32)
+            .build()
+            .expect("audiotestsrc");
+        let conv = gst::ElementFactory::make("audioconvert").build().unwrap();
+        let resample = gst::ElementFactory::make("audioresample").build().unwrap();
+        let enc = gst::ElementFactory::make("avenc_aac")
+            .build()
+            .expect("avenc_aac");
+
+        pipeline.add_many([&src, &conv, &resample, &enc]).unwrap();
+        gst::Element::link_many([&src, &conv, &resample, &enc]).unwrap();
+
+        let target = by_id
+            .get(&format!("{}:audio_input_0", instance_id))
+            .expect("recorder exposes audio_input_0");
+        enc.link(target).expect("link audio into recorder");
+    }
+
+    pipeline
+        .set_state(gst::State::Playing)
+        .expect("pipeline goes to PLAYING");
+
+    let bus = pipeline.bus().expect("pipeline has a bus");
+    let mut reached_eos = false;
+    // 30 s is generous for ~1 s of content; a stalled splitmuxsink burns all of it.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+    while std::time::Instant::now() < deadline {
+        let Some(msg) = bus.timed_pop(gst::ClockTime::from_seconds(1)) else {
+            continue;
+        };
+        match msg.view() {
+            gst::MessageView::Eos(_) => {
+                reached_eos = true;
+                break;
+            }
+            gst::MessageView::Error(err) => {
+                panic!(
+                    "pipeline error from {:?}: {} ({:?})",
+                    err.src().map(|s| s.path_string()),
+                    err.error(),
+                    err.debug()
+                );
+            }
+            _ => {}
+        }
+    }
+
+    pipeline.set_state(gst::State::Null).unwrap();
+    assert!(
+        reached_eos,
+        "pipeline never reached EOS within 30s (container={}, feed connected={})",
+        container,
+        match feed {
+            Feed::VideoOnly => "video only",
+            Feed::AudioOnly => "audio only",
+            Feed::Both => "video + audio",
+        }
+    );
+
+    let dir = media_root.join("recordings");
+    let mut files: Vec<PathBuf> = std::fs::read_dir(&dir)
+        .map(|rd| {
+            rd.filter_map(|e| e.ok())
+                .map(|e| e.path())
+                .filter(|p| p.is_file())
+                .collect()
+        })
+        .unwrap_or_default();
+    files.sort();
+    files
+}
+
+fn assert_recorded(container: &str, feed: Feed, label: &str) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let files = run_recorder(container, feed, tmp.path());
+
+    assert!(
+        !files.is_empty(),
+        "{} / {}: splitmuxsink wrote no file at all",
+        container,
+        label
+    );
+    for f in &files {
+        let len = std::fs::metadata(f).expect("stat recording").len();
+        assert!(
+            len > 0,
+            "{} / {}: recording {} is empty",
+            container,
+            label,
+            f.display()
+        );
+    }
+}
+
+/// The regression: an audio track is configured but the flow connects only video.
+/// Before the fix, splitmuxsink waited forever on the unfed audio pad and no file
+/// was ever written.
+#[test]
+fn video_only_feed_records_despite_configured_audio_track() {
+    gst::init().unwrap();
+    if !plugins_available() {
+        eprintln!("skipping: required GStreamer elements not installed");
+        return;
+    }
+    for container in ["mp4", "mkv", "mpegts"] {
+        if !container_available(container) {
+            eprintln!("skipping container {}: muxer not installed", container);
+            continue;
+        }
+        assert_recorded(container, Feed::VideoOnly, "video only");
+    }
+}
+
+/// The mirror case: a video track is configured but the flow connects only audio.
+#[test]
+fn audio_only_feed_records_despite_configured_video_track() {
+    gst::init().unwrap();
+    if !plugins_available() {
+        eprintln!("skipping: required GStreamer elements not installed");
+        return;
+    }
+    for container in ["mp4", "mkv", "mpegts"] {
+        if !container_available(container) {
+            eprintln!("skipping container {}: muxer not installed", container);
+            continue;
+        }
+        assert_recorded(container, Feed::AudioOnly, "audio only");
+    }
+}
+
+/// Control arm: both configured tracks are connected. This is the case that
+/// already worked, and it must keep working.
+#[test]
+fn both_tracks_fed_records_normally() {
+    gst::init().unwrap();
+    if !plugins_available() {
+        eprintln!("skipping: required GStreamer elements not installed");
+        return;
+    }
+    for container in ["mp4", "mkv", "mpegts"] {
+        if !container_available(container) {
+            eprintln!("skipping container {}: muxer not installed", container);
+            continue;
+        }
+        assert_recorded(container, Feed::Both, "video + audio");
+    }
+}

--- a/docs/HTML_RENDER.md
+++ b/docs/HTML_RENDER.md
@@ -240,7 +240,8 @@ The build uses Ubuntu Questing to match the strom base image's glibc version.
 
 ## Limitations
 
-- **Docker only**: CEF requires X11, which the strom-full image provides via Xvfb
+- **Linux: X11 required**: CEF needs an X server on Linux, which the strom-full image provides via Xvfb. This is why `strom-full` is the supported way to run HTML sources.
+- **macOS: not X11**: CEF renders offscreen through its own macOS path, so Xvfb is not involved and the X11 requirement above does not apply. Running `cefsrc` from a native macOS build is not supported yet — it needs macOS build fixes in gstcefsrc ([centricular/gstcefsrc#110](https://github.com/centricular/gstcefsrc/pull/110)) and, in headless mode, a Cocoa run loop on the main thread (#669). CEF on macOS also refuses to initialise unless the host process is inside an `.app` bundle.
 - **Software rendering by default**: CEF uses CPU rendering; opt in to GPU with `STROM_CEF_GPU=1` (see above)
 - **Memory usage**: CEF spawns multiple processes (browser, renderer, GPU process)
 - **No audio by default**: Use `cefbin` or `cefdemux` if you need audio from web content


### PR DESCRIPTION
## What

- **WHIP Input**: `do_retransmission` now defaults to `false`, diverging from `whipserversrc`'s own default of `true`.
- **WHEP Output**: no behaviour change — still defaults to `true`. Only its comment and property description change.

## Why

The gst-plugins-base abort this property works around ([gstreamer#5057](https://gitlab.freedesktop.org/gstreamer/gstreamer/-/issues/5057)) is a `g_assert` in `gst_rtp_base_depayload_handle_buffer` (`gstrtpbasedepayload.c`), and it lives in `GstRTPBaseDepayload`. Only a depayloader can arm it, and only `rtph264depay` / `rtph265depay` / `rtpklvdepay` call `gst_rtp_base_depayload_delayed()` at all.

In Strom that is exactly one element: the `rtph264depay` that `decodebin` autoplugs behind WHIP Input's `appsrc` — which is where the crash was observed.

That has two consequences:

**WHIP Input must default off.** Leaving RTX on means a lossy remote publisher can abort the whole process, taking every flow on the server with it, and an operator only avoids that by knowing to set an obscure property. The trade is real but lopsided: losing RTX costs loss resilience on the ingest leg (each loss escalates to PLI → forced keyframe instead of a cheap resend), while a hard abort costs the server. Revert once upstream lands a fix.

**WHEP Output was never affected.** `whepserversink` is a send-only `webrtcsink`: the property maps to `do-nack` on a Sendonly transceiver and to `rtprtxsend`, and no depayloader is instantiated anywhere on that path, so the assertion is unreachable. The existing comment and property description claimed the crash applied there too; both now describe the knob as the ordinary bandwidth/quality tunable it actually is.

## Notes

- Supersedes #663, which introduced this property with the older "unconfirmed workaround" rationale. `parse_do_retransmission` already reached `main` via ca59002, so #663 can be closed.
- The exposed property's `default_value` and description were updated to match the parser, and `do_retransmission_defaults_to_true` was renamed accordingly.

## Test

`cargo test --lib do_retransmission` — 6 passed. fmt and clippy clean.