### PR TITLE
fix(pipeline): re-drive a transition poisoned by a transient startup error

### DIFF
--- a/backend/src/api/whep_player.rs
+++ b/backend/src/api/whep_player.rs
@@ -483,7 +483,12 @@ pub async fn whep_endpoint_proxy(
         None => {
             // Not registered: the flow is stopped, never started, or the
             // block's endpoint_id was changed since the player loaded.
-            tracing::warn!("WHEP offer for unregistered endpoint '{}'", endpoint_id);
+            //
+            // debug!, not warn!: the WHEP router carries no auth middleware and
+            // endpoint_id is a percent-decoded path segment, so anyone who can
+            // reach the port would otherwise get a log line per request out of
+            // us. {:?} escapes the value — a decoded newline could forge a line.
+            tracing::debug!("WHEP offer for unregistered endpoint {:?}", endpoint_id);
             return Response::builder()
                 .status(StatusCode::NOT_FOUND)
                 .header(header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
@@ -633,8 +638,10 @@ pub async fn whep_resource_proxy_delete(
     let port = match state.whep_registry().get_port(&endpoint_id).await {
         Some(p) => p,
         None => {
-            tracing::warn!(
-                "WHEP resource DELETE for unregistered endpoint '{}'",
+            // debug! and {:?} for the same reason as the offer path above:
+            // unauthenticated route, attacker-supplied endpoint_id.
+            tracing::debug!(
+                "WHEP resource DELETE for unregistered endpoint {:?}",
                 endpoint_id
             );
             return Response::builder()

--- a/backend/src/gst/pipeline/lifecycle.rs
+++ b/backend/src/gst/pipeline/lifecycle.rs
@@ -2,8 +2,22 @@ use super::{PipelineError, PipelineManager};
 use crate::gst::thread_priority;
 use gstreamer as gst;
 use gstreamer::prelude::*;
+use std::time::Duration;
 use strom_types::PipelineState;
-use tracing::{error, info};
+use tracing::{error, info, warn};
+
+/// How many times to re-drive a failed transition to PLAYING before giving up.
+/// One transient demuxer program change needs a single retry; the extra
+/// attempts cover a feed that churns twice. A genuinely broken pipeline just
+/// fails this many times and then reports the failure.
+const STATE_CHANGE_RETRIES: u32 = 3;
+
+/// How long to let the input settle before re-driving. Measured on a live feed,
+/// the input relinked its pads 1.4-2.1 s after the transient error.
+const STATE_CHANGE_RETRY_SETTLE: Duration = Duration::from_millis(750);
+
+/// How long to wait for the re-driven transition to report a verdict.
+const STATE_CHANGE_RETRY_TIMEOUT: gst::ClockTime = gst::ClockTime::from_seconds(2);
 
 impl PipelineManager {
     /// Start the pipeline (set to PLAYING state).
@@ -105,7 +119,7 @@ impl PipelineManager {
         // Query the actual state GStreamer has reached so far.
         // For Async pipelines this returns the current state (e.g. Paused)
         // without blocking. For NoPreroll/Success it returns the final state.
-        let (result, current_state, pending_state) =
+        let (mut result, mut current_state, mut pending_state) =
             self.pipeline.state(gst::ClockTime::from_mseconds(500));
         info!(
             "Pipeline '{}' state after start: result={:?}, current={:?}, pending={:?}",
@@ -115,16 +129,63 @@ impl PipelineManager {
         // `gst_element_get_state()` reports a still-running transition as
         // `Ok(Async)`. `Err` is only ever GST_STATE_CHANGE_FAILURE, whatever
         // the pending state says: a failure with `pending == Playing` is a
-        // pipeline that aborted the PAUSED -> PLAYING transition (an element
-        // posted a fatal error on the bus) and will never leave PAUSED on its
-        // own. Reporting that as "async in progress" starts a dead flow —
-        // every element that only serves traffic in PLAYING stays down, and
-        // whepserversink's signaller never opens its HTTP port, so all WHEP
-        // offers for the flow's whole lifetime fail with 502.
+        // pipeline that aborted its transition and will never leave its
+        // current state on its own.
+        //
+        // A live input can poison that transition transiently. An MPEG-TS feed
+        // that re-signals its PMT makes tsdemux drain the previous program: it
+        // pushes EOS out of the pad it is removing, and the parser decodebin
+        // autoplugged for that short-lived pad has no complete access unit yet,
+        // so GstBaseParse errors fatally. The element aborts its own state,
+        // which fails the whole pipeline's transition. Measured on a live feed
+        // the two programs were 38 ms apart — under one frame at 25 fps.
+        //
+        // The input recovers on its own a second or two later: decodebin drops
+        // the doomed chain and exposes the new program's pads. Only the
+        // pipeline's state stays poisoned. Re-driving the transition once the
+        // input has settled picks it up — verified: a failed state change
+        // re-driven after the failing condition clears returns Success, and
+        // does not need a detour via READY or a drained bus.
+        //
+        // This deliberately touches nothing in the data path. An earlier
+        // attempt dropped the EOS at the parser instead; that removed the error
+        // but stopped decodebin from ever exposing the replacement pads, and
+        // turned a loud failure into a silent hang.
+        for attempt in 1..=STATE_CHANGE_RETRIES {
+            if result.is_ok() {
+                break;
+            }
+            warn!(
+                "Pipeline '{}' failed its transition (current: {:?}, pending: {:?}) — \
+                 re-driving, attempt {}/{}. A transient input error during startup \
+                 (e.g. a demuxer program change) can do this.",
+                self.flow_name, current_state, pending_state, attempt, STATE_CHANGE_RETRIES
+            );
+
+            std::thread::sleep(STATE_CHANGE_RETRY_SETTLE);
+
+            let _ = self.pipeline.set_state(gst::State::Playing);
+            (result, current_state, pending_state) =
+                self.pipeline.state(STATE_CHANGE_RETRY_TIMEOUT);
+
+            if result.is_ok() {
+                info!(
+                    "Pipeline '{}' recovered on attempt {} (current: {:?}, pending: {:?})",
+                    self.flow_name, attempt, current_state, pending_state
+                );
+            }
+        }
+
+        // Still failing after the retries: the flow is genuinely dead. Say so
+        // rather than reporting it started — callers go on to register WHEP
+        // endpoints, and whepserversink's signaller never opens its HTTP port
+        // on a pipeline whose transition aborted, so every WHEP offer for the
+        // flow's whole lifetime would answer 502 against a "running" flow.
         if let Err(e) = result {
             error!(
-                "Pipeline '{}' failed to reach PLAYING state: {:?} (current: {:?}, pending: {:?})",
-                self.flow_name, e, current_state, pending_state
+                "Pipeline '{}' failed to reach PLAYING state after {} attempts: {:?} \
+                 (current: {:?}, pending: {:?})",
+                self.flow_name, STATE_CHANGE_RETRIES, e, current_state, pending_state
             );
             return Err(PipelineError::StateChange(format!(
                 "State change failed: {:?} - current: {:?}, pending: {:?}",

--- a/backend/src/gst/pipeline/lifecycle.rs
+++ b/backend/src/gst/pipeline/lifecycle.rs
@@ -2,19 +2,21 @@ use super::{PipelineError, PipelineManager};
 use crate::gst::thread_priority;
 use gstreamer as gst;
 use gstreamer::prelude::*;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use strom_types::PipelineState;
 use tracing::{error, info, warn};
 
-/// How many times to re-drive a failed transition to PLAYING before giving up.
-/// One transient demuxer program change needs a single retry; the extra
-/// attempts cover a feed that churns twice. A genuinely broken pipeline just
-/// fails this many times and then reports the failure.
-const STATE_CHANGE_RETRIES: u32 = 3;
+/// How long to keep re-driving a failed transition to PLAYING before giving up.
+/// Measured on a live feed, the input relinked its pads 1.4-2.1 s after the
+/// transient error, so the window has to outlast that. A genuinely broken
+/// pipeline fails every attempt inside the window and then reports the failure.
+const STATE_CHANGE_RETRY_WINDOW: Duration = Duration::from_secs(3);
 
-/// How long to let the input settle before re-driving. Measured on a live feed,
-/// the input relinked its pads 1.4-2.1 s after the transient error.
-const STATE_CHANGE_RETRY_SETTLE: Duration = Duration::from_millis(750);
+/// How long to wait between re-drives. The only way to learn that the input has
+/// settled is to try, so poll rather than sleep out a guess: at 200 ms the
+/// recovery is picked up within 200 ms of it happening instead of at the next
+/// multiple of a long settle time.
+const STATE_CHANGE_RETRY_INTERVAL: Duration = Duration::from_millis(200);
 
 /// How long to wait for the re-driven transition to report a verdict.
 const STATE_CHANGE_RETRY_TIMEOUT: gst::ClockTime = gst::ClockTime::from_seconds(2);
@@ -119,6 +121,15 @@ impl PipelineManager {
         // Query the actual state GStreamer has reached so far.
         // For Async pipelines this returns the current state (e.g. Paused)
         // without blocking. For NoPreroll/Success it returns the final state.
+        //
+        // 500 ms is a sample, not a verdict, and deliberately so: a transition
+        // still in flight comes back as Ok(Async) and is reported as started.
+        // Waiting for it to settle instead would break every input that legally
+        // sits in PAUSED until its first packet arrives — an srtsrc or rtspsrc
+        // with no sender yet must start successfully and pick the feed up later.
+        // The cost is that a fatal error arriving after the sample is not seen
+        // here; the bus handler still reports it, the flow just gets there by
+        // way of a PipelineError event rather than a failed start().
         let (mut result, mut current_state, mut pending_state) =
             self.pipeline.state(gst::ClockTime::from_mseconds(500));
         info!(
@@ -151,18 +162,27 @@ impl PipelineManager {
         // attempt dropped the EOS at the parser instead; that removed the error
         // but stopped decodebin from ever exposing the replacement pads, and
         // turned a loud failure into a silent hang.
-        for attempt in 1..=STATE_CHANGE_RETRIES {
-            if result.is_ok() {
+        let retry_deadline = Instant::now() + STATE_CHANGE_RETRY_WINDOW;
+        let mut attempts = 0u32;
+        while result.is_err() {
+            let now = Instant::now();
+            if now >= retry_deadline {
                 break;
             }
+            attempts += 1;
             warn!(
                 "Pipeline '{}' failed its transition (current: {:?}, pending: {:?}) — \
-                 re-driving, attempt {}/{}. A transient input error during startup \
-                 (e.g. a demuxer program change) can do this.",
-                self.flow_name, current_state, pending_state, attempt, STATE_CHANGE_RETRIES
+                 re-driving, attempt {} ({:?} of the {:?} window left). A transient \
+                 input error during startup (e.g. a demuxer program change) can do this.",
+                self.flow_name,
+                current_state,
+                pending_state,
+                attempts,
+                retry_deadline - now,
+                STATE_CHANGE_RETRY_WINDOW
             );
 
-            std::thread::sleep(STATE_CHANGE_RETRY_SETTLE);
+            std::thread::sleep(STATE_CHANGE_RETRY_INTERVAL);
 
             let _ = self.pipeline.set_state(gst::State::Playing);
             (result, current_state, pending_state) =
@@ -170,8 +190,8 @@ impl PipelineManager {
 
             if result.is_ok() {
                 info!(
-                    "Pipeline '{}' recovered on attempt {} (current: {:?}, pending: {:?})",
-                    self.flow_name, attempt, current_state, pending_state
+                    "Pipeline '{}' reached {:?} on attempt {} (pending: {:?})",
+                    self.flow_name, current_state, attempts, pending_state
                 );
             }
         }
@@ -183,14 +203,55 @@ impl PipelineManager {
         // flow's whole lifetime would answer 502 against a "running" flow.
         if let Err(e) = result {
             error!(
-                "Pipeline '{}' failed to reach PLAYING state after {} attempts: {:?} \
-                 (current: {:?}, pending: {:?})",
-                self.flow_name, STATE_CHANGE_RETRIES, e, current_state, pending_state
+                "Pipeline '{}' failed to reach PLAYING state after {} re-drive attempt(s) \
+                 over {:?}: {:?} (current: {:?}, pending: {:?})",
+                self.flow_name,
+                attempts,
+                STATE_CHANGE_RETRY_WINDOW,
+                e,
+                current_state,
+                pending_state
             );
             return Err(PipelineError::StateChange(format!(
                 "State change failed: {:?} - current: {:?}, pending: {:?}",
                 e, current_state, pending_state
             )));
+        }
+
+        // Reaching PLAYING is not the same as having a data path. The state
+        // says nothing about which of the two things happened upstream:
+        //
+        //   - the input recovered (decodebin dropped the doomed chain and
+        //     exposed the replacement pads) — what the re-drive is for; or
+        //   - the input died. A basesrc that takes a flow error pauses its task
+        //     *and pushes EOS*. That EOS completes the sink's preroll, so the
+        //     re-driven transition reports Success on a pipeline that will never
+        //     carry another buffer.
+        //
+        // Measured on `audiotestsrc ! identity error-after=1 ! fakesink`: the
+        // re-drive returns Success with the pipeline in PLAYING and zero buffers
+        // ever reaching the sink. Reporting that as started is the silent
+        // failure this whole path exists to avoid, so check the outputs before
+        // believing the state. Only on the retry path — a pipeline that started
+        // first time is not suspect, and this must not slow the normal start.
+        if attempts > 0 {
+            let (eos_sinks, total_sinks) = self.eos_sink_count();
+            if total_sinks > 0 && eos_sinks == total_sinks {
+                error!(
+                    "Pipeline '{}' reached {:?} after {} re-drive attempt(s), but all {} \
+                     output(s) are EOS — the input died rather than recovered, so the flow \
+                     would produce nothing for its whole lifetime",
+                    self.flow_name, current_state, attempts, total_sinks
+                );
+                return Err(PipelineError::StateChange(format!(
+                    "Pipeline reached {:?} with no live data path: all {} output(s) are EOS",
+                    current_state, total_sinks
+                )));
+            }
+            info!(
+                "Pipeline '{}' has a live data path after recovery ({}/{} output(s) EOS)",
+                self.flow_name, eos_sinks, total_sinks
+            );
         }
 
         let actual_state = match current_state {
@@ -211,6 +272,45 @@ impl PipelineManager {
         self.start_thumbnail_deactivation_task();
 
         Ok(actual_state)
+    }
+
+    /// Count the pipeline's sink elements, and how many of them have seen EOS
+    /// on every one of their sink pads.
+    ///
+    /// A sink whose pads are all EOS will never receive another buffer. When
+    /// *every* sink is in that state the pipeline has no live output at all —
+    /// which is how a dead input looks after the transition was re-driven. One
+    /// EOS sink among several is not that: it is the doomed chain being drained
+    /// while the rest of the graph runs, exactly what the re-drive recovers
+    /// from. `iterate_sinks()` covers bins too, since a bin holding a sink
+    /// carries the sink flag itself.
+    fn eos_sink_count(&self) -> (usize, usize) {
+        let mut eos = 0usize;
+        let mut total = 0usize;
+        let mut sinks = self.pipeline.iterate_sinks();
+        while let Ok(Some(element)) = sinks.next() {
+            let pads: Vec<gst::Pad> = element
+                .pads()
+                .into_iter()
+                .filter(|pad| pad.direction() == gst::PadDirection::Sink)
+                .collect();
+            if pads.is_empty() {
+                continue;
+            }
+            total += 1;
+            if pads
+                .iter()
+                .all(|pad| pad.pad_flags().contains(gst::PadFlags::EOS))
+            {
+                warn!(
+                    "Pipeline '{}': output '{}' is EOS",
+                    self.flow_name,
+                    element.name()
+                );
+                eos += 1;
+            }
+        }
+        (eos, total)
     }
 
     /// Start periodic task that deactivates idle thumbnail branches.

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -911,7 +911,7 @@ impl AppState {
 
         // Create pipeline with event broadcaster and block registry
         info!("Creating PipelineManager (this may block)...");
-        let mut manager = PipelineManager::new(
+        let mut manager = match PipelineManager::new(
             &flow,
             self.inner.events.clone(),
             &self.inner.block_registry,
@@ -920,7 +920,17 @@ impl AppState {
             Some(self.inner.whip_registry.clone()),
             self.inner.media_path.clone(),
             local_devices,
-        )?;
+        ) {
+            Ok(manager) => manager,
+            Err(e) => {
+                // Any Media Player block built before the failing one has
+                // already put its state in the global registry, and only
+                // unregistering drops the Arc whose Drop takes that block's
+                // internal pipeline to NULL.
+                crate::blocks::builtin::mediaplayer::MEDIA_PLAYER_REGISTRY.unregister_flow(id);
+                return Err(e);
+            }
+        };
         info!("PipelineManager created successfully");
 
         // Set thread registry for CPU monitoring
@@ -935,15 +945,61 @@ impl AppState {
             manager.set_assigned_cpus(assigned_cpus);
         }
 
-        // Start pipeline
+        // Start pipeline.
+        //
+        // start() blocks: a synchronous set_state(Playing), and for a
+        // transition poisoned by a transient input error, seconds of re-driving
+        // on top. This is awaited straight from the HTTP handler and from the
+        // boot auto-restart loop, so run it on the blocking pool rather than
+        // parking a tokio worker for the duration.
         info!("Calling manager.start() (this may block)...");
-        let state = match manager.start() {
+        let (mut manager, start_result) = tokio::task::spawn_blocking(move || {
+            let result = manager.start();
+            (manager, result)
+        })
+        .await
+        .map_err(|e| PipelineError::StateChange(format!("start() task panicked: {}", e)))?;
+
+        let state = match start_result {
             Ok(state) => state,
             Err(e) => {
-                // The manager is dropped here, which takes the pipeline to
-                // Null. Release the CPU allocation too, or a flow that fails
-                // to start leaks its cores until the process restarts.
                 error!("Failed to start flow {}: {}", id, e);
+
+                // Dropping the manager is not enough. Drop only stops the
+                // thumbnail task and probes and sets NULL; stop() is what
+                // removes the bus watch, the thread-priority handler and the
+                // flow's threads from the CPU-monitor registry. Skipping it
+                // leaks one bus watch GSource per failed start and leaves dead
+                // TIDs in the registry, where a reused TID is then attributed
+                // to a flow that no longer exists.
+                //
+                // Unregistering the flow's Media Player instances first mirrors
+                // stop_flow(): the registry holds an Arc per instance whose
+                // Drop is the only thing that takes the block's *internal*
+                // pipeline to NULL, so without it a Media Player flow that
+                // fails to start leaves a decoding pipeline and its file
+                // descriptors running for the life of the process.
+                crate::blocks::builtin::mediaplayer::MEDIA_PLAYER_REGISTRY.unregister_flow(id);
+                let stop_result = tokio::task::spawn_blocking(move || {
+                    let result = manager.stop();
+                    drop(manager);
+                    result
+                })
+                .await;
+                match stop_result {
+                    Ok(Err(stop_err)) => warn!(
+                        "Cleanup after failed start of flow {} could not stop the pipeline: {}",
+                        id, stop_err
+                    ),
+                    Err(join_err) => warn!(
+                        "Cleanup after failed start of flow {} panicked: {}",
+                        id, join_err
+                    ),
+                    Ok(Ok(_)) => {}
+                }
+
+                // Release the CPU allocation too, or a flow that fails to start
+                // leaks its cores until the process restarts.
                 self.inner.affinity_manager.deallocate(id);
                 return Err(e);
             }

--- a/backend/tests/pipeline_start_failure_test.rs
+++ b/backend/tests/pipeline_start_failure_test.rs
@@ -9,6 +9,11 @@
 //! register the flow's WHEP endpoints, but the pipeline never left PAUSED, so
 //! whepserversink's signaller never opened its HTTP port and every WHEP offer
 //! against that flow answered 502 for as long as it "ran".
+//!
+//! This guards the *persistent* case. `start()` also re-drives a transition
+//! that a transient startup error poisoned; that recovery is guarded by
+//! `pipeline_start_retry_test.rs`, which is why the bed here has to be a
+//! pipeline no retry can rescue.
 
 use std::collections::HashMap;
 use strom::blocks::BlockRegistry;
@@ -17,13 +22,12 @@ use strom::gst::pipeline::PipelineManager;
 use strom_types::{Flow, Link};
 use tempfile::NamedTempFile;
 
-/// Build `audiotestsrc → identity error-after=1 → fakesink`.
+/// Build `audiotestsrc → identity → fakesink state-error=paused-to-playing`.
 ///
-/// `identity` errors out on the very first buffer, which is pushed during
-/// preroll. The sink therefore never prerolls, the pipeline never leaves
-/// PAUSED, and the transition to PLAYING fails with PLAYING still pending —
-/// the same shape a live flow produces when a parser inside `decodebin` posts
-/// a fatal error while the pipeline is prerolling.
+/// The sink fails PAUSED -> PLAYING on every attempt, so the pipeline can
+/// never reach PLAYING however many times the transition is re-driven. That
+/// is the shape `start()` must report as a failure rather than as a started
+/// flow.
 ///
 /// Uses only core GStreamer elements plus `audiotestsrc` so it runs in CI.
 fn build_failing_flow(name: &str) -> Flow {
@@ -40,14 +44,7 @@ fn build_failing_flow(name: &str) -> Flow {
     flow.elements.push(strom_types::Element {
         id: "fail".to_string(),
         element_type: "identity".to_string(),
-        properties: {
-            let mut p = HashMap::new();
-            p.insert(
-                "error-after".to_string(),
-                strom_types::PropertyValue::Int(1),
-            );
-            p
-        },
+        properties: HashMap::new(),
         position: [250.0, 200.0].into(),
         pad_properties: HashMap::new(),
     });
@@ -55,7 +52,14 @@ fn build_failing_flow(name: &str) -> Flow {
     flow.elements.push(strom_types::Element {
         id: "sink".to_string(),
         element_type: "fakesink".to_string(),
-        properties: HashMap::new(),
+        properties: {
+            let mut p = HashMap::new();
+            p.insert(
+                "state-error".to_string(),
+                strom_types::PropertyValue::String("paused-to-playing".to_string()),
+            );
+            p
+        },
         position: [400.0, 200.0].into(),
         pad_properties: HashMap::new(),
     });
@@ -117,11 +121,8 @@ async fn test_start_succeeds_for_healthy_pipeline() {
     let media_path = std::env::temp_dir();
 
     let mut flow = build_failing_flow("start_success_test");
-    // Same topology, but identity passes buffers through instead of erroring.
-    flow.elements[1].properties.insert(
-        "error-after".to_string(),
-        strom_types::PropertyValue::Int(-1),
-    );
+    // Same topology, but the sink no longer refuses to go to PLAYING.
+    flow.elements[2].properties.clear();
 
     let mut manager = PipelineManager::new(
         &flow,

--- a/backend/tests/pipeline_start_retry_test.rs
+++ b/backend/tests/pipeline_start_retry_test.rs
@@ -1,0 +1,107 @@
+//! Regression test: a pipeline whose transition to PLAYING is poisoned by a
+//! transient startup error must recover, not stay dead.
+//!
+//! An MPEG-TS feed that re-signals its PMT makes tsdemux drain the previous
+//! program, pushing EOS out of the pad it removes. The parser decodebin
+//! autoplugged for that short-lived pad has no complete access unit yet and
+//! errors fatally, aborting its own state and with it the whole pipeline's
+//! transition. The input recovers on its own moments later — only the
+//! pipeline's state stays poisoned, so `start()` re-drives the transition.
+//!
+//! `identity error-after=1` stands in for the doomed parser: it errors on the
+//! first buffer, pushed during preroll, then stops being a problem, exactly as
+//! decodebin dropping the doomed chain does.
+//!
+//! The opposite case — a pipeline no retry can rescue must still fail — is
+//! guarded by `pipeline_start_failure_test.rs`.
+
+use std::collections::HashMap;
+use strom::blocks::BlockRegistry;
+use strom::events::EventBroadcaster;
+use strom::gst::pipeline::PipelineManager;
+use strom_types::{Flow, Link};
+use tempfile::NamedTempFile;
+
+fn build_flow(name: &str, error_after: i64) -> Flow {
+    let mut flow = Flow::new(name);
+
+    flow.elements.push(strom_types::Element {
+        id: "src".to_string(),
+        element_type: "audiotestsrc".to_string(),
+        properties: HashMap::new(),
+        position: [100.0, 200.0].into(),
+        pad_properties: HashMap::new(),
+    });
+    flow.elements.push(strom_types::Element {
+        id: "fail".to_string(),
+        element_type: "identity".to_string(),
+        properties: {
+            let mut p = HashMap::new();
+            p.insert(
+                "error-after".to_string(),
+                strom_types::PropertyValue::Int(error_after),
+            );
+            p
+        },
+        position: [250.0, 200.0].into(),
+        pad_properties: HashMap::new(),
+    });
+    flow.elements.push(strom_types::Element {
+        id: "sink".to_string(),
+        element_type: "fakesink".to_string(),
+        properties: HashMap::new(),
+        position: [400.0, 200.0].into(),
+        pad_properties: HashMap::new(),
+    });
+
+    flow.links.push(Link {
+        from: "src:src".to_string(),
+        to: "fail:sink".to_string(),
+    });
+    flow.links.push(Link {
+        from: "fail:src".to_string(),
+        to: "sink:sink".to_string(),
+    });
+    flow
+}
+
+fn manager_for(flow: &Flow) -> PipelineManager {
+    let temp_file = NamedTempFile::new().unwrap();
+    let registry = BlockRegistry::new(temp_file.path());
+    PipelineManager::new(
+        flow,
+        EventBroadcaster::new(10),
+        &registry,
+        vec![],
+        "all".to_string(),
+        None,
+        std::env::temp_dir(),
+        std::sync::Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+    )
+    .expect("Failed to create PipelineManager")
+}
+
+/// The guard. `identity` poisons the first transition; the retry inside
+/// `start()` must drive the pipeline to PLAYING anyway.
+///
+/// This fails without the retry loop: the first attempt returns
+/// Err(StateChangeError) and `start()` propagates it.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_start_recovers_from_a_transient_startup_error() {
+    gstreamer::init().unwrap();
+
+    let flow = build_flow("transient_error_recovery", 1);
+    let mut manager = manager_for(&flow);
+
+    let state = manager
+        .start()
+        .expect("start() gave up on a pipeline that a retry recovers");
+
+    assert_eq!(
+        state,
+        strom_types::PipelineState::Playing,
+        "pipeline should be PLAYING after the retry"
+    );
+
+    manager.stop().expect("Failed to stop pipeline");
+}

--- a/backend/tests/pipeline_start_retry_test.rs
+++ b/backend/tests/pipeline_start_retry_test.rs
@@ -1,58 +1,60 @@
 //! Regression test: a pipeline whose transition to PLAYING is poisoned by a
-//! transient startup error must recover, not stay dead.
+//! transient startup error must recover, not stay dead — and "recovered" has to
+//! mean data moves, not just that the state reads PLAYING.
 //!
 //! An MPEG-TS feed that re-signals its PMT makes tsdemux drain the previous
 //! program, pushing EOS out of the pad it removes. The parser decodebin
 //! autoplugged for that short-lived pad has no complete access unit yet and
 //! errors fatally, aborting its own state and with it the whole pipeline's
-//! transition. The input recovers on its own moments later — only the
-//! pipeline's state stays poisoned, so `start()` re-drives the transition.
+//! transition. The input recovers on its own moments later — decodebin drops
+//! the doomed chain and exposes the new program's pads — so only the pipeline's
+//! state stays poisoned and `start()` re-drives the transition.
 //!
 //! `identity error-after=1` stands in for the doomed parser: it errors on the
-//! first buffer, pushed during preroll, then stops being a problem, exactly as
-//! decodebin dropping the doomed chain does.
+//! first buffer, pushed during preroll, then stops being a problem. The
+//! recovering flow puts that doomed chain *alongside* a healthy one, which is
+//! the shape of the real failure: the graph keeps a live data path across the
+//! transient error. A single doomed chain has no such path — the source pauses
+//! its task and pushes EOS, the EOS prerolls the sink, and the re-drive then
+//! reports Success on a pipeline that never carries another buffer. That case
+//! must fail, and is guarded below.
 //!
-//! The opposite case — a pipeline no retry can rescue must still fail — is
+//! The persistent case — a pipeline no retry can rescue must still fail — is
 //! guarded by `pipeline_start_failure_test.rs`.
 
+use gstreamer::prelude::*;
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 use strom::blocks::BlockRegistry;
 use strom::events::EventBroadcaster;
 use strom::gst::pipeline::PipelineManager;
 use strom_types::{Flow, Link};
 use tempfile::NamedTempFile;
 
-fn build_flow(name: &str, error_after: i64) -> Flow {
+fn element(id: &str, element_type: &str, x: f32) -> strom_types::Element {
+    strom_types::Element {
+        id: id.to_string(),
+        element_type: element_type.to_string(),
+        properties: HashMap::new(),
+        position: [x, 200.0].into(),
+        pad_properties: HashMap::new(),
+    }
+}
+
+/// `audiotestsrc -> identity error-after=N -> fakesink`: one chain, and the
+/// error takes it down with it.
+fn build_doomed_flow(name: &str, error_after: i64) -> Flow {
     let mut flow = Flow::new(name);
 
-    flow.elements.push(strom_types::Element {
-        id: "src".to_string(),
-        element_type: "audiotestsrc".to_string(),
-        properties: HashMap::new(),
-        position: [100.0, 200.0].into(),
-        pad_properties: HashMap::new(),
-    });
-    flow.elements.push(strom_types::Element {
-        id: "fail".to_string(),
-        element_type: "identity".to_string(),
-        properties: {
-            let mut p = HashMap::new();
-            p.insert(
-                "error-after".to_string(),
-                strom_types::PropertyValue::Int(error_after),
-            );
-            p
-        },
-        position: [250.0, 200.0].into(),
-        pad_properties: HashMap::new(),
-    });
-    flow.elements.push(strom_types::Element {
-        id: "sink".to_string(),
-        element_type: "fakesink".to_string(),
-        properties: HashMap::new(),
-        position: [400.0, 200.0].into(),
-        pad_properties: HashMap::new(),
-    });
+    flow.elements.push(element("src", "audiotestsrc", 100.0));
+    let mut fail = element("fail", "identity", 250.0);
+    fail.properties.insert(
+        "error-after".to_string(),
+        strom_types::PropertyValue::Int(error_after),
+    );
+    flow.elements.push(fail);
+    flow.elements.push(element("sink", "fakesink", 400.0));
 
     flow.links.push(Link {
         from: "src:src".to_string(),
@@ -61,6 +63,22 @@ fn build_flow(name: &str, error_after: i64) -> Flow {
     flow.links.push(Link {
         from: "fail:src".to_string(),
         to: "sink:sink".to_string(),
+    });
+    flow
+}
+
+/// The doomed chain plus a healthy one, both in the same pipeline. The error
+/// still aborts the pipeline's transition, but the graph keeps a live data path
+/// — so the re-drive has something real to recover.
+fn build_recovering_flow(name: &str) -> Flow {
+    let mut flow = build_doomed_flow(name, 1);
+
+    flow.elements
+        .push(element("src_live", "audiotestsrc", 100.0));
+    flow.elements.push(element("sink_live", "fakesink", 400.0));
+    flow.links.push(Link {
+        from: "src_live:src".to_string(),
+        to: "sink_live:sink".to_string(),
     });
     flow
 }
@@ -81,8 +99,32 @@ fn manager_for(flow: &Flow) -> PipelineManager {
     .expect("Failed to create PipelineManager")
 }
 
+/// Count buffers arriving at one named sink element over `window`.
+fn buffers_at(manager: &PipelineManager, sink_name: &str, window: std::time::Duration) -> u64 {
+    let element = manager
+        .pipeline()
+        .by_name(sink_name)
+        .unwrap_or_else(|| panic!("no element named '{}' in the pipeline", sink_name));
+    let pad = element.static_pad("sink").expect("sink pad");
+
+    let count = Arc::new(AtomicU64::new(0));
+    let counter = count.clone();
+    let probe = pad
+        .add_probe(gstreamer::PadProbeType::BUFFER, move |_, _| {
+            counter.fetch_add(1, Ordering::Relaxed);
+            gstreamer::PadProbeReturn::Ok
+        })
+        .expect("failed to attach probe");
+
+    std::thread::sleep(window);
+    let seen = count.load(Ordering::Relaxed);
+    pad.remove_probe(probe);
+    seen
+}
+
 /// The guard. `identity` poisons the first transition; the retry inside
-/// `start()` must drive the pipeline to PLAYING anyway.
+/// `start()` must drive the pipeline to PLAYING anyway *and* the surviving
+/// chain must still be passing buffers afterwards.
 ///
 /// This fails without the retry loop: the first attempt returns
 /// Err(StateChangeError) and `start()` propagates it.
@@ -90,7 +132,7 @@ fn manager_for(flow: &Flow) -> PipelineManager {
 async fn test_start_recovers_from_a_transient_startup_error() {
     gstreamer::init().unwrap();
 
-    let flow = build_flow("transient_error_recovery", 1);
+    let flow = build_recovering_flow("transient_error_recovery");
     let mut manager = manager_for(&flow);
 
     let state = manager
@@ -101,6 +143,39 @@ async fn test_start_recovers_from_a_transient_startup_error() {
         state,
         strom_types::PipelineState::Playing,
         "pipeline should be PLAYING after the retry"
+    );
+
+    // The point of the recovery: data moves again. Without this the test is
+    // satisfied by a pipeline that reads PLAYING and carries nothing.
+    let seen = buffers_at(&manager, "sink_live", std::time::Duration::from_millis(300));
+    assert!(
+        seen > 0,
+        "no buffers reached the surviving sink after the retry — the pipeline \
+         reads PLAYING but its data path is dead"
+    );
+
+    manager.stop().expect("Failed to stop pipeline");
+}
+
+/// The other half of the guard: when the transient error kills the *only* data
+/// path, the re-driven transition still reports Success — the source pushed EOS
+/// when it took the flow error, and that EOS prerolled the sink. `start()` must
+/// not report such a pipeline as started, or `start_flow()` goes on to register
+/// its WHEP endpoints, mark it auto-restart and leave a flow that produces
+/// nothing for the rest of the process's life.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_start_fails_when_the_transient_error_killed_the_only_data_path() {
+    gstreamer::init().unwrap();
+
+    let flow = build_doomed_flow("transient_error_no_data_path", 1);
+    let mut manager = manager_for(&flow);
+
+    let result = manager.start();
+
+    assert!(
+        result.is_err(),
+        "start() reported {:?} for a pipeline whose only data path is EOS",
+        result
     );
 
     manager.stop().expect("Failed to stop pipeline");


### PR DESCRIPTION
Replaces #706, which was validated against the real feed and did not work. Same diagnosis, different fix.

## Diagnosis (unchanged, captured live)

An MPEG-TS feed re-signals its PMT shortly after the first one. `tsdemux` drains the previous program: it pushes EOS out of the pad it is removing, and the parser `decodebin` autoplugged for that short-lived pad has no complete access unit yet, so `GstBaseParse` errors fatally.

```
.689613  tsdemux69:video_0_0041  done adding pad
.723817  tsdemux69               Draining previous program
.725773  tsdemux69:video_1_0041  done adding pad
.727053  tsdemux69:video_0_0041  Pushing out EOS
.727283  h264parse251  error: No valid frames found before end of stream
```

38 ms — under one frame at 25 fps. Whether it fires depends on how much video landed in that window, which is why it looks random. 5 of 9 starts one day; two deployed instances (0.6.5 and 0.6.6).

## Two approaches measured and rejected first

**Dropping the EOS at the parser** (#706). The shield fired on the right element and the error went away, but `decodebin` then never emitted `pad-added` for the new program. The input never linked its pads while SRT kept delivering:

```
b-input-0-9d0e28ed:srtsrc  connected=True pkts_rx=36060 bytes_rx=49039344 rate=3.00 Mbps
b-input-1-9d0e28ed:srtsrc  connected=True pkts_rx=14666 bytes_rx=19943504 rate=1.22 Mbps   <- shielded input, no pads
```

The pipeline hung at `Ready -> Paused (pending: Playing)`. The EOS is what drives decodebin's teardown of the removed chain — swallowing it trades a loud failure for a silent hang.

**Intercepting the ERROR message.** Measured directly:

```
without bus sync handler: result=Err(StateChangeError) current=Ready pending=Playing
with    bus sync handler: result=Err(StateChangeError) current=Ready pending=Playing
```

Dropping the message changes nothing, because the erroring element aborts its own state rather than the message aborting it at the bin. A `GstBin` subclass overriding `handle_message` would not have helped.

## This fix

The input recovers by itself — decodebin drops the doomed chain and exposes the new program's pads within a second or two. Only the pipeline's state stays poisoned. So re-drive the transition, polling every 200 ms against a 3 s deadline, and report the failure if it still will not go. Polling rather than sleeping out a guess: the only way to learn that the input has settled is to try, so the recovery is picked up within 200 ms of it happening instead of at the next multiple of a long settle time, and the window still outlasts the 1.4-2.1 s relink measured on the live feed.

Reaching PLAYING is not by itself proof of recovery, so the re-drive verifies the data path before believing the state — see the review round below.

Measured beforehand: a failed state change re-driven after the failing condition clears returns `Ok(Success) current=Playing`, and needs neither a detour via READY nor a drained bus.

**This touches nothing in the data path.** That is what makes it safe — it cannot cause the wedge #706 caused. Worst case it costs a few seconds before reporting the same error.

It is a recovery, not a prevention: the demuxer churn that creates the doomed parser is upstream of us and still happens. The retry is loud (`warn!` per attempt, `info!` on recovery) so it stays visible rather than masking a feed that has started misbehaving.

## Tests

`pipeline_start_retry_test.rs` — the guard, in two halves.

- *Recovery must work.* A doomed chain (`audiotestsrc ! identity error-after=1 ! fakesink`) alongside a healthy one, both in the same pipeline. `identity` errors on the first buffer during preroll and stops being a problem afterwards, as decodebin dropping the doomed chain does, and the healthy chain is the live data path the real graph keeps across the transient error. Asserts PLAYING **and** that buffers actually reach the surviving sink.
- *A dead data path must fail.* The doomed chain on its own. The re-driven transition still reports Success there, so this asserts `start()` returns an error.

Verified each half fails when its own fix is reverted: with the retry window set to 0 the recovery test fails with the production signature, and with the liveness check disabled the dead-path test fails.

```
start() gave up on a pipeline that a retry recovers:
StateChange("State change failed: StateChangeError - current: Paused, pending: Playing")
```

`pipeline_start_failure_test.rs` (from #705) needed realigning and this is worth a reviewer's eye. Its bed was `identity error-after=1` — a *transient* error, which this retry now recovers, so its "must fail" premise no longer held and it failed on the full suite run. It moves to `fakesink state-error=paused-to-playing`, which no retry can rescue, so it now guards what it was always meant to: a pipeline that can never reach PLAYING must not be reported as started.

Ran locally, on the final commit: full `cargo test` (all suites green, 0 failures), `cargo clippy --tests`, `cargo fmt --check`. Nothing skipped.

## Review round: what a code review of #705 + #707 found

Reviewed both changes together. Six findings, five fixed in `6a0358f`.

**The re-drive declared recovery from the pipeline state alone, and accepted a pipeline whose data path was already dead.** A `basesrc` that takes a flow error pauses its task *and pushes EOS*. That EOS completes the sink's preroll, so the re-driven `set_state(Playing)` returns Success on a pipeline that will never carry another buffer. Measured on `audiotestsrc ! identity error-after=1 ! fakesink`: `start()` returned `Ok(Playing)` with **zero** buffers reaching the sink over 1.5 s, after which `start_flow()` would register the WHEP endpoints, set `auto_restart` and leave a flow that produces nothing for the life of the process — the silent failure #705 removed, back for this class of input error. Note this was also the retry test's own bed, so the test asserted the regression.

`start()` now checks the outputs before believing the state, on the retry path only: if **every** sink element has EOS on all its sink pads, the flow has no live data path and the start fails. One EOS sink among several is the doomed chain draining while the rest of the graph runs, which is exactly what the re-drive is for. A pipeline that started first time is not suspect and is not checked, so the normal start path is untouched.

**The failed-start path in `start_flow()` dropped the manager instead of calling `stop()`.** `Drop` only aborts the thumbnail task, stops probes and sets NULL. It does not `remove_bus_watch()`, remove the thread-priority handler, or unregister the flow's threads — so each failed start leaked a bus watch GSource onto the main context and left dead TIDs in the CPU-monitor registry, where a reused TID gets attributed to a flow that no longer exists. Worse, it left the flow's Media Player instances in the global registry, and that `Arc`'s `Drop` is the only thing that takes a Media Player block's *internal* pipeline to NULL: a Media Player flow that failed to start left a decoding pipeline and its file descriptors running for the life of the process. Now it unregisters and stops, mirroring `stop_flow()`. The same unregister is also done when `PipelineManager::new()` itself fails — same leak, but it predates these PRs.

**`manager.start()` blocked a tokio worker thread for seconds.** It is awaited straight from the HTTP handler and from the boot auto-restart loop, and the retry loop added seconds of `sleep` + synchronous `set_state` on top. Now on the blocking pool, as is the cleanup `stop()`.

**The WHEP not-registered log lines sat at `warn!` on an unauthenticated route,** keyed by a percent-decoded path segment: one log line per request for anyone who can reach the port, and a decoded newline could forge a line. Now `debug!`, with the value escaped.

**Not fixed, deliberately: the 500 ms state sample.** A transition still in flight comes back as `Ok(Async)` and is reported as started, so a fatal error arriving after the sample is not seen by `start()`. Waiting the transition out instead would break every input that legally sits in PAUSED until its first packet — an `srtsrc` or `rtspsrc` with no sender yet must start successfully and pick the feed up later. Such an error still reaches the runtime through the bus handler as a `PipelineError` event; it just does not fail `start()`. The reasoning is now a comment in the code rather than a silent choice.

## Not yet done

Not yet validated against the real feed. The loop for that is established — CI artifact, bind-mount the binary, start the flow, read the log — and #706 shows why that step is not optional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
