### PR TITLE
fix(scripts): make the pre-commit hook match the checks CI actually runs

### DIFF
--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -6,23 +6,43 @@ set -e
 
 echo "Installing Git hooks for Strom..."
 
-# Check if we're in a git repository
-if [ ! -d ".git" ]; then
-    echo "❌ Error: This script must be run from the root of the git repository"
+# Resolve the hooks directory. --git-common-dir rather than a literal .git:
+# inside a worktree .git is a file, not a directory, and the hooks live in the
+# main checkout's git dir shared by every worktree.
+GIT_COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null) || {
+    echo "❌ Error: not inside a git repository"
+    exit 1
+}
+HOOKS_DIR="$GIT_COMMON_DIR/hooks"
+
+# core.hooksPath overrides the hooks directory, so installing there would be
+# silently ignored. Fail loudly instead of pretending the hook is active.
+CONFIGURED_PATH=$(git config --get core.hooksPath || true)
+if [ -n "$CONFIGURED_PATH" ]; then
+    echo "❌ Error: core.hooksPath is set to '$CONFIGURED_PATH'"
+    echo "   A hook in $HOOKS_DIR would be ignored. Install into that path"
+    echo "   instead, or unset it: git config --unset core.hooksPath"
     exit 1
 fi
 
-# Copy pre-commit hook
+# Locate the hook source relative to this script, so the installer works from
+# any directory.
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+
 echo "→ Installing pre-commit hook..."
-cp scripts/pre-commit .git/hooks/pre-commit
-chmod +x .git/hooks/pre-commit
+mkdir -p "$HOOKS_DIR"
+cp "$SCRIPT_DIR/pre-commit" "$HOOKS_DIR/pre-commit"
+chmod +x "$HOOKS_DIR/pre-commit"
 
 echo ""
 echo "✅ Git hooks installed successfully!"
 echo ""
+echo "Installed to: $HOOKS_DIR/pre-commit"
+echo ""
 echo "The following checks will run before each commit:"
-echo "  • cargo fmt (code formatting)"
-echo "  • cargo clippy (linting)"
+echo "  • cargo fmt --all (code formatting)"
+echo "  • cargo clippy --workspace --all-targets --features efp,nvidia"
+echo "  • cargo clippy for wasm32, when frontend/ is staged"
 echo "  • claude (sensitive content check, if installed)"
 echo ""
 echo "To skip these checks temporarily, use: git commit --no-verify"

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -17,15 +17,37 @@ if ! cargo fmt --all -- --check; then
 fi
 echo "✓ Formatting check passed"
 
-# Run clippy
+# Run clippy. The features matter: nvidia and efp are opt-in, so without them
+# the feature-gated code CI lints is never compiled here and the hook can pass
+# on code CI rejects. --workspace --all-targets covers strom-types,
+# strom-mcp-server and the frontend on the host target in the same pass, which
+# makes this a superset of the two clippy steps in the Linux CI job.
 echo "→ Running clippy linter..."
-if ! cargo clippy --workspace --all-targets -- -D warnings; then
+if ! cargo clippy --workspace --all-targets --features efp,nvidia -- -D warnings; then
     echo ""
     echo "❌ Clippy check failed!"
     echo "   Please fix the issues reported above."
     exit 1
 fi
 echo "✓ Clippy check passed"
+
+# The frontend compiles to WASM too, and cfg(target_arch = "wasm32") code is
+# invisible to the host pass above. CI lints it separately; that target costs
+# ~45s, so only pay it when the frontend actually changed.
+if git diff --cached --name-only --diff-filter=d | grep -q '^frontend/'; then
+    if rustup target list --installed 2>/dev/null | grep -q '^wasm32-unknown-unknown$'; then
+        echo "→ Running clippy on the frontend for wasm32..."
+        if ! cargo clippy --package strom-frontend --target wasm32-unknown-unknown --all-features -- -D warnings; then
+            echo ""
+            echo "❌ Clippy check failed for wasm32!"
+            echo "   Please fix the issues reported above."
+            exit 1
+        fi
+        echo "✓ Clippy check passed for wasm32"
+    else
+        echo "⏭ Skipping wasm32 clippy (target not installed — run: rustup target add wasm32-unknown-unknown)"
+    fi
+fi
 
 # Run tests (optional - can be slow, comment out if needed)
 # echo "→ Running tests..."


### PR DESCRIPTION
The pre-commit hook existed but had never been installed in this checkout, and once installed it would not have caught what CI catches.

## The hook could pass on code CI rejects

It ran `cargo clippy --workspace --all-targets` with **no features**. Both feature-gated paths CI lints are opt-in:

```toml
default = ["nvidia"]
nvidia  = ["dep:nvml-wrapper"]
efp     = ["dep:gst-plugin-efp"]
```

`--workspace` selects every member, and cargo then applies each member's own defaults — so `efp` code was never compiled by the hook at all. CI's Linux gate lints it (`--features efp,nvidia`), which is exactly the false-green a pre-commit hook exists to prevent.

Adding the features keeps it to one invocation rather than copying CI's three:

```
cargo clippy --workspace --all-targets --features efp,nvidia -- -D warnings
```

That is a **superset** of the two clippy steps in the Linux job (`--package strom --features efp,nvidia` and `--package strom-mcp-server`), because `--workspace` also lints `strom-types` and the frontend on the host target, which the Linux job does not do at all. Measured **21 s warm**.

## WASM, but only when it is relevant

The frontend compiles to both native and WASM, and `cfg(target_arch = "wasm32")` code is invisible to the host pass. CI lints it as its own job:

```
cargo clippy --package strom-frontend --target wasm32-unknown-unknown --all-features
```

Measured **45 s warm** — too much to add to every commit when most commits do not touch the frontend. So it runs only when `frontend/` is staged, and skips with an actionable hint when the target is not installed rather than failing cryptically:

```bash
if git diff --cached --name-only --diff-filter=d | grep -q '^frontend/'; then
```

## The installer refused to run from a worktree

`install-hooks.sh` guarded on `[ ! -d ".git" ]`. Inside a worktree `.git` is a **file**, not a directory, so the script exited with "must be run from the root of the git repository" — from the root of a perfectly valid worktree.

Resolved with `git rev-parse --git-common-dir`, which is also the *correct* destination: worktrees share the main checkout's hooks directory, so a hook installed there covers every worktree. Two related fixes came with it:

- the hook source is now located relative to the script, so the installer no longer has to be invoked from the repository root;
- `core.hooksPath`, if set, silently overrides `.git/hooks` — the installer now fails loudly and names the path instead of reporting success for a hook git will ignore.

It also prints where it installed to, and the summary it prints now lists the checks it actually runs.

## Verification

- `bash -n` on both scripts.
- Ran `./scripts/install-hooks.sh` **from inside a worktree** — the case that was broken. It resolved to the main checkout's `.git/hooks` and reported that path.
- Committed this change **through the newly installed hook**: fmt passed, clippy passed, the sensitive-content check ran and returned clean. The wasm32 step was correctly skipped, since only `scripts/` was staged.
- Verified the wasm32 condition separately by staging a frontend file: the guard fires and the installed-target check resolves. Reverted afterwards.

No production code is touched — `scripts/` only, so the CI result here says nothing new about the build. That is expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
