### PR TITLE
feat(monitor): sample per-thread CPU on macOS via mach thread_info

### DIFF
--- a/backend/src/gst/thread_priority.rs
+++ b/backend/src/gst/thread_priority.rs
@@ -407,8 +407,18 @@ pub fn setup_thread_priority_handler(
 
 /// Get the native thread ID of the current thread.
 ///
+/// The value is used as the key in [`ThreadRegistry`] and as the handle the
+/// system monitor samples CPU time with, so each platform returns whatever
+/// identifier its sampling API needs.
+///
 /// On Linux, this returns the TID from gettid() syscall, which is needed
 /// for /proc/{pid}/task/{tid}/stat access.
+///
+/// On macOS, this returns the mach thread port (`mach_port_t`), which is what
+/// `thread_info(THREAD_BASIC_INFO)` takes. It is deliberately not the
+/// `pthread_t`: the port is captured here, on the streaming thread itself, so
+/// the sampler never has to dereference a `pthread_t` whose thread may already
+/// have exited.
 fn get_current_thread_native_id() -> u64 {
     #[cfg(target_os = "linux")]
     {
@@ -419,8 +429,9 @@ fn get_current_thread_native_id() -> u64 {
 
     #[cfg(target_os = "macos")]
     {
-        use thread_priority::thread_native_id;
-        thread_native_id() as u64
+        // pthread_mach_thread_np() on the calling thread is documented as safe
+        // from any thread and returns the task-local port name for it.
+        unsafe { libc::pthread_mach_thread_np(libc::pthread_self()) as u64 }
     }
 
     #[cfg(target_os = "windows")]

--- a/backend/src/gst/thread_priority.rs
+++ b/backend/src/gst/thread_priority.rs
@@ -3,6 +3,7 @@
 //! This module provides functionality to set thread priorities on GStreamer's
 //! internal streaming threads using the bus sync handler mechanism.
 
+use crate::thread_handle::ThreadHandle;
 use crate::thread_registry::ThreadRegistry;
 use gstreamer as gst;
 use gstreamer::prelude::*;
@@ -301,8 +302,11 @@ pub fn setup_thread_priority_handler(
 
             match status_type {
                 gst::StreamStatusType::Enter => {
-                    // Get the native thread ID
-                    let thread_id = get_current_thread_native_id();
+                    // Captured here, on the streaming thread itself, so the
+                    // handle owns whatever reference makes it safe to sample
+                    // after this thread exits.
+                    let handle = ThreadHandle::current();
+                    let thread_id = handle.id();
 
                     debug!(
                         "Thread {} entering streaming loop for element '{}' in pipeline '{}'",
@@ -370,11 +374,11 @@ pub fn setup_thread_priority_handler(
                         } else {
                             None
                         };
-                        registry.register(thread_id, owner.clone(), flow_id, block_id, actual_pinned_cpus);
+                        registry.register(handle, owner.clone(), flow_id, block_id, actual_pinned_cpus);
                     }
                 }
                 gst::StreamStatusType::Leave => {
-                    let thread_id = get_current_thread_native_id();
+                    let thread_id = ThreadHandle::current().id();
 
                     debug!(
                         "Thread {} leaving streaming loop for element '{}' in pipeline '{}'",
@@ -403,50 +407,6 @@ pub fn setup_thread_priority_handler(
     );
 
     state
-}
-
-/// Get the native thread ID of the current thread.
-///
-/// The value is used as the key in [`ThreadRegistry`] and as the handle the
-/// system monitor samples CPU time with, so each platform returns whatever
-/// identifier its sampling API needs.
-///
-/// On Linux, this returns the TID from gettid() syscall, which is needed
-/// for /proc/{pid}/task/{tid}/stat access.
-///
-/// On macOS, this returns the mach thread port (`mach_port_t`), which is what
-/// `thread_info(THREAD_BASIC_INFO)` takes. It is deliberately not the
-/// `pthread_t`: the port is captured here, on the streaming thread itself, so
-/// the sampler never has to dereference a `pthread_t` whose thread may already
-/// have exited.
-fn get_current_thread_native_id() -> u64 {
-    #[cfg(target_os = "linux")]
-    {
-        // Use gettid() syscall to get the actual Linux TID
-        // This is different from pthread_t which is what thread_native_id() returns
-        unsafe { libc::syscall(libc::SYS_gettid) as u64 }
-    }
-
-    #[cfg(target_os = "macos")]
-    {
-        // pthread_mach_thread_np() on the calling thread is documented as safe
-        // from any thread and returns the task-local port name for it.
-        unsafe { libc::pthread_mach_thread_np(libc::pthread_self()) as u64 }
-    }
-
-    #[cfg(target_os = "windows")]
-    {
-        // Use Windows API directly - GetCurrentThreadId returns DWORD (u32)
-        extern "system" {
-            fn GetCurrentThreadId() -> u32;
-        }
-        unsafe { GetCurrentThreadId() as u64 }
-    }
-
-    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
-    {
-        0
-    }
 }
 
 /// Set CPU affinity for a specific thread (Linux only).
@@ -596,7 +556,11 @@ impl SessionThreadConfig {
             let element_name = added.name().to_string();
 
             sink_pad.add_probe(gst::PadProbeType::EVENT_DOWNSTREAM, move |_pad, _info| {
-                let thread_id = get_current_thread_native_id();
+                // Captured on the streaming thread itself. These threads never
+                // send a Leave message, so the handle lives until the flow's
+                // entries are dropped by unregister_flow.
+                let handle = ThreadHandle::current();
+                let thread_id = handle.id();
 
                 // Skip if this thread was already configured (multiple pads
                 // can share the same streaming thread).
@@ -655,7 +619,7 @@ impl SessionThreadConfig {
                         None
                     };
                     registry.register(
-                        thread_id,
+                        handle,
                         element_name.clone(),
                         flow_id,
                         block_id,

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -46,6 +46,7 @@ pub mod storage;
 pub mod system_clock;
 pub mod system_monitor;
 pub mod tams;
+pub mod thread_handle;
 pub mod thread_registry;
 pub mod tls;
 pub mod version;

--- a/backend/src/system_monitor.rs
+++ b/backend/src/system_monitor.rs
@@ -345,6 +345,16 @@ fn get_num_cpus() -> usize {
 /// on macOS). Scaling the ratio by `num_cpus` normalises the result to
 /// per-core percentage: 100.0 is one fully saturated core, and the maximum on
 /// an N-core machine is N * 100.0.
+///
+/// This measures *occupancy*, not work completed. Both platforms' clocks charge
+/// a thread for time spent on a core without adjusting for how fast that core
+/// is, so on heterogeneous CPUs (Apple Silicon P/E cores, ARM big.LITTLE) two
+/// threads both reading 100.0 can differ several-fold in throughput — measured
+/// at 4.5x on an M2 between QOS_CLASS_USER_INTERACTIVE and QOS_CLASS_BACKGROUND.
+/// A thread moved onto a faster core finishes the same work sooner and so
+/// reports a *lower* percentage. Judging a core-placement change therefore
+/// needs a work-rate denominator (buffers or frames per unit of CPU time);
+/// this number alone will move the wrong way.
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 fn cpu_usage_percent(delta_thread: u64, delta_total: u64, num_cpus: usize) -> f32 {
     if delta_total == 0 {

--- a/backend/src/system_monitor.rs
+++ b/backend/src/system_monitor.rs
@@ -2,11 +2,13 @@
 //!
 //! Stats are collected in a background thread to avoid blocking the async runtime.
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::thread;
+#[cfg(target_os = "macos")]
+use std::time::Instant;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use parking_lot::RwLock;
@@ -307,27 +309,57 @@ impl Drop for SystemMonitor {
 
 /// Thread CPU sampler for measuring per-thread CPU usage.
 ///
-/// This uses Linux-specific /proc filesystem to read thread CPU times.
-/// On other platforms, CPU usage is not available and returns None.
+/// On Linux this reads thread CPU times from the /proc filesystem; on macOS it
+/// reads them from mach's `thread_info(THREAD_BASIC_INFO)`. Both report the
+/// same quantity in the same units (see [`cpu_usage_percent`]).
+/// On other platforms, CPU usage is not available and every thread reports 0%.
 pub struct ThreadCpuSampler {
     /// Previous CPU times for each thread (for delta calculation)
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     previous_times: HashMap<u64, ThreadCpuTime>,
     /// Previous total CPU time (for delta calculation)
     #[cfg(target_os = "linux")]
     previous_total_time: u64,
+    /// When the previous sample was taken (macOS denominator, see `sample_macos`)
+    #[cfg(target_os = "macos")]
+    previous_sample_at: Option<Instant>,
     /// Number of CPU cores (for scaling)
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     num_cpus: usize,
 }
 
 /// Get the number of CPUs on this system.
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 fn get_num_cpus() -> usize {
     // Use sysinfo to get CPU count (already a dependency)
     let system =
         System::new_with_specifics(RefreshKind::nothing().with_cpu(CpuRefreshKind::everything()));
     system.cpus().len().max(1)
+}
+
+/// Convert a CPU-time delta into the percentage reported to the UI.
+///
+/// `delta_thread` is the CPU time the thread consumed over the interval and
+/// `delta_total` is the CPU time available across *all* cores over the same
+/// interval; both must be in the same unit (clock ticks on Linux, microseconds
+/// on macOS). Scaling the ratio by `num_cpus` normalises the result to
+/// per-core percentage: 100.0 is one fully saturated core, and the maximum on
+/// an N-core machine is N * 100.0.
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn cpu_usage_percent(delta_thread: u64, delta_total: u64, num_cpus: usize) -> f32 {
+    if delta_total == 0 {
+        return 0.0;
+    }
+    (delta_thread as f32 / delta_total as f32) * 100.0 * num_cpus as f32
+}
+
+/// Convert a mach `time_value_t` to microseconds.
+///
+/// The fields are signed `integer_t`; mach never reports negative CPU time, so
+/// clamping at zero simply keeps the conversion total.
+#[cfg(target_os = "macos")]
+fn time_value_to_micros(t: libc::time_value_t) -> u64 {
+    (t.seconds.max(0) as u64) * 1_000_000 + (t.microseconds.max(0) as u64)
 }
 
 /// CPU time for a single thread.
@@ -338,6 +370,13 @@ struct ThreadCpuTime {
     utime: u64,
     /// System mode CPU time in clock ticks
     stime: u64,
+}
+
+/// Cumulative user+system CPU time for a single thread, in microseconds.
+#[cfg(target_os = "macos")]
+#[derive(Clone, Copy)]
+struct ThreadCpuTime {
+    total_us: u64,
 }
 
 impl ThreadCpuSampler {
@@ -351,8 +390,18 @@ impl ThreadCpuSampler {
         }
     }
 
-    /// Create a new thread CPU sampler (non-Linux stub).
-    #[cfg(not(target_os = "linux"))]
+    /// Create a new thread CPU sampler.
+    #[cfg(target_os = "macos")]
+    pub fn new() -> Self {
+        Self {
+            previous_times: HashMap::new(),
+            previous_sample_at: None,
+            num_cpus: get_num_cpus(),
+        }
+    }
+
+    /// Create a new thread CPU sampler (stub for platforms without sampling).
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
     pub fn new() -> Self {
         Self {}
     }
@@ -360,7 +409,7 @@ impl ThreadCpuSampler {
     /// Sample CPU usage for all threads in the registry.
     ///
     /// Returns ThreadStats with CPU usage percentages for each thread.
-    /// On non-Linux platforms, returns stats with 0% CPU usage.
+    /// On platforms without a sampling backend, returns stats with 0% CPU usage.
     pub fn sample(&mut self, registry: &ThreadRegistry) -> ThreadStats {
         let threads = registry.get_all();
         let timestamp = SystemTime::now()
@@ -371,7 +420,10 @@ impl ThreadCpuSampler {
         #[cfg(target_os = "linux")]
         let thread_stats = self.sample_linux(&threads);
 
-        #[cfg(not(target_os = "linux"))]
+        #[cfg(target_os = "macos")]
+        let thread_stats = self.sample_macos(&threads);
+
+        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
         let thread_stats = self.sample_stub(&threads);
 
         ThreadStats {
@@ -401,16 +453,9 @@ impl ThreadCpuSampler {
                         (current.utime + current.stime).saturating_sub(prev.utime + prev.stime);
                     let delta_total = current_total_time.saturating_sub(self.previous_total_time);
 
-                    if delta_total > 0 {
-                        // CPU usage formula: (thread_cpu_ticks / total_cpu_ticks) * 100% * num_cpus
-                        // - delta_thread: CPU ticks used by this thread (user + system time)
-                        // - delta_total: Total CPU ticks across all cores from /proc/stat
-                        // - Multiplying by num_cpus normalizes to per-core percentage
-                        //   (100% = one full core, 800% max on 8-core system)
-                        (delta_thread as f32 / delta_total as f32) * 100.0 * self.num_cpus as f32
-                    } else {
-                        0.0
-                    }
+                    // delta_thread: CPU ticks used by this thread (user + system time)
+                    // delta_total: total CPU ticks across all cores from /proc/stat
+                    cpu_usage_percent(delta_thread, delta_total, self.num_cpus)
                 } else {
                     0.0
                 };
@@ -488,13 +533,125 @@ impl ThreadCpuSampler {
         0
     }
 
-    /// Stub implementation for non-Linux platforms.
-    #[cfg(not(target_os = "linux"))]
+    /// macOS implementation: read cumulative thread CPU time via mach's
+    /// `thread_info(THREAD_BASIC_INFO)`.
+    ///
+    /// Thread IDs in the registry are mach thread ports, captured on the
+    /// streaming thread itself (see `get_current_thread_native_id`).
+    #[cfg(target_os = "macos")]
+    fn sample_macos(
+        &mut self,
+        threads: &[crate::thread_registry::ThreadInfo],
+    ) -> Vec<ThreadCpuStats> {
+        let now = Instant::now();
+
+        // The Linux path divides the thread's tick delta by the /proc/stat
+        // delta, i.e. by the CPU time accumulated across all cores over the
+        // interval, and then scales by num_cpus. macOS has no /proc/stat, but
+        // that denominator is by construction elapsed wall time times the core
+        // count, so computing it directly yields the same percentage with the
+        // same meaning: 100.0 is one fully saturated core.
+        let delta_total = self
+            .previous_sample_at
+            .map(|prev| now.duration_since(prev).as_micros() as u64)
+            .unwrap_or(0)
+            .saturating_mul(self.num_cpus as u64);
+
+        let mut results = Vec::with_capacity(threads.len());
+
+        for thread in threads {
+            let cpu_usage = match Self::read_thread_cpu_time(thread.thread_id) {
+                Some(current) => {
+                    let cpu_usage = match self.previous_times.get(&thread.thread_id) {
+                        Some(prev) => {
+                            let delta_thread = current.total_us.saturating_sub(prev.total_us);
+                            cpu_usage_percent(delta_thread, delta_total, self.num_cpus)
+                        }
+                        None => 0.0,
+                    };
+
+                    // Store current values for next sample
+                    self.previous_times.insert(thread.thread_id, current);
+
+                    cpu_usage
+                }
+                None => {
+                    // The thread is gone (or was never a live mach port). Drop
+                    // any stored baseline: mach recycles port names, so keeping
+                    // it would produce a bogus spike if this name is handed to a
+                    // new thread before the registry entry is cleaned up.
+                    self.previous_times.remove(&thread.thread_id);
+                    0.0
+                }
+            };
+
+            results.push(ThreadCpuStats {
+                thread_id: thread.thread_id,
+                cpu_usage,
+                element_name: thread.element_name.clone(),
+                flow_id: thread.flow_id,
+                block_id: thread.block_id.clone(),
+                pinned_cpus: thread.pinned_cpus.clone(),
+            });
+        }
+
+        self.previous_sample_at = Some(now);
+
+        // Clean up old entries for threads that no longer exist
+        let active_thread_ids: std::collections::HashSet<u64> =
+            threads.iter().map(|t| t.thread_id).collect();
+        self.previous_times
+            .retain(|id, _| active_thread_ids.contains(id));
+
+        results
+    }
+
+    /// Read cumulative user+system CPU time for a mach thread port.
+    ///
+    /// Returns `None` for a thread that has exited or a port name that was
+    /// never valid. mach reports this as `MACH_SEND_INVALID_DEST` rather than
+    /// `KERN_INVALID_ARGUMENT`, so any non-success return is treated the same
+    /// way: the thread is skipped for this sample. This is a normal race
+    /// against thread teardown and happens on every sampling tick until the
+    /// registry entry is removed, so it is deliberately not logged.
+    #[cfg(target_os = "macos")]
+    fn read_thread_cpu_time(mach_port: u64) -> Option<ThreadCpuTime> {
+        let port = libc::mach_port_t::try_from(mach_port).ok()?;
+
+        let mut info = std::mem::MaybeUninit::<libc::thread_basic_info>::uninit();
+        let mut count = libc::THREAD_BASIC_INFO_COUNT;
+
+        // SAFETY: `info` is sized for thread_basic_info and `count` is its
+        // length in integer_t units, as thread_info() requires. The struct is
+        // only read after a KERN_SUCCESS return, which guarantees mach filled
+        // it in.
+        let result = unsafe {
+            libc::thread_info(
+                port,
+                libc::THREAD_BASIC_INFO as libc::thread_flavor_t,
+                info.as_mut_ptr() as libc::thread_info_t,
+                &mut count,
+            )
+        };
+
+        if result != libc::KERN_SUCCESS {
+            return None;
+        }
+
+        let info = unsafe { info.assume_init() };
+
+        Some(ThreadCpuTime {
+            total_us: time_value_to_micros(info.user_time) + time_value_to_micros(info.system_time),
+        })
+    }
+
+    /// Stub implementation for platforms without a sampling backend.
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
     fn sample_stub(
         &mut self,
         threads: &[crate::thread_registry::ThreadInfo],
     ) -> Vec<ThreadCpuStats> {
-        // On non-Linux platforms, return threads with 0% CPU usage
+        // Without a sampling backend, return threads with 0% CPU usage
         threads
             .iter()
             .map(|thread| ThreadCpuStats {
@@ -512,5 +669,137 @@ impl ThreadCpuSampler {
 impl Default for ThreadCpuSampler {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(all(test, any(target_os = "linux", target_os = "macos")))]
+mod tests {
+    use super::*;
+
+    /// The percentage is normalised per core: a thread that consumed a full
+    /// core's worth of the interval reads 100%, regardless of core count.
+    #[test]
+    fn one_saturated_core_reads_100_percent() {
+        // 8 cores, so the interval offers 8 units of CPU time in total; a
+        // thread using 1 of them has saturated exactly one core.
+        assert_eq!(cpu_usage_percent(1_000, 8_000, 8), 100.0);
+        // Same thread share on a 4-core machine: 1 of 4 units is still one core.
+        assert_eq!(cpu_usage_percent(1_000, 4_000, 4), 100.0);
+    }
+
+    #[test]
+    fn partial_and_multi_core_usage_scale_linearly() {
+        // Half a core.
+        assert_eq!(cpu_usage_percent(500, 8_000, 8), 50.0);
+        // Three cores' worth.
+        assert_eq!(cpu_usage_percent(3_000, 8_000, 8), 300.0);
+        // A thread pegging every core reads num_cpus * 100.
+        assert_eq!(cpu_usage_percent(8_000, 8_000, 8), 800.0);
+    }
+
+    #[test]
+    fn idle_thread_reads_zero() {
+        assert_eq!(cpu_usage_percent(0, 8_000, 8), 0.0);
+    }
+
+    /// The first sample has no previous timestamp, so the denominator is zero.
+    /// It must yield 0%, not a division by zero.
+    #[test]
+    fn zero_interval_reads_zero() {
+        assert_eq!(cpu_usage_percent(1_000, 0, 8), 0.0);
+    }
+
+    /// A thread that has exited, or an id that was never a live mach port,
+    /// must produce no sample rather than a bogus reading. mach reports this as
+    /// MACH_SEND_INVALID_DEST; MACH_PORT_NULL reproduces it deterministically.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn invalid_mach_port_yields_no_sample() {
+        // MACH_PORT_NULL
+        assert!(ThreadCpuSampler::read_thread_cpu_time(0).is_none());
+        // A port name that cannot exist in this task's IPC space.
+        assert!(ThreadCpuSampler::read_thread_cpu_time(0x7fff_ffff).is_none());
+        // Wider than mach_port_t, so it cannot name a port at all.
+        assert!(ThreadCpuSampler::read_thread_cpu_time(u64::MAX).is_none());
+    }
+
+    /// A live thread's port must yield a cumulative time that advances as the
+    /// thread burns CPU. This is what actually breaks if the mach call, the
+    /// flavor, or the time_value conversion is wrong.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn live_mach_port_reports_advancing_cpu_time() {
+        let port = unsafe { libc::pthread_mach_thread_np(libc::pthread_self()) } as u64;
+
+        let before = ThreadCpuSampler::read_thread_cpu_time(port)
+            .expect("the calling thread's own mach port must be readable");
+
+        // Burn a measurable amount of CPU on this thread.
+        let mut sink = 0u64;
+        let spin_until = Instant::now() + Duration::from_millis(200);
+        while Instant::now() < spin_until {
+            sink = sink.wrapping_add(1);
+        }
+        assert!(sink > 0);
+
+        let after = ThreadCpuSampler::read_thread_cpu_time(port)
+            .expect("the calling thread's own mach port must be readable");
+
+        assert!(
+            after.total_us > before.total_us,
+            "cumulative CPU time did not advance: {} -> {}",
+            before.total_us,
+            after.total_us
+        );
+
+        // Spinning for 200ms cannot have consumed more than ~200ms of CPU on
+        // one thread; a much larger delta means the unit conversion is wrong.
+        let delta_us = after.total_us - before.total_us;
+        assert!(
+            delta_us < 1_000_000,
+            "implausible CPU time delta for a 200ms spin: {}us",
+            delta_us
+        );
+    }
+
+    /// The registry stores mach ports on macOS, so a sampler fed a live thread
+    /// must report a plausible non-zero percentage on the second sample.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn sampler_reports_nonzero_for_a_busy_thread() {
+        use crate::thread_registry::ThreadRegistry;
+
+        let registry = ThreadRegistry::new();
+        let flow_id = uuid::Uuid::new_v4();
+        let port = unsafe { libc::pthread_mach_thread_np(libc::pthread_self()) } as u64;
+        registry.register(port, "test-thread".to_string(), flow_id, None, None);
+
+        let mut sampler = ThreadCpuSampler::new();
+
+        // First sample establishes the baseline and reads 0% by construction.
+        let first = sampler.sample(&registry);
+        assert_eq!(first.threads.len(), 1);
+        assert_eq!(first.threads[0].cpu_usage, 0.0);
+
+        let mut sink = 0u64;
+        let spin_until = Instant::now() + Duration::from_millis(200);
+        while Instant::now() < spin_until {
+            sink = sink.wrapping_add(1);
+        }
+        assert!(sink > 0);
+
+        let second = sampler.sample(&registry);
+        let cpu = second.threads[0].cpu_usage;
+        assert!(
+            cpu > 10.0,
+            "a thread spinning for the whole interval should read well above 10%, got {}",
+            cpu
+        );
+        // One thread cannot exceed one core.
+        assert!(
+            cpu < 150.0,
+            "single thread reported above one core: {}",
+            cpu
+        );
     }
 }

--- a/backend/src/system_monitor.rs
+++ b/backend/src/system_monitor.rs
@@ -14,6 +14,8 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use parking_lot::RwLock;
 use sysinfo::{CpuRefreshKind, MemoryRefreshKind, RefreshKind, System};
 
+#[cfg(target_os = "macos")]
+use crate::thread_handle::ThreadHandle;
 use crate::thread_registry::ThreadRegistry;
 use strom_types::{GlRendererInfo, GpuStats, SystemStats, ThreadCpuStats, ThreadStats};
 
@@ -454,10 +456,10 @@ impl ThreadCpuSampler {
         let mut results = Vec::with_capacity(threads.len());
 
         for thread in threads {
-            let cpu_usage = if let Some(current) = Self::read_thread_cpu_time(pid, thread.thread_id)
-            {
+            let thread_id = thread.thread_id();
+            let cpu_usage = if let Some(current) = Self::read_thread_cpu_time(pid, thread_id) {
                 // Calculate delta
-                let prev = self.previous_times.get(&thread.thread_id);
+                let prev = self.previous_times.get(&thread_id);
                 let cpu_usage = if let Some(prev) = prev {
                     let delta_thread =
                         (current.utime + current.stime).saturating_sub(prev.utime + prev.stime);
@@ -471,7 +473,7 @@ impl ThreadCpuSampler {
                 };
 
                 // Store current values for next sample
-                self.previous_times.insert(thread.thread_id, current);
+                self.previous_times.insert(thread_id, current);
 
                 cpu_usage
             } else {
@@ -479,7 +481,7 @@ impl ThreadCpuSampler {
             };
 
             results.push(ThreadCpuStats {
-                thread_id: thread.thread_id,
+                thread_id,
                 cpu_usage,
                 element_name: thread.element_name.clone(),
                 flow_id: thread.flow_id,
@@ -493,7 +495,7 @@ impl ThreadCpuSampler {
 
         // Clean up old entries for threads that no longer exist
         let active_thread_ids: std::collections::HashSet<u64> =
-            threads.iter().map(|t| t.thread_id).collect();
+            threads.iter().map(|t| t.thread_id()).collect();
         self.previous_times
             .retain(|id, _| active_thread_ids.contains(id));
 
@@ -570,9 +572,10 @@ impl ThreadCpuSampler {
         let mut results = Vec::with_capacity(threads.len());
 
         for thread in threads {
-            let cpu_usage = match Self::read_thread_cpu_time(thread.thread_id) {
+            let thread_id = thread.thread_id();
+            let cpu_usage = match Self::read_thread_cpu_time(&thread.handle) {
                 Some(current) => {
-                    let cpu_usage = match self.previous_times.get(&thread.thread_id) {
+                    let cpu_usage = match self.previous_times.get(&thread_id) {
                         Some(prev) => {
                             let delta_thread = current.total_us.saturating_sub(prev.total_us);
                             cpu_usage_percent(delta_thread, delta_total, self.num_cpus)
@@ -581,22 +584,21 @@ impl ThreadCpuSampler {
                     };
 
                     // Store current values for next sample
-                    self.previous_times.insert(thread.thread_id, current);
+                    self.previous_times.insert(thread_id, current);
 
                     cpu_usage
                 }
                 None => {
-                    // The thread is gone (or was never a live mach port). Drop
-                    // any stored baseline: mach recycles port names, so keeping
-                    // it would produce a bogus spike if this name is handed to a
-                    // new thread before the registry entry is cleaned up.
-                    self.previous_times.remove(&thread.thread_id);
+                    // The thread has exited. Drop any stored baseline so the
+                    // entry starts clean if this name is registered again once
+                    // the handle has been released and the name reused.
+                    self.previous_times.remove(&thread_id);
                     0.0
                 }
             };
 
             results.push(ThreadCpuStats {
-                thread_id: thread.thread_id,
+                thread_id,
                 cpu_usage,
                 element_name: thread.element_name.clone(),
                 flow_id: thread.flow_id,
@@ -609,24 +611,29 @@ impl ThreadCpuSampler {
 
         // Clean up old entries for threads that no longer exist
         let active_thread_ids: std::collections::HashSet<u64> =
-            threads.iter().map(|t| t.thread_id).collect();
+            threads.iter().map(|t| t.thread_id()).collect();
         self.previous_times
             .retain(|id, _| active_thread_ids.contains(id));
 
         results
     }
 
-    /// Read cumulative user+system CPU time for a mach thread port.
+    /// Read cumulative user+system CPU time for a thread.
     ///
-    /// Returns `None` for a thread that has exited or a port name that was
-    /// never valid. mach reports this as `MACH_SEND_INVALID_DEST` rather than
-    /// `KERN_INVALID_ARGUMENT`, so any non-success return is treated the same
-    /// way: the thread is skipped for this sample. This is a normal race
-    /// against thread teardown and happens on every sampling tick until the
-    /// registry entry is removed, so it is deliberately not logged.
+    /// Takes a [`ThreadHandle`] rather than a port name, and that is the whole
+    /// safety argument: the handle holds a reference to the port, so the name
+    /// still refers to the thread it was captured from and cannot have been
+    /// recycled to some other — possibly guarded — port. Calling
+    /// `thread_info()` on a recycled name raises `EXC_GUARD` and kills the
+    /// process, with no error return to check.
+    ///
+    /// A thread that has exited keeps its name (the handle holds it) but no
+    /// longer answers, so mach returns a non-success code and the thread is
+    /// skipped for this sample. That happens on every tick between the thread
+    /// exiting and its registry entry being removed, so it is not logged.
     #[cfg(target_os = "macos")]
-    fn read_thread_cpu_time(mach_port: u64) -> Option<ThreadCpuTime> {
-        let port = libc::mach_port_t::try_from(mach_port).ok()?;
+    fn read_thread_cpu_time(handle: &ThreadHandle) -> Option<ThreadCpuTime> {
+        let port = handle.mach_port();
 
         let mut info = std::mem::MaybeUninit::<libc::thread_basic_info>::uninit();
         let mut count = libc::THREAD_BASIC_INFO_COUNT;
@@ -665,7 +672,7 @@ impl ThreadCpuSampler {
         threads
             .iter()
             .map(|thread| ThreadCpuStats {
-                thread_id: thread.thread_id,
+                thread_id: thread.thread_id(),
                 cpu_usage: 0.0, // Not available on this platform
                 element_name: thread.element_name.clone(),
                 flow_id: thread.flow_id,
@@ -719,18 +726,14 @@ mod tests {
         assert_eq!(cpu_usage_percent(1_000, 0, 8), 0.0);
     }
 
-    /// A thread that has exited, or an id that was never a live mach port,
-    /// must produce no sample rather than a bogus reading. mach reports this as
-    /// MACH_SEND_INVALID_DEST; MACH_PORT_NULL reproduces it deterministically.
+    /// A thread that has exited must produce no sample rather than a bogus
+    /// reading. Its handle keeps the port name allocated, so the call is safe
+    /// to make; mach just refuses to answer for a dead thread.
     #[cfg(target_os = "macos")]
     #[test]
-    fn invalid_mach_port_yields_no_sample() {
-        // MACH_PORT_NULL
-        assert!(ThreadCpuSampler::read_thread_cpu_time(0).is_none());
-        // A port name that cannot exist in this task's IPC space.
-        assert!(ThreadCpuSampler::read_thread_cpu_time(0x7fff_ffff).is_none());
-        // Wider than mach_port_t, so it cannot name a port at all.
-        assert!(ThreadCpuSampler::read_thread_cpu_time(u64::MAX).is_none());
+    fn an_exited_thread_yields_no_sample() {
+        let handle = std::thread::spawn(ThreadHandle::current).join().unwrap();
+        assert!(ThreadCpuSampler::read_thread_cpu_time(&handle).is_none());
     }
 
     /// A live thread's port must yield a cumulative time that advances as the
@@ -739,9 +742,9 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn live_mach_port_reports_advancing_cpu_time() {
-        let port = unsafe { libc::pthread_mach_thread_np(libc::pthread_self()) } as u64;
+        let handle = ThreadHandle::current();
 
-        let before = ThreadCpuSampler::read_thread_cpu_time(port)
+        let before = ThreadCpuSampler::read_thread_cpu_time(&handle)
             .expect("the calling thread's own mach port must be readable");
 
         // Burn a measurable amount of CPU on this thread.
@@ -752,7 +755,7 @@ mod tests {
         }
         assert!(sink > 0);
 
-        let after = ThreadCpuSampler::read_thread_cpu_time(port)
+        let after = ThreadCpuSampler::read_thread_cpu_time(&handle)
             .expect("the calling thread's own mach port must be readable");
 
         assert!(
@@ -781,8 +784,13 @@ mod tests {
 
         let registry = ThreadRegistry::new();
         let flow_id = uuid::Uuid::new_v4();
-        let port = unsafe { libc::pthread_mach_thread_np(libc::pthread_self()) } as u64;
-        registry.register(port, "test-thread".to_string(), flow_id, None, None);
+        registry.register(
+            ThreadHandle::current(),
+            "test-thread".to_string(),
+            flow_id,
+            None,
+            None,
+        );
 
         let mut sampler = ThreadCpuSampler::new();
 

--- a/backend/src/system_monitor.rs
+++ b/backend/src/system_monitor.rs
@@ -549,7 +549,7 @@ impl ThreadCpuSampler {
     /// `thread_info(THREAD_BASIC_INFO)`.
     ///
     /// Thread IDs in the registry are mach thread ports, captured on the
-    /// streaming thread itself (see `get_current_thread_native_id`).
+    /// streaming thread itself (see `ThreadHandle::current`).
     #[cfg(target_os = "macos")]
     fn sample_macos(
         &mut self,

--- a/backend/src/thread_handle.rs
+++ b/backend/src/thread_handle.rs
@@ -1,0 +1,234 @@
+//! Owned handles to the threads the CPU sampler reads.
+//!
+//! The registry keeps an identifier for a GStreamer streaming thread and hands
+//! it to [`crate::system_monitor::ThreadCpuSampler`] later, possibly after that
+//! thread has exited. On Linux and Windows the identifier is an integer that is
+//! merely stale once the thread is gone. On macOS it is a mach port name, and a
+//! bare name is not safe to keep.
+//!
+//! `pthread_mach_thread_np()` returns the calling thread's port *name* without
+//! taking a user reference on it. When the thread exits the name is freed, and
+//! the kernel may hand that same name to an unrelated port. Passing a recycled
+//! name to `thread_info()` is not merely wrong: if the name now belongs to a
+//! *guarded* port — libdispatch and XPC guard theirs — the kernel raises
+//! `EXC_GUARD` and kills the process. There is no error return to check.
+//!
+//! [`ThreadHandle`] holds a reference instead: `mach_thread_self()` returns the
+//! same name *with* a send right, and the name stays bound to that thread's
+//! port until the matching `mach_port_deallocate()`. That deallocate happens in
+//! `Drop`, so every way a handle can go away — a single unregister, a whole
+//! flow's entries, the registry itself, one registration overwriting another —
+//! releases the right exactly once. An `Arc` holds it, so a handle cloned out
+//! of the registry (as `ThreadRegistry::get_all` does on every sampling tick)
+//! keeps the port alive for as long as the sampler holds the clone, even if the
+//! entry is unregistered concurrently.
+//!
+//! Invariant: a mach port name is never passed to `thread_info()` unless a live
+//! [`ThreadHandle`] guarantees the name still refers to the same thread.
+
+#[cfg(target_os = "macos")]
+use std::sync::Arc;
+
+/// An identifier for a thread, plus whatever ownership is needed to keep that
+/// identifier meaningful after the thread has exited.
+///
+/// Construct one with [`ThreadHandle::current`], on the thread being
+/// registered. There is deliberately no constructor from a raw integer: on
+/// macOS a bare port name carries no reference, which is the bug this type
+/// exists to prevent.
+#[derive(Clone, Debug)]
+pub struct ThreadHandle {
+    /// Stable identifier used as the registry key and reported to the UI.
+    id: u64,
+    /// macOS only: the send right that keeps `id` naming this thread's port.
+    #[cfg(target_os = "macos")]
+    port: Arc<MachThreadPort>,
+}
+
+impl ThreadHandle {
+    /// Capture a handle to the calling thread.
+    ///
+    /// Must be called on the thread being registered — on macOS the port
+    /// reference can only be taken from the thread itself, which is also what
+    /// makes the capture race-free: the thread is alive by definition.
+    pub fn current() -> Self {
+        #[cfg(target_os = "linux")]
+        {
+            // gettid(), not pthread_self(): /proc/{pid}/task/{tid} is keyed by
+            // the kernel TID.
+            let id = unsafe { libc::syscall(libc::SYS_gettid) as u64 };
+            Self { id }
+        }
+
+        #[cfg(target_os = "macos")]
+        {
+            // SAFETY: mach_thread_self() is callable from any thread and
+            // returns a send right to the caller's own thread port, with a
+            // user reference that MachThreadPort now owns and releases on drop.
+            let port = unsafe { sys::mach_thread_self() };
+            Self {
+                id: port as u64,
+                port: Arc::new(MachThreadPort(port)),
+            }
+        }
+
+        #[cfg(target_os = "windows")]
+        {
+            extern "system" {
+                fn GetCurrentThreadId() -> u32;
+            }
+            let id = unsafe { GetCurrentThreadId() as u64 };
+            Self { id }
+        }
+
+        #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+        {
+            Self { id: 0 }
+        }
+    }
+
+    /// The identifier used as the registry key and reported to the UI.
+    ///
+    /// This is only a number. On macOS, do not pass it to `thread_info()` —
+    /// use [`ThreadHandle::mach_port`], which is reachable only while this
+    /// handle (and therefore the port reference) is alive.
+    pub fn id(&self) -> u64 {
+        self.id
+    }
+
+    /// The mach port name, valid for as long as `self` is alive.
+    #[cfg(target_os = "macos")]
+    pub(crate) fn mach_port(&self) -> libc::mach_port_t {
+        self.port.0
+    }
+}
+
+/// A user reference on a thread's mach port, released on drop.
+#[cfg(target_os = "macos")]
+#[derive(Debug)]
+struct MachThreadPort(libc::mach_port_t);
+
+#[cfg(target_os = "macos")]
+impl Drop for MachThreadPort {
+    fn drop(&mut self) {
+        // SAFETY: releases exactly the reference mach_thread_self() took in
+        // ThreadHandle::current(). The reference count returns to what it was
+        // before, never to zero, so this cannot trip the pinned-port guard.
+        // mach_port_deallocate accepts both a send right and the dead name a
+        // send right becomes, so the thread's liveness does not matter here.
+        unsafe {
+            sys::mach_port_deallocate(sys::mach_task_self_, self.0);
+        }
+    }
+}
+
+/// Mach symbols from `<mach/mach_port.h>` and `<mach/mach_init.h>`.
+///
+/// `libc` deprecated its mach surface in favour of the `mach2` crate and does
+/// not expose `mach_port_deallocate` at all; declaring the handful we need
+/// keeps that dependency out. `ipc_space_t` and `mach_port_name_t` are both
+/// `mach_port_t`, and `mach_task_self()` is a C macro over the global below.
+#[cfg(target_os = "macos")]
+mod sys {
+    extern "C" {
+        pub fn mach_thread_self() -> libc::mach_port_t;
+
+        pub fn mach_port_deallocate(
+            task: libc::mach_port_t,
+            name: libc::mach_port_t,
+        ) -> libc::kern_return_t;
+
+        #[cfg(test)]
+        pub fn mach_port_type(
+            task: libc::mach_port_t,
+            name: libc::mach_port_t,
+            ptype: *mut libc::natural_t,
+        ) -> libc::kern_return_t;
+
+        pub static mach_task_self_: libc::mach_port_t;
+    }
+}
+
+/// Whether `name` is still allocated in this task's IPC space.
+///
+/// `false` means the name has been freed and the kernel may hand it to any
+/// other port — which is exactly the state a cached name must never be in
+/// while something is still willing to call `thread_info()` on it.
+#[cfg(all(test, target_os = "macos"))]
+pub(crate) fn mach_port_name_is_allocated(name: libc::mach_port_t) -> bool {
+    let mut ptype: libc::natural_t = 0;
+    // SAFETY: `ptype` is a valid out parameter; the call only inspects `name`.
+    let kr = unsafe { sys::mach_port_type(sys::mach_task_self_, name, &mut ptype) };
+    kr == libc::KERN_SUCCESS
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A handle captured on another thread must outlive that thread.
+    ///
+    /// On macOS this is the crash fix: without the retained send right the
+    /// port name is freed the moment the thread exits and can be recycled to
+    /// an unrelated — possibly guarded — port, so a later `thread_info()` on
+    /// the cached name can take down the process.
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn handle_keeps_the_port_name_allocated_after_the_thread_exits() {
+        let handle = std::thread::spawn(ThreadHandle::current).join().unwrap();
+        let name = handle.mach_port();
+
+        assert!(
+            mach_port_name_is_allocated(name),
+            "port name {:#x} was freed while a ThreadHandle still held it; it can now be recycled",
+            name
+        );
+
+        drop(handle);
+
+        assert!(
+            !mach_port_name_is_allocated(name),
+            "port name {:#x} is still allocated after the last handle was dropped: the reference leaked",
+            name
+        );
+    }
+
+    /// Cloning a handle must not double-release the reference, and the port
+    /// must survive until the *last* clone is gone. This is what makes it safe
+    /// for the sampler to work from a snapshot taken out of the registry.
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn a_clone_keeps_the_port_alive_after_the_original_is_dropped() {
+        let handle = std::thread::spawn(ThreadHandle::current).join().unwrap();
+        let name = handle.mach_port();
+        let clone = handle.clone();
+
+        drop(handle);
+        assert!(
+            mach_port_name_is_allocated(name),
+            "dropping one clone released the shared port reference"
+        );
+
+        drop(clone);
+        assert!(!mach_port_name_is_allocated(name));
+    }
+
+    /// The calling thread's own handle must name the same port the platform's
+    /// non-owning accessor reports, so the identifier the UI shows and the
+    /// registry keys on does not change meaning with this indirection.
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn current_matches_the_non_owning_port_name() {
+        let handle = ThreadHandle::current();
+        let bare = unsafe { libc::pthread_mach_thread_np(libc::pthread_self()) };
+        assert_eq!(handle.mach_port(), bare);
+        assert_eq!(handle.id(), bare as u64);
+    }
+
+    #[test]
+    fn ids_are_distinct_per_thread() {
+        let a = ThreadHandle::current();
+        let b = std::thread::spawn(ThreadHandle::current).join().unwrap();
+        assert_ne!(a.id(), b.id());
+    }
+}

--- a/backend/src/thread_registry.rs
+++ b/backend/src/thread_registry.rs
@@ -3,6 +3,7 @@
 //! This module maintains a mapping between native thread IDs and the
 //! GStreamer elements that own them, enabling CPU usage correlation.
 
+use crate::thread_handle::ThreadHandle;
 use parking_lot::RwLock;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -11,8 +12,9 @@ use strom_types::FlowId;
 /// Information about a registered GStreamer streaming thread.
 #[derive(Debug, Clone)]
 pub struct ThreadInfo {
-    /// Native thread ID (OS-specific)
-    pub thread_id: u64,
+    /// Owned handle to the thread, safe to sample for as long as it is held
+    /// (see [`ThreadHandle`]).
+    pub handle: ThreadHandle,
     /// Name of the GStreamer element that owns this thread
     pub element_name: String,
     /// Flow ID this thread belongs to
@@ -21,6 +23,14 @@ pub struct ThreadInfo {
     pub block_id: Option<String>,
     /// Logical CPUs this thread is pinned to (None if affinity is off)
     pub pinned_cpus: Option<Vec<usize>>,
+}
+
+impl ThreadInfo {
+    /// Native thread ID (OS-specific), used as the registry key and shown in
+    /// the UI.
+    pub fn thread_id(&self) -> u64 {
+        self.handle.id()
+    }
 }
 
 /// Registry for tracking active GStreamer streaming threads.
@@ -41,14 +51,18 @@ impl ThreadRegistry {
     }
 
     /// Register a thread that has entered its streaming loop.
+    ///
+    /// `handle` must have been captured on that thread; the registry owns it
+    /// from here, which is what keeps it valid to sample.
     pub fn register(
         &self,
-        thread_id: u64,
+        handle: ThreadHandle,
         element_name: String,
         flow_id: FlowId,
         block_id: Option<String>,
         pinned_cpus: Option<Vec<usize>>,
     ) {
+        let thread_id = handle.id();
         tracing::debug!(
             "Registered thread {} for element '{}' in flow {}",
             thread_id,
@@ -59,7 +73,7 @@ impl ThreadRegistry {
         threads.insert(
             thread_id,
             ThreadInfo {
-                thread_id,
+                handle,
                 element_name,
                 flow_id,
                 block_id,
@@ -127,21 +141,30 @@ mod tests {
     use super::*;
     use uuid::Uuid;
 
+    /// A handle to a thread that has already exited, which is the interesting
+    /// case: on macOS the registry entry is the only thing keeping its mach
+    /// port name from being freed and recycled.
+    fn handle_from_finished_thread() -> ThreadHandle {
+        std::thread::spawn(ThreadHandle::current).join().unwrap()
+    }
+
     #[test]
     fn test_register_unregister() {
         let registry = ThreadRegistry::new();
         let flow_id = Uuid::new_v4();
+        let handle = handle_from_finished_thread();
+        let thread_id = handle.id();
 
-        registry.register(12345, "element0".to_string(), flow_id, None, None);
+        registry.register(handle, "element0".to_string(), flow_id, None, None);
         assert_eq!(registry.len(), 1);
 
         let threads = registry.get_all();
         assert_eq!(threads.len(), 1);
-        assert_eq!(threads[0].thread_id, 12345);
+        assert_eq!(threads[0].thread_id(), thread_id);
         assert_eq!(threads[0].element_name, "element0");
         assert_eq!(threads[0].flow_id, flow_id);
 
-        registry.unregister(12345);
+        registry.unregister(thread_id);
         assert!(registry.is_empty());
     }
 
@@ -151,9 +174,27 @@ mod tests {
         let flow1 = Uuid::new_v4();
         let flow2 = Uuid::new_v4();
 
-        registry.register(1, "elem1".to_string(), flow1, None, None);
-        registry.register(2, "elem2".to_string(), flow1, None, None);
-        registry.register(3, "elem3".to_string(), flow2, None, None);
+        registry.register(
+            handle_from_finished_thread(),
+            "elem1".to_string(),
+            flow1,
+            None,
+            None,
+        );
+        registry.register(
+            handle_from_finished_thread(),
+            "elem2".to_string(),
+            flow1,
+            None,
+            None,
+        );
+        registry.register(
+            handle_from_finished_thread(),
+            "elem3".to_string(),
+            flow2,
+            None,
+            None,
+        );
 
         assert_eq!(registry.len(), 3);
 
@@ -162,5 +203,112 @@ mod tests {
 
         let threads = registry.get_all();
         assert_eq!(threads[0].flow_id, flow2);
+    }
+
+    /// A registered thread's mach port name must stay allocated for as long as
+    /// the registry holds it, so a sampler that reaches the entry after the
+    /// thread has exited cannot hit a name the kernel has handed to another —
+    /// possibly guarded — port.
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn a_registered_thread_keeps_its_port_name_after_exiting() {
+        use crate::thread_handle::mach_port_name_is_allocated;
+
+        let registry = ThreadRegistry::new();
+        let handle = handle_from_finished_thread();
+        let name = handle.mach_port();
+        let thread_id = handle.id();
+
+        registry.register(handle, "elem".to_string(), Uuid::new_v4(), None, None);
+
+        assert!(
+            mach_port_name_is_allocated(name),
+            "registry entry did not keep port name {:#x} allocated",
+            name
+        );
+
+        registry.unregister(thread_id);
+
+        assert!(
+            !mach_port_name_is_allocated(name),
+            "unregister leaked the port reference for name {:#x}",
+            name
+        );
+    }
+
+    /// `get_all` hands out clones that the sampler holds across its mach calls,
+    /// so those clones must keep the port alive even if the thread unregisters
+    /// in between.
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn a_snapshot_outlives_a_concurrent_unregister() {
+        use crate::thread_handle::mach_port_name_is_allocated;
+
+        let registry = ThreadRegistry::new();
+        let handle = handle_from_finished_thread();
+        let name = handle.mach_port();
+        let thread_id = handle.id();
+        registry.register(handle, "elem".to_string(), Uuid::new_v4(), None, None);
+
+        let snapshot = registry.get_all();
+        registry.unregister(thread_id);
+
+        assert!(
+            mach_port_name_is_allocated(name),
+            "a snapshot taken before unregister did not keep port name {:#x} alive",
+            name
+        );
+
+        drop(snapshot);
+        assert!(!mach_port_name_is_allocated(name));
+    }
+
+    /// Every unregister path releases the reference, including dropping the
+    /// registry outright and overwriting an entry with the same key.
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn every_removal_path_releases_the_port_reference() {
+        use crate::thread_handle::mach_port_name_is_allocated;
+
+        let flow_id = Uuid::new_v4();
+
+        // unregister_flow
+        let registry = ThreadRegistry::new();
+        let handle = handle_from_finished_thread();
+        let name = handle.mach_port();
+        registry.register(handle, "elem".to_string(), flow_id, None, None);
+        registry.unregister_flow(&flow_id);
+        assert!(
+            !mach_port_name_is_allocated(name),
+            "unregister_flow leaked the reference for name {:#x}",
+            name
+        );
+
+        // Dropping the registry.
+        let registry = ThreadRegistry::new();
+        let handle = handle_from_finished_thread();
+        let name = handle.mach_port();
+        registry.register(handle, "elem".to_string(), flow_id, None, None);
+        drop(registry);
+        assert!(
+            !mach_port_name_is_allocated(name),
+            "dropping the registry leaked the reference for name {:#x}",
+            name
+        );
+
+        // Re-registering the same thread must not leak the displaced entry.
+        let registry = ThreadRegistry::new();
+        let handle = handle_from_finished_thread();
+        let name = handle.mach_port();
+        let thread_id = handle.id();
+        registry.register(handle.clone(), "first".to_string(), flow_id, None, None);
+        registry.register(handle, "second".to_string(), flow_id, None, None);
+        assert_eq!(registry.len(), 1);
+        registry.unregister(thread_id);
+        assert!(
+            !mach_port_name_is_allocated(name),
+            "overwriting an entry leaked the reference for name {:#x}",
+            name
+        );
     }
 }

--- a/backend/tests/thread_port_lifetime_test.rs
+++ b/backend/tests/thread_port_lifetime_test.rs
@@ -1,0 +1,172 @@
+//! Regression test for the `EXC_GUARD` crash in the macOS per-thread CPU sampler.
+//!
+//! Bug: the thread registry stored a streaming thread's mach port *name*, taken
+//! with `pthread_mach_thread_np()`, which does not take a user reference on the
+//! port. Once the thread exited, the name was freed and the kernel was free to
+//! hand it to any other port. `ThreadCpuSampler` then called `thread_info()` on
+//! that stale name, and when the name had been recycled to a *guarded* port
+//! (libdispatch and XPC guard theirs) the kernel raised `EXC_GUARD` and killed
+//! the process. Thread churn — every WHIP session builds and tears down
+//! streaming threads — plus an open stats WebSocket was enough to hit it.
+//!
+//! Fix: the registry holds a `ThreadHandle`, which owns a send right on the
+//! port, so the name stays bound to the thread it was captured from until the
+//! handle is dropped.
+//!
+//! This test drives real GStreamer streaming threads through the real bus sync
+//! handler and the real sampler, then asserts the invariant the fix provides:
+//! a port name held by a snapshot the sampler could still be working from is
+//! never freed, even after the thread has exited and the flow has been torn
+//! down. Revert the fix and the names are gone by then.
+
+use gstreamer as gst;
+use gstreamer::prelude::*;
+use std::time::Duration;
+use strom::gst::thread_priority;
+use strom::system_monitor::ThreadCpuSampler;
+use strom::thread_registry::ThreadRegistry;
+use strom_types::flow::ThreadPriority;
+
+/// How long glib keeps an idle pooled thread before letting it exit.
+const IDLE_REAP: Duration = Duration::from_millis(100);
+
+const REQUIRED_ELEMENTS: &[&str] = &["videotestsrc", "queue", "fakesink"];
+
+/// Skipping on a missing element passes green and guards nothing, so CI sets
+/// `STROM_REQUIRE_GST_PLUGINS=1` to turn a skip into a failure.
+fn missing_element() -> Option<&'static str> {
+    let missing = REQUIRED_ELEMENTS
+        .iter()
+        .copied()
+        .find(|e| gst::ElementFactory::find(e).is_none())?;
+    assert!(
+        std::env::var("STROM_REQUIRE_GST_PLUGINS").is_err(),
+        "STROM_REQUIRE_GST_PLUGINS is set but this element is missing: {missing}"
+    );
+    Some(missing)
+}
+
+/// Each branch runs on its own streaming thread, so the pipeline registers
+/// enough of them for one recycled name to be likely rather than incidental.
+const BRANCHES: usize = 16;
+
+fn build_pipeline() -> gst::Pipeline {
+    let description = (0..BRANCHES)
+        .map(|_| "videotestsrc is-live=true ! queue ! fakesink sync=false")
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    gst::parse::launch(&description)
+        .expect("pipeline should parse")
+        .downcast::<gst::Pipeline>()
+        .expect("parse::launch returns a pipeline")
+}
+
+/// Whether `name` is still allocated in this task's IPC space. `false` means
+/// the kernel may have handed it to an unrelated port, which is exactly when
+/// `thread_info()` becomes unsafe to call.
+#[cfg(target_os = "macos")]
+fn mach_port_name_is_allocated(name: libc::mach_port_t) -> bool {
+    extern "C" {
+        fn mach_port_type(
+            task: libc::mach_port_t,
+            name: libc::mach_port_t,
+            ptype: *mut libc::natural_t,
+        ) -> libc::kern_return_t;
+        static mach_task_self_: libc::mach_port_t;
+    }
+
+    let mut ptype: libc::natural_t = 0;
+    // SAFETY: `ptype` is a valid out parameter; the call only inspects `name`.
+    let kr = unsafe { mach_port_type(mach_task_self_, name, &mut ptype) };
+    kr == libc::KERN_SUCCESS
+}
+
+#[test]
+fn registered_thread_ids_survive_pipeline_teardown() {
+    gst::init().expect("GStreamer should initialise");
+    if let Some(missing) = missing_element() {
+        eprintln!("skipping: missing GStreamer element '{missing}'");
+        return;
+    }
+
+    // GStreamer hands streaming threads back to a glib thread pool that keeps
+    // idle ones alive for 15 seconds by default, so a short teardown/rebuild
+    // cycle reuses the same threads and no port name is ever released. A live
+    // server sits idle for far longer than that between WHIP sessions; shorten
+    // the retention so the same thread churn happens inside a test run.
+    extern "C" {
+        fn g_thread_pool_set_max_idle_time(interval_ms: u32);
+    }
+    // SAFETY: a plain global setter in glib, safe to call at any point.
+    unsafe { g_thread_pool_set_max_idle_time(IDLE_REAP.as_millis() as u32) };
+
+    let registry = ThreadRegistry::new();
+    let mut sampler = ThreadCpuSampler::new();
+    let flow_id = uuid::Uuid::new_v4();
+
+    let mut snapshots = Vec::new();
+    let mut saw_registered_threads = false;
+
+    // Several start/stop cycles, because the crash needs thread churn: each
+    // cycle creates streaming threads, registers them, and joins them again.
+    for _ in 0..5 {
+        let pipeline = build_pipeline();
+        thread_priority::setup_thread_priority_handler(
+            &pipeline,
+            ThreadPriority::Normal,
+            None,
+            flow_id,
+            Some(registry.clone()),
+        );
+
+        pipeline
+            .set_state(gst::State::Playing)
+            .expect("pipeline should start");
+        std::thread::sleep(Duration::from_millis(300));
+
+        // What the stats WebSocket does on every tick, on the real code path.
+        let stats = sampler.sample(&registry);
+        if !stats.threads.is_empty() {
+            saw_registered_threads = true;
+        }
+
+        // Hold a snapshot across teardown: this is the window the sampler works
+        // in, between reading the registry and calling into mach.
+        snapshots.push(registry.get_all());
+
+        thread_priority::remove_thread_priority_handler(&pipeline);
+        pipeline
+            .set_state(gst::State::Null)
+            .expect("pipeline should stop");
+        registry.unregister_flow(&flow_id);
+
+        // Long enough for the pool to reap the threads this cycle created.
+        std::thread::sleep(IDLE_REAP * 6);
+
+        // Sampling after teardown must also be safe.
+        let _ = sampler.sample(&registry);
+    }
+
+    assert!(
+        saw_registered_threads,
+        "no streaming threads were registered, so this test guarded nothing"
+    );
+
+    #[cfg(target_os = "macos")]
+    for snapshot in &snapshots {
+        for info in snapshot {
+            let name = info.thread_id() as libc::mach_port_t;
+            assert!(
+                mach_port_name_is_allocated(name),
+                "mach port name {name:#x} for element '{}' was freed while a registry \
+                 snapshot still held it; the sampler could hand a recycled name to \
+                 thread_info() and take the process down with EXC_GUARD",
+                info.element_name
+            );
+        }
+    }
+
+    // The names are only released once the snapshots are dropped.
+    drop(snapshots);
+}


### PR DESCRIPTION
## Why

Per-thread CPU sampling read `/proc/{pid}/task/{tid}/stat` and `/proc/stat` behind
`cfg(target_os = "linux")`, and the other arm returned nothing. The thread and CPU
views were therefore empty on macOS, so there was no way to see how GStreamer
pipeline threads are actually scheduled.

## What

A macOS backend using mach's `thread_info(THREAD_BASIC_INFO)`, which reports
cumulative user+system time per thread. Same shape and output as the Linux path,
so the existing UI and API surface work unchanged.

mach has no `/proc/stat` equivalent, but the Linux denominator is by construction
elapsed wall time times the core count, so computing it directly yields the same
percentage with the same meaning: `100.0` is one saturated core, `N * 100.0` the
maximum on N cores. Both platforms now share `cpu_usage_percent()` for that
conversion, which leaves the Linux result unchanged.

## Port lifetime

The registry stores a **mach thread port**, not a `pthread_t`, because
`thread_info` needs a `mach_port_t`. Capturing that port correctly is the delicate
part of this PR.

`pthread_mach_thread_np()` — the obvious way to get it — returns the name *without*
taking a user reference. When the thread exits the name is freed and the kernel may
hand it to any other port; I saw port 77831 move from one element to another across
a flow restart. `thread_info()` on a name that has since been recycled to a
*guarded* port (libdispatch and XPC guard theirs) raises `EXC_GUARD` and the kernel
kills the process. It killed a running server:

    EXC_GUARD / GUARD_TYPE_MACH_PORT / ILLEGAL_MOVE on mach port 161251
    ThreadCpuSampler::sample <- AppState::get_thread_stats <- handle_socket_inner

hit while reconnecting WHIP publishers with the vision mixer page open: thread
churn plus an open stats WebSocket. There is no error return to check, so the
"non-success means the thread is gone" handling below cannot catch it.

So `ThreadHandle` captures the port with `mach_thread_self()` instead — the same
name, but with a send right — and releases it in `Drop`. Every way a registry entry
goes away releases the reference exactly once, because they are all `HashMap`
drops: `unregister`, `unregister_flow`, dropping the registry, and one `register`
overwriting another key. The reference lives in an `Arc`, so a snapshot from
`get_all()` keeps the port alive across the sampler's mach calls even if the entry
is unregistered concurrently.

`read_thread_cpu_time()` takes a `&ThreadHandle` rather than a `u64`, which makes
the invariant structural rather than a comment: **a cached port name reaches
`thread_info()` only while something guarantees it still names the same thread.**

A thread that has exited keeps its name — the handle holds it — and mach declines
to answer for it. That yields no sample and drops the stored baseline, and is not
logged: it recurs on every tick until the registry entry is cleaned up.

Threads registered from the session pad probe never post a `Leave` message, so
their handles are held until the flow's entries are dropped at stop. That is a
bounded number of port names per running flow.

No new dependency. `libc` already exposes `thread_info`, `THREAD_BASIC_INFO`,
`thread_basic_info` and `time_value_t`; it has deprecated the rest of its mach
surface in favour of the `mach2` crate and never exposed `mach_port_deallocate`,
so the four symbols beyond that set are declared directly.

## Measured on a running server

Two identical `videotestsrc pattern=snow ! queue ! x264enc ! queue ! fakesink`
chains on an M2 (4P + 4E), cross-checked against `ps -M` per-thread CPU-time
deltas over the same 10s window:

| `ps` rank | `ps` delta | reported by this change |
|---|---|---|
| 1-2 | 8.30 / 8.40% | `src1`/`src2` 7.7-8.8% |
| 3-8 | ~5.1% x 6 | x264enc internal workers - not registered, correctly absent |
| 9-10 | 1.00 / 0.90% | `q1a`/`q2a` 1.08-1.11% |

Identical chains report near-identical CPU. The six unregistered encoder workers
(~31%) account for the gap between the 20% registered sum and 51% process-wide.
Stopping the flow drops to zero threads with no error output; restarting
re-registers and reads 0.00% on the first sample rather than a bogus delta.

## One caveat worth knowing

The percentage measures **occupancy, not work completed**. Neither platform's
clock adjusts for how fast the core is, so on heterogeneous CPUs two threads both
reading `100.0` can differ several-fold in throughput — I measured 4.5x on an M2
between `QOS_CLASS_USER_INTERACTIVE` and `QOS_CLASS_BACKGROUND`. A thread moved
onto a faster core reports a *lower* percentage for the same work. This matches
Linux semantics (including big.LITTLE) and standard tools, so it is not a
deviation, but it means this number alone cannot judge a core-placement change.
The second commit documents this where the function is defined.

## Tests

Fourteen unit tests. Four cover the delta-to-percentage arithmetic without mach.
Three exercise real mach calls: an exited thread yields no sample, cumulative time
advances on a spinning thread, and the sampler reads a live thread end-to-end
through a `ThreadRegistry`. Seven cover port lifetime — the name stays allocated
after the thread exits, a clone keeps it alive after the original is dropped, a
`get_all()` snapshot survives a concurrent `unregister`, and every removal path
releases the reference.

`thread_port_lifetime_test` is the end-to-end guard: five start/stop cycles of a
real 32-thread pipeline through the real bus sync handler and the real sampler,
asserting that port names held by a registry snapshot are still allocated after
teardown. It shortens glib's thread-pool idle retention first — GStreamer returns
streaming threads to a pool that keeps idle ones for 15 seconds, so at the default
no thread exits within a test run and the test guards nothing.

Reverting the port capture to `pthread_mach_thread_np()` fails five tests including
that one, with `mach port name 0x1603 for element 'queue5' was freed while a
registry snapshot still held it`. `sampler_reports_nonzero_for_a_busy_thread`
remains a guard for the sampling arm itself: reverting that falls back to the stub
and reads 0.0.

**Ran on macOS (Apple Silicon, macOS 26.5, GStreamer via Homebrew):**
`cargo test --features efp` — 554 lib tests and every integration test pass,
six full runs clean.
`cargo clippy --all-targets --features efp -- -D warnings` and `cargo fmt --check`
are clean.

**Not run: anything on Linux.** This machine has only `aarch64-apple-darwin`
installed and cross-building the GStreamer stack was not practical, so the shared
`cpu_usage_percent()` refactor on the Linux path has been reviewed by hand but
never compiled. That is the main thing worth a careful look in review — Linux CI
will be its first real check.

## CI gap

The macOS CI job is `workflow_dispatch`-only, so nothing here is guarded on a pull
request: not the mach-backed sampling tests, and not the port-lifetime guards that
would catch a return of the crash above.
