### PR TITLE
chore(release): bump version to 0.6.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6575,7 +6575,7 @@ dependencies = [
 
 [[package]]
 name = "strom"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6652,7 +6652,7 @@ dependencies = [
 
 [[package]]
 name = "strom-frontend"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -6688,7 +6688,7 @@ dependencies = [
 
 [[package]]
 name = "strom-mcp-server"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "anyhow",
  "reqwest 0.13.4",
@@ -6702,7 +6702,7 @@ dependencies = [
 
 [[package]]
 name = "strom-types"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "garde",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["types", "backend", "frontend", "mcp-server"]
 default-members = ["backend"]
 
 [workspace.package]
-version = "0.6.6"
+version = "0.6.7"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Per Enstedt <per.enstedt@eyevinn.se>"]

--- a/openapi.json
+++ b/openapi.json
@@ -10,7 +10,7 @@
     "license": {
       "name": "MIT OR Apache-2.0"
     },
-    "version": "0.6.6-dev"
+    "version": "0.6.7"
   },
   "paths": {
     "/api/auth/status": {


### PR DESCRIPTION
Release version bump from 0.6.6 to 0.6.7.

## What changed

| File | Change |
| --- | --- |
| `Cargo.toml` | `[workspace.package] version` 0.6.6 -> 0.6.7 |
| `Cargo.lock` | Refreshed; only the four strom crates' own version lines moved |
| `openapi.json` | `info.version` `0.6.6-dev` -> `0.6.7` |

All member crates (`backend`, `frontend`, `types`, `mcp-server`) use
`version.workspace = true`, so no member manifest needed editing.

The `Cargo.lock` diff is 8 lines: `strom`, `strom-frontend`,
`strom-mcp-server` and `strom-types` each going 0.6.6 -> 0.6.7. No
third-party dependency version changed.

## OpenAPI version drift

`backend/src/openapi.rs` sets `spec.info.version` from
`env!("CARGO_PKG_VERSION")`, so the generated spec has always carried the
real crate version. The committed `openapi.json` snapshot, however, read
`"0.6.6-dev"` — a value the generator never produces for a released
version. It went unnoticed because the snapshot test
(`backend/tests/openapi_test.rs`) strips `info.version` before comparing,
precisely so that patch bumps do not fail the snapshot. That same strip
means nothing guards the field, and it drifted. This PR sets it to
`0.6.7`, matching what the generator emits at this version.

## Commands run

- `cargo update --workspace --offline` — succeeded offline; locked only the four workspace crates
- `git diff Cargo.lock` — verified no third-party version lines moved
- `cargo metadata --no-deps --format-version 1 | grep -o '"version":"0\.6\.[0-9]*"' | sort -u` — reports `"version":"0.6.7"` only
- `cargo check --workspace` — passed
- `cargo test --test openapi_test` — passed (1 test, `openapi_spec_snapshot`); confirms no API-shape drift, though by design it does not check `info.version`

Nothing was skipped.

## Version references found and deliberately left alone

- `backend/static/vision-mixer.html` line 1242: `v2.39-roll-punch-fix` — a per-file cache-busting marker for the static asset, not the product version.
- `docs/CHANGELOG.md`: `## [0.6.5] - 2026-06-12` — historical changelog entry.
- `installer/windows/Product.wxs`: `Version="$(var.ProductVersion)"` — supplied at build time by `.github/workflows/release-msi.yml` / `Build-Installer.ps1`, not hard-coded.
- Third-party tool pins in `.github/workflows/`, `Dockerfile`, `docker/`, `scripts/`, `installer/windows/Prepare-*.ps1` (Trunk, Zig, GStreamer, Graphviz, CEF, sccache) — unrelated to the product version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
