### PR TITLE
fix(api): stop discarding links written with a bare element id

### DIFF
--- a/backend/src/api/flows.rs
+++ b/backend/src/api/flows.rs
@@ -26,49 +26,157 @@ use tracing::{debug, error, info, trace, warn};
 use crate::layout;
 use crate::state::AppState;
 
-/// Check if a pad reference is valid (exists on an element or block).
+/// Which end of a link an endpoint sits on.
 ///
-/// For elements, we just check if the element exists.
-/// For blocks with computed pads, we strictly validate against the valid_block_pads set.
-/// For blocks without computed pads, we trust the static pad definition and just check block existence.
-fn is_pad_valid(
-    pad_ref: &str,
-    valid_block_pads: &std::collections::HashSet<String>,
-    element_ids: &std::collections::HashSet<String>,
-    block_ids: &std::collections::HashSet<String>,
-    blocks_with_computed_pads: &std::collections::HashSet<String>,
-) -> bool {
-    // Parse the pad reference (format: "element_id:pad_name" or "block_id:pad_name")
-    let parts: Vec<&str> = pad_ref.split(':').collect();
-    if parts.len() < 2 {
-        return false;
-    }
+/// A bare node reference means "the element's own pad", so which pad that is
+/// depends on the side: the source end of a link needs an output pad, the
+/// destination end an input pad.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum LinkSide {
+    From,
+    To,
+}
 
-    let node_id = parts[0];
-
-    // Check if it's an element by looking it up in element_ids
-    // (Don't rely on ID prefix - gst-launch imports use element_type as ID prefix like "videotestsrc_0")
-    if element_ids.contains(node_id) {
-        // For elements, we just check if the element exists
-        // The actual pad validation happens at pipeline build time
-        return true;
-    }
-
-    // Check if it's a block by looking it up in block_ids
-    // (Don't rely on ID prefix - could change in the future)
-    if block_ids.contains(node_id) {
-        // Only strictly validate blocks that have computed pads
-        if blocks_with_computed_pads.contains(node_id) {
-            // This block has dynamic pads - validate against computed external pads
-            return valid_block_pads.contains(pad_ref);
+impl LinkSide {
+    fn pad_kind(self) -> &'static str {
+        match self {
+            LinkSide::From => "output",
+            LinkSide::To => "input",
         }
-        // For blocks without computed pads, assume valid (uses static pad definition from block definition)
-        // The actual pad existence will be validated at pipeline build time
-        return true;
+    }
+}
+
+/// Why a link endpoint could not be used as sent.
+#[derive(Debug)]
+enum EndpointProblem {
+    /// The caller named something this flow does not contain, or a bare
+    /// reference that does not resolve to exactly one pad. A caller mistake:
+    /// the request is rejected rather than quietly trimmed.
+    Rejected(String),
+    /// The endpoint names a pad on a block whose current properties no longer
+    /// produce it (e.g. the track count was lowered). Expected drift, not a
+    /// caller mistake, so the link is pruned.
+    StaleBlockPad(String),
+}
+
+impl EndpointProblem {
+    fn message(&self) -> &str {
+        match self {
+            EndpointProblem::Rejected(m) | EndpointProblem::StaleBlockPad(m) => m,
+        }
+    }
+}
+
+/// The external pads a block instance exposes.
+struct BlockPads {
+    inputs: Vec<String>,
+    outputs: Vec<String>,
+    /// True when the pads were computed from the instance's properties. Only
+    /// then is the pad list authoritative enough to call a named pad stale;
+    /// blocks that fall back to their static definition are trusted and
+    /// validated at pipeline build time.
+    computed: bool,
+}
+
+impl BlockPads {
+    fn pads_on(&self, side: LinkSide) -> &[String] {
+        match side {
+            LinkSide::From => &self.outputs,
+            LinkSide::To => &self.inputs,
+        }
+    }
+}
+
+/// True for the two element-level spellings of a pad reference: a bare id, and
+/// the `"id::"` marker `ElementPadRef::to_string_format()` produces.
+fn is_element_only_ref(pad_ref: &str) -> bool {
+    !pad_ref.contains(':') || pad_ref.ends_with("::")
+}
+
+/// Resolve one end of a link against the nodes in the flow.
+///
+/// Returns the endpoint to store: `None` keeps what the caller sent, `Some`
+/// replaces it with a resolved form. A bare reference to an element stays bare,
+/// since GStreamer picks compatible pads when linking element to element. A
+/// bare reference to a block is rewritten to `block_id:pad_name`, because block
+/// expansion resolves external pads by name.
+fn resolve_link_endpoint(
+    pad_ref: &str,
+    side: LinkSide,
+    element_ids: &std::collections::HashSet<String>,
+    block_pads: &std::collections::HashMap<String, BlockPads>,
+) -> Result<Option<String>, EndpointProblem> {
+    // "element_id", "element_id::", "node_id:pad_name". The node id is the
+    // first segment; a block's internal element is not addressable from a flow
+    // link, so everything after the first colon is the pad name.
+    let (node_id, pad_name) = match pad_ref.strip_suffix("::") {
+        Some(node) => (node, None),
+        None => match pad_ref.split_once(':') {
+            Some((node, pad)) => (node, Some(pad)),
+            None => (pad_ref, None),
+        },
+    };
+
+    if node_id.is_empty() {
+        return Err(EndpointProblem::Rejected(format!(
+            "'{}' does not name an element or block",
+            pad_ref
+        )));
     }
 
-    // Unknown node type
-    false
+    if element_ids.contains(node_id) {
+        // Elements are checked for existence only; the pad itself is resolved
+        // when the pipeline is built, where request and dynamic pads are known.
+        return Ok(None);
+    }
+
+    let Some(pads) = block_pads.get(node_id) else {
+        return Err(EndpointProblem::Rejected(format!(
+            "'{}' does not name an element or block in this flow",
+            pad_ref
+        )));
+    };
+
+    let Some(pad_name) = pad_name else {
+        // Bare block reference - resolve it to the block's only pad on this side.
+        let candidates = pads.pads_on(side);
+        return match candidates {
+            [only] => Ok(Some(format!("{}:{}", node_id, only))),
+            [] => Err(EndpointProblem::Rejected(format!(
+                "block '{}' has no {} pad to link",
+                node_id,
+                side.pad_kind()
+            ))),
+            many => Err(EndpointProblem::Rejected(format!(
+                "block '{}' has {} {} pads ({}); name one, e.g. '{}:{}'",
+                node_id,
+                many.len(),
+                side.pad_kind(),
+                many.join(", "),
+                node_id,
+                many[0]
+            ))),
+        };
+    };
+
+    if !pads.computed {
+        // Static pad definition - trusted, validated at pipeline build time.
+        return Ok(None);
+    }
+
+    if pads
+        .inputs
+        .iter()
+        .chain(pads.outputs.iter())
+        .any(|name| name == pad_name)
+    {
+        return Ok(None);
+    }
+
+    Err(EndpointProblem::StaleBlockPad(format!(
+        "block '{}' no longer has a pad '{}'",
+        node_id, pad_name
+    )))
 }
 
 /// List all flows.
@@ -187,8 +295,13 @@ pub async fn get_flow(
 }
 
 /// Prepare a flow for storage: trim endpoint strings, compute pads,
-/// validate links, and apply auto-layout if needed.
-fn prepare_flow(flow: &mut Flow) {
+/// resolve links, and apply auto-layout if needed.
+///
+/// Returns `Err` with a caller-facing description of every link that could not
+/// be resolved. The flow is not fit to store in that case - a request that
+/// carries an unusable link is answered with 400 rather than persisted with the
+/// link missing.
+fn prepare_flow(flow: &mut Flow) -> Result<(), String> {
     // Trim endpoint string properties to avoid whitespace-related issues
     for block in &mut flow.blocks {
         let prop_name = match block.block_definition_id.as_str() {
@@ -223,61 +336,122 @@ fn prepare_flow(flow: &mut Flow) {
         }
     }
 
-    // Remove links that reference pads that no longer exist on blocks
-    let mut valid_block_pads = std::collections::HashSet::new();
-    let mut blocks_with_computed_pads = std::collections::HashSet::new();
-
+    // Resolve every link the caller sent. Links are only dropped when a block
+    // pad genuinely disappeared; anything else is reported back so the caller
+    // learns about it instead of getting a stored flow with links missing.
+    let mut block_pads: std::collections::HashMap<String, BlockPads> =
+        std::collections::HashMap::new();
     for block in &flow.blocks {
-        if let Some(ref external_pads) = block.computed_external_pads {
-            blocks_with_computed_pads.insert(block.id.clone());
-            for input in &external_pads.inputs {
-                valid_block_pads.insert(format!("{}:{}", block.id, input.name));
+        let pads = match &block.computed_external_pads {
+            Some(computed) => BlockPads {
+                inputs: computed.inputs.iter().map(|p| p.name.clone()).collect(),
+                outputs: computed.outputs.iter().map(|p| p.name.clone()).collect(),
+                computed: true,
+            },
+            None => BlockPads {
+                inputs: Vec::new(),
+                outputs: Vec::new(),
+                computed: false,
+            },
+        };
+        block_pads.insert(block.id.clone(), pads);
+    }
+
+    // Blocks without computed pads expose the pads of their static definition.
+    // Those are only needed to resolve a bare block reference, so build the
+    // definition list only when the flow actually contains one.
+    if block_pads.values().any(|pads| !pads.computed)
+        && flow
+            .links
+            .iter()
+            .any(|link| is_element_only_ref(&link.from) || is_element_only_ref(&link.to))
+    {
+        let definitions = crate::blocks::builtin::get_all_builtin_blocks();
+        for block in &flow.blocks {
+            let Some(pads) = block_pads.get_mut(&block.id) else {
+                continue;
+            };
+            if pads.computed {
+                continue;
             }
-            for output in &external_pads.outputs {
-                valid_block_pads.insert(format!("{}:{}", block.id, output.name));
+            if let Some(definition) = definitions
+                .iter()
+                .find(|d| d.id == block.block_definition_id)
+            {
+                pads.inputs = definition
+                    .external_pads
+                    .inputs
+                    .iter()
+                    .map(|p| p.name.clone())
+                    .collect();
+                pads.outputs = definition
+                    .external_pads
+                    .outputs
+                    .iter()
+                    .map(|p| p.name.clone())
+                    .collect();
             }
         }
     }
 
     let element_ids: std::collections::HashSet<String> =
         flow.elements.iter().map(|e| e.id.clone()).collect();
-    let block_ids: std::collections::HashSet<String> =
-        flow.blocks.iter().map(|b| b.id.clone()).collect();
 
-    let initial_link_count = flow.links.len();
-    flow.links.retain(|link| {
-        let from_valid = is_pad_valid(
-            &link.from,
-            &valid_block_pads,
-            &element_ids,
-            &block_ids,
-            &blocks_with_computed_pads,
-        );
-        let to_valid = is_pad_valid(
-            &link.to,
-            &valid_block_pads,
-            &element_ids,
-            &block_ids,
-            &blocks_with_computed_pads,
-        );
+    let mut kept: Vec<strom_types::Link> = Vec::with_capacity(flow.links.len());
+    let mut rejected: Vec<String> = Vec::new();
+    let mut pruned = 0usize;
 
-        if !from_valid || !to_valid {
-            info!(
-                "Removing invalid link: {} -> {} (pad no longer exists)",
-                link.from, link.to
-            );
-            false
-        } else {
-            true
+    for link in std::mem::take(&mut flow.links) {
+        let from = resolve_link_endpoint(&link.from, LinkSide::From, &element_ids, &block_pads);
+        let to = resolve_link_endpoint(&link.to, LinkSide::To, &element_ids, &block_pads);
+
+        match (from, to) {
+            (Ok(from_resolved), Ok(to_resolved)) => {
+                kept.push(strom_types::Link {
+                    from: from_resolved.unwrap_or(link.from),
+                    to: to_resolved.unwrap_or(link.to),
+                });
+            }
+            (from, to) => {
+                let problems: Vec<EndpointProblem> =
+                    [from.err(), to.err()].into_iter().flatten().collect();
+                let detail = problems
+                    .iter()
+                    .map(|problem| problem.message())
+                    .collect::<Vec<_>>()
+                    .join("; ");
+
+                if problems
+                    .iter()
+                    .any(|problem| matches!(problem, EndpointProblem::Rejected(_)))
+                {
+                    warn!(
+                        "Rejecting flow '{}': invalid link {} -> {} ({})",
+                        flow.name, link.from, link.to, detail
+                    );
+                    rejected.push(format!("'{}' -> '{}': {}", link.from, link.to, detail));
+                } else {
+                    warn!(
+                        "Pruning stale link {} -> {} from flow '{}': {}",
+                        link.from, link.to, flow.name, detail
+                    );
+                    pruned += 1;
+                }
+            }
         }
-    });
+    }
 
-    if flow.links.len() < initial_link_count {
+    flow.links = kept;
+
+    if pruned > 0 {
         info!(
-            "Removed {} invalid link(s) from flow '{}'",
-            initial_link_count - flow.links.len(),
-            flow.name
+            "Pruned {} stale link(s) from flow '{}' (block pads changed)",
+            pruned, flow.name
         );
+    }
+
+    if !rejected.is_empty() {
+        return Err(rejected.join(" | "));
     }
 
     // Apply auto-layout if needed
@@ -288,6 +462,8 @@ fn prepare_flow(flow: &mut Flow) {
         );
         layout::apply_auto_layout(flow);
     }
+
+    Ok(())
 }
 
 /// Create a new flow.
@@ -304,6 +480,7 @@ fn prepare_flow(flow: &mut Flow) {
     request_body = Flow,
     responses(
         (status = 201, description = "Flow created", body = FlowResponse),
+        (status = 400, description = "Invalid flow name, or a link that names an unknown element, block or pad", body = ErrorResponse),
         (status = 409, description = "A flow with the supplied id already exists", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse)
     )
@@ -345,7 +522,15 @@ pub async fn create_flow(
     flow.properties.created_at = Some(now.clone());
     flow.properties.last_modified = Some(now);
 
-    prepare_flow(&mut flow);
+    if let Err(details) = prepare_flow(&mut flow) {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse::with_details(
+                "Flow contains link(s) that cannot be resolved",
+                details,
+            )),
+        ));
+    }
 
     info!("Creating flow: {} ({})", flow.name, flow.id);
 
@@ -416,7 +601,15 @@ pub async fn update_flow(
     info!("Updating flow: {} ({})", flow.name, flow.id);
     debug!("Update flow request body: {:?}", flow);
 
-    prepare_flow(&mut flow);
+    if let Err(details) = prepare_flow(&mut flow) {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse::with_details(
+                "Flow contains link(s) that cannot be resolved",
+                details,
+            )),
+        ));
+    }
 
     // Update last_modified timestamp (preserve created_at from old flow)
     flow.properties.last_modified = Some(Local::now().to_rfc3339());
@@ -2397,235 +2590,225 @@ pub async fn get_block_thumbnail(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashSet;
+    use std::collections::{HashMap, HashSet};
 
     // ========================================================================
-    // is_pad_valid() tests - prevent regression of gst-launch import bug
+    // resolve_link_endpoint() tests - these cover the gst-launch import bug
+    // (element ids that do not start with 'e') and the bare-reference form
+    // documented on `Link`.
     // ========================================================================
 
-    /// Helper to create element_ids set from a slice
+    /// Helper to create the element id set from a slice
     fn element_ids(ids: &[&str]) -> HashSet<String> {
         ids.iter().map(|s| s.to_string()).collect()
     }
 
-    /// Helper to create valid_block_pads set from a slice
-    fn block_pads(pads: &[&str]) -> HashSet<String> {
-        pads.iter().map(|s| s.to_string()).collect()
+    /// Helper to build a block whose pads were computed from its properties
+    fn computed_block(inputs: &[&str], outputs: &[&str]) -> BlockPads {
+        BlockPads {
+            inputs: inputs.iter().map(|s| s.to_string()).collect(),
+            outputs: outputs.iter().map(|s| s.to_string()).collect(),
+            computed: true,
+        }
     }
 
-    /// Helper to create blocks_with_computed_pads set from a slice
-    fn computed_blocks(ids: &[&str]) -> HashSet<String> {
-        ids.iter().map(|s| s.to_string()).collect()
+    /// Helper to build a block that falls back to its static pad definition
+    fn static_block(inputs: &[&str], outputs: &[&str]) -> BlockPads {
+        BlockPads {
+            inputs: inputs.iter().map(|s| s.to_string()).collect(),
+            outputs: outputs.iter().map(|s| s.to_string()).collect(),
+            computed: false,
+        }
     }
 
-    /// Helper to create block_ids set from a slice
-    fn block_ids_set(ids: &[&str]) -> HashSet<String> {
-        ids.iter().map(|s| s.to_string()).collect()
+    fn blocks(entries: Vec<(&str, BlockPads)>) -> HashMap<String, BlockPads> {
+        entries
+            .into_iter()
+            .map(|(id, pads)| (id.to_string(), pads))
+            .collect()
+    }
+
+    /// `Ok(None)` means "store what the caller sent".
+    fn assert_kept_as_sent(pad_ref: &str, side: LinkSide, elements: &HashSet<String>) {
+        let resolved = resolve_link_endpoint(pad_ref, side, elements, &HashMap::new());
+        match resolved {
+            Ok(None) => {}
+            Ok(Some(other)) => panic!("'{}' should be stored unchanged, got '{}'", pad_ref, other),
+            Err(problem) => panic!("'{}' should be accepted: {}", pad_ref, problem.message()),
+        }
     }
 
     #[test]
-    fn test_is_pad_valid_ui_created_element() {
+    fn ui_created_element_pads_are_accepted() {
         // UI-created elements have IDs starting with 'e' like "e1234abcd..."
         let elements = element_ids(&["e1234567890abcdef"]);
-        let blocks = block_pads(&[]);
-        let block_ids = block_ids_set(&[]);
-        let computed = computed_blocks(&[]);
 
-        assert!(
-            is_pad_valid(
-                "e1234567890abcdef:src",
-                &blocks,
-                &elements,
-                &block_ids,
-                &computed
-            ),
-            "UI-created element pads should be valid"
-        );
-        assert!(
-            is_pad_valid(
-                "e1234567890abcdef:sink",
-                &blocks,
-                &elements,
-                &block_ids,
-                &computed
-            ),
-            "UI-created element sink pads should be valid"
-        );
+        assert_kept_as_sent("e1234567890abcdef:src", LinkSide::From, &elements);
+        assert_kept_as_sent("e1234567890abcdef:sink", LinkSide::To, &elements);
     }
 
     #[test]
-    fn test_is_pad_valid_gst_launch_imported_element() {
+    fn gst_launch_imported_element_pads_are_accepted() {
         // gst-launch imported elements have IDs like "videotestsrc_0", "videoconvert_1"
-        // This was the bug - these were incorrectly rejected because they don't start with 'e'
+        // This was a bug once - these were rejected because they don't start with 'e'
         let elements = element_ids(&["videotestsrc_0", "videoconvert_1", "fakesink_2"]);
-        let blocks = block_pads(&[]);
-        let block_ids = block_ids_set(&[]);
-        let computed = computed_blocks(&[]);
 
-        assert!(
-            is_pad_valid(
-                "videotestsrc_0:src",
-                &blocks,
-                &elements,
-                &block_ids,
-                &computed
-            ),
-            "gst-launch imported element pads should be valid"
-        );
-        assert!(
-            is_pad_valid(
-                "videoconvert_1:sink",
-                &blocks,
-                &elements,
-                &block_ids,
-                &computed
-            ),
-            "gst-launch imported element sink pads should be valid"
-        );
-        assert!(
-            is_pad_valid("fakesink_2:sink", &blocks, &elements, &block_ids, &computed),
-            "gst-launch imported sink element pads should be valid"
-        );
+        assert_kept_as_sent("videotestsrc_0:src", LinkSide::From, &elements);
+        assert_kept_as_sent("videoconvert_1:sink", LinkSide::To, &elements);
+        assert_kept_as_sent("fakesink_2:sink", LinkSide::To, &elements);
     }
 
     #[test]
-    fn test_is_pad_valid_user_named_element() {
+    fn user_named_element_pads_are_accepted() {
         // Users can name elements anything, e.g., "mysource", "output"
         let elements = element_ids(&["mysource", "myfilter", "output"]);
-        let blocks = block_pads(&[]);
-        let block_ids = block_ids_set(&[]);
-        let computed = computed_blocks(&[]);
 
-        assert!(
-            is_pad_valid("mysource:src", &blocks, &elements, &block_ids, &computed),
-            "User-named element pads should be valid"
-        );
-        assert!(
-            is_pad_valid("output:sink", &blocks, &elements, &block_ids, &computed),
-            "User-named sink pads should be valid"
-        );
+        assert_kept_as_sent("mysource:src", LinkSide::From, &elements);
+        assert_kept_as_sent("output:sink", LinkSide::To, &elements);
     }
 
     #[test]
-    fn test_is_pad_valid_block_with_computed_pads() {
-        // Blocks have IDs starting with 'b' and computed external pads
+    fn bare_element_reference_is_accepted_and_left_alone() {
+        // The documented element-level form: GStreamer picks compatible pads
+        // when the pipeline is built, so there is nothing to resolve here.
+        let elements = element_ids(&["src0", "caps0"]);
+
+        assert_kept_as_sent("src0", LinkSide::From, &elements);
+        assert_kept_as_sent("caps0", LinkSide::To, &elements);
+        // The "::" spelling that ElementPadRef::to_string_format() produces.
+        assert_kept_as_sent("src0::", LinkSide::From, &elements);
+    }
+
+    #[test]
+    fn bare_block_reference_resolves_to_its_only_pad_on_that_side() {
         let elements = element_ids(&[]);
-        let blocks = block_pads(&[
-            "b1234:audio_in",
-            "b1234:audio_out",
-            "b5678:video_in",
-            "b5678:video_out",
-        ]);
-        let block_ids = block_ids_set(&["b1234", "b5678"]);
-        let computed = computed_blocks(&["b1234", "b5678"]);
+        let block_pads = blocks(vec![("b1234", computed_block(&["sink"], &["src"]))]);
 
-        assert!(
-            is_pad_valid("b1234:audio_in", &blocks, &elements, &block_ids, &computed),
-            "Block with computed pads - valid pad should work"
+        assert_eq!(
+            resolve_link_endpoint("b1234", LinkSide::From, &elements, &block_pads)
+                .expect("a block with one output resolves"),
+            Some("b1234:src".to_string()),
+            "a bare block on the source side resolves to its only output pad"
         );
-        assert!(
-            is_pad_valid("b5678:video_out", &blocks, &elements, &block_ids, &computed),
-            "Block with computed pads - valid output should work"
-        );
-        assert!(
-            !is_pad_valid(
-                "b1234:nonexistent",
-                &blocks,
-                &elements,
-                &block_ids,
-                &computed
-            ),
-            "Block with computed pads - invalid pad should fail"
+        assert_eq!(
+            resolve_link_endpoint("b1234", LinkSide::To, &elements, &block_pads)
+                .expect("a block with one input resolves"),
+            Some("b1234:sink".to_string()),
+            "a bare block on the destination side resolves to its only input pad"
         );
     }
 
     #[test]
-    fn test_is_pad_valid_block_without_computed_pads() {
-        // Blocks without computed pads use static definitions - assume valid
+    fn bare_block_reference_with_several_pads_is_rejected_by_name() {
         let elements = element_ids(&[]);
-        let blocks = block_pads(&[]);
-        let block_ids = block_ids_set(&["b9999"]); // b9999 exists but not in computed set
-        let computed = computed_blocks(&[]);
+        let block_pads = blocks(vec![(
+            "b1234",
+            computed_block(&["audio_0", "audio_1"], &["video"]),
+        )]);
 
+        let problem = resolve_link_endpoint("b1234", LinkSide::To, &elements, &block_pads)
+            .expect_err("an ambiguous bare reference must be rejected");
+        assert!(matches!(problem, EndpointProblem::Rejected(_)));
         assert!(
-            is_pad_valid("b9999:any_pad", &blocks, &elements, &block_ids, &computed),
-            "Block without computed pads should be assumed valid"
+            problem.message().contains("audio_0") && problem.message().contains("audio_1"),
+            "the error must name the candidate pads: {}",
+            problem.message()
         );
     }
 
     #[test]
-    fn test_is_pad_valid_nonexistent_element() {
+    fn bare_block_reference_uses_static_pads_when_none_were_computed() {
+        let elements = element_ids(&[]);
+        let block_pads = blocks(vec![("b9999", static_block(&["sink"], &["src"]))]);
+
+        assert_eq!(
+            resolve_link_endpoint("b9999", LinkSide::From, &elements, &block_pads).unwrap(),
+            Some("b9999:src".to_string())
+        );
+    }
+
+    #[test]
+    fn block_pad_that_was_computed_away_is_stale_not_a_caller_error() {
+        let elements = element_ids(&[]);
+        let block_pads = blocks(vec![(
+            "b1234",
+            computed_block(&["audio_in"], &["audio_out"]),
+        )]);
+
+        assert_kept_as_sent_with_blocks("b1234:audio_in", LinkSide::To, &elements, &block_pads);
+        assert_kept_as_sent_with_blocks("b1234:audio_out", LinkSide::From, &elements, &block_pads);
+
+        let problem =
+            resolve_link_endpoint("b1234:nonexistent", LinkSide::To, &elements, &block_pads)
+                .expect_err("a pad the block no longer has must be flagged");
+        assert!(
+            matches!(problem, EndpointProblem::StaleBlockPad(_)),
+            "a vanished block pad is drift, so the link is pruned rather than the request rejected"
+        );
+    }
+
+    #[test]
+    fn named_pad_on_a_block_without_computed_pads_is_trusted() {
+        let elements = element_ids(&[]);
+        let block_pads = blocks(vec![("b9999", static_block(&[], &[]))]);
+
+        assert_kept_as_sent_with_blocks("b9999:any_pad", LinkSide::To, &elements, &block_pads);
+    }
+
+    #[test]
+    fn unknown_node_is_a_caller_error() {
         let elements = element_ids(&["elem1"]);
-        let blocks = block_pads(&[]);
-        let block_ids = block_ids_set(&[]);
-        let computed = computed_blocks(&[]);
+        let block_pads = blocks(vec![("b456", computed_block(&["sink"], &["src"]))]);
 
-        assert!(
-            !is_pad_valid("nonexistent:src", &blocks, &elements, &block_ids, &computed),
-            "Non-existent element should be invalid"
-        );
+        for pad_ref in ["nonexistent:src", "nonexistent", ""] {
+            let problem = resolve_link_endpoint(pad_ref, LinkSide::From, &elements, &block_pads)
+                .expect_err("an unknown node must be rejected");
+            assert!(
+                matches!(problem, EndpointProblem::Rejected(_)),
+                "'{}' names nothing in the flow, so the request must fail",
+                pad_ref
+            );
+        }
     }
 
     #[test]
-    fn test_is_pad_valid_malformed_pad_ref() {
-        let elements = element_ids(&["elem1"]);
-        let blocks = block_pads(&[]);
-        let block_ids = block_ids_set(&[]);
-        let computed = computed_blocks(&[]);
-
-        assert!(
-            !is_pad_valid("no_colon", &blocks, &elements, &block_ids, &computed),
-            "Pad ref without colon should be invalid"
-        );
-        assert!(
-            !is_pad_valid("", &blocks, &elements, &block_ids, &computed),
-            "Empty pad ref should be invalid"
-        );
-    }
-
-    #[test]
-    fn test_is_pad_valid_mixed_elements_and_blocks() {
+    fn mixed_elements_and_blocks() {
         // Realistic scenario with both UI elements and blocks
         let elements = element_ids(&["e123", "videotestsrc_0"]);
-        let blocks = block_pads(&["b456:audio_in", "b456:audio_out"]);
-        let block_ids = block_ids_set(&["b456"]);
-        let computed = computed_blocks(&["b456"]);
+        let block_pads = blocks(vec![(
+            "b456",
+            computed_block(&["audio_in"], &["audio_out"]),
+        )]);
 
-        // Elements
-        assert!(is_pad_valid(
-            "e123:src", &blocks, &elements, &block_ids, &computed
-        ));
-        assert!(is_pad_valid(
+        assert_kept_as_sent_with_blocks("e123:src", LinkSide::From, &elements, &block_pads);
+        assert_kept_as_sent_with_blocks(
             "videotestsrc_0:src",
-            &blocks,
+            LinkSide::From,
             &elements,
-            &block_ids,
-            &computed
-        ));
+            &block_pads,
+        );
+        assert_kept_as_sent_with_blocks("b456:audio_in", LinkSide::To, &elements, &block_pads);
 
-        // Blocks
-        assert!(is_pad_valid(
-            "b456:audio_in",
-            &blocks,
-            &elements,
-            &block_ids,
-            &computed
+        assert!(matches!(
+            resolve_link_endpoint("b456:nonexistent", LinkSide::To, &elements, &block_pads),
+            Err(EndpointProblem::StaleBlockPad(_))
         ));
-        assert!(!is_pad_valid(
-            "b456:nonexistent",
-            &blocks,
-            &elements,
-            &block_ids,
-            &computed
+        assert!(matches!(
+            resolve_link_endpoint("unknown:src", LinkSide::From, &elements, &block_pads),
+            Err(EndpointProblem::Rejected(_))
         ));
+    }
 
-        // Invalid
-        assert!(!is_pad_valid(
-            "unknown:src",
-            &blocks,
-            &elements,
-            &block_ids,
-            &computed
-        ));
+    fn assert_kept_as_sent_with_blocks(
+        pad_ref: &str,
+        side: LinkSide,
+        elements: &HashSet<String>,
+        block_pads: &HashMap<String, BlockPads>,
+    ) {
+        match resolve_link_endpoint(pad_ref, side, elements, block_pads) {
+            Ok(None) => {}
+            Ok(Some(other)) => panic!("'{}' should be stored unchanged, got '{}'", pad_ref, other),
+            Err(problem) => panic!("'{}' should be accepted: {}", pad_ref, problem.message()),
+        }
     }
 }

--- a/backend/src/gst/pipeline/linking.rs
+++ b/backend/src/gst/pipeline/linking.rs
@@ -276,6 +276,16 @@ impl PipelineManager {
             })?;
 
             debug!("Successfully linked: {} -> {}", link.from, link.to);
+        } else if let Some(sink_pad_name) = to_pad {
+            // Source is element-level, destination names a pad: let GStreamer
+            // pick a compatible source pad but honour the sink pad the caller
+            // asked for. link() would ignore it and pick both ends itself.
+            src.link_pads(None::<&str>, sink, Some(sink_pad_name))
+                .map_err(|e| {
+                    PipelineError::LinkError(link.from.clone(), format!("{} - {}", link.to, e))
+                })?;
+
+            debug!("Successfully linked: {} -> {}", link.from, link.to);
         } else {
             // Simple link without pad names - check if sink is an aggregator
             let element_type_name = sink

--- a/backend/tests/bare_link_pads_test.rs
+++ b/backend/tests/bare_link_pads_test.rs
@@ -1,0 +1,307 @@
+//! Regression tests for links being silently discarded by `POST /api/flows`.
+//!
+//! `is_pad_valid` used to reject any pad reference without a colon, and
+//! `prepare_flow` then dropped those links with `flow.links.retain(...)`. A
+//! caller that posted the documented bare form (`{"from": "src0", "to":
+//! "caps0"}`) got 201 Created and a stored flow with `"links": []`, and only
+//! found out when starting the flow failed with a GStreamer "not-linked" error.
+//!
+//! These tests call `create_flow` and `update_flow` directly, so reverting the
+//! fix in `backend/src/api/flows.rs` turns them red.
+
+use axum::extract::State;
+use axum::http::StatusCode;
+use std::collections::HashMap;
+use strom::api::flows::{create_flow, update_flow};
+use strom::json_rejection::JsonBody;
+use strom::state::AppState;
+use strom::storage::JsonFileStorage;
+use strom_types::block::{BlockInstance, Position};
+use strom_types::{Element, Flow, Link, PropertyValue};
+use tempfile::NamedTempFile;
+
+fn new_state() -> AppState {
+    let storage_file = NamedTempFile::new().unwrap();
+    let blocks_file = NamedTempFile::new().unwrap();
+    let storage = JsonFileStorage::new(storage_file.path());
+    AppState::new(
+        storage,
+        blocks_file.path(),
+        std::env::temp_dir(),
+        vec![],
+        "all".to_string(),
+        vec![],
+    )
+}
+
+fn element(id: &str, element_type: &str, x: f32) -> Element {
+    Element {
+        id: id.to_string(),
+        element_type: element_type.to_string(),
+        properties: HashMap::new(),
+        pad_properties: HashMap::new(),
+        position: (x, 0.0),
+    }
+}
+
+fn compositor(id: &str, num_inputs: u64, x: f32) -> BlockInstance {
+    let mut properties = HashMap::new();
+    properties.insert("num_inputs".to_string(), PropertyValue::UInt(num_inputs));
+    BlockInstance {
+        id: id.to_string(),
+        block_definition_id: "builtin.compositor".to_string(),
+        name: None,
+        properties,
+        position: Position { x, y: 0.0 },
+        runtime_data: None,
+        computed_external_pads: None,
+    }
+}
+
+/// A flow of two elements wired with the bare form documented on `Link`.
+fn bare_link_flow(name: &str) -> Flow {
+    let mut flow = Flow::new(name);
+    flow.elements.push(element("src0", "videotestsrc", 0.0));
+    flow.elements.push(element("caps0", "capsfilter", 200.0));
+    flow.links.push(Link {
+        from: "src0".to_string(),
+        to: "caps0".to_string(),
+    });
+    flow
+}
+
+/// The bug: a bare element id is a documented link form, and it must survive
+/// being stored. This is the assertion that fails if the fix is reverted.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn create_flow_keeps_links_written_with_bare_element_ids() {
+    gstreamer::init().unwrap();
+    let state = new_state();
+
+    let flow = bare_link_flow("bare-links");
+    let id = flow.id;
+
+    let (status, body) = create_flow(State(state.clone()), JsonBody(flow))
+        .await
+        .expect("a flow with bare links must be accepted");
+
+    assert_eq!(status, StatusCode::CREATED);
+    assert_eq!(
+        body.0.flow.links.len(),
+        1,
+        "the response must carry the link the caller sent"
+    );
+
+    let stored = state.get_flow(&id).await.expect("flow must be stored");
+    assert_eq!(
+        stored.links.len(),
+        1,
+        "the stored flow must carry the link the caller sent"
+    );
+    assert_eq!(stored.links[0].from, "src0");
+    assert_eq!(stored.links[0].to, "caps0");
+}
+
+/// The same form must survive an update, which runs the same preparation step.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn update_flow_keeps_links_written_with_bare_element_ids() {
+    gstreamer::init().unwrap();
+    let state = new_state();
+
+    let mut flow = bare_link_flow("bare-links-update");
+    let id = flow.id;
+    flow.links.clear();
+
+    let _created = create_flow(State(state.clone()), JsonBody(flow.clone()))
+        .await
+        .expect("create should succeed");
+
+    flow.links.push(Link {
+        from: "src0".to_string(),
+        to: "caps0".to_string(),
+    });
+    let body = update_flow(
+        State(state.clone()),
+        axum::extract::Path(id),
+        JsonBody(flow),
+    )
+    .await
+    .expect("an update with bare links must be accepted");
+
+    assert_eq!(body.0.flow.links.len(), 1);
+    let stored = state.get_flow(&id).await.expect("flow must be stored");
+    assert_eq!(
+        stored.links.len(),
+        1,
+        "the update must not discard the link the caller sent"
+    );
+}
+
+/// A link the server cannot use must fail the request, naming the link. The
+/// old behaviour was 201 Created with the link quietly removed.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn create_flow_rejects_a_link_to_an_unknown_node() {
+    gstreamer::init().unwrap();
+    let state = new_state();
+
+    let mut flow = bare_link_flow("unknown-node");
+    let id = flow.id;
+    flow.links.push(Link {
+        from: "caps0:src".to_string(),
+        to: "ghost:sink".to_string(),
+    });
+
+    let (status, body) = create_flow(State(state.clone()), JsonBody(flow))
+        .await
+        .expect_err("a link naming an unknown element must be rejected");
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    let rendered = format!("{:?}", body.0);
+    assert!(
+        rendered.contains("ghost:sink"),
+        "the error must name the offending link, got: {}",
+        rendered
+    );
+    assert!(
+        state.get_flow(&id).await.is_none(),
+        "a rejected flow must not be stored"
+    );
+}
+
+/// Update has the same contract: no silent trimming.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn update_flow_rejects_a_link_to_an_unknown_node() {
+    gstreamer::init().unwrap();
+    let state = new_state();
+
+    let mut flow = bare_link_flow("unknown-node-update");
+    let id = flow.id;
+    let _created = create_flow(State(state.clone()), JsonBody(flow.clone()))
+        .await
+        .expect("create should succeed");
+
+    flow.links.push(Link {
+        from: "caps0:src".to_string(),
+        to: "ghost:sink".to_string(),
+    });
+    let (status, _body) = update_flow(
+        State(state.clone()),
+        axum::extract::Path(id),
+        JsonBody(flow),
+    )
+    .await
+    .expect_err("a link naming an unknown element must be rejected");
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    let stored = state.get_flow(&id).await.expect("flow must still exist");
+    assert_eq!(
+        stored.links.len(),
+        1,
+        "the rejected update must not have replaced the stored flow"
+    );
+}
+
+/// A bare reference to a block resolves to that block's only pad on that side,
+/// so it is stored in the explicit form the pipeline builder resolves.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn create_flow_resolves_a_bare_block_reference_to_its_only_pad() {
+    gstreamer::init().unwrap();
+    let state = new_state();
+
+    let mut flow = Flow::new("bare-block");
+    let id = flow.id;
+    flow.elements.push(element("src0", "videotestsrc", 0.0));
+    flow.elements.push(element("sink0", "fakesink", 400.0));
+    // One input, one output: both sides are unambiguous.
+    flow.blocks.push(compositor("b0", 1, 200.0));
+    flow.links.push(Link {
+        from: "src0:src".to_string(),
+        to: "b0".to_string(),
+    });
+    flow.links.push(Link {
+        from: "b0".to_string(),
+        to: "sink0:sink".to_string(),
+    });
+
+    let _created = create_flow(State(state.clone()), JsonBody(flow))
+        .await
+        .expect("bare block references must be accepted");
+
+    let stored = state.get_flow(&id).await.expect("flow must be stored");
+    assert_eq!(stored.links.len(), 2, "both links must be stored");
+    assert_eq!(
+        stored.links[0].to, "b0:video_in_0",
+        "a bare block on the destination side resolves to its only input pad"
+    );
+    assert_eq!(
+        stored.links[1].from, "b0:video_out",
+        "a bare block on the source side resolves to its only output pad"
+    );
+}
+
+/// An ambiguous bare block reference is a caller error, not something to guess
+/// at or drop.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn create_flow_rejects_an_ambiguous_bare_block_reference() {
+    gstreamer::init().unwrap();
+    let state = new_state();
+
+    let mut flow = Flow::new("ambiguous-block");
+    let id = flow.id;
+    flow.elements.push(element("src0", "videotestsrc", 0.0));
+    flow.blocks.push(compositor("b0", 2, 200.0));
+    flow.links.push(Link {
+        from: "src0:src".to_string(),
+        to: "b0".to_string(),
+    });
+
+    let (status, body) = create_flow(State(state.clone()), JsonBody(flow))
+        .await
+        .expect_err("a bare reference to a multi-input block must be rejected");
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    let rendered = format!("{:?}", body.0);
+    assert!(
+        rendered.contains("video_in_0") && rendered.contains("video_in_1"),
+        "the error must name the pads to choose from, got: {}",
+        rendered
+    );
+    assert!(state.get_flow(&id).await.is_none());
+}
+
+/// Pruning still has a job: a block's pads follow its properties, so a link to
+/// a pad the block no longer produces is drift rather than a caller mistake.
+/// That link is dropped and the request succeeds - the case the old blanket
+/// prune existed for.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn create_flow_prunes_a_link_to_a_pad_the_block_no_longer_has() {
+    gstreamer::init().unwrap();
+    let state = new_state();
+
+    let mut flow = Flow::new("stale-block-pad");
+    let id = flow.id;
+    flow.elements.push(element("src0", "videotestsrc", 0.0));
+    flow.elements.push(element("src1", "videotestsrc", 0.0));
+    // Two inputs, so video_in_2 belongs to an older, wider compositor.
+    flow.blocks.push(compositor("b0", 2, 200.0));
+    flow.links.push(Link {
+        from: "src0:src".to_string(),
+        to: "b0:video_in_0".to_string(),
+    });
+    flow.links.push(Link {
+        from: "src1:src".to_string(),
+        to: "b0:video_in_2".to_string(),
+    });
+
+    let (status, _body) = create_flow(State(state.clone()), JsonBody(flow))
+        .await
+        .expect("a stale block pad must not fail the request");
+
+    assert_eq!(status, StatusCode::CREATED);
+    let stored = state.get_flow(&id).await.expect("flow must be stored");
+    assert_eq!(
+        stored.links.len(),
+        1,
+        "only the link to the vanished pad is dropped"
+    );
+    assert_eq!(stored.links[0].to, "b0:video_in_0");
+}

--- a/openapi.json
+++ b/openapi.json
@@ -740,6 +740,16 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid flow name, or a link that names an unknown element, block or pad",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
           "409": {
             "description": "A flow with the supplied id already exists",
             "content": {
@@ -6714,11 +6724,11 @@
         "properties": {
           "from": {
             "type": "string",
-            "description": "Source element and pad (format: \"element_id\" or \"element_id:pad_name\")"
+            "description": "Source element and pad.\n\nAccepted forms:\n- `\"element_id:pad_name\"` - a named pad\n- `\"element_id\"` (or `\"element_id::\"`) - element-level link, GStreamer\n  picks compatible pads\n- `\"block_id:external_pad_name\"` - a block's external pad\n- `\"block_id\"` - resolved when the flow is stored to the block's only\n  output pad; a block with several output pads is rejected with 400"
           },
           "to": {
             "type": "string",
-            "description": "Destination element and pad (format: \"element_id\" or \"element_id:pad_name\")"
+            "description": "Destination element and pad. Same forms as `from`; a bare `\"block_id\"`\nresolves to the block's only input pad."
           }
         }
       },

--- a/types/src/element.rs
+++ b/types/src/element.rs
@@ -34,9 +34,18 @@ pub struct Element {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct Link {
-    /// Source element and pad (format: "element_id" or "element_id:pad_name")
+    /// Source element and pad.
+    ///
+    /// Accepted forms:
+    /// - `"element_id:pad_name"` - a named pad
+    /// - `"element_id"` (or `"element_id::"`) - element-level link, GStreamer
+    ///   picks compatible pads
+    /// - `"block_id:external_pad_name"` - a block's external pad
+    /// - `"block_id"` - resolved when the flow is stored to the block's only
+    ///   output pad; a block with several output pads is rejected with 400
     pub from: String,
-    /// Destination element and pad (format: "element_id" or "element_id:pad_name")
+    /// Destination element and pad. Same forms as `from`; a bare `"block_id"`
+    /// resolves to the block's only input pad.
     pub to: String,
 }
 


### PR DESCRIPTION
## Problem

`POST /api/flows` answered 201 Created and stored the flow with `"links": []` when the links
used the bare element form that the `Link` doc comment documents as valid:

```json
{"from": "src0", "to": "caps0"}
```

`is_pad_valid` split the pad reference on `:` and returned `false` for anything with fewer than
two parts; `prepare_flow` then dropped those links with `flow.links.retain(...)`. The caller
learned nothing until `POST /api/flows/{id}/start` failed with a GStreamer "not-linked" error.
`POST /api/flows/{id}` (update) discarded them the same way.

## Decision: support the bare form (option a)

The code was wrong, not the doc:

- `ElementPadRef::from_string` already parses a bare id into `pad_name: None`, and
  `to_string_format` already round-trips it as `"id::"`.
- `try_link_elements_refs` already implements element-level linking (`src.link(sink)`), and the
  `"id::"` spelling already passed validation. Only the bare spelling was rejected.
- Element-level linking is what `gst-launch` does (`videotestsrc ! x264enc`): GStreamer picks
  compatible pads, request pads included.

A bare reference to an **element** is now accepted and stored exactly as sent. A bare reference
to a **block** cannot be left alone — block expansion resolves external pads by name — so it is
resolved to the block's only output pad (`from`) or only input pad (`to`) and stored in the
explicit `block_id:pad_name` form. A block with several pads on that side is ambiguous and is
rejected with 400 naming the candidates.

## No more silent drops

`prepare_flow` now returns `Err` with a caller-facing description of every link it cannot use,
and both `create_flow` and `update_flow` answer **400** with that detail instead of storing a
trimmed flow. The offending link is named in the message, e.g.

```
Flow contains link(s) that cannot be resolved
'caps0:src' -> 'ghost:sink': 'ghost:sink' does not name an element or block in this flow
```

## Pruning is kept, but only where it is legitimate

A block's external pads follow its own properties: lower a compositor's `num_inputs` and
`b0:video_in_2` stops existing. The frontend does not prune those links itself, and an exported
flow from before such a change can be imported later, so this drift is not a caller mistake.
That one case — the node exists, is a block, has computed pads, and does not have the named pad
— is still pruned (logged as `Pruning stale link ...`) and the request succeeds. Everything else
(unknown node, unresolvable bare reference) is a 400. The two paths are distinct enum variants,
`EndpointProblem::StaleBlockPad` vs `Rejected`, so they cannot be conflated again.

## Other paths checked

- `update_flow`: runs the same `prepare_flow`, so it gets the same fix (covered by tests).
- gst-launch import (`POST /api/gst-launch/parse`): always emits `id:pad` for both ends, so it
  never produced bare links itself. It hands elements and links to the frontend, which creates
  the flow through `create_flow` — covered by the fix.
- Flow load from storage and `start_flow` recompute external pads but never prune links, so
  nothing was being discarded there.
- Not fixed here: the frontend's `parse_pad_ref` returns `None` for a bare reference, so such a
  link is not *drawn* in the graph editor. It is preserved across load/save (links are stored
  verbatim), so this is a rendering gap, not data loss.

## Also fixed

`try_link_elements_refs` ignored the destination pad when the source was element-level:
`{"from": "src0", "to": "mux0:sink_0"}` fell into the `src.link(sink)` branch and let GStreamer
pick both ends. Now that the bare source form is reachable through the API, that combination
links with `link_pads(None, sink, Some(pad))`.

## Tests

Ran locally on this machine, against this branch as rebased onto `main` (`1c06c37`):

- `cargo test --test bare_link_pads_test` - **new file, 7 tests, all pass.** They call
  `create_flow` / `update_flow` directly rather than reimplementing validation inline.
- **Revert check:** temporarily restoring the old "a reference without a colon is invalid, drop
  the link" behaviour in `resolve_link_endpoint` turns **5 of the 7 red**
  (`create_flow_keeps_links_written_with_bare_element_ids`,
  `update_flow_keeps_links_written_with_bare_element_ids`,
  `create_flow_resolves_a_bare_block_reference_to_its_only_pad`,
  `create_flow_rejects_an_ambiguous_bare_block_reference`,
  `update_flow_rejects_a_link_to_an_unknown_node`). The temporary patch was reverted afterwards
  and is not part of this branch.
- `cargo test --lib api::flows` - 11 tests pass. The old `is_pad_valid` unit tests were rewritten
  against `resolve_link_endpoint`, keeping the gst-launch-imported-id cases they were written for
  and adding the bare-form, ambiguity and staleness cases.
- `cargo test --test openapi_test` - failed first, diff reviewed, `openapi.json` updated
  intentionally (`create_flow` now documents its 400; the `Link` field descriptions changed),
  then re-run and passing.
- `cargo fmt --all` and the repo's pre-commit clippy run pass.

All three suites were re-run after the rebase, so the numbers above are from the exact tree
proposed here.

Not run: the rest of the backend test suite and the pipeline/GStreamer integration tests. This
change does not touch pipeline construction apart from the `link_pads` branch above, and the
machine was under disk pressure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
