### PR TITLE
feat(liveaudiorouter): add a live matrix audio router

### DIFF
--- a/backend/src/blocks/builtin/liveaudiorouter.rs
+++ b/backend/src/blocks/builtin/liveaudiorouter.rs
@@ -1,0 +1,395 @@
+//! Live audio channel router built on GStreamer's `audiomixmatrix`.
+//!
+//! Sibling of `builtin.audiorouter`, which wires a static
+//! `deinterleave`/`tee`/`interleave` graph from a matrix snapshot taken at
+//! `build()` time and therefore needs a flow restart to reroute a channel. This
+//! block keeps a single `audiomixmatrix` whose `matrix` property is rewritten in
+//! place, so `routing_matrix` is exposed as a live property.
+//!
+//! Chain: audioconvert → audiomixmatrix → audioconvert
+//!
+//! The surrounding `audioconvert` elements absorb the channel-count and format
+//! negotiation on both sides: `audiomixmatrix` accepts exactly `in-channels`
+//! channels on its sink and emits exactly `out-channels` on its src, which
+//! upstream and downstream have no reason to already match.
+//!
+//! `routing_matrix` uses the same JSON shape as `builtin.audiorouter`
+//! (`{"i0c0": ["o0c1"]}`). `audiomixmatrix` is a single-stream element, so the
+//! stream index in those keys is always 0 and only the channel index varies.
+
+use crate::blocks::{BlockBuildContext, BlockBuildError, BlockBuildResult, BlockBuilder};
+use gstreamer as gst;
+use gstreamer::prelude::*;
+use std::collections::HashMap;
+use strom_types::{block::*, element::ElementPadRef, PropertyValue, *};
+use tracing::{info, warn};
+
+/// Maximum channels on either side of the matrix. Mirrors `audiorouter`'s limit.
+const MAX_CHANNELS: usize = 64;
+
+/// Element-id tail of the `audiomixmatrix`. The live-update interceptor matches
+/// on it, so it must stay in step with the element naming in `build()` and with
+/// the `PropertyMapping` in the block definition.
+const MATRIX_ELEMENT_ID_TAIL: &str = ":live_router_matrix";
+
+/// GStreamer type hint written into each serialized matrix cell.
+///
+/// `audiomixmatrix` declares `matrix` as an array of arrays of `gdouble`, and
+/// the value has to deserialize under that spec. Kept as a named constant
+/// because it is the one token in this file that a GStreamer version could
+/// plausibly disagree about.
+const MATRIX_CELL_TYPE: &str = "gdouble";
+
+/// Live Audio Router block builder.
+pub struct LiveAudioRouterBuilder;
+
+/// Parse a channel count property, clamped to a matrix `audiomixmatrix` accepts.
+fn parse_channel_count(
+    properties: &HashMap<String, PropertyValue>,
+    key: &str,
+    default: usize,
+) -> usize {
+    properties
+        .get(key)
+        .and_then(|v| match v {
+            PropertyValue::UInt(u) => Some(*u as usize),
+            PropertyValue::Int(i) if *i > 0 => Some(*i as usize),
+            _ => None,
+        })
+        .unwrap_or(default)
+        .clamp(1, MAX_CHANNELS)
+}
+
+/// Parse a routing key like `i0c1` or `o2c3` into (stream index, channel index).
+///
+/// Duplicated from `audiorouter` rather than shared: that block is deliberately
+/// left untouched by this change, and the key format is part of this block's own
+/// property contract.
+fn parse_routing_key(key: &str, prefix: char) -> Option<(usize, usize)> {
+    if !key.starts_with(prefix) {
+        return None;
+    }
+
+    let rest = &key[1..];
+    let c_pos = rest.find('c')?;
+
+    let stream_idx: usize = rest[..c_pos].parse().ok()?;
+    let channel_idx: usize = rest[c_pos + 1..].parse().ok()?;
+
+    Some((stream_idx, channel_idx))
+}
+
+/// Serialize an `[output][input]` coefficient grid as a GStreamer value array.
+fn serialize_matrix(rows: &[Vec<f64>]) -> String {
+    let serialized_rows: Vec<String> = rows
+        .iter()
+        .map(|row| {
+            let cells: Vec<String> = row
+                .iter()
+                .map(|v| format!("({}){:.1}", MATRIX_CELL_TYPE, v))
+                .collect();
+            format!("<{}>", cells.join(", "))
+        })
+        .collect();
+    format!("<{}>", serialized_rows.join(", "))
+}
+
+/// Convert the block's JSON routing matrix into the value-array string that
+/// `audiomixmatrix`'s `matrix` property accepts.
+///
+/// `audiomixmatrix` indexes the matrix `[output][input]`, so the result has
+/// `out_channels` rows of `in_channels` coefficients. An empty matrix (`""` or
+/// `"{}"`) means straight through: output channel N takes input channel N.
+///
+/// Returns `None` when the JSON does not parse. Callers must not fall back to
+/// forwarding the raw string: it would reach `set_property_from_str`, which
+/// panics on a value it cannot deserialize. Entries that parse but address a
+/// channel outside the configured counts are logged and skipped, since a matrix
+/// left over from a wider configuration should not block the rest of the update.
+pub fn routing_matrix_to_gst_array(
+    json_str: &str,
+    in_channels: usize,
+    out_channels: usize,
+) -> Option<String> {
+    let mut rows = vec![vec![0.0f64; in_channels]; out_channels];
+
+    let trimmed = json_str.trim();
+    if trimmed.is_empty() || trimmed == "{}" {
+        for (out_ch, row) in rows.iter_mut().enumerate() {
+            if let Some(cell) = row.get_mut(out_ch) {
+                *cell = 1.0;
+            }
+        }
+        return Some(serialize_matrix(&rows));
+    }
+
+    let parsed: HashMap<String, Vec<String>> = serde_json::from_str(trimmed).ok()?;
+
+    for (src_key, dest_keys) in parsed {
+        let Some((_, in_ch)) = parse_routing_key(&src_key, 'i') else {
+            warn!(
+                "Live Audio Router: invalid routing source key '{}'",
+                src_key
+            );
+            continue;
+        };
+        if in_ch >= in_channels {
+            warn!(
+                "Live Audio Router: source key '{}' addresses input channel {} but only {} are configured",
+                src_key, in_ch, in_channels
+            );
+            continue;
+        }
+
+        for dest_key in dest_keys {
+            let Some((_, out_ch)) = parse_routing_key(&dest_key, 'o') else {
+                warn!("Live Audio Router: invalid routing dest key '{}'", dest_key);
+                continue;
+            };
+            if out_ch >= out_channels {
+                warn!(
+                    "Live Audio Router: destination key '{}' addresses output channel {} but only {} are configured",
+                    dest_key, out_ch, out_channels
+                );
+                continue;
+            }
+            rows[out_ch][in_ch] = 1.0;
+        }
+    }
+
+    Some(serialize_matrix(&rows))
+}
+
+/// Try to handle a property update as a Live Audio Router matrix change.
+///
+/// Returns `true` when the update belongs to this block, in which case the
+/// caller must skip the default property-set path. The block's `routing_matrix`
+/// is JSON, while the element's own property is a `gdouble` value array named
+/// `matrix`, so the generic path cannot carry it — and would panic handing JSON
+/// to `set_property_from_str`. A value this function rejects is therefore still
+/// reported as handled: the previous matrix stays in effect and the audio keeps
+/// flowing.
+///
+/// Coupling note: the matching keys (`routing_matrix`, `:live_router_matrix`)
+/// mirror the block's `PropertyMapping` and element naming.
+pub fn try_apply_live_matrix(
+    element: &gst::Element,
+    element_id: &str,
+    prop_name: &str,
+    value: &PropertyValue,
+) -> bool {
+    if prop_name != "routing_matrix" {
+        return false;
+    }
+    if !element_id.ends_with(MATRIX_ELEMENT_ID_TAIL) {
+        return false;
+    }
+
+    let PropertyValue::String(json_str) = value else {
+        warn!(
+            "Live Audio Router '{}' received a non-string routing_matrix value {:?}, keeping previous matrix",
+            element_id, value
+        );
+        return true;
+    };
+
+    let in_channels = element.property::<u32>("in-channels") as usize;
+    let out_channels = element.property::<u32>("out-channels") as usize;
+    if in_channels == 0 || out_channels == 0 {
+        warn!(
+            "Live Audio Router '{}' has in-channels={} out-channels={}, cannot size a matrix",
+            element_id, in_channels, out_channels
+        );
+        return true;
+    }
+
+    let Some(serialized) = routing_matrix_to_gst_array(json_str, in_channels, out_channels) else {
+        warn!(
+            "Live Audio Router '{}' received an unparseable routing_matrix, keeping previous matrix",
+            element_id
+        );
+        return true;
+    };
+
+    element.set_property_from_str("matrix", &serialized);
+    info!(
+        "Live Audio Router '{}' matrix updated ({} in x {} out)",
+        element_id, in_channels, out_channels
+    );
+    true
+}
+
+/// Output channel mask for a given channel count, matching `audiorouter`:
+/// 1ch = front-mono, 2ch = stereo pair, 3+ = unpositioned.
+fn channel_mask(channels: usize) -> u64 {
+    match channels {
+        1 => 0x1,
+        2 => 0x3,
+        _ => 0x0,
+    }
+}
+
+impl BlockBuilder for LiveAudioRouterBuilder {
+    fn build(
+        &self,
+        instance_id: &str,
+        properties: &HashMap<String, PropertyValue>,
+        _ctx: &BlockBuildContext,
+    ) -> Result<BlockBuildResult, BlockBuildError> {
+        info!("Building LiveAudioRouter block instance: {}", instance_id);
+
+        let in_channels = parse_channel_count(properties, "in_channels", 2);
+        let out_channels = parse_channel_count(properties, "out_channels", 2);
+
+        let json_str = match properties.get("routing_matrix") {
+            Some(PropertyValue::String(s)) => s.as_str(),
+            _ => "{}",
+        };
+
+        let matrix = match routing_matrix_to_gst_array(json_str, in_channels, out_channels) {
+            Some(matrix) => matrix,
+            None => {
+                warn!(
+                    "LiveAudioRouter {}: routing_matrix is not valid JSON, starting straight through",
+                    instance_id
+                );
+                routing_matrix_to_gst_array("{}", in_channels, out_channels)
+                    .expect("an empty matrix always serializes")
+            }
+        };
+
+        info!(
+            "LiveAudioRouter config: {} in x {} out, matrix {}",
+            in_channels, out_channels, matrix
+        );
+
+        let in_id = format!("{}:live_router_in", instance_id);
+        let in_elem = gst::ElementFactory::make("audioconvert")
+            .name(&in_id)
+            .build()
+            .map_err(|e| BlockBuildError::ElementCreation(format!("audioconvert: {}", e)))?;
+
+        let matrix_id = format!("{}{}", instance_id, MATRIX_ELEMENT_ID_TAIL);
+        let matrix_elem = gst::ElementFactory::make("audiomixmatrix")
+            .name(&matrix_id)
+            .property("in-channels", in_channels as u32)
+            .property("out-channels", out_channels as u32)
+            .property("channel-mask", channel_mask(out_channels))
+            .property_from_str("matrix", &matrix)
+            .build()
+            .map_err(|e| BlockBuildError::ElementCreation(format!("audiomixmatrix: {}", e)))?;
+
+        let out_id = format!("{}:live_router_out", instance_id);
+        let out_elem = gst::ElementFactory::make("audioconvert")
+            .name(&out_id)
+            .build()
+            .map_err(|e| BlockBuildError::ElementCreation(format!("audioconvert: {}", e)))?;
+
+        let internal_links = vec![
+            (
+                ElementPadRef::pad(&in_id, "src"),
+                ElementPadRef::pad(&matrix_id, "sink"),
+            ),
+            (
+                ElementPadRef::pad(&matrix_id, "src"),
+                ElementPadRef::pad(&out_id, "sink"),
+            ),
+        ];
+
+        Ok(BlockBuildResult {
+            elements: vec![
+                (in_id, in_elem),
+                (matrix_id, matrix_elem),
+                (out_id, out_elem),
+            ],
+            internal_links,
+            bus_message_handler: None,
+            pad_properties: HashMap::new(),
+        })
+    }
+}
+
+// ============================================================================
+// Block Definition
+// ============================================================================
+
+/// Get Live Audio Router block definitions.
+pub fn get_blocks() -> Vec<BlockDefinition> {
+    vec![liveaudiorouter_definition()]
+}
+
+fn liveaudiorouter_definition() -> BlockDefinition {
+    BlockDefinition {
+        id: "builtin.liveaudiorouter".to_string(),
+        name: "Live Audio Router".to_string(),
+        description: "Route audio channels through a matrix that can be changed while the flow is running. Single input and output stream; use Audio Router for multi-stream routing that does not need live changes.".to_string(),
+        category: "Audio".to_string(),
+        exposed_properties: vec![
+            ExposedProperty {
+                name: "in_channels".to_string(),
+                label: "Input Channels".to_string(),
+                description: "Number of channels on the input stream (1-64). Changing this rebuilds the flow.".to_string(),
+                property_type: PropertyType::UInt,
+                default_value: Some(PropertyValue::UInt(2)),
+                mapping: PropertyMapping {
+                    element_id: "live_router_matrix".to_string(),
+                    property_name: "in-channels".to_string(),
+                    transform: None,
+                },
+                live: false,
+                persist: None,
+            },
+            ExposedProperty {
+                name: "out_channels".to_string(),
+                label: "Output Channels".to_string(),
+                description: "Number of channels on the output stream (1-64). Changing this rebuilds the flow.".to_string(),
+                property_type: PropertyType::UInt,
+                default_value: Some(PropertyValue::UInt(2)),
+                mapping: PropertyMapping {
+                    element_id: "live_router_matrix".to_string(),
+                    property_name: "out-channels".to_string(),
+                    transform: None,
+                },
+                live: false,
+                persist: None,
+            },
+            ExposedProperty {
+                name: "routing_matrix".to_string(),
+                label: "Routing Matrix".to_string(),
+                description: "JSON routing matrix, applied without restarting the flow. Format: {\"i0c0\": [\"o0c0\", \"o0c1\"]} where iXcY = input channel Y, oXcY = output channel Y; the stream index X is always 0. Empty or {} routes every input channel straight through to the output channel with the same index.".to_string(),
+                property_type: PropertyType::Multiline,
+                default_value: Some(PropertyValue::String("{}".to_string())),
+                mapping: PropertyMapping {
+                    element_id: "live_router_matrix".to_string(),
+                    property_name: "routing_matrix".to_string(),
+                    transform: None,
+                },
+                live: true,
+                persist: None,
+            },
+        ],
+        external_pads: ExternalPads {
+            inputs: vec![ExternalPad {
+                label: None,
+                name: "audio_in".to_string(),
+                media_type: MediaType::Audio,
+                internal_element_id: "live_router_in".to_string(),
+                internal_pad_name: "sink".to_string(),
+            }],
+            outputs: vec![ExternalPad {
+                label: None,
+                name: "audio_out".to_string(),
+                media_type: MediaType::Audio,
+                internal_element_id: "live_router_out".to_string(),
+                internal_pad_name: "src".to_string(),
+            }],
+        },
+        built_in: true,
+        ui_metadata: Some(BlockUIMetadata {
+            icon: Some("🔀".to_string()),
+            width: Some(3.0),
+            height: Some(2.5),
+            ..Default::default()
+        }),
+    }
+}

--- a/backend/src/blocks/builtin/mod.rs
+++ b/backend/src/blocks/builtin/mod.rs
@@ -15,6 +15,7 @@ pub mod efpsrt;
 pub mod efpsrt_input;
 pub mod inter;
 pub mod latency;
+pub mod liveaudiorouter;
 pub mod loudness;
 pub mod mediaplayer;
 pub mod meter;
@@ -78,6 +79,9 @@ pub fn get_all_builtin_blocks() -> Vec<BlockDefinition> {
 
     // Add Latency blocks
     blocks.extend(latency::get_blocks());
+
+    // Add Live Audio Router blocks
+    blocks.extend(liveaudiorouter::get_blocks());
 
     // Add Loudness blocks
     blocks.extend(loudness::get_blocks());
@@ -153,6 +157,7 @@ pub fn get_builder(block_definition_id: &str) -> Option<Arc<dyn BlockBuilder>> {
         "builtin.inter_output" => Some(Arc::new(inter::InterOutputBuilder)),
         "builtin.inter_input" => Some(Arc::new(inter::InterInputBuilder)),
         "builtin.latency" => Some(Arc::new(latency::LatencyBuilder)),
+        "builtin.liveaudiorouter" => Some(Arc::new(liveaudiorouter::LiveAudioRouterBuilder)),
         "builtin.loudness" => Some(Arc::new(loudness::LoudnessBuilder)),
         "builtin.media_player" => Some(Arc::new(mediaplayer::MediaPlayerBuilder)),
         "builtin.meter" => Some(Arc::new(meter::MeterBuilder)),

--- a/backend/src/gst/pipeline/properties.rs
+++ b/backend/src/gst/pipeline/properties.rs
@@ -242,6 +242,19 @@ impl PipelineManager {
             return Ok(());
         }
 
+        // Live Audio Router block: `routing_matrix` is JSON, while the element's
+        // own property is a value array named `matrix`. Intercept before the
+        // generic string path can hand the JSON to `set_property_from_str`,
+        // which panics on a value it cannot deserialize.
+        if crate::blocks::builtin::liveaudiorouter::try_apply_live_matrix(
+            element,
+            element_id,
+            property_name,
+            value,
+        ) {
+            return Ok(());
+        }
+
         // Translate property name/value for elements that need conversion.
         // Mixer lsp-rs elements use different property names than LV2 conventions.
         // AudioGain stores gain in dB but GStreamer volume element expects linear.

--- a/backend/tests/liveaudiorouter_live_matrix_test.rs
+++ b/backend/tests/liveaudiorouter_live_matrix_test.rs
@@ -1,0 +1,334 @@
+//! Regression test: `builtin.liveaudiorouter` must apply a `routing_matrix`
+//! change to an already-running pipeline.
+//!
+//! The existing `builtin.audiorouter` snapshots its matrix at `build()` time and
+//! declares `routing_matrix` non-live, so rerouting a channel needs a flow
+//! restart (issue #661). The live block wraps `audiomixmatrix`, whose `matrix`
+//! property can be rewritten while the element is PLAYING.
+//!
+//! The runtime test feeds one tone into a two-channel input, routes it to output
+//! channel 0, then rewrites the matrix mid-stream to send it to output channel 1
+//! instead, and reads the `level` element's per-channel peaks on both sides of
+//! the change. Asserting on measured peaks rather than on the property value is
+//! deliberate: reading `matrix` back would pass even if the element ignored the
+//! new value for the audio it is actually producing.
+
+use gstreamer as gst;
+use gstreamer::glib;
+use gstreamer::prelude::*;
+use gstreamer::MessageView;
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+use strom::blocks::builtin::liveaudiorouter::{self, LiveAudioRouterBuilder};
+use strom::blocks::{BlockBuildContext, BlockBuilder};
+use strom_types::PropertyValue;
+
+/// Elements this test needs beyond core GStreamer. `audiomixmatrix` is in
+/// gst-plugins-bad and `level` in gst-plugins-good; both packages are in the
+/// Linux job's list in `.github/workflows/ci.yml`.
+const REQUIRED: &[&str] = &[
+    "audiotestsrc",
+    "audioconvert",
+    "capsfilter",
+    "audiomixmatrix",
+    "level",
+    "fakesink",
+];
+
+/// Peak (dBFS) above which an output channel counts as carrying the tone.
+const LOUD_DB: f64 = -20.0;
+/// Peak (dBFS) below which an output channel counts as silent.
+const SILENT_DB: f64 = -60.0;
+
+/// Skipping on a missing element passes green and guards nothing, so CI sets
+/// `STROM_REQUIRE_GST_PLUGINS=1` to turn a skip into a failure.
+fn plugins_available() -> bool {
+    // `ElementFactory::find` panics if the registry has not been loaded yet, and
+    // this runs before the pipeline is built.
+    gst::init().unwrap();
+    let missing: Vec<&str> = REQUIRED
+        .iter()
+        .copied()
+        .filter(|e| gst::ElementFactory::find(e).is_none())
+        .collect();
+    if missing.is_empty() {
+        return true;
+    }
+    assert!(
+        std::env::var("STROM_REQUIRE_GST_PLUGINS").is_err(),
+        "STROM_REQUIRE_GST_PLUGINS is set but these elements are missing: {}",
+        missing.join(", ")
+    );
+    false
+}
+
+fn properties(entries: &[(&str, PropertyValue)]) -> HashMap<String, PropertyValue> {
+    entries
+        .iter()
+        .map(|(k, v)| (k.to_string(), v.clone()))
+        .collect()
+}
+
+#[test]
+fn an_empty_matrix_routes_every_input_channel_straight_through() {
+    assert_eq!(
+        liveaudiorouter::routing_matrix_to_gst_array("{}", 2, 2)
+            .expect("an empty matrix is valid input"),
+        "<<(gdouble)1.0, (gdouble)0.0>, <(gdouble)0.0, (gdouble)1.0>>"
+    );
+}
+
+#[test]
+fn a_routing_entry_lands_in_the_row_of_its_destination_channel() {
+    // audiomixmatrix indexes its matrix [output][input], so routing input
+    // channel 0 to output channel 1 must fill row 1 column 0, not row 0.
+    assert_eq!(
+        liveaudiorouter::routing_matrix_to_gst_array(r#"{"i0c0": ["o0c1"]}"#, 2, 2)
+            .expect("valid JSON"),
+        "<<(gdouble)0.0, (gdouble)0.0>, <(gdouble)1.0, (gdouble)0.0>>"
+    );
+}
+
+#[test]
+fn one_input_channel_can_fan_out_to_several_output_channels() {
+    assert_eq!(
+        liveaudiorouter::routing_matrix_to_gst_array(r#"{"i0c0": ["o0c0", "o0c1"]}"#, 2, 2)
+            .expect("valid JSON"),
+        "<<(gdouble)1.0, (gdouble)0.0>, <(gdouble)1.0, (gdouble)0.0>>"
+    );
+}
+
+#[test]
+fn unparseable_json_is_rejected_instead_of_reaching_gstreamer() {
+    // The live path hands this string to set_property_from_str, which panics on
+    // a value it cannot deserialize. Rejecting it here is what keeps a typo in
+    // the properties panel from taking the backend down.
+    let rejected = liveaudiorouter::routing_matrix_to_gst_array("{not json", 2, 2);
+    assert!(rejected.is_none());
+}
+
+struct RouterPipe {
+    pipeline: gst::Pipeline,
+    matrix: gst::Element,
+    matrix_id: String,
+    bus: gst::Bus,
+    level_name: String,
+}
+
+impl RouterPipe {
+    /// `audiotestsrc` (mono tone) -> `audioconvert` -> two-channel caps -> the
+    /// block under test -> `level` -> `fakesink`.
+    ///
+    /// The mono source is upmixed to two identical input channels, so which
+    /// *output* channel carries the tone is decided purely by the matrix.
+    fn new(routing_matrix: &str) -> Self {
+        gst::init().unwrap();
+        let pipeline = gst::Pipeline::new();
+
+        let props = properties(&[
+            ("in_channels", PropertyValue::UInt(2)),
+            ("out_channels", PropertyValue::UInt(2)),
+            (
+                "routing_matrix",
+                PropertyValue::String(routing_matrix.to_string()),
+            ),
+        ]);
+        let ctx = BlockBuildContext::new(vec![], "all".to_string());
+        let built = LiveAudioRouterBuilder
+            .build("router", &props, &ctx)
+            .expect("the block builds");
+
+        let by_id: HashMap<String, gst::Element> = built.elements.iter().cloned().collect();
+        for (_, elem) in &built.elements {
+            pipeline.add(elem).expect("add block element");
+        }
+        for (from, to) in &built.internal_links {
+            let src = by_id
+                .get(&from.element_id)
+                .expect("internal link source element exists");
+            let sink = by_id
+                .get(&to.element_id)
+                .expect("internal link sink element exists");
+            src.link(sink).expect("internal link");
+        }
+
+        let block_in = by_id
+            .get("router:live_router_in")
+            .expect("block exposes an input element")
+            .clone();
+        let block_out = by_id
+            .get("router:live_router_out")
+            .expect("block exposes an output element")
+            .clone();
+        let matrix_id = "router:live_router_matrix".to_string();
+        let matrix = by_id
+            .get(&matrix_id)
+            .expect("block exposes a matrix element")
+            .clone();
+
+        let src = gst::ElementFactory::make("audiotestsrc")
+            .property("is-live", true)
+            .property_from_str("wave", "sine")
+            .property("freq", 1000.0_f64)
+            // Short buffers so `level` reports often and the assertion window
+            // after the matrix change stays small.
+            .property("samplesperbuffer", 48_i32)
+            .build()
+            .expect("audiotestsrc");
+        let convert = gst::ElementFactory::make("audioconvert")
+            .build()
+            .expect("audioconvert");
+        let caps = gst::Caps::builder("audio/x-raw")
+            .field("channels", 2i32)
+            .build();
+        let capsfilter = gst::ElementFactory::make("capsfilter")
+            .property("caps", &caps)
+            .build()
+            .expect("capsfilter");
+        let level_name = "router_level";
+        let level = gst::ElementFactory::make("level")
+            .name(level_name)
+            .property("post-messages", true)
+            .property("interval", gst::ClockTime::from_mseconds(10).nseconds())
+            .build()
+            .expect("level");
+        let sink = gst::ElementFactory::make("fakesink")
+            .property("sync", false)
+            .build()
+            .expect("fakesink");
+
+        pipeline
+            .add_many([&src, &convert, &capsfilter, &level, &sink])
+            .expect("add harness elements");
+        gst::Element::link_many([&src, &convert, &capsfilter, &block_in])
+            .expect("link the source chain into the block");
+        gst::Element::link_many([&block_out, &level, &sink])
+            .expect("link the block into the measuring chain");
+
+        let bus = pipeline.bus().expect("pipeline has a bus");
+        pipeline
+            .set_state(gst::State::Playing)
+            .expect("pipeline reaches PLAYING");
+
+        RouterPipe {
+            pipeline,
+            matrix,
+            matrix_id,
+            bus,
+            level_name: level_name.to_string(),
+        }
+    }
+
+    /// Apply a new matrix the way a live property update from the API does.
+    fn set_routing_matrix(&self, json: &str) {
+        let handled = liveaudiorouter::try_apply_live_matrix(
+            &self.matrix,
+            &self.matrix_id,
+            "routing_matrix",
+            &PropertyValue::String(json.to_string()),
+        );
+        assert!(
+            handled,
+            "the live-update interceptor must claim routing_matrix for this element"
+        );
+    }
+
+    /// Per-channel peaks from the next `level` message posted by our own level
+    /// element.
+    fn next_peaks(&self, timeout: Duration) -> Vec<f64> {
+        let deadline = Instant::now() + timeout;
+        while Instant::now() < deadline {
+            let Some(msg) = self.bus.timed_pop_filtered(
+                gst::ClockTime::from_mseconds(100),
+                &[gst::MessageType::Element],
+            ) else {
+                continue;
+            };
+            let MessageView::Element(element_msg) = msg.view() else {
+                continue;
+            };
+            let Some(s) = element_msg.structure() else {
+                continue;
+            };
+            if s.name() != "level" {
+                continue;
+            }
+            let from_our_level = msg
+                .src()
+                .map(|src| src.name().to_string())
+                .is_some_and(|name| name == self.level_name);
+            if !from_our_level {
+                continue;
+            }
+            if let Ok(array) = s.get::<glib::ValueArray>("peak") {
+                let peaks: Vec<f64> = array.iter().filter_map(|v| v.get::<f64>().ok()).collect();
+                if !peaks.is_empty() {
+                    return peaks;
+                }
+            }
+        }
+        panic!("no level message arrived within {:?}", timeout);
+    }
+
+    /// Poll `level` until `expected_loud` is the only output channel carrying
+    /// the tone. Polling rather than reading a single message tolerates the
+    /// buffers already in flight when the matrix changed.
+    fn wait_for_only_channel(&self, expected_loud: usize, timeout: Duration) -> Vec<f64> {
+        let deadline = Instant::now() + timeout;
+        let mut last: Vec<f64> = Vec::new();
+        while Instant::now() < deadline {
+            let peaks = self.next_peaks(Duration::from_secs(2));
+            if peaks.len() == 2 {
+                let other = 1 - expected_loud;
+                if peaks[expected_loud] > LOUD_DB && peaks[other] < SILENT_DB {
+                    return peaks;
+                }
+            }
+            last = peaks;
+        }
+        panic!(
+            "output channel {} never became the only channel carrying audio \
+             (loud > {} dB, other < {} dB); last peaks seen: {:?}",
+            expected_loud, LOUD_DB, SILENT_DB, last
+        );
+    }
+}
+
+impl Drop for RouterPipe {
+    fn drop(&mut self) {
+        let _ = self.pipeline.set_state(gst::State::Null);
+    }
+}
+
+/// The guard for issue #661: rerouting must take effect without a flow restart.
+///
+/// Reverting the block to the old snapshot-at-build behaviour makes the second
+/// `wait_for_only_channel` time out, because the tone stays on channel 0.
+#[test]
+fn a_routing_matrix_change_moves_audio_between_output_channels_while_playing() {
+    if !plugins_available() {
+        return;
+    }
+
+    // Start with the tone on output channel 0 only.
+    let pipe = RouterPipe::new(r#"{"i0c0": ["o0c0"]}"#);
+    let before = pipe.wait_for_only_channel(0, Duration::from_secs(10));
+
+    // Reroute to output channel 1 while the pipeline keeps playing.
+    pipe.set_routing_matrix(r#"{"i0c0": ["o0c1"]}"#);
+
+    let after = pipe.wait_for_only_channel(1, Duration::from_secs(10));
+
+    assert!(
+        before[0] > after[0],
+        "output channel 0 should have lost the tone: before={:?} after={:?}",
+        before,
+        after
+    );
+    assert!(
+        after[1] > before[1],
+        "output channel 1 should have gained the tone: before={:?} after={:?}",
+        before,
+        after
+    );
+}


### PR DESCRIPTION
Class A — the test below fails without this fix.

Fixes #661

## Problem

`builtin.audiorouter` declares its routing matrix non-live. `backend/src/blocks/builtin/audiorouter.rs:847`:

```rust
        live: false,
```

That flag is on the `routing_matrix` exposed property, whose mapping targets the pseudo-element `_block` (`audiorouter.rs:842-846`), because the matrix is not a GStreamer property at all — it is consumed at `build()` time to decide how the block's internal `deinterleave`/`interleave` pads are linked. Once the flow is running the wiring is fixed, so changing a route needs a flow restart.

Making the existing property live is not enough on its own: the generic live-update path writes strings straight through. `backend/src/gst/pipeline/properties.rs:73-75`:

```rust
        match prop_value {
            PropertyValue::String(v) => {
                element.set_property_from_str(prop_name, v);
```

`set_property_from_str` panics on a property it cannot find or a value it cannot deserialize, so handing it a JSON routing matrix would take the backend down rather than return an error.

## Change

A new sibling block `builtin.liveaudiorouter`, built on `audiomixmatrix` (gst-plugins-bad) instead of `deinterleave`/`interleave`. Chain: `audioconvert` -> `audiomixmatrix` -> `audioconvert`. `audiomixmatrix` holds the routing as a `matrix` property (a value array of `gdouble` rows, indexed `[output][input]`) that can be rewritten while the element is PLAYING, so no relinking is involved.

Three parts:

- `backend/src/blocks/builtin/liveaudiorouter.rs` (new) — the block, plus `routing_matrix_to_gst_array()` which converts the existing `{"i0c0": ["o0c1"]}` JSON syntax into the matrix literal, and `try_apply_live_matrix()` which performs the live write.
- `backend/src/gst/pipeline/properties.rs` — an 11-line dispatch hook that gives `try_apply_live_matrix` a chance to claim the property before the generic string path above can reach `set_property_from_str`.
- `backend/src/blocks/builtin/mod.rs` — registry entries (module, `get_all_builtin_blocks`, `get_builder`).

The interceptor returns `true` even when it rejects the JSON as unparseable. That is deliberate: claiming the property and logging a warning is what keeps a typo in the properties panel from panicking the backend. It follows the existing precedent of `time_offset::try_apply_live_offset` immediately above it in the same function.

The triage discussion also raised changing `builtin.audiorouter` in place. That was rejected there because `audiomixmatrix` cannot reproduce the existing block's multi-stream (up to 8 in / 8 out) pad topology, so an in-place swap would be a breaking change to every existing flow using it. This block is single-stream, multi-channel, and additive.

## Evidence

Two concluded CI runs, red on the test-only commit and green on the commit that adds the block:

| Commit | Run | Conclusion |
|---|---|---|
| `ceab483` test only | [33381858279](https://github.com/Eyevinn/strom/actions/runs/33381858279) (on `1157680`, see caveat) | **failure** |
| `6dbbbba` test + block | [33382957051](https://github.com/Eyevinn/strom/actions/runs/33382957051) | **success** |

The red run fails in `Run Clippy on backend`:

```
error[E0432]: unresolved import `strom::blocks::builtin::liveaudiorouter`
error: could not compile `strom` (test "liveaudiorouter_live_matrix_test") due to 1 previous error
```

The green run executes all five tests, including the runtime one:

```
test an_empty_matrix_routes_every_input_channel_straight_through ... ok
test a_routing_entry_lands_in_the_row_of_its_destination_channel ... ok
test one_input_channel_can_fan_out_to_several_output_channels ... ok
test unparseable_json_is_rejected_instead_of_reaching_gstreamer ... ok
test a_routing_matrix_change_moves_audio_between_output_channels_while_playing ... ok
```

The job runs with `STROM_REQUIRE_GST_PLUGINS=1`, so a missing `audiomixmatrix` or `level` would have failed rather than skipped green. Both elements are already in the Linux job's package list (`gstreamer1.0-plugins-bad`, `gstreamer1.0-plugins-good`), so no workflow change was needed.

`backend/tests/liveaudiorouter_live_matrix_test.rs` feeds a 1 kHz tone into a two-channel input, routes it to output channel 0, then calls `liveaudiorouter::try_apply_live_matrix` mid-stream to send it to output channel 1, and reads a `level` element's per-channel peaks on both sides of the change. It asserts on measured peaks, not on the property value — reading `matrix` back would pass even if the element ignored the new value for the audio it is actually producing. This is what confirms the load-bearing assumption that `audiomixmatrix` applies a new `matrix` to audio it is already producing rather than latching it at caps negotiation; I could not verify that from documentation alone.

To run it locally:

```
STROM_REQUIRE_GST_PLUGINS=1 cargo test --features efp,nvidia --test liveaudiorouter_live_matrix_test
```

## Not verified

- **I compiled and ran nothing myself.** No Rust toolchain existed in the environment I ran in (`cargo --version` and `pkg-config --modversion gstreamer-1.0` both report command not found). Every execution result above is CI's, not mine.
- **The red run is on a superseded SHA.** Run 33381858279 ran against commit 1 as `1157680`; after a formatting fix and a harness fix the branch was rewritten, so commit 1 is now `ceab483`. The only difference in the test file between those two SHAs is a three-line `gst::init()` call added to the plugin guard, which cannot affect the `unresolved import` compile error the red run demonstrates. I chose not to bounce the branch head back to commit 1 purely to regenerate that run, since that would leave this PR pointing at a non-building commit while CI ran.
- **The red is a compile error, not a failing assertion.** Commit 1 cannot build because the test imports the module commit 2 adds. So the red/green pair does not by itself prove the runtime behaviour would regress if only the *liveness* were reverted. Reverting liveness specifically means setting `live: false` on the new block's `routing_matrix` property and removing the hook in `properties.rs`; that makes `wait_for_only_channel(1, ...)` time out rather than fail to build. I did not produce that third state, because doing so would have meant a third commit.
- **Scope gap, not dropped silently:** the triage note suggested deriving channel counts from the negotiated input caps. This does not implement that. In `audiomixmatrix`'s manual mode the matrix dimensions *are* `in-channels`/`out-channels`, so they must be known at `build()` time; `in_channels`/`out_channels` are therefore plain non-live properties. Auto-derivation would need the element's automatic mode, which is a different design and should be a separate decision.
- No frontend work and no GUI run. The block appears via the generic block list and its `routing_matrix` uses the existing `Multiline` property editor, so it should render, but I did not confirm it visually.
- Channel counts are clamped to 1..=64 silently rather than rejected, matching `MAX_CHANNELS` in `audiorouter.rs`.
- Only the Linux jobs exercised the tests; the macOS and Windows build jobs were skipped by the workflow's own conditions.

## Blast radius

- `backend/src/gst/pipeline/properties.rs` is shared by every live property update in the product, so the hook is the only part of this diff that can affect existing flows. It is guarded twice: `try_apply_live_matrix` returns `false` immediately unless the property name is exactly `routing_matrix` *and* the element id ends with `:live_router_matrix`. No existing block produces an element with that suffix, so for every current caller the function returns `false` and control falls through to the unchanged translation chain. The green run's 546 passing unit tests plus the existing integration tests exercise that fall-through path.
- Call sites reach that function through `AppState::update_element_property` (`backend/src/state.rs:1691`), which is the single funnel used by the REST handler (`backend/src/api/flows.rs:999`), the MCP tool (`backend/src/mcp/handler.rs:549`) and the internal callers at `state.rs:1803`, `1978` and `1993`. Reading `state.rs:1672-1699`: it resolves the pipeline, delegates, then broadcasts `StromEvent::PropertyChanged`. The hook returns `Ok(())` on the same path the existing `time_offset` hook does, so the event still fires and no contract changes.
- `backend/src/blocks/builtin/mod.rs` gains three additive entries. No block-list snapshot test exists, and no API or WebSocket type changed, so `openapi.json` is untouched — the `API Contract Check` job passes.
- The existing `builtin.audiorouter` is not modified. Existing flows keep their current behaviour, including the restart requirement.

<!-- strom-agent protocol=v3 kind=fix issue=661 class=A -->
