### PR TITLE
fix(pipeline): fail start() when the pipeline cannot reach PLAYING

### DIFF
--- a/backend/src/api/whep_player.rs
+++ b/backend/src/api/whep_player.rs
@@ -481,6 +481,9 @@ pub async fn whep_endpoint_proxy(
     let port = match state.whep_registry().get_port(&endpoint_id).await {
         Some(p) => p,
         None => {
+            // Not registered: the flow is stopped, never started, or the
+            // block's endpoint_id was changed since the player loaded.
+            tracing::warn!("WHEP offer for unregistered endpoint '{}'", endpoint_id);
             return Response::builder()
                 .status(StatusCode::NOT_FOUND)
                 .header(header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
@@ -588,11 +591,23 @@ pub async fn whep_endpoint_proxy(
 
             builder.body(Body::from(body_bytes)).unwrap()
         }
-        Err(e) => Response::builder()
-            .status(StatusCode::BAD_GATEWAY)
-            .header(header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
-            .body(Body::from(format!("Proxy error: {}", e)))
-            .unwrap(),
+        Err(e) => {
+            // The endpoint is in the registry but its whepserversink is not
+            // answering on the registered port — most often because the flow's
+            // pipeline never reached PLAYING, so the signaller never opened it.
+            // Without this the client sees a bare 502 and the log says nothing.
+            tracing::error!(
+                "WHEP offer proxy to {} for endpoint '{}' failed: {}",
+                target_url,
+                endpoint_id,
+                e
+            );
+            Response::builder()
+                .status(StatusCode::BAD_GATEWAY)
+                .header(header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
+                .body(Body::from(format!("Proxy error: {}", e)))
+                .unwrap()
+        }
     }
 }
 
@@ -618,6 +633,10 @@ pub async fn whep_resource_proxy_delete(
     let port = match state.whep_registry().get_port(&endpoint_id).await {
         Some(p) => p,
         None => {
+            tracing::warn!(
+                "WHEP resource DELETE for unregistered endpoint '{}'",
+                endpoint_id
+            );
             return Response::builder()
                 .status(StatusCode::NOT_FOUND)
                 .header(header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
@@ -641,11 +660,19 @@ pub async fn whep_resource_proxy_delete(
                 .body(Body::empty())
                 .unwrap()
         }
-        Err(e) => Response::builder()
-            .status(StatusCode::BAD_GATEWAY)
-            .header(header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
-            .body(Body::from(format!("Proxy error: {}", e)))
-            .unwrap(),
+        Err(e) => {
+            tracing::error!(
+                "WHEP resource DELETE proxy to {} for endpoint '{}' failed: {}",
+                target_url,
+                endpoint_id,
+                e
+            );
+            Response::builder()
+                .status(StatusCode::BAD_GATEWAY)
+                .header(header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
+                .body(Body::from(format!("Proxy error: {}", e)))
+                .unwrap()
+        }
     }
 }
 
@@ -696,6 +723,10 @@ pub async fn whep_resource_proxy_patch(
     let port = match state.whep_registry().get_port(&endpoint_id).await {
         Some(p) => p,
         None => {
+            tracing::warn!(
+                "WHEP trickle-ICE PATCH for unregistered endpoint '{}'",
+                endpoint_id
+            );
             return Response::builder()
                 .status(StatusCode::NOT_FOUND)
                 .header(header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
@@ -730,11 +761,19 @@ pub async fn whep_resource_proxy_patch(
                 .body(Body::empty())
                 .unwrap()
         }
-        Err(e) => Response::builder()
-            .status(StatusCode::BAD_GATEWAY)
-            .header(header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
-            .body(Body::from(format!("Proxy error: {}", e)))
-            .unwrap(),
+        Err(e) => {
+            tracing::error!(
+                "WHEP trickle-ICE PATCH proxy to {} for endpoint '{}' failed: {}",
+                target_url,
+                endpoint_id,
+                e
+            );
+            Response::builder()
+                .status(StatusCode::BAD_GATEWAY)
+                .header(header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
+                .body(Body::from(format!("Proxy error: {}", e)))
+                .unwrap()
+        }
     }
 }
 

--- a/backend/src/gst/pipeline/lifecycle.rs
+++ b/backend/src/gst/pipeline/lifecycle.rs
@@ -112,22 +112,24 @@ impl PipelineManager {
             self.flow_name, result, current_state, pending_state
         );
 
+        // `gst_element_get_state()` reports a still-running transition as
+        // `Ok(Async)`. `Err` is only ever GST_STATE_CHANGE_FAILURE, whatever
+        // the pending state says: a failure with `pending == Playing` is a
+        // pipeline that aborted the PAUSED -> PLAYING transition (an element
+        // posted a fatal error on the bus) and will never leave PAUSED on its
+        // own. Reporting that as "async in progress" starts a dead flow —
+        // every element that only serves traffic in PLAYING stays down, and
+        // whepserversink's signaller never opens its HTTP port, so all WHEP
+        // offers for the flow's whole lifetime fail with 502.
         if let Err(e) = result {
-            if pending_state == gst::State::VoidPending {
-                error!(
-                    "Pipeline '{}' failed to reach PLAYING state: {:?} (current: {:?})",
-                    self.flow_name, e, current_state
-                );
-                return Err(PipelineError::StateChange(format!(
-                    "State change failed: {:?} - current: {:?}",
-                    e, current_state
-                )));
-            }
-            // Async state change still in progress — not an error
-            info!(
-                "Pipeline '{}' state change still in progress (current: {:?}, pending: {:?})",
-                self.flow_name, current_state, pending_state
+            error!(
+                "Pipeline '{}' failed to reach PLAYING state: {:?} (current: {:?}, pending: {:?})",
+                self.flow_name, e, current_state, pending_state
             );
+            return Err(PipelineError::StateChange(format!(
+                "State change failed: {:?} - current: {:?}, pending: {:?}",
+                e, current_state, pending_state
+            )));
         }
 
         let actual_state = match current_state {

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -937,7 +937,17 @@ impl AppState {
 
         // Start pipeline
         info!("Calling manager.start() (this may block)...");
-        let state = manager.start()?;
+        let state = match manager.start() {
+            Ok(state) => state,
+            Err(e) => {
+                // The manager is dropped here, which takes the pipeline to
+                // Null. Release the CPU allocation too, or a flow that fails
+                // to start leaks its cores until the process restarts.
+                error!("Failed to start flow {}: {}", id, e);
+                self.inner.affinity_manager.deallocate(id);
+                return Err(e);
+            }
+        };
         info!("manager.start() returned with state: {:?}", state);
 
         // Store pipeline manager and keep a reference for SDP generation

--- a/backend/tests/pipeline_start_failure_test.rs
+++ b/backend/tests/pipeline_start_failure_test.rs
@@ -1,0 +1,142 @@
+//! Regression test: a pipeline that aborts its PAUSED -> PLAYING transition
+//! must make `PipelineManager::start()` fail.
+//!
+//! `gst_element_get_state()` reports a still-running transition as `Ok(Async)`
+//! and a failed one as `Err`, whatever the pending state says. `start()` used
+//! to treat `Err` with `pending == Playing` as "async still in progress" and
+//! return `Ok(Paused)`, so a flow whose pipeline had already posted a fatal
+//! error on the bus was reported as started. `start_flow()` then went on to
+//! register the flow's WHEP endpoints, but the pipeline never left PAUSED, so
+//! whepserversink's signaller never opened its HTTP port and every WHEP offer
+//! against that flow answered 502 for as long as it "ran".
+
+use std::collections::HashMap;
+use strom::blocks::BlockRegistry;
+use strom::events::EventBroadcaster;
+use strom::gst::pipeline::PipelineManager;
+use strom_types::{Flow, Link};
+use tempfile::NamedTempFile;
+
+/// Build `audiotestsrc → identity error-after=1 → fakesink`.
+///
+/// `identity` errors out on the very first buffer, which is pushed during
+/// preroll. The sink therefore never prerolls, the pipeline never leaves
+/// PAUSED, and the transition to PLAYING fails with PLAYING still pending —
+/// the same shape a live flow produces when a parser inside `decodebin` posts
+/// a fatal error while the pipeline is prerolling.
+///
+/// Uses only core GStreamer elements plus `audiotestsrc` so it runs in CI.
+fn build_failing_flow(name: &str) -> Flow {
+    let mut flow = Flow::new(name);
+
+    flow.elements.push(strom_types::Element {
+        id: "src".to_string(),
+        element_type: "audiotestsrc".to_string(),
+        properties: HashMap::new(),
+        position: [100.0, 200.0].into(),
+        pad_properties: HashMap::new(),
+    });
+
+    flow.elements.push(strom_types::Element {
+        id: "fail".to_string(),
+        element_type: "identity".to_string(),
+        properties: {
+            let mut p = HashMap::new();
+            p.insert(
+                "error-after".to_string(),
+                strom_types::PropertyValue::Int(1),
+            );
+            p
+        },
+        position: [250.0, 200.0].into(),
+        pad_properties: HashMap::new(),
+    });
+
+    flow.elements.push(strom_types::Element {
+        id: "sink".to_string(),
+        element_type: "fakesink".to_string(),
+        properties: HashMap::new(),
+        position: [400.0, 200.0].into(),
+        pad_properties: HashMap::new(),
+    });
+
+    flow.links.push(Link {
+        from: "src:src".to_string(),
+        to: "fail:sink".to_string(),
+    });
+    flow.links.push(Link {
+        from: "fail:src".to_string(),
+        to: "sink:sink".to_string(),
+    });
+
+    flow
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_start_fails_when_pipeline_cannot_reach_playing() {
+    gstreamer::init().unwrap();
+
+    let temp_file = NamedTempFile::new().unwrap();
+    let registry = BlockRegistry::new(temp_file.path());
+    let events = EventBroadcaster::new(10);
+    let media_path = std::env::temp_dir();
+
+    let flow = build_failing_flow("start_failure_test");
+
+    let mut manager = PipelineManager::new(
+        &flow,
+        events,
+        &registry,
+        vec![],
+        "all".to_string(),
+        None,
+        media_path,
+        std::sync::Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+    )
+    .expect("Failed to create PipelineManager");
+
+    let result = manager.start();
+
+    assert!(
+        result.is_err(),
+        "start() reported success for a pipeline that never reached PLAYING \
+         (returned {:?}) — callers register WHEP endpoints for a dead flow",
+        result
+    );
+}
+
+/// Control: the same harness on a healthy flow still starts. Guards against
+/// "fix" the failure path by rejecting every async start.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_start_succeeds_for_healthy_pipeline() {
+    gstreamer::init().unwrap();
+
+    let temp_file = NamedTempFile::new().unwrap();
+    let registry = BlockRegistry::new(temp_file.path());
+    let events = EventBroadcaster::new(10);
+    let media_path = std::env::temp_dir();
+
+    let mut flow = build_failing_flow("start_success_test");
+    // Same topology, but identity passes buffers through instead of erroring.
+    flow.elements[1].properties.insert(
+        "error-after".to_string(),
+        strom_types::PropertyValue::Int(-1),
+    );
+
+    let mut manager = PipelineManager::new(
+        &flow,
+        events,
+        &registry,
+        vec![],
+        "all".to_string(),
+        None,
+        media_path,
+        std::sync::Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+    )
+    .expect("Failed to create PipelineManager");
+
+    let state = manager.start().expect("Healthy pipeline failed to start");
+    assert_eq!(state, strom_types::PipelineState::Playing);
+
+    manager.stop().expect("Failed to stop pipeline");
+}


### PR DESCRIPTION
## Problem

WHEP outputs randomly answer 502 for the whole lifetime of a production run. Observed on a deployed host running 0.6.5 and 0.6.6 — both affected.

`gst_element_get_state()` reports a still-running transition as `Ok(Async)`. `Err` is only ever `GST_STATE_CHANGE_FAILURE`, whatever the pending state says. `start()` checked `pending == VoidPending` to tell the two apart, so a pipeline that had already aborted PAUSED → PLAYING with PLAYING still pending was logged as "state change still in progress" and returned `Ok(Paused)`.

`start_flow()` then registered the flow's WHEP endpoints and reported the flow as started, but the pipeline never left PAUSED, so `whepserversink`'s signaller never opened its HTTP port. Every WHEP offer against that flow answered 502 for as long as it "ran", while the UI showed it running.

## Evidence

Captured on a live failing flow:

```
Pipeline 'Demo Production-...' state after start: result=Err(StateChangeError), current=Paused, pending=Playing
Pipeline 'Demo Production-...' state change still in progress (current: Paused, pending: Playing)
ERROR Pipeline error in flow 'Demo Production-...': No valid frames found before end of stream
Registering WHEP endpoint 'mv-...' on port 37881
Registering WHEP endpoint 'pgm-...' on port 35387
```

No `-> Playing` ever followed, and nothing was listening on either port:

```
$ ss -ltn | grep -E ":(37881|35387)\b"     # no output
$ curl -X POST http://127.0.0.1:37881/whep/endpoint
Failed to connect to 127.0.0.1 port 37881: Couldn't connect to server
```

Across 9 flow starts in one day, 5 hit this and returned 502 on every WHEP offer; the 4 that reached PLAYING served normally.

## Changes

- `lifecycle.rs`: any `Err` from `pipeline.state()` fails the start, regardless of pending state. The error now names both current and pending.
- `state.rs`: release the CPU affinity allocation when `start()` fails. That path is now reachable, and the cores leaked until the process restarted.
- `whep_player.rs`: log the proxy error behind each 502, and the endpoint id behind each unregistered-endpoint 404. Previously the cause only existed in the response body, so the log showed a bare 502 with no reason.

## Scope

This makes a dead flow fail loudly instead of silently. It does **not** fix the underlying startup race — a `tsdemux` PMT change ~38 ms into the stream tears down the video pad it just created, and the `h264parse` decodebin autoplugged for it posts a fatal error before it has parsed a complete access unit. That fix follows separately.

## Tests

`backend/tests/pipeline_start_failure_test.rs` drives the real `PipelineManager::start()` with `audiotestsrc ! identity error-after=1 ! fakesink`. `identity` errors on the first buffer, which is pushed during preroll, so the sink never prerolls and the pipeline fails the transition with PLAYING still pending — the same state shape as production. A control test on the same topology with `error-after=-1` asserts a healthy async start still succeeds.

Verified the guard fails without the fix (stashed `lifecycle.rs`, re-ran):

```
start() reported success for a pipeline that never reached PLAYING
(returned Ok(Paused)) — callers register WHEP endpoints for a dead flow
```

`audiotestsrc` comes from `gstreamer1.0-plugins-base` and `identity`/`fakesink` from core, both already in the CI package list, so the test actually executes in CI.

Ran locally: full `cargo test` (530 unit + all integration suites, 0 failed), `cargo fmt --check`, `cargo clippy --all-targets`. All clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)