### PR TITLE
fix(gst): check property values against the spec instead of panicking

### DIFF
--- a/backend/src/api/flows.rs
+++ b/backend/src/api/flows.rs
@@ -23,6 +23,7 @@ use strom_types::{
 };
 use tracing::{debug, error, info, trace, warn};
 
+use crate::gst::PipelineError;
 use crate::layout;
 use crate::state::AppState;
 
@@ -558,6 +559,7 @@ pub async fn delete_flow(
     ),
     responses(
         (status = 200, description = "Flow started", body = FlowResponse),
+        (status = 400, description = "Flow definition rejected", body = ErrorResponse),
         (status = 404, description = "Flow not found", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse)
     )
@@ -568,12 +570,18 @@ pub async fn start_flow(
 ) -> Result<Json<FlowResponse>, (StatusCode, Json<ErrorResponse>)> {
     // Start the pipeline
     if let Err(e) = state.start_flow(&id).await {
+        // A property the flow definition got wrong is the client's mistake, not
+        // the server's: the same errors are a 400 on the live update path.
+        let (status, message) = match e {
+            PipelineError::FlowNotFound(_) => (StatusCode::NOT_FOUND, "Flow not found"),
+            PipelineError::InvalidProperty { .. } | PipelineError::PropertyNotMutable { .. } => {
+                (StatusCode::BAD_REQUEST, "Failed to start flow")
+            }
+            _ => (StatusCode::INTERNAL_SERVER_ERROR, "Failed to start flow"),
+        };
         return Err((
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse::with_details(
-                "Failed to start flow",
-                e.to_string(),
-            )),
+            status,
+            Json(ErrorResponse::with_details(message, e.to_string())),
         ));
     }
 

--- a/backend/src/gst/pipeline/mod.rs
+++ b/backend/src/gst/pipeline/mod.rs
@@ -137,6 +137,9 @@ pub enum PipelineError {
     #[error("Invalid flow: {0}")]
     InvalidFlow(String),
 
+    #[error("Flow not found: {0}")]
+    FlowNotFound(String),
+
     #[error("Property {property} on element {element} cannot be changed in {state:?} state")]
     PropertyNotMutable {
         element: String,

--- a/backend/src/gst/pipeline/properties.rs
+++ b/backend/src/gst/pipeline/properties.rs
@@ -69,134 +69,36 @@ impl PipelineManager {
             }
         }
 
-        // Set property based on type
-        match prop_value {
-            PropertyValue::String(v) => {
-                element.set_property_from_str(prop_name, v);
+        // Everything below ends up in a GLib property setter, and those panic
+        // rather than fail: on a property that is missing, read-only or
+        // construct-only, on a value whose type GLib would have to coerce, and
+        // on one it has to clamp into range. A flow definition names both the
+        // property and the value, so all of those are reachable straight from a
+        // request body. Resolve the spec first and convert against it.
+        let pspec =
+            element
+                .find_property(prop_name)
+                .ok_or_else(|| PipelineError::InvalidProperty {
+                    element: element_id.to_string(),
+                    property: prop_name.to_string(),
+                    reason: "Property not found".to_string(),
+                })?;
+
+        let value = checked_property_value(&pspec, prop_value).map_err(|reason| {
+            PipelineError::InvalidProperty {
+                element: element_id.to_string(),
+                property: prop_name.to_string(),
+                reason,
             }
-            PropertyValue::Int(v) => {
-                // Check property type to determine if we need i32, i64, or unsigned types
-                if let Some(pspec) = element.find_property(prop_name) {
-                    let type_name = pspec.value_type().name();
-                    if type_name == "gint" || type_name == "glong" {
-                        // Property expects i32
-                        if let Ok(v32) = i32::try_from(*v) {
-                            element.set_property(prop_name, v32);
-                        } else {
-                            return Err(PipelineError::InvalidProperty {
-                                element: element_id.to_string(),
-                                property: prop_name.to_string(),
-                                reason: format!("Value {} doesn't fit in i32", v),
-                            });
-                        }
-                    } else if type_name == "guint" || type_name == "gulong" {
-                        // Property expects u32, but we got a signed int
-                        // Convert if value is positive and fits in u32
-                        if *v >= 0 {
-                            if let Ok(v32) = u32::try_from(*v) {
-                                element.set_property(prop_name, v32);
-                            } else {
-                                return Err(PipelineError::InvalidProperty {
-                                    element: element_id.to_string(),
-                                    property: prop_name.to_string(),
-                                    reason: format!("Value {} doesn't fit in u32", v),
-                                });
-                            }
-                        } else {
-                            return Err(PipelineError::InvalidProperty {
-                                element: element_id.to_string(),
-                                property: prop_name.to_string(),
-                                reason: format!(
-                                    "Property expects unsigned integer, got negative value: {}",
-                                    v
-                                ),
-                            });
-                        }
-                    } else if type_name == "guint64" {
-                        // Property expects u64, convert if positive
-                        if *v >= 0 {
-                            element.set_property(prop_name, *v as u64);
-                        } else {
-                            return Err(PipelineError::InvalidProperty {
-                                element: element_id.to_string(),
-                                property: prop_name.to_string(),
-                                reason: format!(
-                                    "Property expects unsigned integer, got negative value: {}",
-                                    v
-                                ),
-                            });
-                        }
-                    } else if type_name == "gint64" {
-                        // Property expects i64
-                        element.set_property(prop_name, *v);
-                    } else if type_name == "gdouble" {
-                        // Property expects f64 — coerce (e.g. volume sent as int)
-                        element.set_property(prop_name, *v as f64);
-                    } else if type_name == "gfloat" {
-                        // Property expects f32 — coerce
-                        element.set_property(prop_name, *v as f32);
-                    } else {
-                        // Try i64, might work
-                        element.set_property(prop_name, *v);
-                    }
-                } else {
-                    // Property not found, try anyway
-                    element.set_property(prop_name, *v);
-                }
+        })?;
+
+        set_checked_value(element, prop_name, &value).map_err(|reason| {
+            PipelineError::InvalidProperty {
+                element: element_id.to_string(),
+                property: prop_name.to_string(),
+                reason,
             }
-            PropertyValue::UInt(v) => {
-                // Check property type to determine if we need u32 or u64
-                if let Some(pspec) = element.find_property(prop_name) {
-                    let type_name = pspec.value_type().name();
-                    if type_name == "guint" || type_name == "gulong" {
-                        // Property expects u32
-                        if let Ok(v32) = u32::try_from(*v) {
-                            element.set_property(prop_name, v32);
-                        } else {
-                            return Err(PipelineError::InvalidProperty {
-                                element: element_id.to_string(),
-                                property: prop_name.to_string(),
-                                reason: format!("Value {} doesn't fit in u32", v),
-                            });
-                        }
-                    } else if type_name == "guint64" {
-                        // Property expects u64
-                        element.set_property(prop_name, *v);
-                    } else if type_name == "gdouble" {
-                        // Property expects f64 — coerce
-                        element.set_property(prop_name, *v as f64);
-                    } else if type_name == "gfloat" {
-                        // Property expects f32 — coerce
-                        element.set_property(prop_name, *v as f32);
-                    } else {
-                        // Try u64, might work
-                        element.set_property(prop_name, *v);
-                    }
-                } else {
-                    // Property not found, try anyway
-                    element.set_property(prop_name, *v);
-                }
-            }
-            PropertyValue::Float(v) => {
-                // Check property type to determine if we need f32 or f64
-                if let Some(pspec) = element.find_property(prop_name) {
-                    let type_name = pspec.value_type().name();
-                    if type_name == "gfloat" {
-                        // Property expects f32
-                        element.set_property(prop_name, *v as f32);
-                    } else {
-                        // Property expects f64 (gdouble) or unknown, use f64
-                        element.set_property(prop_name, *v);
-                    }
-                } else {
-                    // Property not found, try anyway with f64
-                    element.set_property(prop_name, *v);
-                }
-            }
-            PropertyValue::Bool(v) => {
-                element.set_property(prop_name, *v);
-            }
-        }
+        })?;
 
         Ok(())
     }
@@ -682,16 +584,32 @@ impl PipelineManager {
             return Ok(());
         }
 
-        // Use set_property_from_str for all types - GStreamer handles type conversion automatically
-        let value_str = match prop_value {
-            PropertyValue::String(v) => v.clone(),
-            PropertyValue::Int(v) => v.to_string(),
-            PropertyValue::UInt(v) => v.to_string(),
-            PropertyValue::Float(v) => v.to_string(),
-            PropertyValue::Bool(v) => v.to_string(),
-        };
+        // Same checked conversion as the element path: `set_property_from_str`
+        // panics on a value it cannot parse for the property, and pad
+        // properties come from the flow definition too.
+        let pspec = pad
+            .find_property(prop_name)
+            .ok_or_else(|| PipelineError::InvalidProperty {
+                element: format!("{}:{}", element_id, pad_name),
+                property: prop_name.to_string(),
+                reason: "Property not found on pad".to_string(),
+            })?;
 
-        pad.set_property_from_str(prop_name, &value_str);
+        let value = checked_property_value(&pspec, prop_value).map_err(|reason| {
+            PipelineError::InvalidProperty {
+                element: format!("{}:{}", element_id, pad_name),
+                property: prop_name.to_string(),
+                reason,
+            }
+        })?;
+
+        set_checked_value(pad, prop_name, &value).map_err(|reason| {
+            PipelineError::InvalidProperty {
+                element: format!("{}:{}", element_id, pad_name),
+                property: prop_name.to_string(),
+                reason,
+            }
+        })?;
 
         Ok(())
     }
@@ -873,5 +791,534 @@ impl PipelineManager {
         }
 
         Ok(())
+    }
+}
+
+/// How many enum members an error message lists before it gives up.
+const MAX_LISTED_ENUM_VALUES: usize = 24;
+
+/// Convert a client-supplied `PropertyValue` into a `glib::Value` that `pspec`
+/// is known to accept.
+///
+/// GLib's property setters signal every kind of misuse by panicking: an
+/// unwritable or construct-only property, a value whose type it would have to
+/// coerce, and a value `g_param_value_validate` has to clamp all abort the
+/// calling thread. `POST /api/flows` lets a client pick the property name and
+/// the value, so an unchecked `set_property` turns a request body into a panic
+/// — `{"pattern": 1}` on a `videotestsrc` is enough, and the unwind crosses the
+/// axum handler and skips the flow's teardown. Nothing reaches GLib from here
+/// without having been checked against the spec first.
+fn checked_property_value(
+    pspec: &glib::ParamSpec,
+    prop_value: &PropertyValue,
+) -> Result<glib::Value, String> {
+    if !pspec.flags().contains(glib::ParamFlags::WRITABLE) {
+        return Err("Property is not writable".to_string());
+    }
+    if pspec.flags().contains(glib::ParamFlags::CONSTRUCT_ONLY) {
+        return Err(
+            "Property is construct-only and cannot be set after element creation".to_string(),
+        );
+    }
+
+    let target = pspec.value_type();
+    let target_name = target.name();
+
+    // Strings go through GStreamer's own deserializer, which understands enum
+    // nicks, flag lists ("a+b"), caps, fractions and structures. It is the same
+    // conversion `set_property_from_str` performs, without its `unwrap` — a
+    // string that doesn't parse comes back as an error rather than a panic.
+    if let PropertyValue::String(v) = prop_value {
+        if target == gst::Structure::static_type() && v == "NULL" {
+            return Ok(None::<gst::Structure>.to_value());
+        }
+        return deserialized_value(pspec, v, target_name);
+    }
+
+    if let PropertyValue::Bool(v) = prop_value {
+        if target == glib::Type::BOOL {
+            return Ok(v.to_value());
+        }
+    }
+
+    // GLib enums are integers underneath, so an integer that names a real
+    // member is as good as its nick string. One that doesn't is an error:
+    // GLib would clamp it to the property default and then panic because it
+    // had to clamp.
+    if target.is_a(glib::Type::ENUM) {
+        let n = integer_operand(prop_value, target_name)?;
+        let class = glib::EnumClass::with_type(target)
+            .ok_or_else(|| format!("Cannot read the enum class of {}", target_name))?;
+        return i32::try_from(n)
+            .ok()
+            .and_then(|n| class.to_value(n))
+            .ok_or_else(|| {
+                format!(
+                    "{} is not a valid {} value ({})",
+                    n,
+                    target_name,
+                    enum_choices(&class)
+                )
+            });
+    }
+
+    // Flags are a bitmask of integers, so the deserializer assembles the whole
+    // mask at once; `check_against_spec` is what tests it against the class.
+    if target.is_a(glib::Type::FLAGS) {
+        let n = integer_operand(prop_value, target_name)?;
+        let bits =
+            u32::try_from(n).map_err(|_| format!("{} is not a {} bitmask", n, target_name))?;
+        return deserialized_value(pspec, &bits.to_string(), target_name);
+    }
+
+    // Numbers: convert into the property's own type and reject anything outside
+    // the range the spec declares, for the same reason as the enum above.
+    macro_rules! ranged_int {
+        ($spec:ty, $rust:ty) => {{
+            let n = integer_operand(prop_value, target_name)?;
+            let (min, max) = pspec
+                .downcast_ref::<$spec>()
+                .map(|p| (p.minimum() as i128, p.maximum() as i128))
+                .unwrap_or((<$rust>::MIN as i128, <$rust>::MAX as i128));
+            if n < min || n > max {
+                return Err(out_of_range(n, target_name, min, max));
+            }
+            Ok((n as $rust).to_value())
+        }};
+    }
+
+    macro_rules! ranged_float {
+        ($spec:ty, $rust:ty) => {{
+            let n = float_operand(prop_value, target_name)?;
+            let (min, max) = pspec
+                .downcast_ref::<$spec>()
+                .map(|p| (p.minimum() as f64, p.maximum() as f64))
+                .unwrap_or((<$rust>::MIN as f64, <$rust>::MAX as f64));
+            // A NaN fails this comparison too, which is what we want.
+            if !(min..=max).contains(&n) {
+                return Err(out_of_range(n, target_name, min, max));
+            }
+            Ok((n as $rust).to_value())
+        }};
+    }
+
+    match target {
+        glib::Type::I8 => ranged_int!(glib::ParamSpecChar, i8),
+        glib::Type::U8 => ranged_int!(glib::ParamSpecUChar, u8),
+        glib::Type::I32 => ranged_int!(glib::ParamSpecInt, i32),
+        glib::Type::U32 => ranged_int!(glib::ParamSpecUInt, u32),
+        glib::Type::I64 => ranged_int!(glib::ParamSpecInt64, i64),
+        glib::Type::U64 => ranged_int!(glib::ParamSpecUInt64, u64),
+        glib::Type::F32 => ranged_float!(glib::ParamSpecFloat, f32),
+        glib::Type::F64 => ranged_float!(glib::ParamSpecDouble, f64),
+        // Everything else — booleans written as 0/1, fractions, caps,
+        // structures, boxed and object types, and the C `long` types glib-rs
+        // cannot build a `Value` for — is only reachable through the
+        // deserializer, so hand it the value's text form. A pad property
+        // rejected here is only logged (`linking.rs`) and the flow starts
+        // misconfigured, so accept every shape GStreamer can parse.
+        _ => deserialized_value(pspec, &text_form(prop_value), target_name),
+    }
+}
+
+/// Build a value from its text form and check the result against the spec.
+///
+/// `gst_value_deserialize` parses text into the property's type but never
+/// consults the `GParamSpec`, so `"-5"` for a `gint` whose minimum is `-1`
+/// comes back happily — GLib then clamps it and panics because it had to.
+/// `-5` in its integer form is rejected before it gets that far; two
+/// spellings of one value must not differ, and `catch_unwind` is a backstop
+/// rather than the guard an ordinary request runs into.
+fn deserialized_value(
+    pspec: &glib::ParamSpec,
+    text: &str,
+    target_name: &str,
+) -> Result<glib::Value, String> {
+    let value = glib::Value::deserialize_with_pspec(text, pspec)
+        .map_err(|_| format!("Cannot parse \"{}\" as {}", text, target_name))?;
+    check_against_spec(pspec, &value, target_name)?;
+    Ok(value)
+}
+
+/// Reject a deserialized value the `GParamSpec` would have to clamp.
+///
+/// Enums need no check here: GStreamer's deserializer resolves them through
+/// the enum class and fails on a name, nick or integer that is not a member.
+/// Flags and the ranged numeric types do — the deserializer assembles those
+/// arithmetically and hands back whatever it read.
+fn check_against_spec(
+    pspec: &glib::ParamSpec,
+    value: &glib::Value,
+    target_name: &str,
+) -> Result<(), String> {
+    let target = pspec.value_type();
+
+    if target.is_a(glib::Type::FLAGS) {
+        let class = glib::FlagsClass::with_type(target)
+            .ok_or_else(|| format!("Cannot read the flags class of {}", target_name))?;
+        let mask = class.values().iter().fold(0u32, |m, v| m | v.value());
+        // Flags transform to their integer form; a class GLib cannot transform
+        // is left to the `catch_unwind`.
+        if let Some(bits) = value
+            .transform::<u32>()
+            .ok()
+            .and_then(|v| v.get::<u32>().ok())
+        {
+            if bits & !mask != 0 {
+                return Err(format!(
+                    "{} sets bits that are not part of {} (valid mask: {:#x})",
+                    bits, target_name, mask
+                ));
+            }
+        }
+        return Ok(());
+    }
+
+    macro_rules! check_int {
+        ($spec:ty, $rust:ty) => {{
+            if let (Some(p), Ok(n)) = (pspec.downcast_ref::<$spec>(), value.get::<$rust>()) {
+                let (n, min, max) = (n as i128, p.minimum() as i128, p.maximum() as i128);
+                if n < min || n > max {
+                    return Err(out_of_range(n, target_name, min, max));
+                }
+            }
+        }};
+    }
+
+    macro_rules! check_float {
+        ($spec:ty, $rust:ty) => {{
+            if let (Some(p), Ok(n)) = (pspec.downcast_ref::<$spec>(), value.get::<$rust>()) {
+                let (n, min, max) = (n as f64, p.minimum() as f64, p.maximum() as f64);
+                if !(min..=max).contains(&n) {
+                    return Err(out_of_range(n, target_name, min, max));
+                }
+            }
+        }};
+    }
+
+    match target {
+        glib::Type::I8 => check_int!(glib::ParamSpecChar, i8),
+        glib::Type::U8 => check_int!(glib::ParamSpecUChar, u8),
+        glib::Type::I32 => check_int!(glib::ParamSpecInt, i32),
+        glib::Type::U32 => check_int!(glib::ParamSpecUInt, u32),
+        glib::Type::I64 => check_int!(glib::ParamSpecInt64, i64),
+        glib::Type::U64 => check_int!(glib::ParamSpecUInt64, u64),
+        glib::Type::F32 => check_float!(glib::ParamSpecFloat, f32),
+        glib::Type::F64 => check_float!(glib::ParamSpecDouble, f64),
+        _ => {}
+    }
+
+    Ok(())
+}
+
+/// One wording for "the spec would have had to clamp this".
+fn out_of_range<T: std::fmt::Display>(n: T, target_name: &str, min: T, max: T) -> String {
+    format!(
+        "Value {} is out of range for {} ({}..={})",
+        n, target_name, min, max
+    )
+}
+
+/// The text form GStreamer's deserializer takes.
+fn text_form(prop_value: &PropertyValue) -> String {
+    match prop_value {
+        PropertyValue::String(v) => v.clone(),
+        PropertyValue::Int(v) => v.to_string(),
+        PropertyValue::UInt(v) => v.to_string(),
+        PropertyValue::Float(v) => v.to_string(),
+        PropertyValue::Bool(v) => v.to_string(),
+    }
+}
+
+/// Apply an already-checked value, refusing to let GLib abort the thread.
+///
+/// `checked_property_value` aims to leave nothing for GLib to reject, but a
+/// `GParamSpec` subclass may carry validation of its own that it can only
+/// report by panicking. An unwind from here would cross the axum handler,
+/// which drops the client's connection without a response and skips the
+/// caller's teardown, leaving a half-built flow behind — so treat a panic as
+/// one more way for the value to be invalid.
+fn set_checked_value<O: IsA<glib::Object>>(
+    obj: &O,
+    prop_name: &str,
+    value: &glib::Value,
+) -> Result<(), String> {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        obj.set_property_from_value(prop_name, value);
+    }))
+    .map_err(|_| "GLib rejected the value (see the log for details)".to_string())
+}
+
+/// The integer a client meant, whatever numeric shape it arrived in.
+fn integer_operand(prop_value: &PropertyValue, target_name: &str) -> Result<i128, String> {
+    match prop_value {
+        PropertyValue::Int(v) => Ok(*v as i128),
+        PropertyValue::UInt(v) => Ok(*v as i128),
+        // A client that went through JSON may have lost the difference between
+        // 2 and 2.0. A value with an actual fraction is a real mismatch.
+        PropertyValue::Float(v) if v.is_finite() && v.fract() == 0.0 => Ok(*v as i128),
+        PropertyValue::Float(v) => Err(format!(
+            "Property expects {}, got the non-integer value {}",
+            target_name, v
+        )),
+        PropertyValue::Bool(_) => Err(format!("Property expects {}, got a boolean", target_name)),
+        PropertyValue::String(_) => Err(format!("Property expects {}, got a string", target_name)),
+    }
+}
+
+/// The float a client meant, whatever numeric shape it arrived in.
+fn float_operand(prop_value: &PropertyValue, target_name: &str) -> Result<f64, String> {
+    match prop_value {
+        PropertyValue::Float(v) => Ok(*v),
+        PropertyValue::Int(v) => Ok(*v as f64),
+        PropertyValue::UInt(v) => Ok(*v as f64),
+        PropertyValue::Bool(_) => Err(format!("Property expects {}, got a boolean", target_name)),
+        PropertyValue::String(_) => Err(format!("Property expects {}, got a string", target_name)),
+    }
+}
+
+/// The members of an enum, for an error message that tells a client what it
+/// could have sent instead.
+fn enum_choices(class: &glib::EnumClass) -> String {
+    let values = class.values();
+    let mut listed: Vec<String> = values
+        .iter()
+        .take(MAX_LISTED_ENUM_VALUES)
+        .map(|v| format!("{}={}", v.value(), v.nick()))
+        .collect();
+    if values.len() > MAX_LISTED_ENUM_VALUES {
+        listed.push("...".to_string());
+    }
+    format!("valid: {}", listed.join(", "))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `videotestsrc` carries one of everything this module has to get right:
+    /// an enum (`pattern`), a ranged integer (`num-buffers`), a boolean
+    /// (`is-live`) and, from `GstObject`, a string (`name`). It ships in
+    /// gstreamer-plugins-base, which CI installs, so these tests run rather
+    /// than skip.
+    fn videotestsrc() -> gst::Element {
+        gst::init().unwrap();
+        gst::ElementFactory::make("videotestsrc")
+            .build()
+            .expect("videotestsrc missing - install gstreamer1.0-plugins-base")
+    }
+
+    fn convert(
+        element: &gst::Element,
+        prop_name: &str,
+        prop_value: PropertyValue,
+    ) -> Result<glib::Value, String> {
+        let pspec = element
+            .find_property(prop_name)
+            .unwrap_or_else(|| panic!("videotestsrc has no '{}' property", prop_name));
+        checked_property_value(&pspec, &prop_value)
+    }
+
+    /// An integer names an enum member as well as its nick does, and the value
+    /// that comes back is the enum's own type, not the `gint64` the operand
+    /// arrived as.
+    #[test]
+    fn enum_accepts_an_in_range_integer() {
+        let src = videotestsrc();
+        let value = convert(&src, "pattern", PropertyValue::Int(1)).expect("1 is `snow`");
+
+        let (_class, member) =
+            glib::EnumValue::from_value(&value).expect("not an enum value of the property's type");
+        assert_eq!(member.nick(), "snow");
+
+        // And it is actually accepted by the element.
+        src.set_property_from_value("pattern", &value);
+        assert_eq!(
+            glib::EnumValue::from_value(&src.property_value("pattern"))
+                .unwrap()
+                .1
+                .nick(),
+            "snow"
+        );
+    }
+
+    #[test]
+    fn enum_accepts_a_nick_string() {
+        let src = videotestsrc();
+        let value = convert(&src, "pattern", PropertyValue::String("snow".to_string()))
+            .expect("`snow` is a pattern nick");
+        assert_eq!(
+            glib::EnumValue::from_value(&value).unwrap().1.value(),
+            1,
+            "nick did not resolve to the same member as the integer"
+        );
+    }
+
+    /// The reported panic: GLib clamps an unknown enum integer to the property
+    /// default and then aborts because it had to clamp.
+    #[test]
+    fn enum_rejects_an_out_of_range_integer() {
+        let src = videotestsrc();
+        let err = convert(&src, "pattern", PropertyValue::Int(99_999))
+            .expect_err("99999 is not a GstVideoTestSrcPattern");
+        assert!(err.contains("99999"), "unhelpful message: {}", err);
+        assert!(
+            err.contains("snow"),
+            "message lists no alternatives: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn enum_rejects_an_unknown_nick() {
+        let src = videotestsrc();
+        convert(
+            &src,
+            "pattern",
+            PropertyValue::String("harlequin".to_string()),
+        )
+        .expect_err("`harlequin` is not a pattern nick");
+    }
+
+    #[test]
+    fn integer_property_accepts_a_value_inside_the_declared_range() {
+        let src = videotestsrc();
+        let value = convert(&src, "num-buffers", PropertyValue::Int(10)).expect("10 is in range");
+        assert_eq!(value.get::<i32>().expect("not a gint"), 10);
+    }
+
+    /// `num-buffers` is a `gint` but its spec starts at -1. A value GLib would
+    /// have to clamp panics just like a type mismatch does.
+    #[test]
+    fn integer_property_rejects_a_value_the_spec_would_clamp() {
+        let src = videotestsrc();
+        let err = convert(&src, "num-buffers", PropertyValue::Int(-5))
+            .expect_err("-5 is below the num-buffers minimum");
+        assert!(err.contains("-1"), "message omits the range: {}", err);
+    }
+
+    #[test]
+    fn integer_property_rejects_a_value_too_wide_for_the_type() {
+        let src = videotestsrc();
+        convert(&src, "num-buffers", PropertyValue::Int(5_000_000_000))
+            .expect_err("5000000000 does not fit in a gint");
+    }
+
+    /// A client that has been through JSON may have lost the difference
+    /// between 2 and 2.0, but 2.5 is a real mismatch.
+    #[test]
+    fn integer_property_accepts_a_whole_float_but_not_a_fractional_one() {
+        let src = videotestsrc();
+        let value =
+            convert(&src, "num-buffers", PropertyValue::Float(10.0)).expect("10.0 is a whole 10");
+        assert_eq!(value.get::<i32>().unwrap(), 10);
+
+        convert(&src, "num-buffers", PropertyValue::Float(10.5))
+            .expect_err("10.5 is not an integer");
+    }
+
+    #[test]
+    fn integer_property_rejects_a_string_that_is_not_a_number() {
+        let src = videotestsrc();
+        convert(
+            &src,
+            "num-buffers",
+            PropertyValue::String("not-a-number".to_string()),
+        )
+        .expect_err("`not-a-number` is not a gint");
+    }
+
+    #[test]
+    fn boolean_property_rejects_a_non_boolean_string() {
+        let src = videotestsrc();
+        convert(&src, "is-live", PropertyValue::String("banana".to_string()))
+            .expect_err("`banana` is not a gboolean");
+    }
+
+    /// Any shape GStreamer's deserializer can parse for the target type is
+    /// accepted, rather than turned into a type error the caller may only log.
+    #[test]
+    fn a_number_names_a_string_property() {
+        let src = videotestsrc();
+        let value = convert(&src, "name", PropertyValue::Int(5))
+            .expect("5 is a gchararray GStreamer takes");
+        assert_eq!(value.get::<String>().expect("not a gchararray"), "5");
+    }
+
+    /// Booleans arrive as 0/1 from clients that went through a form or an
+    /// untyped config. Both spellings reach the same `gboolean`.
+    #[test]
+    fn boolean_property_accepts_an_integer() {
+        let src = videotestsrc();
+        for (sent, expected) in [
+            (PropertyValue::Int(1), true),
+            (PropertyValue::Int(0), false),
+        ] {
+            let value = convert(&src, "is-live", sent).expect("0 and 1 are gbooleans");
+            assert_eq!(value.get::<bool>().expect("not a gboolean"), expected);
+        }
+    }
+
+    /// Pad properties come from the same flow definition and take the same
+    /// conversion. `linking.rs` only logs a pad property it cannot set, so a
+    /// rejection here starts the flow misconfigured instead of reporting
+    /// anything. `audiomixer`'s `sink_%u` pads carry the `mute` a mixer route
+    /// sets.
+    #[test]
+    fn pad_boolean_property_accepts_an_integer() {
+        gst::init().unwrap();
+        let mixer = gst::ElementFactory::make("audiomixer")
+            .build()
+            .expect("audiomixer missing - install gstreamer1.0-plugins-base");
+        let pad = mixer.request_pad_simple("sink_%u").expect("no sink pad");
+        let pspec = pad.find_property("mute").expect("no 'mute' on the pad");
+
+        let value = checked_property_value(&pspec, &PropertyValue::Int(1)).expect("1 is muted");
+        pad.set_property_from_value("mute", &value);
+        assert!(pad.property::<bool>("mute"));
+    }
+
+    /// The clamp path the type check misses, in its string spelling: `-5` is
+    /// below the `num-buffers` minimum whether it arrives as a number or as
+    /// text, and GLib panics on either.
+    #[test]
+    fn integer_property_rejects_an_out_of_range_string() {
+        let src = videotestsrc();
+        let err = convert(&src, "num-buffers", PropertyValue::String("-5".to_string()))
+            .expect_err("-5 is below the num-buffers minimum");
+        assert!(err.contains("-1"), "message omits the range: {}", err);
+    }
+
+    /// `rtspsrc protocols` is a `GstRTSPLowerTrans` bitmask. GStreamer's
+    /// deserializer reads a raw integer without consulting the flags class, so
+    /// stray bits arrive intact and GLib rejects them by panicking.
+    #[test]
+    fn flags_property_rejects_stray_bits_in_a_string() {
+        gst::init().unwrap();
+        let src = gst::ElementFactory::make("rtspsrc")
+            .build()
+            .expect("rtspsrc missing - install gstreamer1.0-plugins-good");
+        let pspec = src.find_property("protocols").unwrap();
+
+        let value = checked_property_value(&pspec, &PropertyValue::String("0x4".to_string()))
+            .expect("udp-mcast is a real GstRTSPLowerTrans bit");
+        src.set_property_from_value("protocols", &value);
+
+        let err = checked_property_value(&pspec, &PropertyValue::String("0xff0".to_string()))
+            .expect_err("0xff0 sets bits GstRTSPLowerTrans does not define");
+        assert!(err.contains("mask"), "message omits the mask: {}", err);
+    }
+
+    /// The `gdouble` coercion the mixer relies on: a client that sends volume
+    /// as 1 rather than 1.0 still gets a gdouble.
+    #[test]
+    fn double_property_accepts_an_integer() {
+        gst::init().unwrap();
+        let volume = gst::ElementFactory::make("volume")
+            .build()
+            .expect("volume missing - install gstreamer1.0-plugins-base");
+        let pspec = volume.find_property("volume").unwrap();
+        let value = checked_property_value(&pspec, &PropertyValue::Int(1)).expect("1 is a volume");
+        assert_eq!(value.get::<f64>().expect("not a gdouble"), 1.0);
     }
 }

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -875,10 +875,7 @@ impl AppState {
 
         let Some(mut flow) = flow else {
             error!("Flow not found: {}", id);
-            return Err(PipelineError::InvalidFlow(format!(
-                "Flow not found: {}",
-                id
-            )));
+            return Err(PipelineError::FlowNotFound(id.to_string()));
         };
 
         // Check if pipeline is already running

--- a/backend/tests/property_type_panic_test.rs
+++ b/backend/tests/property_type_panic_test.rs
@@ -1,0 +1,207 @@
+//! Regression test: a property value of the wrong type in a flow definition
+//! must fail the build, not panic the task that is serving the request.
+//!
+//! `POST /api/flows` lets a client name both a property and its value, and GLib
+//! reports every kind of misuse by panicking. Handing one to
+//! `element.set_property()` without checking it against the spec unwinds the
+//! task at `POST /api/flows/{id}/start`: the client gets a dropped connection
+//! instead of a response, and `start_flow`'s error path — which tears the
+//! half-built flow down — never runs.
+//!
+//! Each case here panics if the checked conversion is reverted, which fails
+//! the test.
+
+use std::collections::HashMap;
+use strom::blocks::BlockRegistry;
+use strom::events::EventBroadcaster;
+use strom::gst::pipeline::{PipelineError, PipelineManager};
+use strom_types::{Flow, Link, PropertyValue};
+use tempfile::NamedTempFile;
+
+/// `videotestsrc` ships in gstreamer-plugins-base, which the CI job installs,
+/// so these tests run there rather than skipping green.
+const REQUIRED: &[&str] = &["videotestsrc", "fakesink"];
+
+/// Skipping on a missing element passes green and guards nothing, so CI sets
+/// `STROM_REQUIRE_GST_PLUGINS=1` to turn a skip into a failure.
+fn plugins_available() -> bool {
+    gstreamer::init().unwrap();
+    let missing: Vec<&str> = REQUIRED
+        .iter()
+        .copied()
+        .filter(|e| gstreamer::ElementFactory::find(e).is_none())
+        .collect();
+    if missing.is_empty() {
+        return true;
+    }
+    assert!(
+        strom_types::env::var_opt("STROM_REQUIRE_GST_PLUGINS").is_none(),
+        "STROM_REQUIRE_GST_PLUGINS is set but these elements are missing: {}",
+        missing.join(", ")
+    );
+    false
+}
+
+/// `videotestsrc → fakesink`, with `properties` applied to the source.
+fn flow_with_source_properties(name: &str, properties: HashMap<String, PropertyValue>) -> Flow {
+    let mut flow = Flow::new(name);
+
+    flow.elements.push(strom_types::Element {
+        id: "src0".to_string(),
+        element_type: "videotestsrc".to_string(),
+        properties,
+        position: [100.0, 200.0].into(),
+        pad_properties: HashMap::new(),
+    });
+
+    flow.elements.push(strom_types::Element {
+        id: "sink".to_string(),
+        element_type: "fakesink".to_string(),
+        properties: HashMap::new(),
+        position: [400.0, 200.0].into(),
+        pad_properties: HashMap::new(),
+    });
+
+    flow.links.push(Link {
+        from: "src0:src".to_string(),
+        to: "sink:sink".to_string(),
+    });
+
+    flow
+}
+
+fn one_property(name: &str, value: PropertyValue) -> HashMap<String, PropertyValue> {
+    let mut properties = HashMap::new();
+    properties.insert(name.to_string(), value);
+    properties
+}
+
+/// Build the pipeline the way `start_flow` does.
+fn build(flow: &Flow) -> Result<PipelineManager, PipelineError> {
+    let temp_file = NamedTempFile::new().unwrap();
+    let registry = BlockRegistry::new(temp_file.path());
+
+    PipelineManager::new(
+        flow,
+        EventBroadcaster::new(10),
+        &registry,
+        vec![],
+        "all".to_string(),
+        None,
+        std::env::temp_dir(),
+        std::sync::Arc::new(std::sync::Mutex::new(HashMap::new())),
+    )
+}
+
+fn expect_invalid_property(flow: &Flow, expected_property: &str) -> String {
+    match build(flow) {
+        Ok(_) => panic!("pipeline built despite an invalid value for '{expected_property}'"),
+        Err(PipelineError::InvalidProperty {
+            property, reason, ..
+        }) => {
+            assert_eq!(property, expected_property);
+            reason
+        }
+        Err(other) => panic!("expected InvalidProperty, got {other:?}"),
+    }
+}
+
+/// The reported repro: an integer for an enum property.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn out_of_range_enum_integer_is_rejected() {
+    if !plugins_available() {
+        return;
+    }
+    let flow = flow_with_source_properties(
+        "enum_out_of_range",
+        one_property("pattern", PropertyValue::Int(99_999)),
+    );
+    let reason = expect_invalid_property(&flow, "pattern");
+    assert!(reason.contains("99999"), "unhelpful message: {reason}");
+}
+
+/// GLib enums do have integer values, so an in-range one is accepted rather
+/// than turned into a second error. The nick string keeps working too.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn in_range_enum_integer_is_accepted() {
+    if !plugins_available() {
+        return;
+    }
+    let flow = flow_with_source_properties(
+        "enum_in_range",
+        one_property("pattern", PropertyValue::Int(1)),
+    );
+    build(&flow).expect("pattern 1 (`snow`) is a valid GstVideoTestSrcPattern");
+
+    let flow = flow_with_source_properties(
+        "enum_nick",
+        one_property("pattern", PropertyValue::String("snow".to_string())),
+    );
+    build(&flow).expect("the nick form regressed");
+}
+
+/// A string that is not a number, for a `gint` property.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn unparseable_string_for_an_integer_property_is_rejected() {
+    if !plugins_available() {
+        return;
+    }
+    let flow = flow_with_source_properties(
+        "string_for_int",
+        one_property(
+            "num-buffers",
+            PropertyValue::String("not-a-number".to_string()),
+        ),
+    );
+    expect_invalid_property(&flow, "num-buffers");
+}
+
+/// `num-buffers` is a `gint` whose spec starts at -1. GLib clamps a value
+/// below that and then panics because it had to clamp — a type check alone
+/// would not have caught this one.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn integer_below_the_declared_minimum_is_rejected() {
+    if !plugins_available() {
+        return;
+    }
+    let flow = flow_with_source_properties(
+        "int_out_of_range",
+        one_property("num-buffers", PropertyValue::Int(-5)),
+    );
+    let reason = expect_invalid_property(&flow, "num-buffers");
+    assert!(reason.contains("-1"), "message omits the range: {reason}");
+}
+
+/// A property the element does not have must fail before it reaches GLib, which
+/// panics on it.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn unknown_property_is_rejected() {
+    if !plugins_available() {
+        return;
+    }
+    let flow = flow_with_source_properties(
+        "unknown_property",
+        one_property("no-such-property", PropertyValue::Int(1)),
+    );
+    let reason = expect_invalid_property(&flow, "no-such-property");
+    assert!(reason.contains("not found"), "unhelpful message: {reason}");
+}
+
+/// Control: the same harness on a flow with valid properties still builds and
+/// runs. Guards against "fixing" the panic by rejecting everything.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn valid_properties_still_build_and_start() {
+    if !plugins_available() {
+        return;
+    }
+    let mut properties = one_property("pattern", PropertyValue::String("snow".to_string()));
+    properties.insert("num-buffers".to_string(), PropertyValue::Int(5));
+    properties.insert("is-live".to_string(), PropertyValue::Bool(false));
+
+    let flow = flow_with_source_properties("valid_properties", properties);
+    let mut manager = build(&flow).expect("a valid flow no longer builds");
+
+    let state = manager.start().expect("a valid flow no longer starts");
+    assert_eq!(state, strom_types::PipelineState::Playing);
+    manager.stop().expect("failed to stop pipeline");
+}

--- a/openapi.json
+++ b/openapi.json
@@ -3155,6 +3155,16 @@
               }
             }
           },
+          "400": {
+            "description": "Flow definition rejected",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Flow not found",
             "content": {


### PR DESCRIPTION
## The bug

A flow definition names both a property and its value, and `properties.rs` handed whatever arrived straight to GLib whenever it did not recognise the property's type:

```rust
} else {
    // Try i64, might work
    element.set_property(prop_name, *v);
}
...
} else {
    // Property not found, try anyway
    element.set_property(prop_name, *v);
}
```

GLib's setters report every kind of misuse by panicking, so:

```
POST /api/flows        {"id":"src0","element_type":"videotestsrc","properties":{"pattern":1}}
POST /api/flows/{id}/start

panicked at backend/src/gst/pipeline/properties.rs:140:33:
property 'pattern' ... (expected: 'GstVideoTestSrcPattern', got: 'gint64')
```

Every arm had that shape, not just `Int`. `PropertyValue::String` was no safer — it went through `set_property_from_str`, which is `find_property(..).unwrap()` followed by `Value::deserialize_with_pspec(..).unwrap()`. So four distinct ways a request body reached a panic:

| what the client sends | what GLib does |
| --- | --- |
| a value of the wrong type | `validate_property_type` panics on the type check |
| a property the element does not have | `find_property().unwrap()` panics |
| a property that is read-only or construct-only | `validate_property_type` panics on the flags check |
| a value the spec would clamp (`num-buffers: -5`, an out-of-range enum integer) | `g_param_value_validate` reports the clamp, glib-rs panics because it happened |

The last row is the easy one to miss: a type check alone does not catch it.

## Is it a denial of service?

Not a process kill, but worse than a bad error message.

- No `panic = "abort"` in any profile and no `CatchPanicLayer` on the router, so the panic unwinds.
- `axum-server` 0.8 serves each accepted connection in a `tokio::spawn`ed task, so tokio catches the unwind at the task boundary. The worker thread and the process survive.
- The client gets a dropped connection and no HTTP response.
- **`start_flow`'s error path never runs.** On a clean error it calls `teardown_flow`; on a panic it does not, so the half-built pipeline and whatever the blocks registered on the way are leaked. Every repeat of the request leaks again.

Reachable by anything that can talk to the API — authenticated when auth is configured, unauthenticated otherwise.

## The fix

Resolve the `GParamSpec` first and convert against it (`checked_property_value`), returning `PipelineError::InvalidProperty` for every row of that table.

No value shape that applied before stops applying. Enums, flags and the ranged numeric types have typed conversions, so an integer names an enum or flags member as well as its nick string does: `{"pattern": 1}` is as good as `{"pattern": "snow"}`, and one that names no real member is a clean error listing the alternatives:

```json
{"error": "Failed to start flow",
 "details": "Invalid property value for src0.pattern: 99999 is not a valid GstVideoTestSrcPattern value (valid: 0=smpte, 1=snow, 2=black, ...)"}
```

Everything else — a boolean written as `0`/`1`, an integer for a `GstFraction`, caps, structures — goes to GStreamer's own deserializer in its text form, which is the conversion `set_property_from_str` performed, minus its `unwrap`. That matters most for pad properties: `linking.rs` only logs one it cannot set, so a rejection there would start the flow misconfigured rather than report anything.

What the deserializer returns is checked against the spec too. `gst_value_deserialize` parses text into the property's type but never consults the `GParamSpec`, so `{"num-buffers": "-5"}` came back happily and was caught only by the `catch_unwind`, while `{"num-buffers": -5}` gave a clean message. Both now say:

```
Invalid property value for src0.num-buffers: Value -5 is out of range for gint (-1..=2147483647)
```

The same check covers a flags string with bits the class does not define (`rtspsrc protocols=0xff0` deserializes fine and GLib then rejects it).

The set itself is still wrapped in `catch_unwind`. A `GParamSpec` subclass can carry validation of its own that it only reports by panicking, and this module's guarantee should not rest on having enumerated every one; `gst/discovery.rs` already uses `catch_unwind` the same way. With the range check in place it is a backstop rather than the thing an ordinary request runs into.

`start_flow` now answers **400** instead of 500 for a property the client got wrong, matching the live property-update path, and **404** for an unknown flow id — that case returned `InvalidFlow("Flow not found: ...")`, which the handler mapped to 500 while `openapi.json` advertised 404. It gets a `PipelineError::FlowNotFound` of its own rather than widening `InvalidFlow`, which also carries block-expansion failures that are not 404s. `openapi.json` is regenerated for the added 400 response.

## Left alone

`get_element_property` has a dead `"GEnum"` match arm — an element's enum property reports its own GType name (`GstVideoTestSrcPattern`), never `"GEnum"`, so enum properties fall through to "Unsupported property type" and are silently dropped from `GET .../properties`. The pad version of the same function gets it right (`value_type().is_a(glib::Type::ENUM)`). It is a read-path bug with no panic in it, and fixing it changes what the API returns, so it belongs in its own PR.

The other `InvalidFlow("Flow not found: ...")` sites (block property updates, and the live-update handlers) keep their current status mapping. This PR only touches the handler whose mapping it is already changing.

## Tests

Both layers call the real module.

`backend/tests/property_type_panic_test.rs` — 6 tests driving `PipelineManager::new` the way `start_flow` does: out-of-range enum integer, in-range enum integer accepted (and the nick form still working), unparseable string for a `gint` property, an integer below the spec minimum, an unknown property, plus a control that a valid flow still builds, starts and stops.

`backend/src/gst/pipeline/properties.rs` — 16 unit tests on `checked_property_value` itself, asserting the exact `glib::Value` type and contents: the enum member, `gint` range, whole vs. fractional float, `gdouble` built from an integer (the mixer path), a `gboolean` built from `0`/`1`, a `gboolean` pad property on an `audiomixer` `sink_%u` pad, `"-5"` rejected for `num-buffers`, and stray bits rejected for `rtspsrc protocols`.

### Reverting the fix fails the tests

With `properties.rs` restored to its pre-fix state and the test file kept, 5 of the 6 fail and the control (`valid_properties_still_build_and_start`) passes, so they are not merely asserting "everything fails now":

```
thread 'out_of_range_enum_integer_is_rejected' panicked at
  backend/src/gst/pipeline/properties.rs:140:33
```

That is the exact line from the report.

Dropping just the post-deserialize range check (the `check_against_spec` call) fails `integer_property_rejects_an_out_of_range_string` and `flags_property_rejects_stray_bits_in_a_string`, and leaves the other 14 green — verified this way rather than assumed.

### CI

`videotestsrc`, `audiomixer` and `fakesink` come from `gstreamer1.0-plugins-base` and `rtspsrc` from `gstreamer1.0-plugins-good`, both already in the package list of every test job in `.github/workflows/ci.yml`, so these run in CI rather than skipping. The test uses the repo's `STROM_REQUIRE_GST_PLUGINS` guard, read through `strom_types::env::var_opt` so a blank value means unset.

### What was actually run (macOS, debug)

- `cargo test` over the whole backend: **620 passed, 0 failed, 1 ignored** (the ignored one is pre-existing in `jitterbuffer_mute_test`)
- `cargo test --test property_type_panic_test`: 6 passed
- `cargo test --lib gst::pipeline::properties`: 16 passed
- `cargo test --test openapi_test`: passes, and `openapi.json` needed no further change
- `cargo clippy --all-targets --features efp,nvidia -- -D warnings`, `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo fmt --all -- --check`: clean
- Against a fresh headless server: an unknown flow id returns **404**; `{"pattern": 99999}`, `{"num-buffers": "-5"}`, `{"num-buffers": -5}` and an unknown property each return **400** (both spellings of `-5` with the same message); `{"pattern": 1}`, `{"is-live": 1}` and `pad_properties: {"sink_0": {"mute": 1}}` on an `audiomixer` each start **200**. No panics in the log and the server stayed up.

Rebased onto current `main`.

Not run: the Linux and Windows CI jobs, and anything needing hardware this machine does not have.

---
Authored by Claude (Claude Code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

