### PR TITLE
fix(mpegtssrt): stop srtsink replaying a stale PAT/PMT to every caller

### DIFF
--- a/backend/src/blocks/builtin/mpegtssrt.rs
+++ b/backend/src/blocks/builtin/mpegtssrt.rs
@@ -81,26 +81,14 @@ fn strip_stream_header(pad: &gst::Pad, label: &str) {
         }
 
         let mut stripped = caps.copy();
-        match stripped
-            .get_mut()
-            .and_then(|caps| caps.structure_mut(0))
-            .map(|s| s.remove_field("streamheader"))
-        {
-            Some(()) => {
-                info!(
-                    "MPEGTSSRT {}: removed streamheader from muxer output caps \
-                     (late SRT callers read the live PAT/PMT instead of a frozen copy)",
-                    label
-                );
-                info.data = Some(gst::PadProbeData::Event(gst::event::Caps::new(&stripped)));
-            }
-            None => {
-                warn!(
-                    "MPEGTSSRT {}: could not remove streamheader from muxer output caps; \
-                     late SRT callers may see a stale program definition",
-                    label
-                );
-            }
+        if let Some(structure) = stripped.make_mut().structure_mut(0) {
+            structure.remove_field("streamheader");
+            info!(
+                "MPEGTSSRT {}: removed streamheader from muxer output caps \
+                 (late SRT callers read the live PAT/PMT instead of a frozen copy)",
+                label
+            );
+            info.data = Some(gst::PadProbeData::Event(gst::event::Caps::new(&stripped)));
         }
 
         gst::PadProbeReturn::Ok

--- a/backend/src/blocks/builtin/mpegtssrt.rs
+++ b/backend/src/blocks/builtin/mpegtssrt.rs
@@ -38,6 +38,75 @@ use std::sync::Arc;
 use strom_types::{block::*, element::ElementPadRef, PropertyValue, *};
 use tracing::{debug, error, info, warn};
 
+/// Remove `streamheader` from the caps leaving `pad`.
+///
+/// `mpegtsmux` advertises the PAT/PMT it wrote first as `streamheader`, and
+/// `srtsink` replays those buffers to every caller that connects afterwards.
+/// That header is a snapshot taken when the muxer produced its first output,
+/// while the tables in the live stream keep moving: this block links its video
+/// and audio chains to the muxer only once caps arrive, so the first PMT can
+/// list video alone, and any later caps change bumps the table version again.
+///
+/// A caller connecting later therefore receives a program definition that
+/// disagrees with the data that follows it. Its demuxer builds a program from
+/// the header, sees the real tables a few packets later, and tears the program
+/// down again — pushing EOS into the parser that was autoplugged for the pad it
+/// is removing. With less than one frame buffered that parser's EOS error is
+/// fatal, which aborts the receiving pipeline's transition to PLAYING.
+///
+/// Measured against a sender that had been running for four weeks: every
+/// connect replayed a video-only PMT ahead of a live PMT carrying video and
+/// audio, byte-identical across connects. Completing the header is not enough —
+/// a second sender replayed a header listing both streams that still disagreed
+/// on version. Any frozen header eventually drifts, so send none.
+///
+/// Without it a caller waits for the next periodic PAT/PMT — 100 ms by
+/// default — and gets tables that match the stream.
+fn strip_stream_header(pad: &gst::Pad, label: &str) {
+    let label = label.to_string();
+    pad.add_probe(gst::PadProbeType::EVENT_DOWNSTREAM, move |_pad, info| {
+        let Some(gst::PadProbeData::Event(event)) = info.data.as_ref() else {
+            return gst::PadProbeReturn::Ok;
+        };
+        let gst::EventView::Caps(caps_event) = event.view() else {
+            return gst::PadProbeReturn::Ok;
+        };
+
+        let caps = caps_event.caps();
+        let has_header = caps
+            .structure(0)
+            .is_some_and(|s| s.has_field("streamheader"));
+        if !has_header {
+            return gst::PadProbeReturn::Ok;
+        }
+
+        let mut stripped = caps.copy();
+        match stripped
+            .get_mut()
+            .and_then(|caps| caps.structure_mut(0))
+            .map(|s| s.remove_field("streamheader"))
+        {
+            Some(()) => {
+                info!(
+                    "MPEGTSSRT {}: removed streamheader from muxer output caps \
+                     (late SRT callers read the live PAT/PMT instead of a frozen copy)",
+                    label
+                );
+                info.data = Some(gst::PadProbeData::Event(gst::event::Caps::new(&stripped)));
+            }
+            None => {
+                warn!(
+                    "MPEGTSSRT {}: could not remove streamheader from muxer output caps; \
+                     late SRT callers may see a stale program definition",
+                    label
+                );
+            }
+        }
+
+        gst::PadProbeReturn::Ok
+    });
+}
+
 /// MPEG-TS/SRT Output block builder.
 pub struct MpegTsSrtOutputBuilder;
 
@@ -181,6 +250,16 @@ impl BlockBuilder for MpegTsSrtOutputBuilder {
         }
 
         info!("MPEG-TS muxer configured: alignment=7, pcr-interval=40ms");
+
+        // Keep srtsink from replaying a frozen PAT/PMT to every later caller.
+        if let Some(mux_src) = mux.static_pad("src") {
+            strip_stream_header(&mux_src, instance_id);
+        } else {
+            warn!(
+                "MPEGTSSRT {}: mpegtsmux has no src pad, cannot remove streamheader",
+                instance_id
+            );
+        }
 
         // Create srtsink
         let sink_id = format!("{}:srtsink", instance_id);

--- a/backend/tests/mpegtssrt_streamheader_test.rs
+++ b/backend/tests/mpegtssrt_streamheader_test.rs
@@ -1,0 +1,301 @@
+//! Regression test: the MPEG-TS/SRT output must not hand `srtsink` a
+//! `streamheader`.
+//!
+//! `mpegtsmux` advertises the PAT/PMT it wrote first as `streamheader`, and
+//! `srtsink` replays those buffers to every caller that connects afterwards.
+//! The header is a snapshot taken when the muxer produced its first output —
+//! but this block links its video and audio chains to the muxer only once caps
+//! arrive, so that first PMT can list video alone, and later caps changes bump
+//! the table version again. The header never moves.
+//!
+//! A caller connecting later therefore receives a program definition that
+//! disagrees with the data behind it: its demuxer builds a program from the
+//! header, sees the real tables a few packets on, and tears that program down
+//! again — pushing EOS into the parser autoplugged for the pad it removes. With
+//! under one frame buffered that parser's EOS error is fatal, and it aborts the
+//! *receiving* pipeline's transition to PLAYING. That is how a WHEP output ends
+//! up answering 502 for a whole production run.
+//!
+//! Measured against a sender that had been up four weeks: three separate
+//! connects each replayed a byte-identical video-only PMT ahead of a live PMT
+//! carrying video and audio.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use strom::blocks::builtin::mpegtssrt::MpegTsSrtOutputBuilder;
+use strom::blocks::{BlockBuildContext, BlockBuilder};
+use strom_types::PropertyValue;
+
+use gstreamer as gst;
+use gstreamer::prelude::*;
+
+/// Elements this test needs beyond core GStreamer. Missing on a bare CI image.
+const REQUIRED: &[&str] = &[
+    "mpegtsmux",
+    "srtsink",
+    "x264enc",
+    "h264parse",
+    "avenc_aac",
+    "aacparse",
+    "videotestsrc",
+    "audiotestsrc",
+    "audioconvert",
+    "audioresample",
+    "capsfilter",
+];
+
+/// Skipping on a missing element passes green and guards nothing, so CI sets
+/// `STROM_REQUIRE_GST_PLUGINS=1` to turn a skip into a failure.
+fn plugins_available() -> bool {
+    let missing: Vec<&str> = REQUIRED
+        .iter()
+        .copied()
+        .filter(|e| gst::ElementFactory::find(e).is_none())
+        .collect();
+    if missing.is_empty() {
+        return true;
+    }
+    assert!(
+        std::env::var("STROM_REQUIRE_GST_PLUGINS").is_err(),
+        "STROM_REQUIRE_GST_PLUGINS is set but these elements are missing: {}",
+        missing.join(", ")
+    );
+    false
+}
+
+/// A free UDP port for the SRT listener. Binding one and dropping it races with
+/// anything else on the host, but the socket is never used — srtsink only has
+/// to reach PLAYING so the caps travel.
+fn srt_port() -> u16 {
+    std::net::UdpSocket::bind("127.0.0.1:0")
+        .and_then(|s| s.local_addr())
+        .map(|a| a.port())
+        .expect("no free UDP port for the SRT listener")
+}
+
+/// Every caps `srtsink` was handed while the muxer ran.
+///
+/// Sampling `current_caps()` once is not enough: mpegtsmux sends caps before it
+/// has written any tables and sends them again, with the `streamheader`
+/// attached, once it has. Only the whole sequence answers the question.
+#[derive(Default)]
+struct CapsSeen {
+    all: Vec<gst::Caps>,
+}
+
+impl CapsSeen {
+    fn with_streamheader(&self) -> Option<&gst::Caps> {
+        self.all
+            .iter()
+            .find(|c| c.structure(0).is_some_and(|s| s.has_field("streamheader")))
+    }
+}
+
+/// Build the block with one video and one audio track, feed both, and collect
+/// every caps event that reached `srtsink` — which is what it would replay.
+fn caps_reaching_srtsink() -> CapsSeen {
+    let instance_id = "tsout";
+
+    let mut props: HashMap<String, PropertyValue> = HashMap::new();
+    props.insert("num_video_tracks".to_string(), PropertyValue::UInt(1));
+    props.insert("num_audio_tracks".to_string(), PropertyValue::UInt(1));
+    // Listener that nothing ever connects to: the test only reads the caps
+    // srtsink was handed, never the socket. wait_for_connection=false keeps it
+    // from blocking in render while we wait for those caps.
+    props.insert(
+        "srt_uri".to_string(),
+        PropertyValue::String(format!("srt://127.0.0.1:{}?mode=listener", srt_port())),
+    );
+    props.insert(
+        "wait_for_connection".to_string(),
+        PropertyValue::Bool(false),
+    );
+
+    let ctx = BlockBuildContext::new(vec![], "all".to_string());
+    let built = MpegTsSrtOutputBuilder
+        .build(instance_id, &props, &ctx)
+        .expect("mpegts/srt output block builds");
+
+    let pipeline = gst::Pipeline::new();
+    let mut by_id: HashMap<String, gst::Element> = HashMap::new();
+    for (id, element) in &built.elements {
+        pipeline.add(element).expect("add block element");
+        by_id.insert(id.clone(), element.clone());
+    }
+
+    // The pipeline builder applies these; without them mpegtsmux:src never
+    // reaches srtsink and the muxer stalls with not-linked.
+    for (from, to) in &built.internal_links {
+        let src = by_id
+            .get(&from.element_id)
+            .unwrap_or_else(|| panic!("internal link source {} missing", from.element_id));
+        let sink = by_id
+            .get(&to.element_id)
+            .unwrap_or_else(|| panic!("internal link target {} missing", to.element_id));
+        match (&from.pad_name, &to.pad_name) {
+            (Some(src_pad), Some(sink_pad)) => {
+                let src_pad = src
+                    .static_pad(src_pad)
+                    .unwrap_or_else(|| panic!("{} has no pad {}", from.element_id, src_pad));
+                let sink_pad = sink
+                    .static_pad(sink_pad)
+                    .unwrap_or_else(|| panic!("{} has no pad {}", to.element_id, sink_pad));
+                src_pad
+                    .link(&sink_pad)
+                    .unwrap_or_else(|e| panic!("internal pad link failed: {:?}", e));
+            }
+            _ => src
+                .link(sink)
+                .unwrap_or_else(|e| panic!("internal element link failed: {:?}", e)),
+        }
+    }
+
+    let video_src = gst::ElementFactory::make("videotestsrc")
+        .property("num-buffers", 60i32)
+        .property("is-live", true)
+        .build()
+        .expect("videotestsrc");
+    let video_caps = gst::ElementFactory::make("capsfilter")
+        .property(
+            "caps",
+            gst::Caps::builder("video/x-raw")
+                .field("width", 320i32)
+                .field("height", 240i32)
+                .field("framerate", gst::Fraction::new(25, 1))
+                .build(),
+        )
+        .build()
+        .expect("capsfilter");
+    let video_enc = gst::ElementFactory::make("x264enc")
+        .property("key-int-max", 10u32)
+        .property_from_str("tune", "zerolatency")
+        .build()
+        .expect("x264enc");
+
+    pipeline
+        .add_many([&video_src, &video_caps, &video_enc])
+        .unwrap();
+    gst::Element::link_many([&video_src, &video_caps, &video_enc]).unwrap();
+    video_enc
+        .link(
+            by_id
+                .get(&format!("{}:video_input", instance_id))
+                .expect("block exposes video_input"),
+        )
+        .expect("link video into the block");
+
+    let audio_src = gst::ElementFactory::make("audiotestsrc")
+        .property("num-buffers", 120i32)
+        .property("is-live", true)
+        .build()
+        .expect("audiotestsrc");
+    let audio_conv = gst::ElementFactory::make("audioconvert").build().unwrap();
+    let audio_resample = gst::ElementFactory::make("audioresample").build().unwrap();
+    let audio_enc = gst::ElementFactory::make("avenc_aac")
+        .build()
+        .expect("avenc_aac");
+
+    pipeline
+        .add_many([&audio_src, &audio_conv, &audio_resample, &audio_enc])
+        .unwrap();
+    gst::Element::link_many([&audio_src, &audio_conv, &audio_resample, &audio_enc]).unwrap();
+    audio_enc
+        .link(
+            by_id
+                .get(&format!("{}:audio_input_0", instance_id))
+                .expect("block exposes audio_input_0"),
+        )
+        .expect("link audio into the block");
+
+    for setup in ctx.take_element_setups() {
+        setup(
+            uuid::Uuid::new_v4(),
+            strom::events::EventBroadcaster::new(16),
+        );
+    }
+
+    let srtsink = by_id
+        .get(&format!("{}:srtsink", instance_id))
+        .expect("block exposes srtsink");
+    let sink_pad = srtsink.static_pad("sink").expect("srtsink has a sink pad");
+
+    let seen: Arc<Mutex<CapsSeen>> = Arc::default();
+    let recorder = seen.clone();
+    sink_pad
+        .add_probe(gst::PadProbeType::EVENT_DOWNSTREAM, move |_pad, info| {
+            if let Some(gst::PadProbeData::Event(event)) = info.data.as_ref() {
+                if let gst::EventView::Caps(caps_event) = event.view() {
+                    recorder
+                        .lock()
+                        .unwrap()
+                        .all
+                        .push(caps_event.caps().to_owned());
+                }
+            }
+            gst::PadProbeReturn::Ok
+        })
+        .expect("probe attaches to the srtsink sink pad");
+
+    pipeline
+        .set_state(gst::State::Playing)
+        .expect("pipeline goes to PLAYING");
+
+    // Run long enough for the muxer to write its first tables — that is when it
+    // would attach the streamheader, so stopping before it does would let the
+    // test pass on a broken build.
+    let bus = pipeline.bus().expect("pipeline has a bus");
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    let mut error = None;
+    while std::time::Instant::now() < deadline {
+        if let Some(msg) = bus.timed_pop(gst::ClockTime::from_mseconds(200)) {
+            match msg.view() {
+                gst::MessageView::Error(err) => {
+                    error = Some(format!("{} ({:?})", err.error(), err.debug()));
+                    break;
+                }
+                gst::MessageView::Eos(_) => break,
+                _ => {}
+            }
+        }
+    }
+
+    let _ = pipeline.set_state(gst::State::Null);
+
+    if let Some(e) = error {
+        panic!("pipeline errored while the muxer ran: {}", e);
+    }
+
+    let seen = Arc::try_unwrap(seen)
+        .map(|m| m.into_inner().unwrap())
+        .unwrap_or_else(|arc| CapsSeen {
+            all: arc.lock().unwrap().all.clone(),
+        });
+    assert!(
+        !seen.all.is_empty(),
+        "srtsink never received caps — the muxer produced no output, so the test proved nothing"
+    );
+    seen
+}
+
+/// The guard. Reverting the strip puts `streamheader` back in these caps, and
+/// `srtsink` starts replaying a frozen PAT/PMT to every later caller.
+#[test]
+fn srtsink_receives_no_streamheader() {
+    gst::init().unwrap();
+    if !plugins_available() {
+        eprintln!("skipping: required GStreamer elements are missing");
+        return;
+    }
+
+    let seen = caps_reaching_srtsink();
+
+    assert!(
+        seen.with_streamheader().is_none(),
+        "srtsink was handed a streamheader in one of {} caps event(s): {}. It \
+         replays that frozen PAT/PMT to every caller that connects later, so \
+         their demuxer sees a program definition that disagrees with the live \
+         tables and tears down the program it just built.",
+        seen.all.len(),
+        seen.with_streamheader().unwrap()
+    );
+}

--- a/backend/tests/mpegtssrt_streamheader_test.rs
+++ b/backend/tests/mpegtssrt_streamheader_test.rs
@@ -240,9 +240,10 @@ fn caps_reaching_srtsink() -> CapsSeen {
         .set_state(gst::State::Playing)
         .expect("pipeline goes to PLAYING");
 
-    // Run long enough for the muxer to write its first tables — that is when it
-    // would attach the streamheader, so stopping before it does would let the
-    // test pass on a broken build.
+    // Collect until EOS — the test sources are finite, so this is ~3 s. What
+    // matters is not stopping before the muxer writes its first tables, since
+    // that is when it attaches the streamheader and a shorter run would let the
+    // test pass on a broken build. The 10 s is a deadline, not a run length.
     let bus = pipeline.bus().expect("pipeline has a bus");
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
     let mut error = None;
@@ -250,7 +251,14 @@ fn caps_reaching_srtsink() -> CapsSeen {
         if let Some(msg) = bus.timed_pop(gst::ClockTime::from_mseconds(200)) {
             match msg.view() {
                 gst::MessageView::Error(err) => {
-                    error = Some(format!("{} ({:?})", err.error(), err.debug()));
+                    // Name the element: srt_port() races with the host, so a
+                    // failure to bind the listener must not read as the
+                    // regression this test guards.
+                    let src = err
+                        .src()
+                        .map(|o| o.name().to_string())
+                        .unwrap_or_else(|| "unknown".to_string());
+                    error = Some(format!("{}: {} ({:?})", src, err.error(), err.debug()));
                     break;
                 }
                 gst::MessageView::Eos(_) => break,

--- a/docs/archive/WHEP_502_ON_TSDEMUX_PROGRAM_CHANGE.md
+++ b/docs/archive/WHEP_502_ON_TSDEMUX_PROGRAM_CHANGE.md
@@ -1,0 +1,241 @@
+# WHEP outputs answer 502 for a whole production run
+
+> **Archived — code is the source of truth.** This is a troubleshooting record from
+> 2026-08-26/27, not a spec. It documents what was measured, which fixes failed and why,
+> and the root cause that was finally proven. The code has very likely drifted since —
+> read the code for the current implementation.
+
+## Symptom
+
+Starting a production sometimes produces WHEP outputs that nobody can play. Every
+`POST /whep/<endpoint>` answers `502 Bad Gateway`, for the entire life of that flow.
+Restarting the flow sometimes helps, sometimes not. The UI shows the production as
+running the whole time, with no error anywhere.
+
+In one 27-hour log window: 61 × 502, and 5 of 9 flow starts affected. Reproduced on two
+independent deployments.
+
+## Root cause
+
+**Strom's own MPEG-TS/SRT output hands `srtsink` a `streamheader` that is a frozen
+snapshot of the first PAT/PMT it ever wrote, and `srtsink` replays that snapshot to every
+caller that connects afterwards.**
+
+The MPEG-TS/SRT output block requests `mpegtsmux` sink pads dynamically, as caps arrive on
+each of its chains. The muxer therefore produces its first output — and freezes its
+`streamheader` caps — while only the video chain is linked. That header holds a PAT and a
+**video-only PMT**. It never updates; the tables in the live stream keep moving, both as
+the remaining chains link and as later caps changes bump the table version.
+
+So a receiver connecting at any point, however long after the sender started, gets:
+
+1. the frozen header: a program with video only;
+2. a few packets later, the live PMT: video **and** audio.
+
+Its `tsdemux` builds a program from the header, sees the real tables, and tears that
+program down again — pushing EOS out of the pad it removes. The `h264parse` that
+`decodebin` autoplugged for that short-lived pad has data but no complete access unit, so
+`GstBaseParse` posts a **fatal** error. The element aborts its own state, which fails the
+whole receiving pipeline's PAUSED → PLAYING transition. `whepserversink`'s signaller never
+opens its HTTP port, and the proxy answers 502 for the rest of the flow's life.
+
+Steps 1–3 happen on **100 % of connects**. Only the last step is a race — whether a full
+access unit landed inside the window — which is why it presented as "sometimes the
+production starts".
+
+### The evidence
+
+Captured from a sender that had been running unrestarted for four weeks. Three separate
+connects, each a fresh SRT caller:
+
+```
+pkt  1  PMT v0  [0x41:h264]                    <- the frozen header
+pkt 12  PMT v1  [0x41:h264, 0x42:aac-adts]     <- the live tables
+```
+
+The first two packets were **byte-identical across all three connects**, diverging only
+from packet 3 — that is a replay, not live data:
+
+```
+first 188 bytes (1 pkt):  IDENTICAL
+first 376 bytes (2 pkts): IDENTICAL     <- PAT + video-only PMT
+first 752 bytes (4 pkts): differ        <- live data from here
+```
+
+The receiving side matched, pad for pad. `tsdemux` names pads
+`<type>_<program_generation>_<pid>`, so the generation counter shows the program being
+re-created with the same video PID:
+
+```
+video_0_0041  done adding pad
+Draining previous program
+video_1_0041  done adding pad
+audio_1_0042  done adding pad
+video_0_0041  Pushing out EOS
+h264parse  error: No valid frames found before end of stream
+```
+
+A second sender showed a milder variant: its frozen header listed **both** streams but at
+an older table version than the live stream. The version bump alone was enough to make
+`tsdemux` re-create the program. **Completing the header is therefore not a fix** — any
+frozen header eventually disagrees with a long-running stream. It has to go.
+
+## The fix
+
+Strip `streamheader` from the caps leaving `mpegtsmux`, with an `EVENT_DOWNSTREAM` pad
+probe, so `srtsink` has nothing stale to replay. A caller then simply waits for the next
+periodic PAT/PMT — 100 ms by default — and gets tables that match the data behind them.
+
+Guarded by `mpegtssrt_streamheader_test.rs`, which builds the real block, feeds it video
+and audio, and asserts that no caps event reaching `srtsink` carries a `streamheader`.
+Verified to fail when the strip is removed.
+
+Measured after the fix, against a locally reproduced sender:
+
+- three consecutive connects no longer share a byte of their heads (nothing replayed);
+- each connect sees exactly one PAT and one PMT, listing video and audio, with no version
+  change;
+- five consecutive receiver starts: no program drain, no parser error, program generation
+  0 throughout.
+
+Whether the EFP/SRT output needs the same treatment was not investigated — it uses a
+different muxer, and nothing was measured for it.
+
+## How it was found
+
+The container log was 95.6 % one repeated warning (an unrelated `audiomixer` latency
+message), which buried everything else and rotated real evidence away within a day. After
+filtering that out, the 502s clustered perfectly: every failing run had
+`No valid frames found before end of stream` from the input's `decodebin`, every
+succeeding run did not. Nine starts, no exceptions.
+
+The origin of the EOS was then captured live by raising the GStreamer log level at runtime
+(`PUT /api/gst-log-level`) to
+`GST_EVENT:5,basesrc:5,tsdemux:5,baseparse:5,decodebin:5,srtsrc:5` for one flow start,
+then resetting it to `*:0`. 246 861 lines in 12 seconds.
+
+Note: `current` in the `/api/gst-log-level` response is Strom's cached string, not
+GStreamer's real thresholds. Verify against actual log output, not the API. Runtime log
+levels do not reset themselves.
+
+What finally settled it was a PSI tracer — a small script that reassembles PAT/PMT
+sections from a capture and prints every version and content change with a timestamp,
+plus continuity-counter errors so packet loss is not mistaken for a table change. Pointing
+that at a plain `srtsrc ! filesink` capture of the live stream took the question from
+inference to arithmetic. Anything similar will do; the point is to read the tables rather
+than reason about them.
+
+## Ruled out by experiment
+
+None of these reproduce the failure — do not re-test them:
+
+| Hypothesis | Result |
+|---|---|
+| Dead SRT peer | Warnings and reconnect only; pipeline reaches PLAYING |
+| Peer connects, sends partial stream, disconnects | Same — no EOS |
+| Joining a live stream mid-GOP into a prerolling pipeline | 6/6 clean |
+| Non-default SRT config on the block | Production runs all defaults |
+| The sending file looping | Irrelevant; the file is minutes long, the fault far more frequent |
+| Mid-stream join to a sender with a correct header | 10/10 clean, no drain |
+| A late joiner to a stream whose PMT already changed | Sees only the current version |
+
+The failure *shape* also reproduces deterministically with a truncated transport stream —
+`head -c $((188*40)) full.ts` fails, `$((188*60))` is clean — which is useful for
+exercising the parser's EOS path but says nothing about the cause.
+
+## Fixes tried before the cause was known
+
+### Landed — report the failure honestly (#705)
+
+`gst_element_get_state()` reports a still-running transition as `Ok(Async)`; `Err` is only
+ever `GST_STATE_CHANGE_FAILURE`, whatever the pending state says. `start()` now fails on
+any `Err` instead of checking `pending == VoidPending`.
+
+This fixes no cause. It converts a green-but-dead production into an explicit start
+failure, which is what the operator needed in order to know to restart.
+
+### Failed — drop the EOS at the parser (#706, closed)
+
+Idea: the EOS from a program change is meaningless for a live input that reconnects on its
+own, so drop it at the sink pad of every parser `decodebin` autoplugs inside the block.
+
+Validated against a real feed: the shield fired on the right element and the fatal error
+went away — but `decodebin` then never emitted `pad-added` for the new program. The input
+never linked its pads while SRT kept delivering, and the pipeline hung in PAUSED.
+
+**The EOS is what drives decodebin's teardown of the removed chain.** Swallowing it trades
+a loud failure for a silent hang. Dead end.
+
+### Also measured — intercepting the ERROR message cannot work
+
+```
+without bus sync handler: result=Err(StateChangeError) current=Ready pending=Playing
+with    bus sync handler: result=Err(StateChangeError) current=Ready pending=Playing
+```
+
+Dropping the message changes nothing: the erroring element aborts its **own** state; the
+message is not what aborts the transition at the bin. A `GstBin` subclass overriding
+`handle_message` would not help. Worth knowing before anyone reaches for one.
+
+### Parked — re-drive the state change (#707)
+
+Re-drive the failed transition, on the theory that the input recovers on its own and only
+the pipeline's state stays poisoned. Parked once the root cause was found, and it had two
+problems of its own worth recording:
+
+- Reaching PLAYING is not proof of a live data path, so it grew a liveness check —
+  "every sink is EOS means the input died". That discriminator assumes the doomed chain
+  has its own sink. In the real graph the doomed chain sits inside `decodebin`, upstream
+  of a shared output, so a single-output flow has no case where the check does its job.
+- Its own regression test passes in isolation but fails under a full parallel suite run.
+
+It was containment for a symptom that can be removed at the source.
+
+## Still worth doing
+
+A single input's internal decode error should not be able to fail the whole production's
+state change. The architecturally clean answer is to isolate each input in its own
+`gst::Pipeline` bridged with appsrc/appsink — the pattern the Media Player block already
+uses, explicitly to isolate downstream from seeks, file switches and EOS. A log from this
+investigation shows one healthy input felled by another input's error, so this is not
+hypothetical.
+
+That is a much larger change to the most critical input block, with its own risks around
+timestamps, live sync and latency. It was not attempted here, and it is defence in depth
+rather than a fix: a third-party sender can present the same stale-header behaviour, and
+we do not control it.
+
+## Testing pitfall that cost hours
+
+**A CI artifact binary is not the same build as the Docker image**, and swapping one into a
+running container produces misleading results. The image is built with different feature
+flags per architecture — notably GUI on/off and GPU support on/off.
+
+A CI binary built with the GUI enabled starts the native GUI inside the container. With no
+accelerated display Mesa falls back to `llvmpipe`, and eight software-rendering threads
+burn ~370 % CPU at idle — which starves the server and makes everything else look broken.
+Every measurement taken on that container was worthless.
+
+If you need to test a branch on a deployment host, build with the Dockerfile's flags for
+that architecture, or build the image itself. Sanity-check a candidate binary against the
+one in the image, for example by comparing which GPU and GUI symbols each contains.
+
+Better still: reproduce locally. Both ends of this failure were Strom, so the whole chain
+ran on a laptop — sender flow, receiver, and capture — which turned a 12-second window on
+a production host into an experiment that could be repeated in seconds.
+
+## Related
+
+- The `audiomixer` latency warning flood that made this hard to see:
+  `Impossible to configure latency: max 1.125 s < min 2.000 s`, 310 572 of 324 926 lines.
+  Separate bug, not investigated here.
+- `WHEP Output: Found free port` binds port 0, reads the number and drops the listener
+  before handing it to `whepserversink` — a TOCTOU that has not bitten yet but shares an
+  ephemeral range with everything else on a host-networked box.
+- `start_flow()` checks `pipelines.contains_key()` under a read lock, releases it, then
+  builds and starts the pipeline before inserting — a ~3.5 s window in which two concurrent
+  starts of the same flow both pass the guard. Observed in the wild; the second insert
+  replaces the first manager and leaves its WHEP registrations pointing at dead ports.
+- The failure paths in `start_flow()` do not agree with each other on cleanup: the
+  endpoint-conflict paths skip the Media Player registry and the CPU allocation that the
+  other paths release. Worth folding into one shared teardown.


### PR DESCRIPTION
Root cause of the WHEP 502s that #705, #706 and #707 were all circling. It is not the feed re-signalling its PMT, and not upstream of us — it is our own MPEG-TS/SRT output, on every single connect.

## The chain

1. The output block requests `mpegtsmux` sink pads **dynamically**, as caps arrive on each chain.
2. The muxer therefore produces its first output — and freezes its `streamheader` caps — while only the video chain is linked. That header holds a PAT and a **video-only PMT**.
3. `srtsink` replays the streamheader to every caller that connects afterwards, for the life of the flow. The header never updates; the live tables keep moving.
4. A receiver gets the frozen program (video only), then the real PMT (video + audio) a few packets later. Its `tsdemux` tears down the program it just built and pushes EOS out of the pad it removes.
5. The `h264parse` that `decodebin` autoplugged for that short-lived pad has no complete access unit yet, so `GstBaseParse` errors **fatally**. The element aborts its own state, failing the receiving pipeline's PAUSED → PLAYING transition. `whepserversink`'s signaller never opens its HTTP port and every WHEP offer answers 502 for the whole run.

Steps 1–4 happen on **100 % of connects**. Only step 5 is a race — whether a full access unit landed in the window — which is why it presented as "5 of 9 starts".

## Evidence

Captured from a sender that had been running unrestarted for four weeks. Three separate connects, each a fresh SRT caller:

```
pkt  1  PMT v0  [0x41:h264]                    <- the frozen header
pkt 12  PMT v1  [0x41:h264, 0x42:aac-adts]     <- the live tables
```

```
first 188 bytes (1 pkt):  IDENTICAL
first 376 bytes (2 pkts): IDENTICAL     <- PAT + video-only PMT
first 752 bytes (4 pkts): differ        <- live data from here
```

Byte-identical heads across three independent connects is a replay, not live data.

The receiving side matched pad for pad — `tsdemux` names pads `<type>_<program_generation>_<pid>`, and the generation counter shows the program being re-created with the same video PID:

```
video_0_0041  done adding pad
Draining previous program
video_1_0041  done adding pad
audio_1_0042  done adding pad
video_0_0041  Pushing out EOS
h264parse  error: No valid frames found before end of stream
```

## Why not just complete the header

A second sender's frozen header listed **both** streams but at an older table version than the live stream. The version bump alone re-created the program. Any frozen header eventually disagrees with a long-running stream, so pre-requesting all mux pads would have fixed one sender and not the other. The field has to go.

Without it a caller waits for the next periodic PAT/PMT — 100 ms by default — and gets tables that match the data behind them. That is exactly the mid-stream join case, measured clean 10/10 before this change.

## Measured after the fix

Against a locally reproduced sender (both ends are Strom, so the whole chain runs on a laptop):

- three consecutive connects share no bytes of their heads — nothing is replayed;
- each connect sees exactly one PAT and one PMT, listing video and audio, with no version change;
- five consecutive receiver starts: no program drain, no parser error, program generation 0 throughout.

## Tests

`mpegtssrt_streamheader_test.rs` builds the real block, feeds it video and audio, applies the block's own internal links, and asserts that **no** caps event reaching `srtsink` carries a `streamheader`.

Sampling `current_caps()` once is not enough and the first version of this test was not a guard: mpegtsmux sends caps before it has written any tables and sends them again, with the header attached, once it has — so the early sample passed with the fix reverted. The test now records **every** caps event `srtsink` is handed, collecting until EOS — roughly 3 s for the finite test sources; the 10 s in the loop is a deadline, not a run length — and asserts none carries the field. **Verified in both directions: it fails with the strip removed, passes with it in place.**

Ran locally on the final commit: `cargo test` (full suite, all green), `cargo clippy --tests`, `cargo fmt --check`. The new test executed — it is not one of the skip-on-missing-element kind, and every element it needs is already in the CI package list. `check-linux` sets `STROM_REQUIRE_GST_PLUGINS=1`, so a missing element there fails rather than skipping green.

## Review follow-up (second commit)

- The caps-rewrite probe used `get_mut()` with a `None` arm that warned about a stale program definition. `caps.copy()` returns a `Caps` with refcount 1 and `has_header` had already proved `structure(0)` exists, so that arm could never run — it advertised a safety net that was not there. Replaced with the infallible `make_mut()`, matching the sibling probe in the WHEP block.
- `srt_port()` binds a UDP socket, reads the port and drops it before handing it to `srtsink`, so the host can claim it in that window. The bus error read as "pipeline errored while the muxer ran", indistinguishable from the regression under test; it now names the erroring element, so a listener that failed to bind says so.
- Re-verified after both changes: the test passes, and still fails with the strip neutralised.

## Not in scope

- The EFP/SRT output uses a different muxer; whether `efpmux` sets a streamheader was not measured, so it is untouched.
- Receiver-side isolation (each input in its own `gst::Pipeline` bridged with appsrc/appsink) is still worth doing as defence in depth — a third-party sender can present the same behaviour and we do not control it.

`docs/archive/WHEP_502_ON_TSDEMUX_PROGRAM_CHANGE.md` is **new** in this PR: the proven cause, the measurements, and what was ruled out. It supersedes the working theory carried in #705/#706/#707, which attributed the program change to the feed and called it unpreventable — nothing in the repo held that conclusion, so no existing doc is replaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
