### PR TITLE
fix(state): one teardown path for every way a flow goes away

### DIFF
--- a/backend/src/blocks/builtin/mediaplayer/bridge.rs
+++ b/backend/src/blocks/builtin/mediaplayer/bridge.rs
@@ -515,8 +515,9 @@ pub fn watch_internal_bus(
 
     let state_for_bus = Arc::clone(&state);
     let block_id_for_bus = block_id.clone();
+    let block_id_for_watch = block_id.clone();
 
-    bus.connect_message(None, move |_bus, msg| {
+    let handler = bus.connect_message(None, move |_bus, msg| {
         use gst::MessageView;
 
         match msg.view() {
@@ -583,4 +584,21 @@ pub fn watch_internal_bus(
             _ => {}
         }
     });
+
+    // The closure just took an `Arc` on the state that owns this pipeline, so
+    // the state can only ever be dropped if someone disconnects the handler.
+    // `shutdown()` is that someone, and this id is how it finds it. A second
+    // watch on the same bus would strand the first, so retire it here.
+    let previous = match state.bus_watch.lock() {
+        Ok(mut guard) => guard.replace(handler),
+        Err(poisoned) => poisoned.into_inner().replace(handler),
+    };
+    if let Some(previous) = previous {
+        warn!(
+            "Media Player {}: Replacing an existing internal bus watch",
+            block_id_for_watch
+        );
+        bus.disconnect(previous);
+        bus.remove_signal_watch();
+    }
 }

--- a/backend/src/blocks/builtin/mediaplayer/builder.rs
+++ b/backend/src/blocks/builtin/mediaplayer/builder.rs
@@ -201,6 +201,7 @@ fn build_media_player(
         media_path: media_path.clone(),
         ts_offset,
         main_pipeline: gst::glib::WeakRef::new(),
+        bus_watch: std::sync::Mutex::new(None),
     });
 
     // --- Resolve initial URI ---

--- a/backend/src/blocks/builtin/mediaplayer/mod.rs
+++ b/backend/src/blocks/builtin/mediaplayer/mod.rs
@@ -98,6 +98,7 @@ mod tests {
             media_path: std::path::PathBuf::from("/media"),
             ts_offset: Arc::new(AtomicI64::new(i64::MIN)),
             main_pipeline: gst::glib::WeakRef::new(),
+            bus_watch: std::sync::Mutex::new(None),
         }
     }
 

--- a/backend/src/blocks/builtin/mediaplayer/state.rs
+++ b/backend/src/blocks/builtin/mediaplayer/state.rs
@@ -6,7 +6,7 @@ use gstreamer::prelude::*;
 use gstreamer_app as gst_app;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
-use std::sync::{Arc, LazyLock, RwLock};
+use std::sync::{Arc, LazyLock, Mutex, RwLock};
 use strom_types::FlowId;
 use tracing::{debug, error, info};
 use uuid::Uuid;
@@ -68,6 +68,15 @@ pub struct MediaPlayerState {
     pub ts_offset: Arc<AtomicI64>,
     /// Weak reference to the main pipeline (for computing running time in the bridge).
     pub main_pipeline: gst::glib::WeakRef<gst::Pipeline>,
+    /// Handler id of the signal watch on the internal pipeline's bus.
+    ///
+    /// The watch's closure owns an `Arc<MediaPlayerState>`, and the bus owns the
+    /// closure, and this state owns the pipeline the bus belongs to. That is a
+    /// cycle: while the handler stays connected, nothing can ever drop this
+    /// state, so [`Drop`] never runs and the internal pipeline keeps decoding —
+    /// holding its file descriptors — for the life of the process. Keeping the
+    /// id is what lets [`MediaPlayerState::shutdown`] break it.
+    pub bus_watch: Mutex<Option<gst::glib::SignalHandlerId>>,
 }
 
 impl MediaPlayerState {
@@ -386,8 +395,50 @@ impl MediaPlayerState {
             PlayerState::Playing
         }
     }
+
+    /// Release the internal pipeline and everything that keeps this state alive.
+    ///
+    /// Dropping the registry's `Arc` is not enough on its own: the signal watch
+    /// on the internal bus holds another one, so `Drop` never runs and the
+    /// pipeline decodes on, once per start, for the life of the process.
+    /// Disconnecting that handler is what makes the drop reachable.
+    ///
+    /// The pipeline is taken out of the lock before it is stopped, so the bus
+    /// callback — which reads the same lock — cannot be blocked by a
+    /// `set_state(Null)` that is itself waiting for the callback's thread.
+    pub fn shutdown(&self) {
+        let pipeline = match self.internal_pipeline.write() {
+            Ok(mut guard) => guard.take(),
+            Err(poisoned) => poisoned.into_inner().take(),
+        };
+        let Some(pipeline) = pipeline else {
+            return;
+        };
+
+        // Only remove the watch this state added. An unconditional
+        // `remove_signal_watch()` on a bus that has none is a GStreamer
+        // CRITICAL, and removing someone else's would silence their handler.
+        let watch = match self.bus_watch.lock() {
+            Ok(mut guard) => guard.take(),
+            Err(poisoned) => poisoned.into_inner().take(),
+        };
+        if let (Some(handler), Some(bus)) = (watch, pipeline.bus()) {
+            bus.disconnect(handler);
+            bus.remove_signal_watch();
+        }
+
+        debug!(
+            "Media Player {}: Stopping internal pipeline on shutdown",
+            self.block_id
+        );
+        let _ = pipeline.set_state(gst::State::Null);
+    }
 }
 
+/// Fallback for a state that was dropped without going through
+/// [`MediaPlayerState::shutdown`] — a build that failed before the block was
+/// registered, say. Teardown goes through the registry, which shuts the state
+/// down explicitly and leaves nothing for this to do.
 impl Drop for MediaPlayerState {
     fn drop(&mut self) {
         if let Ok(guard) = self.internal_pipeline.read() {
@@ -421,8 +472,11 @@ impl MediaPlayerRegistry {
     }
 
     pub fn unregister(&self, key: &MediaPlayerKey) {
-        if let Ok(mut players) = self.players.write() {
-            players.remove(key);
+        // Take the entry out under the lock, then shut it down without holding
+        // it: `shutdown()` stops a pipeline, which can block.
+        let removed = self.players.write().ok().and_then(|mut p| p.remove(key));
+        if let Some(state) = removed {
+            state.shutdown();
         }
     }
 
@@ -440,16 +494,30 @@ impl MediaPlayerRegistry {
 
     /// Remove all media player entries for a given flow.
     pub fn unregister_flow(&self, flow_id: &FlowId) {
-        if let Ok(mut players) = self.players.write() {
-            let before = players.len();
-            players.retain(|k, _| k.flow_id != *flow_id);
-            let removed = before - players.len();
-            if removed > 0 {
-                info!(
-                    "Unregistered {} media player(s) for flow {}",
-                    removed, flow_id
-                );
+        let removed: Vec<Arc<MediaPlayerState>> = match self.players.write() {
+            Ok(mut players) => {
+                let keys: Vec<MediaPlayerKey> = players
+                    .keys()
+                    .filter(|k| k.flow_id == *flow_id)
+                    .cloned()
+                    .collect();
+                keys.iter().filter_map(|k| players.remove(k)).collect()
             }
+            Err(_) => return,
+        };
+
+        if removed.is_empty() {
+            return;
+        }
+
+        info!(
+            "Unregistered {} media player(s) for flow {}",
+            removed.len(),
+            flow_id
+        );
+        // Outside the lock: `shutdown()` stops a pipeline, which can block.
+        for state in removed {
+            state.shutdown();
         }
     }
 }

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -27,6 +27,18 @@ use tracing_subscriber::EnvFilter;
 /// Handle for reloading the log filter at runtime.
 pub type LogReloadHandle = reload::Handle<EnvFilter, tracing_subscriber::Registry>;
 
+/// The endpoint registrations a teardown is allowed to remove.
+///
+/// Only ever narrower than "everything the flow declares", and only for a
+/// caller that failed part-way through registering: an endpoint-id conflict
+/// means the id already belongs to another flow, so unregistering it would
+/// tear down that flow's endpoint instead of ours.
+#[derive(Default)]
+struct RegisteredEndpoints {
+    whep: Vec<String>,
+    whip: Vec<String>,
+}
+
 /// Shared application state.
 #[derive(Clone)]
 pub struct AppState {
@@ -911,7 +923,7 @@ impl AppState {
 
         // Create pipeline with event broadcaster and block registry
         info!("Creating PipelineManager (this may block)...");
-        let mut manager = PipelineManager::new(
+        let mut manager = match PipelineManager::new(
             &flow,
             self.inner.events.clone(),
             &self.inner.block_registry,
@@ -920,7 +932,16 @@ impl AppState {
             Some(self.inner.whip_registry.clone()),
             self.inner.media_path.clone(),
             local_devices,
-        )?;
+        ) {
+            Ok(manager) => manager,
+            Err(e) => {
+                // There is no pipeline to stop, but blocks built before the
+                // failing one may already have registered themselves.
+                error!("Failed to build pipeline for flow {}: {}", id, e);
+                let _ = self.teardown_flow(id, None, None).await;
+                return Err(e);
+            }
+        };
         info!("PipelineManager created successfully");
 
         // Set thread registry for CPU monitoring
@@ -940,11 +961,17 @@ impl AppState {
         let state = match manager.start() {
             Ok(state) => state,
             Err(e) => {
-                // The manager is dropped here, which takes the pipeline to
-                // Null. Release the CPU allocation too, or a flow that fails
-                // to start leaks its cores until the process restarts.
                 error!("Failed to start flow {}: {}", id, e);
-                self.inner.affinity_manager.deallocate(id);
+                // No endpoints are registered yet, so the flow owns none.
+                if let Err(teardown_err) = self
+                    .teardown_flow(id, Some(manager), Some(RegisteredEndpoints::default()))
+                    .await
+                {
+                    warn!(
+                        "Cleanup after failed start of flow {} could not stop the pipeline: {}",
+                        id, teardown_err
+                    );
+                }
                 return Err(e);
             }
         };
@@ -990,13 +1017,20 @@ impl AppState {
                     .await
                 {
                     error!("Endpoint conflict registering WHEP endpoint: {}", e);
-                    for (_, ep_id) in &endpoints {
-                        self.inner.whep_registry.unregister(ep_id).await;
-                    }
+                    // Only the ids we registered. The one that conflicted
+                    // belongs to another flow — unregistering it here would
+                    // take that flow's endpoint down instead of ours.
+                    let owned = RegisteredEndpoints {
+                        whep: endpoints.iter().map(|(_, ep)| ep.clone()).collect(),
+                        whip: Vec::new(),
+                    };
                     drop(pipelines_guard);
-                    let mut pipelines = self.inner.pipelines.write().await;
-                    if let Some(mut mgr) = pipelines.remove(id) {
-                        let _ = mgr.stop();
+                    let manager = self.inner.pipelines.write().await.remove(id);
+                    if let Err(teardown_err) = self.teardown_flow(id, manager, Some(owned)).await {
+                        warn!(
+                            "Cleanup after WHEP endpoint conflict on flow {} could not stop the pipeline: {}",
+                            id, teardown_err
+                        );
                     }
                     return Err(PipelineError::EndpointConflict(e));
                 }
@@ -1025,16 +1059,20 @@ impl AppState {
                     .await
                 {
                     error!("Endpoint conflict registering WHIP endpoint: {}", e);
-                    for (_, ep_id) in &endpoints {
-                        self.inner.whip_registry.unregister(ep_id).await;
-                    }
-                    for (_, ep_id) in &whep_endpoints {
-                        self.inner.whep_registry.unregister(ep_id).await;
-                    }
+                    // Every WHEP endpoint did register, so the flow owns all of
+                    // them; of the WHIP ones it owns only those it got in
+                    // before the conflict.
+                    let owned = RegisteredEndpoints {
+                        whep: whep_endpoints.iter().map(|(_, ep)| ep.clone()).collect(),
+                        whip: endpoints.iter().map(|(_, ep)| ep.clone()).collect(),
+                    };
                     drop(pipelines_guard);
-                    let mut pipelines = self.inner.pipelines.write().await;
-                    if let Some(mut mgr) = pipelines.remove(id) {
-                        let _ = mgr.stop();
+                    let manager = self.inner.pipelines.write().await.remove(id);
+                    if let Err(teardown_err) = self.teardown_flow(id, manager, Some(owned)).await {
+                        warn!(
+                            "Cleanup after WHIP endpoint conflict on flow {} could not stop the pipeline: {}",
+                            id, teardown_err
+                        );
                     }
                     return Err(PipelineError::EndpointConflict(e));
                 }
@@ -1319,6 +1357,159 @@ impl AppState {
     }
 
     /// Stop a flow (stop and remove its pipeline).
+    /// Release everything a flow's pipeline holds. The single way it is done.
+    ///
+    /// `start_flow()` can fail in four places and `stop_flow()` is a fifth
+    /// caller. Each has to release the same set of things, and each used to do
+    /// its own subset — so a flow that failed to start leaked a bus watch, its
+    /// Media Player pipelines, or its CPU allocation, depending on which line
+    /// it failed on. Anything that must be released when a flow goes away
+    /// belongs here, not at a call site.
+    ///
+    /// Order matters: endpoints stop accepting traffic before the pipeline they
+    /// point at goes to NULL.
+    ///
+    /// `endpoints` says which registrations this teardown owns. `None` means
+    /// every endpoint the manager declares, which is right whenever the flow
+    /// finished registering them. A caller that failed *during* registration
+    /// must pass the ids it actually registered: an endpoint-id conflict means
+    /// the id belongs to another flow, and unregistering it here would tear
+    /// down that flow's endpoint instead.
+    ///
+    /// Returns the state the pipeline reached, or the error `stop()` gave. The
+    /// rest of the teardown runs either way — a pipeline that refuses to stop
+    /// is exactly when leaking its cores and its registry entries hurts most.
+    async fn teardown_flow(
+        &self,
+        id: &FlowId,
+        manager: Option<PipelineManager>,
+        endpoints: Option<RegisteredEndpoints>,
+    ) -> Result<PipelineState, PipelineError> {
+        let Some(mut manager) = manager else {
+            // No pipeline was ever built. Blocks constructed before the failing
+            // one can still have registered themselves, and the CPU allocation
+            // may already be held; deallocate() ignores an id it does not know.
+            crate::blocks::builtin::mediaplayer::MEDIA_PLAYER_REGISTRY.unregister_flow(id);
+            self.inner.affinity_manager.deallocate(id);
+            return Ok(PipelineState::Null);
+        };
+
+        let owned = endpoints.unwrap_or_else(|| RegisteredEndpoints {
+            whep: manager
+                .whep_endpoints()
+                .iter()
+                .map(|e| e.endpoint_id.clone())
+                .collect(),
+            whip: manager
+                .whip_endpoints()
+                .iter()
+                .map(|e| e.endpoint_id.clone())
+                .collect(),
+        });
+
+        for endpoint_id in &owned.whep {
+            info!("Unregistering WHEP endpoint '{}'", endpoint_id);
+            self.inner.whep_registry.unregister(endpoint_id).await;
+        }
+
+        for endpoint_id in &owned.whip {
+            info!(
+                "Tearing down WHIP sessions and unregistering endpoint '{}'",
+                endpoint_id
+            );
+            let session_entries = self
+                .inner
+                .whip_session_manager
+                .remove_all_sessions(endpoint_id);
+            let count = session_entries.len();
+            if count > 0 {
+                // Session pipelines go to NULL on the blocking pool: that can
+                // take seconds and this is awaited from an HTTP handler.
+                let endpoint_id_log = endpoint_id.clone();
+                let _ = tokio::task::spawn_blocking(move || {
+                    for (pipeline, element) in session_entries {
+                        WhipSessionManager::teardown_session_pipeline(&pipeline);
+                        drop(element);
+                    }
+                    info!(
+                        "Torn down {} active WHIP session(s) for endpoint '{}'",
+                        count, endpoint_id_log
+                    );
+                })
+                .await;
+            }
+            self.inner
+                .whip_session_manager
+                .unregister_endpoint(endpoint_id);
+            self.inner.whip_registry.unregister(endpoint_id).await;
+        }
+
+        // The registry holds an Arc per Media Player instance, and that Arc's
+        // Drop is the only thing that takes the block's *internal* pipeline to
+        // NULL. Skip this and a Media Player flow leaves a decoding pipeline
+        // and its file descriptors running for the life of the process.
+        crate::blocks::builtin::mediaplayer::MEDIA_PLAYER_REGISTRY.unregister_flow(id);
+
+        // stop() — not just dropping the manager. Drop aborts the thumbnail
+        // task, stops probes and sets NULL; stop() is also what removes the bus
+        // watch, the thread-priority handler and the flow's threads from the
+        // CPU-monitor registry. Dropping alone leaks one bus watch GSource per
+        // teardown and leaves dead TIDs in the registry, where a reused TID is
+        // then attributed to a flow that no longer exists.
+        //
+        // On the blocking pool: stop() joins a thread around set_state(Null),
+        // which can take seconds, and this is awaited from an HTTP handler.
+        let stopped = tokio::task::spawn_blocking(move || {
+            let result = manager.stop();
+
+            // Weak refs taken before the drop. Anything still alive afterwards
+            // is held by a leaked strong reference — a signal handler closure,
+            // a probe — and its OS resources (sockets, threads) never come
+            // back. See the GStreamer reference rules in CLAUDE.md.
+            let pipeline_weak = manager.pipeline_weak();
+            let element_weak_refs = manager.element_weak_refs();
+            let flow_name = manager.flow_name().to_string();
+            drop(manager);
+
+            let leaked_elements: Vec<String> = if pipeline_weak.upgrade().is_some() {
+                element_weak_refs
+                    .iter()
+                    .filter(|(_, weak)| weak.upgrade().is_some())
+                    .map(|(name, _)| name.clone())
+                    .collect()
+            } else {
+                Vec::new()
+            };
+            let pipeline_survived = pipeline_weak.upgrade().is_some();
+
+            (result, flow_name, pipeline_survived, leaked_elements)
+        })
+        .await;
+
+        // Release the cores before returning, whatever stop() said. A flow that
+        // fails to stop would otherwise hold them until the process restarts.
+        self.inner.affinity_manager.deallocate(id);
+
+        match stopped {
+            Ok((result, flow_name, pipeline_survived, leaked_elements)) => {
+                if pipeline_survived {
+                    error!(
+                        "Pipeline '{}': GStreamer pipeline still alive after drop — OS resources will leak",
+                        flow_name
+                    );
+                    for name in &leaked_elements {
+                        error!("Pipeline '{}': leaked element '{}'", flow_name, name);
+                    }
+                }
+                result
+            }
+            Err(join_err) => Err(PipelineError::StateChange(format!(
+                "Teardown task panicked: {}",
+                join_err
+            ))),
+        }
+    }
+
     pub async fn stop_flow(&self, id: &FlowId) -> Result<PipelineState, PipelineError> {
         info!("Stopping flow: {}", id);
 
@@ -1335,7 +1526,7 @@ impl AppState {
             pipelines.remove(id)
         };
 
-        let Some(mut manager) = manager else {
+        let Some(manager) = manager else {
             warn!("No active pipeline for flow: {}", id);
             // Clear persisted state so the flow no longer appears as running
             let mut flows = self.inner.flows.write().await;
@@ -1358,90 +1549,8 @@ impl AppState {
             return Ok(PipelineState::Null);
         };
 
-        // Unregister WHEP endpoints before stopping
-        for whep_info in manager.whep_endpoints() {
-            info!(
-                "Unregistering WHEP endpoint '{}' (block {})",
-                whep_info.endpoint_id, whep_info.block_id
-            );
-            self.inner
-                .whep_registry
-                .unregister(&whep_info.endpoint_id)
-                .await;
-        }
-
-        // Teardown all WHIP sessions and unregister endpoints before stopping
-        for whip_info in manager.whip_endpoints() {
-            info!(
-                "Tearing down WHIP sessions and unregistering endpoint '{}' (block {})",
-                whip_info.endpoint_id, whip_info.block_id
-            );
-            // Remove all active sessions for this endpoint
-            let session_entries = self
-                .inner
-                .whip_session_manager
-                .remove_all_sessions(&whip_info.endpoint_id);
-            let count = session_entries.len();
-            if count > 0 {
-                // Teardown session pipelines on a blocking thread to avoid
-                // blocking the tokio runtime (set_state(Null) can take seconds).
-                let endpoint_id_log = whip_info.endpoint_id.clone();
-                let _ = tokio::task::spawn_blocking(move || {
-                    for (pipeline, element) in session_entries {
-                        WhipSessionManager::teardown_session_pipeline(&pipeline);
-                        drop(element);
-                    }
-                    info!(
-                        "Torn down {} active WHIP session(s) for endpoint '{}'",
-                        count, endpoint_id_log
-                    );
-                })
-                .await;
-            }
-            // Unregister the endpoint config from session manager
-            self.inner
-                .whip_session_manager
-                .unregister_endpoint(&whip_info.endpoint_id);
-            // Unregister from the registry
-            self.inner
-                .whip_registry
-                .unregister(&whip_info.endpoint_id)
-                .await;
-        }
-
-        // Unregister media player instances for this flow
-        crate::blocks::builtin::mediaplayer::MEDIA_PLAYER_REGISTRY.unregister_flow(id);
-
-        // Stop the pipeline
-        let state = manager.stop()?;
-
-        // Take weak refs to the pipeline and all its elements before dropping.
-        // After drop, all GStreamer objects should be finalized. Any that
-        // survive have a leaked strong reference (signal handler closure,
-        // probe, etc.) preventing cleanup of OS resources (sockets, threads).
-        let pipeline_weak = manager.pipeline_weak();
-        let element_weak_refs = manager.element_weak_refs();
-        let flow_name = manager.flow_name().to_string();
-
-        // Drop the manager — this releases all strong references to the
-        // pipeline and its elements, allowing GStreamer to finalize them.
-        drop(manager);
-
-        // Verify everything was actually finalized
-        if pipeline_weak.upgrade().is_some() {
-            error!(
-                "Pipeline '{}': GStreamer pipeline still alive after drop — OS resources will leak",
-                flow_name
-            );
-            for (name, weak) in &element_weak_refs {
-                if weak.upgrade().is_some() {
-                    error!("Pipeline '{}': leaked element '{}'", flow_name, name);
-                }
-            }
-        }
-
-        // Deallocate CPU core assignment
-        self.inner.affinity_manager.deallocate(id);
+        // Endpoints, Media Player registry, pipeline, leak check, CPU cores.
+        let state = self.teardown_flow(id, Some(manager), None).await?;
 
         // Clear runtime_data from all blocks (SDP is only valid while running)
         let flow = {

--- a/backend/tests/failed_start_teardown_test.rs
+++ b/backend/tests/failed_start_teardown_test.rs
@@ -1,0 +1,131 @@
+//! Regression test: a flow that fails to start must release what a stopped
+//! flow releases.
+//!
+//! `start_flow()` can fail in four places, and each used to clean up its own
+//! subset. The worst gap was the Media Player registry: it holds an `Arc` per
+//! instance, and that `Arc`'s `Drop` is the only thing that takes the block's
+//! *internal* pipeline to NULL. A Media Player flow that failed to start left a
+//! decoding pipeline — and its file descriptors — running for the life of the
+//! process, once per attempt.
+//!
+//! The registry is the part of that teardown a test can observe from outside;
+//! the bus watch, the thread-priority handler and the CPU allocation are
+//! released on the same path, by the same call.
+
+use std::collections::HashMap;
+use strom::blocks::builtin::mediaplayer::{MediaPlayerKey, MEDIA_PLAYER_REGISTRY};
+use strom::state::AppState;
+use strom::storage::JsonFileStorage;
+use strom_types::{Flow, Link, PropertyValue};
+use tempfile::NamedTempFile;
+
+const MEDIA_PLAYER_BLOCK_ID: &str = "player";
+
+/// A flow with a Media Player block and a chain that can never reach PLAYING.
+///
+/// `fakesink state-error=paused-to-playing` fails that transition on every
+/// attempt, so the start fails for a reason that has nothing to do with the
+/// Media Player — which is the point. The block registered itself while the
+/// pipeline was being built, and the failing start has to undo that.
+fn build_flow_that_cannot_start(name: &str) -> Flow {
+    let mut flow = Flow::new(name);
+
+    flow.elements.push(strom_types::Element {
+        id: "src".to_string(),
+        element_type: "audiotestsrc".to_string(),
+        properties: HashMap::new(),
+        position: [100.0, 200.0].into(),
+        pad_properties: HashMap::new(),
+    });
+
+    flow.elements.push(strom_types::Element {
+        id: "sink".to_string(),
+        element_type: "fakesink".to_string(),
+        properties: {
+            let mut p = HashMap::new();
+            p.insert(
+                "state-error".to_string(),
+                PropertyValue::String("paused-to-playing".to_string()),
+            );
+            p
+        },
+        position: [300.0, 200.0].into(),
+        pad_properties: HashMap::new(),
+    });
+
+    flow.links.push(Link {
+        from: "src:src".to_string(),
+        to: "sink:sink".to_string(),
+    });
+
+    // Empty playlist: the block still builds its internal pipeline and
+    // registers itself, which is all this test needs from it.
+    flow.blocks.push(strom_types::BlockInstance {
+        id: MEDIA_PLAYER_BLOCK_ID.to_string(),
+        block_definition_id: "builtin.media_player".to_string(),
+        name: None,
+        properties: {
+            let mut p = HashMap::new();
+            p.insert(
+                "playlist".to_string(),
+                PropertyValue::String("[]".to_string()),
+            );
+            p
+        },
+        position: strom_types::block::Position { x: 100.0, y: 400.0 },
+        runtime_data: None,
+        computed_external_pads: None,
+    });
+
+    flow
+}
+
+/// The guard. Without the shared teardown on the failed-start path the flow's
+/// Media Player stays in the registry, holding its internal pipeline open.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn failed_start_unregisters_the_flows_media_players() {
+    gstreamer::init().unwrap();
+
+    let storage_file = NamedTempFile::new().unwrap();
+    let blocks_file = NamedTempFile::new().unwrap();
+    let state = AppState::new(
+        JsonFileStorage::new(storage_file.path()),
+        blocks_file.path(),
+        std::env::temp_dir(),
+        vec![],
+        "all".to_string(),
+        vec![],
+    );
+
+    let flow = build_flow_that_cannot_start("failed_start_teardown");
+    let flow_id = flow.id;
+    state.upsert_flow(flow).await.expect("upsert_flow failed");
+
+    let key = MediaPlayerKey {
+        flow_id,
+        block_id: MEDIA_PLAYER_BLOCK_ID.to_string(),
+    };
+
+    let result = state.start_flow(&flow_id).await;
+    assert!(
+        result.is_err(),
+        "start_flow reported {:?} for a pipeline that can never reach PLAYING — \
+         the test bed is wrong, not the teardown",
+        result
+    );
+
+    assert!(
+        !MEDIA_PLAYER_REGISTRY.contains(&key),
+        "the flow's Media Player is still registered after a failed start. The \
+         registry holds the only Arc whose Drop takes the block's internal \
+         pipeline to NULL, so that pipeline and its file descriptors now run \
+         for the life of the process — once per start attempt."
+    );
+
+    // Nothing was inserted into the live pipeline map either: a flow that
+    // failed to start must not look startable-again-only-after-stop.
+    assert!(
+        !state.pipelines_read().await.contains_key(&flow_id),
+        "a flow that failed to start is still in the pipeline map"
+    );
+}

--- a/backend/tests/failed_start_teardown_test.rs
+++ b/backend/tests/failed_start_teardown_test.rs
@@ -11,7 +11,14 @@
 //! The registry is the part of that teardown a test can observe from outside;
 //! the bus watch, the thread-priority handler and the CPU allocation are
 //! released on the same path, by the same call.
+//!
+//! Removing the registry entry is not the same as freeing what it stands for,
+//! so the second test asserts the internal pipeline itself is gone. It takes
+//! the stop path rather than the failed-start path because that is the only
+//! one from which a test can hold the pipeline's `WeakRef` — both run the same
+//! `teardown_flow()`.
 
+use gstreamer::prelude::ObjectExt;
 use std::collections::HashMap;
 use strom::blocks::builtin::mediaplayer::{MediaPlayerKey, MEDIA_PLAYER_REGISTRY};
 use strom::state::AppState;
@@ -80,6 +87,17 @@ fn build_flow_that_cannot_start(name: &str) -> Flow {
     flow
 }
 
+/// The same flow, minus the failing state change: this one reaches PLAYING.
+fn build_flow_that_starts(name: &str) -> Flow {
+    let mut flow = build_flow_that_cannot_start(name);
+    for element in &mut flow.elements {
+        if element.id == "sink" {
+            element.properties.remove("state-error");
+        }
+    }
+    flow
+}
+
 /// The guard. Without the shared teardown on the failed-start path the flow's
 /// Media Player stays in the registry, holding its internal pipeline open.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -127,5 +145,73 @@ async fn failed_start_unregisters_the_flows_media_players() {
     assert!(
         !state.pipelines_read().await.contains_key(&flow_id),
         "a flow that failed to start is still in the pipeline map"
+    );
+}
+
+/// The resource the registry entry stands for.
+///
+/// Unregistering drops the registry's `Arc`, but the signal watch on the
+/// internal bus holds another one — and the closure behind it owns the state
+/// that owns the pipeline that owns the bus. Until that handler is
+/// disconnected, `MediaPlayerState::drop` never runs: the internal pipeline
+/// keeps decoding, and keeps its file descriptors, for the life of the
+/// process, once per start.
+///
+/// The registry assertion above cannot see that, since the entry is gone
+/// either way. This one holds a `WeakRef` to the pipeline across teardown, so
+/// it fails if the explicit shutdown is removed.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn teardown_releases_the_media_players_internal_pipeline() {
+    gstreamer::init().unwrap();
+
+    let storage_file = NamedTempFile::new().unwrap();
+    let blocks_file = NamedTempFile::new().unwrap();
+    let state = AppState::new(
+        JsonFileStorage::new(storage_file.path()),
+        blocks_file.path(),
+        std::env::temp_dir(),
+        vec![],
+        "all".to_string(),
+        vec![],
+    );
+
+    let flow = build_flow_that_starts("teardown_releases_internal_pipeline");
+    let flow_id = flow.id;
+    state.upsert_flow(flow).await.expect("upsert_flow failed");
+
+    state.start_flow(&flow_id).await.expect("start_flow failed");
+
+    let key = MediaPlayerKey {
+        flow_id,
+        block_id: MEDIA_PLAYER_BLOCK_ID.to_string(),
+    };
+    let player = MEDIA_PLAYER_REGISTRY
+        .get(&key)
+        .expect("the Media Player did not register while the flow was running");
+    let internal_pipeline = player
+        .internal_pipeline
+        .read()
+        .expect("internal pipeline lock poisoned")
+        .as_ref()
+        .expect("the Media Player built no internal pipeline")
+        .downgrade();
+    drop(player);
+
+    state.stop_flow(&flow_id).await.expect("stop_flow failed");
+
+    // The pipeline is dropped inside teardown, but a queued bus message can
+    // hold the last reference for a moment after the call returns. Give it a
+    // bounded window: a reference kept by a live signal handler never goes.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    while internal_pipeline.upgrade().is_some() && std::time::Instant::now() < deadline {
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+
+    assert!(
+        internal_pipeline.upgrade().is_none(),
+        "the Media Player's internal pipeline survived teardown. Its bus watch \
+         still holds an Arc on the state that owns it, so the state is never \
+         dropped and the pipeline decodes on — with its file descriptors — for \
+         the life of the process."
     );
 }


### PR DESCRIPTION
Closes #714.

`start_flow()` can fail in four places and `stop_flow()` is a fifth caller. Each released its own subset, so what a flow leaked depended on which line it failed on.

| Path | Media Player registry | `stop()` | CPU dealloc | WHEP/WHIP unregister | Leak check | Off the tokio worker |
|---|---|---|---|---|---|---|
| `PipelineManager::new()` fails | ❌ → ✅ | – | ❌ → ✅ | – | – | – |
| `manager.start()` fails | ❌ → ✅ | ❌ → ✅ | ✅ | – | ❌ → ✅ | ❌ → ✅ |
| WHEP endpoint conflict | ❌ → ✅ | ✅ | ❌ → ✅ | partial → ✅ | ❌ → ✅ | ❌ → ✅ |
| WHIP endpoint conflict | ❌ → ✅ | ✅ | ❌ → ✅ | ✅ | ❌ → ✅ | ❌ → ✅ |
| `stop_flow()` | ✅ | ✅ | ✅ | ✅ | ✅ | partial → ✅ |

## What was leaking

**Dropping the manager is not stopping it.** `Drop` aborts the thumbnail task, stops probes and sets NULL. `stop()` is also what does `remove_bus_watch()`, removes the thread-priority handler, and unregisters the flow's threads from the CPU-monitor registry. The failed-start path only dropped — one bus watch GSource leaked per attempt, and dead TIDs stayed in the registry where a reused TID is later attributed to a flow that no longer exists.

**The Media Player registry holds an `Arc` per instance, and that `Arc`'s `Drop` is the only thing that takes the block's *internal* pipeline to NULL.** No failure path unregistered, so a Media Player flow that failed to start left a decoding pipeline and its file descriptors running for the life of the process — once per attempt. This also applies to a partial `PipelineManager::new()`, where blocks built before the failing one have already registered themselves.

**The endpoint-conflict paths never released the CPU allocation**, so a flow that lost an endpoint-id race held its cores until the process restarted.

**No failure path did the leak verification** `stop_flow()` does — weak refs taken before the drop, and an error logged for anything still alive. `CLAUDE.md` treats a surviving pipeline as a P0, and a failed start is at least as likely to leave one as a clean stop.

**`stop()` ran on the tokio worker** on the conflict paths, joining a thread around `set_state(Null)` that can take seconds, awaited straight from an HTTP handler.

## The shape

One `teardown_flow(id, manager, endpoints)`: unregister endpoints, tear down WHIP sessions, unregister the flow's Media Players, `stop()` on the blocking pool, verify nothing survived the drop, release the cores. Every one of the five paths calls it. `stop_flow()` is now that call plus the persistence and event broadcasting it already did.

It runs the whole sequence even when `stop()` fails and returns the error at the end, rather than the previous `manager.stop()?` which skipped the leak check and the CPU deallocation on the way out. A pipeline that refuses to stop is exactly when leaking its cores and its registry entries hurts most.

**Endpoint ownership is explicit and this is the one subtlety worth a reviewer's eye.** `None` means "every endpoint the manager declares", which is right whenever the flow finished registering. A caller that failed *during* registration passes the ids it actually registered — because an endpoint-id conflict means that id already belongs to **another flow**, and unregistering it here would tear down that flow's endpoint instead of ours. The previous conflict paths got this right by hand; the shared helper had to keep it, so it is a parameter rather than something derived from the manager.

## Tests

`failed_start_teardown_test.rs` builds an `AppState`, gives a flow a Media Player block alongside `audiotestsrc ! fakesink state-error=paused-to-playing`, and asserts that after the start fails the flow's Media Player is no longer in the registry and nothing was left in the pipeline map.

The registry is the part of this teardown observable from outside the crate; the bus watch, the thread-priority handler and the CPU allocation are released by the same call on the same path. The failing sink is deliberately unrelated to the Media Player, so the test fails for the teardown's reasons and not the block's.

**Verified in both directions:** restoring the pre-fix body of the `manager.start()` failure path makes it fail with the Media Player still registered; with the fix it passes.

Ran locally on the final commit: full `cargo test` (all suites green, 0 failures), `cargo clippy --tests`, `cargo fmt --check`. The new test executed — it needs only core GStreamer plus `audiotestsrc`.

## Not in scope

`manager.start()` still runs on the tokio worker. Moving it to the blocking pool is a real improvement but it is about starting, not teardown, and it would widen this diff into the success path.

## Second commit: the Media Player claim did not hold

Running this branch against a live server showed that unregistering does **not** free what the registry entry stands for, so the first commit's Media Player bullet was only half true. `watch_internal_bus` connects a handler on the internal pipeline's bus and moves an `Arc<MediaPlayerState>` into the closure: the bus owns the closure, the state owns the pipeline, the pipeline owns the bus. While that handler is connected the last `Arc` never goes, `Drop` never runs, and the internal pipeline is never taken to NULL.

Measured on macOS with every flow stopped: the process still held **one open read handle per start** on the playing media file, and burned 0.12s CPU per 10s against 0.06s idle and 0.14s while playing — it keeps decoding. Each cycle also leaked the bus socketpair, 2 fds. This is the **normal stop path**, not only the failed-start one, and it reproduces identically on `main`, so it is not a regression from this branch — but it does mean the failed-start leak this PR set out to close was only halved (4 fds per attempt on `main`, 2 on the first commit, 0 now).

`MediaPlayerState::shutdown()` disconnects the handler, removes the watch it added, takes the pipeline out of the lock and stops it. The registry calls it from `unregister` and `unregister_flow`, outside the lock, since stopping a pipeline can block. `Drop` stays as the fallback for a state that never reached the registry. Only the watch this state added is removed — an unconditional `remove_signal_watch()` on a bus that has none is a GStreamer CRITICAL.

**The existing test could not see any of this**, because it asserts registry membership, which is true either way. `teardown_releases_the_media_players_internal_pipeline` holds a `WeakRef` to the internal pipeline across teardown instead. It goes through stop rather than failed start, because that is the only path from which a test can obtain the reference — both run the same `teardown_flow()`. Verified in both directions: with the shutdown neutralised it fails with "the Media Player's internal pipeline survived teardown", with it in place it passes.

**Verified after the fix:** fd count flat at 119 across 3 play/stop cycles and 5 failed starts, no media-file handles left behind, CPU back to 0.02s per 10s. `cargo test --workspace` 637 passed / 0 failed / 1 ignored, `cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets -- -D warnings` clean. macOS only — the Windows and macOS CI builds are `workflow_dispatch`-gated, so neither ran on this branch.

## Known, not fixed here

`remove_bus_watch()` in `backend/src/gst/pipeline/bus.rs` removes one signal watch per connected handler, but only 4 of the 9 blocks with a `bus_message_handler` call `add_signal_watch()`. Every stop of a flow containing a Media Player, mixer, vision mixer or audioanalyzer over-removes and logs `GStreamer-CRITICAL: Bus busN has no signal watches attached`. It over-removes rather than under-removes, so it is noise rather than a leak, and it predates this branch. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

