### PR TITLE
docs(agent): scope class= to fix markers, so its absence stops being a finding

### DIFF
--- a/scripts/agent/PROTOCOL.md
+++ b/scripts/agent/PROTOCOL.md
@@ -106,6 +106,12 @@ exists; `feature` adds something new. Most of the board is not `bug`, so getting
 mislabels the work: an `enhancement` implemented under the `bug` vocabulary ships as
 `fix(scope): …` with a commit claiming to "reproduce" a defect that never existed.
 
+`class=` appears **only** on a `kind=fix` marker — a PR the implementation stage authored. It
+never appears on a review of somebody else's PR, and looking for it there produces a
+false finding: a run reported "five open PRs are missing `class=`" about five PRs it had
+merely reviewed. "Find the open class=C PRs" therefore means "the fix PRs you opened", which
+`gh pr list --author @me --draft` answers.
+
 `excluded=` lists the areas from `FIX.md`'s exclusion gate that the fix would **break or take
 a lifetime risk in**, comma-separated, or `none`. It is not a list of areas the diff merely
 touches, and the difference decides whether the gate is a real check or a rubber stamp:

--- a/scripts/agent/SUMMARY.md
+++ b/scripts/agent/SUMMARY.md
@@ -83,7 +83,10 @@ exact command where there is one. If it is empty, that itself is the useful sign
 Two things belong in `needs_human` **every run**, not just the run that discovered them, because
 otherwise they scroll away and the work stalls silently:
 
-- the dispatch command for every open `class=C` PR, which cannot reach class A without it;
+- the dispatch command for every open `class=C` PR **that the implementation stage authored**
+  (`gh pr list --author @me --draft`), which cannot reach class A without it. A review you
+  posted on someone else's PR carries no `class=` and never will — do not report its absence
+  as a finding;
 - every issue `board.sh` lists under "replied, but not by someone who may decide", and every
   candidate you read as *not* a decision — with the sentence you based that on, so a human can
   overrule you in one reply.


### PR DESCRIPTION
The first run under the new protocol reported a false finding: *"all 5 open PRs' agent review
markers are missing `verdict=`/`radius=`/`confidence=`/`class=` fields entirely, so no open
class=C PR could be identified for a dispatch reminder this run"*.

Four of those five are other people's PRs that the triage stage had only reviewed. `class=`
belongs to a `kind=fix` marker — a PR the implementation stage authored — so it was never
going to be there, and its absence is not a defect. The run spent a `needs_human` slot on it.

`PROTOCOL.md` now says where `class=` lives and does not live, and `SUMMARY.md` scopes
class=C dispatch detection to `gh pr list --author @me --draft` rather than "PRs with agent
markers".

Docs only. `scripts/agent/test-agent-scripts.sh`: 40 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)