### PR TITLE
fix(whip): stop a session's inactivity watchdog when the session ends

### DIFF
--- a/backend/src/api/whip_ingest.rs
+++ b/backend/src/api/whip_ingest.rs
@@ -10,13 +10,15 @@ use crate::api::sdp_transform::{
 use crate::blocks::builtin::whip::create_whipserversrc_for_session;
 use crate::json_rejection::JsonBody;
 use crate::state::AppState;
-use crate::whip_session_manager::WhipSessionManager;
+use crate::whip_session_manager::{NewWhipSession, WhipSessionManager};
 use axum::{
     body::Body,
     extract::{Path, State},
     http::{header, HeaderMap, StatusCode},
     response::{Html, IntoResponse, Response},
 };
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use tracing::{debug, error, info, warn};
 
 /// Serve the WHIP ingest page.
@@ -145,11 +147,21 @@ pub async fn whip_post(
         }
     };
 
-    // Create a new whipserversrc for this session in an isolated pipeline
+    // Create a new whipserversrc for this session in an isolated pipeline.
+    // `cleanup_sent` is handed to both the session's callbacks and (below) the
+    // session manager, so that every teardown path can stop the session's
+    // inactivity watchdog.
     let config_for_session = config.clone();
     let cleanup_tx = state.whip_session_manager().cleanup_sender();
+    let cleanup_sent = Arc::new(AtomicBool::new(false));
+    let cleanup_sent_for_session = cleanup_sent.clone();
     let (element, session_pipeline, port) = match tokio::task::spawn_blocking(move || {
-        create_whipserversrc_for_session(&config_for_session, slot, cleanup_tx)
+        create_whipserversrc_for_session(
+            &config_for_session,
+            slot,
+            cleanup_tx,
+            cleanup_sent_for_session,
+        )
     })
     .await
     {
@@ -157,6 +169,9 @@ pub async fn whip_post(
         Ok(Err(e)) => {
             error!("Failed to create whipserversrc for session: {}", e);
             config.release_slot(slot);
+            // Abandoned session: stop its inactivity watchdog. Every early return
+            // below does the same — a watchdog left running outlives its session.
+            cleanup_sent.store(true, Ordering::SeqCst);
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 format!("Failed to create session: {}", e),
@@ -166,6 +181,7 @@ pub async fn whip_post(
         Err(e) => {
             error!("spawn_blocking panicked: {}", e);
             config.release_slot(slot);
+            cleanup_sent.store(true, Ordering::SeqCst);
             return (StatusCode::INTERNAL_SERVER_ERROR, "Internal error").into_response();
         }
     };
@@ -182,6 +198,7 @@ pub async fn whip_post(
             error!("Failed to read request body: {}", e);
             // Teardown the element we just created and release slot
             config.release_slot(slot);
+            cleanup_sent.store(true, Ordering::SeqCst);
             let session_pipeline_clone = session_pipeline.clone();
             tokio::task::spawn_blocking(move || {
                 WhipSessionManager::teardown_session_pipeline(&session_pipeline_clone);
@@ -228,6 +245,7 @@ pub async fn whip_post(
         Err(e) => {
             error!("Failed to create HTTP client: {}", e);
             config.release_slot(slot);
+            cleanup_sent.store(true, Ordering::SeqCst);
             let session_pipeline_clone = session_pipeline.clone();
             tokio::task::spawn_blocking(move || {
                 WhipSessionManager::teardown_session_pipeline(&session_pipeline_clone);
@@ -271,6 +289,7 @@ pub async fn whip_post(
                 );
                 if attempt == max_attempts - 1 {
                     config.release_slot(slot);
+                    cleanup_sent.store(true, Ordering::SeqCst);
                     let session_pipeline_clone = session_pipeline.clone();
                     tokio::task::spawn_blocking(move || {
                         WhipSessionManager::teardown_session_pipeline(&session_pipeline_clone);
@@ -289,6 +308,7 @@ pub async fn whip_post(
         Some(tuple) => tuple,
         None => {
             config.release_slot(slot);
+            cleanup_sent.store(true, Ordering::SeqCst);
             let session_pipeline_clone = session_pipeline.clone();
             tokio::task::spawn_blocking(move || {
                 WhipSessionManager::teardown_session_pipeline(&session_pipeline_clone);
@@ -307,6 +327,7 @@ pub async fn whip_post(
         // cannot be used and would otherwise occupy the slot until the inactivity
         // watchdog fires.
         config.release_slot(slot);
+        cleanup_sent.store(true, Ordering::SeqCst);
         let session_pipeline_clone = session_pipeline.clone();
         tokio::task::spawn_blocking(move || {
             WhipSessionManager::teardown_session_pipeline(&session_pipeline_clone);
@@ -338,14 +359,17 @@ pub async fn whip_post(
                     "WHIP: Registering session resource_id='{}' on port {} for endpoint '{}' (slot {})",
                     resource_id, port, endpoint_id, slot
                 );
-                let registered = state.whip_session_manager().register_session(
-                    resource_id.to_string(),
-                    port,
-                    element,
-                    session_pipeline,
-                    endpoint_id.clone(),
-                    slot,
-                );
+                let registered = state
+                    .whip_session_manager()
+                    .register_session(NewWhipSession {
+                        resource_id: resource_id.to_string(),
+                        port,
+                        element,
+                        session_pipeline,
+                        endpoint_id: endpoint_id.clone(),
+                        slot,
+                        cleanup_sent,
+                    });
                 if !registered {
                     warn!(
                         "WHIP: Session '{}' was cleaned up before registration (ICE failed early)",
@@ -353,6 +377,7 @@ pub async fn whip_post(
                     );
                 }
             } else {
+                cleanup_sent.store(true, Ordering::SeqCst);
                 warn!(
                     "WHIP: Unexpected Location header format: '{}', session not registered",
                     loc_str
@@ -360,6 +385,7 @@ pub async fn whip_post(
             }
         }
     } else if status.is_success() {
+        cleanup_sent.store(true, Ordering::SeqCst);
         warn!("WHIP: No Location header in successful POST response, session not registered");
     }
 

--- a/backend/src/blocks/builtin/whip.rs
+++ b/backend/src/blocks/builtin/whip.rs
@@ -502,6 +502,32 @@ fn build_whipserversrc(
     })
 }
 
+/// How long a session may go without a buffer before the watchdog tears it down.
+const INACTIVITY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// How often the watchdog re-checks its stop flag while waiting.
+const WATCHDOG_POLL: std::time::Duration = std::time::Duration::from_millis(250);
+
+/// Sleep until `deadline`, waking every `WATCHDOG_POLL` to re-check `stop`.
+///
+/// Returns true if `stop` was set (the caller should give up), false if the
+/// deadline was reached. The wait is sliced rather than one long sleep so a
+/// session's watchdog thread cannot outlive the session: a watchdog that fires
+/// after teardown asks the session manager to clean up a port it no longer knows,
+/// and the manager then marks that recycled port pending cleanup for nothing.
+fn wait_until_deadline_or_stop(stop: &AtomicBool, deadline: Instant) -> bool {
+    loop {
+        if stop.load(Ordering::SeqCst) {
+            return true;
+        }
+        let now = Instant::now();
+        if now >= deadline {
+            return false;
+        }
+        std::thread::sleep(WATCHDOG_POLL.min(deadline - now));
+    }
+}
+
 /// Create a new whipserversrc element for a single WHIP client session.
 ///
 /// Each session runs in its own isolated GStreamer pipeline to avoid
@@ -512,10 +538,15 @@ fn build_whipserversrc(
 /// appsrc targets are the pre-built slot elements.
 ///
 /// Returns (element, session_pipeline, port) on success.
+/// `cleanup_sent` is owned by the caller so it can be handed to the session
+/// manager alongside the session: every teardown path sets it, which both
+/// suppresses duplicate cleanup requests and stops this session's inactivity
+/// watchdog thread.
 pub fn create_whipserversrc_for_session(
     config: &WhipEndpointConfig,
     slot: usize,
     cleanup_tx: tokio::sync::mpsc::UnboundedSender<SessionCleanupRequest>,
+    cleanup_sent: Arc<AtomicBool>,
 ) -> Result<(gst::Element, gst::Pipeline, u16), String> {
     // Allocate a free port
     let listener =
@@ -583,9 +614,8 @@ pub fn create_whipserversrc_for_session(
     let block_id_for_callback = config.instance_id.clone();
     let ice_transport_policy = config.ice_transport_policy.clone();
     let jitterbuffer_latency_ms = config.jitterbuffer_latency_ms;
-    // Flag to ensure only one cleanup request per session (shared across ICE callback,
-    // inactivity watchdog, etc.)
-    let cleanup_sent = Arc::new(AtomicBool::new(false));
+    // `cleanup_sent` ensures only one cleanup request per session (shared across the
+    // ICE callback, the inactivity watchdog and the session manager's teardown paths).
     let cleanup_sent_for_ice = cleanup_sent.clone();
     let cleanup_tx_for_ice = cleanup_tx.clone();
 
@@ -717,9 +747,14 @@ pub fn create_whipserversrc_for_session(
 
     // Inactivity watchdog: tracks when the last buffer arrived on any stream.
     // A background thread checks this and triggers cleanup if no data arrives
-    // for INACTIVITY_TIMEOUT_SECS (covers the case where ICE disconnect
+    // for INACTIVITY_TIMEOUT (covers the case where ICE disconnect
     // notification doesn't fire from the isolated session pipeline).
-    const INACTIVITY_TIMEOUT_SECS: u64 = 10;
+    //
+    // The wait is sliced rather than one long sleep so that `cleanup_sent` — set by
+    // the ICE callback and by every teardown path in the session manager — ends the
+    // thread promptly. A watchdog that outlived its session would send a cleanup
+    // request for a port the manager no longer knows, and the manager would then mark
+    // that (recycled) port pending cleanup for nothing.
     let last_buffer_epoch = Instant::now();
     let last_buffer_ms = Arc::new(AtomicU64::new(0));
     {
@@ -730,9 +765,10 @@ pub fn create_whipserversrc_for_session(
             .name(format!("whip-watchdog-{}", port))
             .spawn(move || {
                 loop {
-                    std::thread::sleep(std::time::Duration::from_secs(INACTIVITY_TIMEOUT_SECS));
-                    // Exit if another path (ICE callback, DELETE) already triggered cleanup
-                    if cleanup_sent_watchdog.load(Ordering::SeqCst) {
+                    let deadline = Instant::now() + INACTIVITY_TIMEOUT;
+                    if wait_until_deadline_or_stop(&cleanup_sent_watchdog, deadline) {
+                        // Another path (ICE callback, DELETE, flow stop) finished
+                        // with this session.
                         break;
                     }
                     let last = last_buffer_ms_watchdog.load(Ordering::Relaxed);
@@ -742,7 +778,7 @@ pub fn create_whipserversrc_for_session(
                     }
                     let elapsed_ms = last_buffer_epoch.elapsed().as_millis() as u64;
                     let idle_ms = elapsed_ms.saturating_sub(last);
-                    if idle_ms >= INACTIVITY_TIMEOUT_SECS * 1000 {
+                    if idle_ms >= INACTIVITY_TIMEOUT.as_millis() as u64 {
                         if !cleanup_sent_watchdog.swap(true, Ordering::SeqCst) {
                             info!(
                                 "WHIP Input: Inactivity timeout ({}s idle) on port {}, triggering cleanup",
@@ -1790,6 +1826,51 @@ mod tests {
             "do_retransmission",
             PropertyValue::Bool(false)
         )])));
+    }
+
+    /// The inactivity watchdog must stop as soon as a teardown path sets the
+    /// session's `cleanup_sent` flag, not when its next timeout would have been.
+    /// A watchdog that outlives its session sends a cleanup request for a port the
+    /// session manager no longer knows, which marks that recycled port poisoned.
+    #[test]
+    fn watchdog_wait_returns_as_soon_as_the_stop_flag_is_set() {
+        let stop = Arc::new(AtomicBool::new(false));
+        let setter = stop.clone();
+        std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(50));
+            setter.store(true, Ordering::SeqCst);
+        });
+
+        // A deadline far beyond the flag: a wait that ignores the flag fails here by
+        // running the full 30 s, rather than returning in a poll interval.
+        let deadline = Instant::now() + std::time::Duration::from_secs(30);
+        let started = Instant::now();
+        let stopped = wait_until_deadline_or_stop(&stop, deadline);
+
+        assert!(
+            stopped,
+            "wait must report that it was stopped, not timed out"
+        );
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(5),
+            "wait took {:?} — it is not polling the stop flag",
+            started.elapsed()
+        );
+    }
+
+    /// With no stop flag set the wait must still run to its deadline, otherwise the
+    /// watchdog would never reach its inactivity check.
+    #[test]
+    fn watchdog_wait_runs_to_the_deadline_when_not_stopped() {
+        let stop = Arc::new(AtomicBool::new(false));
+        let deadline = Instant::now() + std::time::Duration::from_millis(300);
+        let stopped = wait_until_deadline_or_stop(&stop, deadline);
+
+        assert!(!stopped, "wait must report a timeout, not a stop");
+        assert!(
+            Instant::now() >= deadline,
+            "wait returned before its deadline"
+        );
     }
 
     /// The block property must reach the `WhipEndpointConfig` handed to the

--- a/backend/src/whip_session_manager.rs
+++ b/backend/src/whip_session_manager.rs
@@ -11,9 +11,10 @@ use crate::blocks::DynamicWebrtcbinStore;
 use gstreamer as gst;
 use gstreamer::prelude::*;
 use gstreamer_app as gst_app;
-use std::collections::{HashMap, HashSet};
-use std::sync::atomic::AtomicBool;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
+use std::time::{Duration, Instant};
 use strom_types::block::StreamMode;
 use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
@@ -118,6 +119,28 @@ struct WhipSession {
     endpoint_id: String,
     /// The slot index assigned to this session
     slot: usize,
+    /// Set once the session is finished, by whichever path tears it down.
+    /// Stops the session's inactivity watchdog thread and suppresses duplicate
+    /// cleanup requests. Shared with the callbacks in `whip.rs`.
+    cleanup_sent: Arc<AtomicBool>,
+}
+
+/// A freshly created WHIP session, handed to `register_session`.
+pub struct NewWhipSession {
+    /// The resource_id assigned by the internal whipserversrc signaller
+    pub resource_id: String,
+    /// Internal port where this session's whipserversrc is listening
+    pub port: u16,
+    /// The whipserversrc element for this session
+    pub element: gst::Element,
+    /// The isolated pipeline for this session's whipserversrc
+    pub session_pipeline: gst::Pipeline,
+    /// The endpoint this session belongs to
+    pub endpoint_id: String,
+    /// The slot index assigned to this session
+    pub slot: usize,
+    /// Shared with the session's own callbacks; see `WhipSession::cleanup_sent`.
+    pub cleanup_sent: Arc<AtomicBool>,
 }
 
 /// Manages WHIP sessions across all endpoints.
@@ -132,10 +155,20 @@ pub struct WhipSessionManager {
     cleanup_tx: mpsc::UnboundedSender<SessionCleanupRequest>,
     /// Channel receiver — taken once when starting the cleanup task
     cleanup_rx: Mutex<Option<mpsc::UnboundedReceiver<SessionCleanupRequest>>>,
-    /// Ports for sessions that died before register_session was called.
-    /// register_session checks this set and skips registration if the port is present.
-    pending_cleanup_ports: Mutex<HashSet<u16>>,
+    /// Ports for sessions that died before register_session was called, with the
+    /// time they were marked. register_session checks this map and skips
+    /// registration if the port is present and the mark has not expired.
+    ///
+    /// Marks expire after `PENDING_CLEANUP_TTL`: session ports come from the OS
+    /// ephemeral range and are recycled, so a mark that is never claimed must not
+    /// poison a later, unrelated session that happens to be given the same port.
+    pending_cleanup_ports: Mutex<HashMap<u16, Instant>>,
 }
+
+/// How long a pending-cleanup mark stays valid. The window it has to cover is the
+/// gap between a session dying and `register_session` running for it, which is
+/// sub-second in practice.
+const PENDING_CLEANUP_TTL: Duration = Duration::from_secs(30);
 
 impl WhipSessionManager {
     pub fn new() -> Self {
@@ -145,7 +178,7 @@ impl WhipSessionManager {
             sessions: RwLock::new(HashMap::new()),
             cleanup_tx,
             cleanup_rx: Mutex::new(Some(cleanup_rx)),
-            pending_cleanup_ports: Mutex::new(HashSet::new()),
+            pending_cleanup_ports: Mutex::new(HashMap::new()),
         }
     }
 
@@ -221,8 +254,11 @@ impl WhipSessionManager {
                 None => {
                     // Session not registered yet (ICE failed before register_session).
                     // Mark port as pending cleanup so register_session skips it.
+                    // The mark expires after PENDING_CLEANUP_TTL so it cannot poison
+                    // a later session that is handed the same recycled port.
                     let mut pending = manager.pending_cleanup_ports.lock().unwrap();
-                    pending.insert(req.port);
+                    pending.retain(|_, marked| marked.elapsed() < PENDING_CLEANUP_TTL);
+                    pending.insert(req.port, Instant::now());
                     warn!(
                         "WhipSessionManager: Session on port {} not found, marked for pending cleanup (reason: {})",
                         req.port, req.reason
@@ -254,19 +290,24 @@ impl WhipSessionManager {
     /// If the session's port is in the pending_cleanup_ports set (ICE failed before
     /// registration), the session is immediately torn down instead of being registered.
     /// Returns true if registered, false if immediately cleaned up.
-    pub fn register_session(
-        &self,
-        resource_id: String,
-        port: u16,
-        element: gst::Element,
-        session_pipeline: gst::Pipeline,
-        endpoint_id: String,
-        slot: usize,
-    ) -> bool {
+    pub fn register_session(&self, session: NewWhipSession) -> bool {
+        let NewWhipSession {
+            resource_id,
+            port,
+            element,
+            session_pipeline,
+            endpoint_id,
+            slot,
+            cleanup_sent,
+        } = session;
+
         // Check if this port was marked for cleanup before we could register it
         {
             let mut pending = self.pending_cleanup_ports.lock().unwrap();
-            if pending.remove(&port) {
+            pending.retain(|_, marked| marked.elapsed() < PENDING_CLEANUP_TTL);
+            if pending.remove(&port).is_some() {
+                // Nothing will tear this session down later, so stop its watchdog here.
+                cleanup_sent.store(true, Ordering::SeqCst);
                 warn!(
                     "WhipSessionManager: Session '{}' on port {} died before registration, tearing down immediately",
                     resource_id, port
@@ -297,6 +338,7 @@ impl WhipSessionManager {
                 session_pipeline,
                 endpoint_id,
                 slot,
+                cleanup_sent,
             },
         );
         true
@@ -322,9 +364,10 @@ impl WhipSessionManager {
         resource_id: &str,
     ) -> Option<(gst::Element, gst::Pipeline, String, u16, usize)> {
         let mut sessions = self.sessions.write().unwrap();
-        sessions
-            .remove(resource_id)
-            .map(|s| (s.element, s.session_pipeline, s.endpoint_id, s.port, s.slot))
+        sessions.remove(resource_id).map(|s| {
+            s.cleanup_sent.store(true, Ordering::SeqCst);
+            (s.element, s.session_pipeline, s.endpoint_id, s.port, s.slot)
+        })
     }
 
     /// Remove a session by its internal port (reverse lookup for auto-cleanup).
@@ -341,6 +384,7 @@ impl WhipSessionManager {
 
         if let Some(rid) = resource_id {
             sessions.remove(&rid).map(|s| {
+                s.cleanup_sent.store(true, Ordering::SeqCst);
                 (
                     rid,
                     s.element,
@@ -373,6 +417,7 @@ impl WhipSessionManager {
                     "WhipSessionManager: Removing session '{}' for endpoint '{}'",
                     resource_id, endpoint_id
                 );
+                session.cleanup_sent.store(true, Ordering::SeqCst);
                 result.push((session.session_pipeline, session.element));
             }
         }
@@ -439,5 +484,137 @@ impl WhipSessionManager {
 impl Default for WhipSessionManager {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dummy_session() -> (gst::Element, gst::Pipeline, Arc<AtomicBool>) {
+        let _ = gst::init();
+        let element = gst::ElementFactory::make("fakesrc")
+            .build()
+            .expect("fakesrc is part of gstreamer core");
+        let pipeline = gst::Pipeline::new();
+        (element, pipeline, Arc::new(AtomicBool::new(false)))
+    }
+
+    /// A session's `cleanup_sent` flag is the only way to stop its inactivity
+    /// watchdog thread. Every path that removes a session must set it, or the
+    /// watchdog outlives the session and asks for cleanup of a port that is gone.
+    fn register(manager: &WhipSessionManager, resource_id: &str, port: u16) -> Arc<AtomicBool> {
+        let (element, pipeline, cleanup_sent) = dummy_session();
+        let registered = manager.register_session(NewWhipSession {
+            resource_id: resource_id.to_string(),
+            port,
+            element,
+            session_pipeline: pipeline,
+            endpoint_id: "endpoint".to_string(),
+            slot: 0,
+            cleanup_sent: cleanup_sent.clone(),
+        });
+        assert!(registered, "session should register");
+        assert!(
+            !cleanup_sent.load(Ordering::SeqCst),
+            "a freshly registered session is not finished"
+        );
+        cleanup_sent
+    }
+
+    #[test]
+    fn remove_session_stops_the_watchdog() {
+        let manager = WhipSessionManager::new();
+        let cleanup_sent = register(&manager, "resource-a", 40001);
+
+        assert!(manager.remove_session("resource-a").is_some());
+
+        assert!(
+            cleanup_sent.load(Ordering::SeqCst),
+            "remove_session (WHIP DELETE) must stop the session's watchdog"
+        );
+    }
+
+    #[test]
+    fn remove_session_by_port_stops_the_watchdog() {
+        let manager = WhipSessionManager::new();
+        let cleanup_sent = register(&manager, "resource-b", 40002);
+
+        assert!(manager.remove_session_by_port(40002).is_some());
+
+        assert!(
+            cleanup_sent.load(Ordering::SeqCst),
+            "auto-cleanup by port must stop the session's watchdog"
+        );
+    }
+
+    #[test]
+    fn remove_all_sessions_stops_the_watchdog() {
+        let manager = WhipSessionManager::new();
+        let cleanup_sent = register(&manager, "resource-c", 40003);
+
+        assert_eq!(manager.remove_all_sessions("endpoint").len(), 1);
+
+        assert!(
+            cleanup_sent.load(Ordering::SeqCst),
+            "flow stop must stop the session's watchdog"
+        );
+    }
+
+    /// A pending-cleanup mark that is never claimed must not survive: session ports
+    /// come from the OS ephemeral range and are recycled, so a stale mark would
+    /// destroy a later, unrelated session that is handed the same port.
+    #[test]
+    fn expired_pending_cleanup_mark_does_not_reject_a_recycled_port() {
+        let manager = WhipSessionManager::new();
+        {
+            let mut pending = manager.pending_cleanup_ports.lock().unwrap();
+            pending.insert(40004, Instant::now() - PENDING_CLEANUP_TTL * 2);
+        }
+
+        let (element, pipeline, cleanup_sent) = dummy_session();
+        let registered = manager.register_session(NewWhipSession {
+            resource_id: "resource-d".to_string(),
+            port: 40004,
+            element,
+            session_pipeline: pipeline,
+            endpoint_id: "endpoint".to_string(),
+            slot: 0,
+            cleanup_sent: cleanup_sent.clone(),
+        });
+
+        assert!(
+            registered,
+            "an expired pending-cleanup mark must not poison a recycled port"
+        );
+        assert!(!cleanup_sent.load(Ordering::SeqCst));
+    }
+
+    /// The mark must still do its job inside the TTL: a session that died before
+    /// registration is torn down rather than registered.
+    #[test]
+    fn fresh_pending_cleanup_mark_still_rejects_the_session() {
+        let manager = WhipSessionManager::new();
+        {
+            let mut pending = manager.pending_cleanup_ports.lock().unwrap();
+            pending.insert(40005, Instant::now());
+        }
+
+        let (element, pipeline, cleanup_sent) = dummy_session();
+        let registered = manager.register_session(NewWhipSession {
+            resource_id: "resource-e".to_string(),
+            port: 40005,
+            element,
+            session_pipeline: pipeline,
+            endpoint_id: "endpoint".to_string(),
+            slot: 0,
+            cleanup_sent: cleanup_sent.clone(),
+        });
+
+        assert!(!registered, "a fresh mark must still reject the session");
+        assert!(
+            cleanup_sent.load(Ordering::SeqCst),
+            "a rejected session's watchdog must be stopped too"
+        );
     }
 }


### PR DESCRIPTION
Fixes #717.

## The bug

A WHIP session's inactivity watchdog is a thread that only ends when the session's `cleanup_sent` flag is set. That flag lived inside `whip.rs` and was set by exactly two things: the ICE-state callback and the watchdog itself. It was not stored in `WhipSession`, so no teardown path could reach it.

On every normal disconnect the thread therefore outlived its session, woke up 10-20 s later and asked the session manager to clean up a port the manager no longer knew. Observed locally on v0.6.6, two of two sessions, both after a clean `DELETE`:

```
12:44:21.527  Registering session bd8365d7... on port 61783
12:44:37.973  WHIP DELETE ... bd8365d7... cleaned up (slot 0 released)
12:44:51.238  WHIP Input: Inactivity timeout (13s idle) on port 61783, triggering cleanup
12:44:51.238  WARN WhipSessionManager: Session on port 61783 not found, marked for pending cleanup
```

That mark is permanent — only a matching `register_session` removes one. Since session ports come from the OS ephemeral range (`TcpListener::bind("127.0.0.1:0")`) and are recycled, the marks accumulate until a healthy new session is handed a poisoned port and is destroyed at registration with the misleading `died before registration, tearing down immediately`.

Separately, a session that never received a buffer (`last_buffer_ms == 0`) left its watchdog looping forever — one leaked thread per such session, which is precisely the case the watchdog exists to cover.

## The fix

- `cleanup_sent` is now created by the caller (`whip_post`) and handed to both `create_whipserversrc_for_session` and, via the new `NewWhipSession`, to the session manager.
- Every path that ends a session sets it: `remove_session` (WHIP DELETE), `remove_session_by_port` (auto-cleanup), `remove_all_sessions` (flow stop), the reject-at-registration path, and each early return in `whip_post` that abandons a session it just created.
- The watchdog waits in 250 ms slices (`wait_until_deadline_or_stop`) instead of one 10 s sleep, so it observes the flag promptly rather than at its next timeout — including in the `last == 0` case, which is what removes the immortal thread.
- Pending-cleanup marks get a 30 s TTL. The window they exist to cover is the sub-second gap between a session dying and `register_session` running for it, so an unclaimed mark must not survive to reject an unrelated session on a recycled port. The TTL subsumes endpoint-scoped clearing, so `unregister_endpoint` is unchanged.

`register_session` grew past clippy's argument limit, so its parameters moved into a `NewWhipSession` struct.

## Tests

New unit tests, all of which run in CI (GStreamer core only — `fakesrc`, no network, no `whipserversrc`):

`backend/src/whip_session_manager.rs`
- `remove_session_stops_the_watchdog`
- `remove_session_by_port_stops_the_watchdog`
- `remove_all_sessions_stops_the_watchdog`
- `expired_pending_cleanup_mark_does_not_reject_a_recycled_port`
- `fresh_pending_cleanup_mark_still_rejects_the_session` (guards that the TTL did not disable the original behaviour)

`backend/src/blocks/builtin/whip.rs`
- `watchdog_wait_returns_as_soon_as_the_stop_flag_is_set`
- `watchdog_wait_runs_to_the_deadline_when_not_stopped`

**Revert check:** with the `cleanup_sent.store(...)` calls and the TTL `retain` removed but the signatures kept, four of the five manager tests fail. The two watchdog-wait tests guard the sliced wait: a wait that ignores the flag runs the full 30 s deadline and trips the elapsed-time assertion.

**Ran locally** (macOS, Apple M5 Pro): `cargo fmt --all --check`, `cargo clippy --all-targets` (clean), `cargo test` — 537 lib tests plus all integration suites pass, 0 failures. One pre-existing `ignored` test, `test_jitterbuffer_stalls_without_drop_on_latency`, unrelated to this change. Not run: any live WHIP publish against a real browser.

## Not addressed

The two branches at the end of `whip_post` that never register the session (unexpected `Location` format, no `Location` header) still leak the session pipeline — nothing tears it down, before or after this change. They now set `cleanup_sent`, so at least the watchdog thread ends; the pipeline leak is pre-existing and left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
