### PR TITLE
fix(whep): quieten and escape the unregistered-endpoint log lines

### DIFF
--- a/backend/src/api/whep_player.rs
+++ b/backend/src/api/whep_player.rs
@@ -483,7 +483,12 @@ pub async fn whep_endpoint_proxy(
         None => {
             // Not registered: the flow is stopped, never started, or the
             // block's endpoint_id was changed since the player loaded.
-            tracing::warn!("WHEP offer for unregistered endpoint '{}'", endpoint_id);
+            //
+            // debug!, not warn!: the WHEP router carries no auth middleware and
+            // endpoint_id is a percent-decoded path segment, so anyone who can
+            // reach the port would otherwise get a log line per request out of
+            // us. {:?} escapes the value — a decoded newline could forge a line.
+            tracing::debug!("WHEP offer for unregistered endpoint {:?}", endpoint_id);
             return Response::builder()
                 .status(StatusCode::NOT_FOUND)
                 .header(header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
@@ -633,8 +638,10 @@ pub async fn whep_resource_proxy_delete(
     let port = match state.whep_registry().get_port(&endpoint_id).await {
         Some(p) => p,
         None => {
-            tracing::warn!(
-                "WHEP resource DELETE for unregistered endpoint '{}'",
+            // debug! and {:?} for the same reason as the offer path above:
+            // unauthenticated route, attacker-supplied endpoint_id.
+            tracing::debug!(
+                "WHEP resource DELETE for unregistered endpoint {:?}",
                 endpoint_id
             );
             return Response::builder()


### PR DESCRIPTION
Split out of #707, which is being closed. The change is unrelated to that PR's subject and stands on its own.

Two log lines on the WHEP proxy routes sat at `warn!` and printed `endpoint_id` unescaped:

- `whep_endpoint_proxy` — the offer path
- `whep_resource_proxy_delete` — the resource DELETE path

The WHEP router carries no auth middleware, and `endpoint_id` is a percent-decoded path segment. So anyone who can reach the port got one `warn!` line per request out of us, keyed by a value they control. A decoded newline in that value could forge a log line.

Both drop to `debug!`, and the value is printed with `{:?}` so it is escaped. The HTTP behaviour is unchanged — both paths still answer 404.

Ran locally: `cargo check`, `cargo fmt --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
