### PR TITLE
chore(deps): bump gstreamer and gstreamer-video to 0.25.3 together

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1903,7 +1903,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2337,7 +2337,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2779,9 +2779,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer"
-version = "0.25.2"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28ca0c594cac4e86f5444aaa767c7bb810340c0710667a6467d3ead248e35e84"
+checksum = "ab4527e1b9bae8d29ce137bde5b8eec8ae8f78f13ad00fc6e70cbe227d6ad027"
 dependencies = [
  "cfg-if",
  "futures-channel",
@@ -2789,7 +2789,7 @@ dependencies = [
  "futures-util",
  "glib",
  "gstreamer-sys",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "kstring",
  "libc",
  "muldiv",
@@ -3073,9 +3073,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-video"
-version = "0.25.2"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bf728cb21499561ea0d6ce584e550bf2b98b279cc7741067ee42f41f98b486e"
+checksum = "7907cb8a73edc98cf279e5de7370bb2c245b7bedf623ba8c7e59648cd4739133"
 dependencies = [
  "cfg-if",
  "futures-channel",
@@ -3673,6 +3673,15 @@ name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]
@@ -5783,7 +5792,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5842,7 +5851,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6822,7 +6831,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Replaces #656. Dependabot bumped `gstreamer-video` to 0.25.3 on its own, leaving `gstreamer` core at 0.25.2 — the version skew flagged on that PR. The two crates are released in lockstep, so they move together here.

`Cargo.toml` needs no change: the family is already pinned at `"0.25"`, which admits 0.25.3. This is a lock-only change.

## Why not just merge #656

Beyond the skew, that PR's lock was generated against a June base and had drifted:

- Its failing checks were against code that no longer exists (`cannot find pad_panic_to_error in gst`, from a run dated 2026-06-29).
- It **downgraded** unrelated transitives to get there — `windows-sys` 0.61.2 → 0.60.2/0.59.0/0.52.0 in four places.

Regenerating from current main avoids both.

## Lock changes

| | |
|---|---|
| `gstreamer` | 0.25.2 → 0.25.3 |
| `gstreamer-video` | 0.25.2 → 0.25.3 |
| `itertools` | 0.15.0 added — `gstreamer` 0.25.3 requires it |
| `windows-sys` | five dependents unified 0.52.0 → 0.59.0 |

The `windows-sys` part is cargo re-resolving, not something requested. I tried to avoid it: `--precise` on either crate, and on both together, produces the same unification, and the two-step `--precise` route is worse — it drops `windows-sys` 0.59.0 but moves one dependent *down* to 0.52.0. The version chosen here is the one where every move is an upgrade. No packages are added or removed beyond `itertools`, and the set of `windows-sys` versions in the tree is unchanged.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Dependency update

## Testing

**What was actually run**, locally on macOS (GStreamer 1.28.6, aarch64):

- `cargo build` — clean, no new warnings and no deprecations surfaced by the bump
- `STROM_REQUIRE_GST_PLUGINS=1 cargo test --workspace` — **530 unit tests plus every integration test green**, 0 failures. Includes `pipeline_lifecycle_test` and both recorder tests. The one skip is the pre-existing `test_jitterbuffer_stalls_without_drop_on_latency`, gated on the installed GStreamer version and unrelated to this change.
- `cargo clippy --workspace --all-targets` — clean, zero lints
- `cargo fmt --all --check` — clean

**Not done:** I did not audit the upstream 0.25.3 changelogs, so this PR does not claim to know what the patch releases contain beyond the fact that the workspace builds and passes against them. It is offered as "the skew is resolved and nothing regressed here", not as "these specific upstream fixes are wanted".

**Not verified:** Windows and Linux. This is a lock-only change with no `cfg`-specific code, but the `windows-sys` unification only affects Windows builds, and Windows is off for PRs. Worth a `platforms=both` dispatch before merging — note that per #702 the Windows job currently cannot report a test failure, so read the log rather than trusting the green tick.

## Checklist

- [x] I have run `cargo fmt --all`
- [x] I have run `cargo clippy --workspace --all-targets`
- [x] I have run `cargo test --workspace`
- [x] I have updated documentation as needed (not applicable — lock-only)
- [ ] I have added tests for new functionality (not applicable — no behaviour change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
