### PR TITLE
perf(video): convert and scale in one pass in the Video Format block

### DIFF
--- a/backend/src/blocks/builtin/devicesrc.rs
+++ b/backend/src/blocks/builtin/devicesrc.rs
@@ -79,7 +79,7 @@
 //! without changes here.
 
 use crate::blocks::{BlockBuildContext, BlockBuildError, BlockBuildResult, BlockBuilder};
-use crate::gpu::video_convert_mode;
+use crate::gpu::{self, video_convert_mode};
 use gstreamer as gst;
 use gstreamer::prelude::*;
 use std::collections::HashMap;
@@ -197,6 +197,7 @@ impl BlockBuilder for LocalInputBuilder {
                 .map_err(|e| {
                     BlockBuildError::ElementCreation(format!("{}: {}", convert_element_name, e))
                 })?;
+            gpu::configure_video_convert(&videoconvert);
 
             let video_caps = gst::Caps::builder("video/x-raw").build();
             let videocaps = gst::ElementFactory::make("capsfilter")

--- a/backend/src/blocks/builtin/ndi.rs
+++ b/backend/src/blocks/builtin/ndi.rs
@@ -5,7 +5,7 @@
 //! Requires the NDI SDK from NewTek/Vizrt to be installed.
 
 use crate::blocks::{BlockBuildContext, BlockBuildError, BlockBuildResult, BlockBuilder};
-use crate::gpu::video_convert_mode;
+use crate::gpu::{self, video_convert_mode};
 use gstreamer as gst;
 use gstreamer::prelude::*;
 use std::collections::HashMap;
@@ -217,6 +217,7 @@ impl BlockBuilder for NDIInputBuilder {
                     .map_err(|e| {
                         BlockBuildError::ElementCreation(format!("{}: {}", convert_element_name, e))
                     })?;
+                gpu::configure_video_convert(&videoconvert);
 
                 let video_caps = gst::Caps::builder("video/x-raw").build();
                 let videocaps = gst::ElementFactory::make("capsfilter")
@@ -304,6 +305,7 @@ impl BlockBuilder for NDIInputBuilder {
                     .map_err(|e| {
                         BlockBuildError::ElementCreation(format!("{}: {}", convert_element_name, e))
                     })?;
+                gpu::configure_video_convert(&videoconvert);
 
                 let caps = gst::Caps::builder("video/x-raw").build();
                 let capsfilter = gst::ElementFactory::make("capsfilter")
@@ -499,6 +501,7 @@ impl BlockBuilder for NDIOutputBuilder {
                     .map_err(|e| {
                         BlockBuildError::ElementCreation(format!("{}: {}", convert_element_name, e))
                     })?;
+                gpu::configure_video_convert(&videoconvert);
 
                 // Audio path
                 let audioconvert_id = format!("{}:audioconvert", instance_id);
@@ -585,6 +588,7 @@ impl BlockBuilder for NDIOutputBuilder {
                     .map_err(|e| {
                         BlockBuildError::ElementCreation(format!("{}: {}", convert_element_name, e))
                     })?;
+                gpu::configure_video_convert(&videoconvert);
 
                 let ndisink = gst::ElementFactory::make("ndisink")
                     .name(&ndisink_id)

--- a/backend/src/blocks/builtin/videoenc.rs
+++ b/backend/src/blocks/builtin/videoenc.rs
@@ -17,7 +17,7 @@
 //! - capsfilter: Sets output caps for proper codec negotiation
 
 use crate::blocks::{BlockBuildContext, BlockBuildError, BlockBuildResult, BlockBuilder};
-use crate::gpu::video_convert_mode;
+use crate::gpu::{self, video_convert_mode};
 use gstreamer as gst;
 use gstreamer::prelude::*;
 use std::collections::HashMap;
@@ -129,6 +129,7 @@ impl BlockBuilder for VideoEncBuilder {
             .map_err(|e| {
                 BlockBuildError::ElementCreation(format!("{}: {}", convert_element_name, e))
             })?;
+        gpu::configure_video_convert(&videoconvert);
 
         let encoder = gst::ElementFactory::make(&encoder_name)
             .name(&encoder_id)

--- a/backend/src/blocks/builtin/videoformat.rs
+++ b/backend/src/blocks/builtin/videoformat.rs
@@ -6,7 +6,7 @@
 //! - Color format (pixel format) - enforced by caps
 //!
 //! All properties are optional. The block creates a fixed chain of elements:
-//! videoscale -> videoconvert -> capsfilter
+//! videoconvertscale -> capsfilter
 //!
 //! TEMPORARY: videorate element removed to avoid frame duplication issues.
 //!
@@ -98,21 +98,18 @@ impl BlockBuilder for VideoFormatBuilder {
         let caps_str = caps_fields.join(",");
         info!("VideoFormat block caps: {}", caps_str);
 
-        // Always create all elements for consistent external pad references
-        // Elements will just pass through if their respective properties aren't set
-        let scale_id = format!("{}:videoscale", instance_id);
-        // Use detected video convert mode (autovideoconvert if GPU interop works, videoconvert otherwise)
-        // Note: We always use "videoconvert" as the element ID for consistent external pad references,
-        // even when the actual GStreamer element is "autovideoconvert"
-        let convert_mode = video_convert_mode();
-        let convert_element_name = convert_mode.element_name();
-        let convert_id = format!("{}:videoconvert", instance_id);
+        // `videoconvertscale` converts and scales in a single walk of the frame.
+        //
+        // The element ID is "videoscale": the block's external input pad
+        // resolves through that name (see `external_pads` below), and saved
+        // flows resolve their links through it at build time, so renaming it
+        // breaks every saved flow that links into this block. The ID names the
+        // role, not the factory.
+        let convert_id = format!("{}:videoscale", instance_id);
         let capsfilter_id = format!("{}:capsfilter", instance_id);
 
-        let videoscale = gst::ElementFactory::make("videoscale")
-            .name(&scale_id)
-            .build()
-            .map_err(|e| BlockBuildError::ElementCreation(format!("videoscale: {}", e)))?;
+        // videoconvertscale on the CPU; autovideoconvert scales as well as converts.
+        let convert_element_name = video_convert_mode().convert_scale_element_name();
 
         // TEMPORARY: videorate removed to avoid frame duplication issues
         // let videorate = gst::ElementFactory::make("videorate")
@@ -120,13 +117,15 @@ impl BlockBuilder for VideoFormatBuilder {
         //     .build()
         //     .map_err(|e| BlockBuildError::ElementCreation(format!("videorate: {}", e)))?;
 
-        let videoconvert = gst::ElementFactory::make(convert_element_name)
+        let convert_scale = gst::ElementFactory::make(convert_element_name)
             .name(&convert_id)
             .build()
             .map_err(|e| {
                 BlockBuildError::ElementCreation(format!("{}: {}", convert_element_name, e))
             })?;
-        gpu::configure_video_convert(&videoconvert);
+        // Raises `n-threads` off the stock default of 1, for both the
+        // converting and the scaling half.
+        gpu::configure_video_convert(&convert_scale);
 
         // capsfilter with caps (only constraints specified properties)
         let caps = caps_str.parse::<gst::Caps>().map_err(|_| {
@@ -139,26 +138,19 @@ impl BlockBuilder for VideoFormatBuilder {
             .build()
             .map_err(|e| BlockBuildError::ElementCreation(format!("capsfilter: {}", e)))?;
 
-        info!("VideoFormat block created (chain: videoscale -> {} -> capsfilter) [videorate TEMPORARILY REMOVED]", convert_element_name);
+        info!(
+            "VideoFormat block created (chain: {} -> capsfilter) [videorate TEMPORARILY REMOVED]",
+            convert_element_name
+        );
 
-        // Chain: videoscale -> videoconvert/autovideoconvert -> capsfilter (videorate temporarily removed)
-        let internal_links = vec![
-            (
-                ElementPadRef::pad(&scale_id, "src"),
-                ElementPadRef::pad(&convert_id, "sink"),
-            ),
-            (
-                ElementPadRef::pad(&convert_id, "src"),
-                ElementPadRef::pad(&capsfilter_id, "sink"),
-            ),
-        ];
+        // Chain: videoconvertscale/autovideoconvert -> capsfilter (videorate temporarily removed)
+        let internal_links = vec![(
+            ElementPadRef::pad(&convert_id, "src"),
+            ElementPadRef::pad(&capsfilter_id, "sink"),
+        )];
 
         Ok(BlockBuildResult {
-            elements: vec![
-                (scale_id, videoscale),
-                (convert_id, videoconvert),
-                (capsfilter_id, capsfilter),
-            ],
+            elements: vec![(convert_id, convert_scale), (capsfilter_id, capsfilter)],
             internal_links,
             bus_message_handler: None,
             pad_properties: HashMap::new(),
@@ -182,7 +174,7 @@ fn videoformat_definition() -> BlockDefinition {
             ExposedProperty {
                 name: "resolution".to_string(),
                 label: "Resolution".to_string(),
-                description: "Video resolution - creates videoscale element. Leave empty to pass through.".to_string(),
+                description: "Video resolution - applied by the videoconvertscale element. Leave empty to pass through.".to_string(),
                 property_type: PropertyType::Enum {
                     values: common_video_resolution_enum_values(true), // include empty "-" option
                 },
@@ -214,7 +206,7 @@ fn videoformat_definition() -> BlockDefinition {
             ExposedProperty {
                 name: "format".to_string(),
                 label: "Pixel Format".to_string(),
-                description: "Pixel format/color space - creates videoconvert element. Leave empty to pass through.".to_string(),
+                description: "Pixel format/color space - applied by the videoconvertscale element. Leave empty to pass through.".to_string(),
                 property_type: PropertyType::Enum {
                     values: common_video_pixel_format_enum_values(true),
                 },
@@ -251,5 +243,210 @@ fn videoformat_definition() -> BlockDefinition {
             height: Some(2.0),
             ..Default::default()
         }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::blocks::BlockBuildContext;
+    use gst::prelude::*;
+
+    fn init_gst() {
+        let _ = gst::init();
+        // video_convert_mode() panics until this has run.
+        crate::gpu::detect_gpu_capabilities();
+    }
+
+    fn props(pairs: &[(&str, &str)]) -> HashMap<String, PropertyValue> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), PropertyValue::String(v.to_string())))
+            .collect()
+    }
+
+    fn build(pairs: &[(&str, &str)]) -> BlockBuildResult {
+        init_gst();
+        let ctx = BlockBuildContext::new(Vec::new(), "all".to_string());
+        VideoFormatBuilder
+            .build("vf0", &props(pairs), &ctx)
+            .expect("VideoFormat block must build")
+    }
+
+    /// Guards external pad stability. Saved flows store links as
+    /// `block_id:external_pad_name` and resolve them through the block
+    /// definition's `internal_element_id` at build time, so a definition that
+    /// names an element the builder does not produce silently breaks every
+    /// saved flow linking into this block.
+    ///
+    /// Renaming the conversion element without updating `external_pads` (or
+    /// vice versa) fails here.
+    #[test]
+    fn external_pads_resolve_to_built_elements() {
+        let result = build(&[("resolution", "1280x720"), ("format", "I420")]);
+        let built: Vec<&str> = result.elements.iter().map(|(id, _)| id.as_str()).collect();
+
+        let definition = videoformat_definition();
+        let pads = definition
+            .external_pads
+            .inputs
+            .iter()
+            .chain(definition.external_pads.outputs.iter());
+
+        for pad in pads {
+            let resolved = format!("vf0:{}", pad.internal_element_id);
+            assert!(
+                built.contains(&resolved.as_str()),
+                "external pad '{}' resolves to element '{}', which the builder does not create. \
+                 Built elements: {:?}",
+                pad.name,
+                resolved,
+                built
+            );
+        }
+    }
+
+    /// The block builds exactly one conversion element plus the capsfilter.
+    /// Splitting the conversion back into separate scale and convert elements
+    /// fails this test.
+    #[test]
+    fn builds_one_conversion_element_not_two() {
+        let result = build(&[("resolution", "1280x720"), ("format", "I420")]);
+
+        assert_eq!(
+            result.elements.len(),
+            2,
+            "expected one conversion element plus the capsfilter, got {:?}",
+            result
+                .elements
+                .iter()
+                .map(|(id, _)| id.as_str())
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(
+            result.internal_links.len(),
+            1,
+            "a two-element chain has exactly one internal link"
+        );
+
+        let factory = result.elements[0]
+            .1
+            .factory()
+            .expect("built element has a factory")
+            .name()
+            .to_string();
+        assert!(
+            factory == "videoconvertscale" || factory == "autovideoconvert",
+            "conversion element must convert and scale in one pass, got '{}'",
+            factory
+        );
+    }
+
+    /// The single element must actually do both jobs: reject 1080p RGBA in,
+    /// 720p I420 out unless one element performed both the scale and the
+    /// colorspace conversion.
+    #[test]
+    fn one_element_both_scales_and_converts() {
+        let result = build(&[("resolution", "1280x720"), ("format", "I420")]);
+
+        let pipeline = gst::Pipeline::new();
+        let src = gst::ElementFactory::make("videotestsrc")
+            .property("num-buffers", 2i32)
+            .property("is-live", false)
+            .build()
+            .expect("videotestsrc is in gst-plugins-base");
+        let in_caps = gst::ElementFactory::make("capsfilter")
+            .property(
+                "caps",
+                "video/x-raw,width=1920,height=1080,format=RGBA,framerate=30/1"
+                    .parse::<gst::Caps>()
+                    .unwrap(),
+            )
+            .build()
+            .unwrap();
+        let sink = gst::ElementFactory::make("fakesink")
+            .property("sync", false)
+            .build()
+            .unwrap();
+
+        let convert = &result.elements[0].1;
+        let capsfilter = &result.elements[1].1;
+        pipeline
+            .add_many([&src, &in_caps, convert, capsfilter, &sink])
+            .unwrap();
+        gst::Element::link_many([&src, &in_caps, convert, capsfilter, &sink])
+            .expect("the block's single element must link 1080p RGBA to 720p I420");
+
+        pipeline.set_state(gst::State::Playing).unwrap();
+        let bus = pipeline.bus().unwrap();
+        let msg = bus.timed_pop_filtered(
+            gst::ClockTime::from_seconds(10),
+            &[gst::MessageType::Eos, gst::MessageType::Error],
+        );
+
+        let out_caps = capsfilter
+            .static_pad("src")
+            .unwrap()
+            .current_caps()
+            .expect("output caps must be negotiated");
+        pipeline.set_state(gst::State::Null).unwrap();
+
+        match msg {
+            Some(m) if m.type_() == gst::MessageType::Error => {
+                panic!("pipeline error: {:?}", m)
+            }
+            None => panic!("pipeline did not reach EOS"),
+            _ => {}
+        }
+
+        let s = out_caps.structure(0).unwrap();
+        assert_eq!(s.get::<i32>("width").unwrap(), 1280);
+        assert_eq!(s.get::<i32>("height").unwrap(), 720);
+        assert_eq!(s.get::<String>("format").unwrap(), "I420");
+    }
+
+    /// The block leaves `method` unset and takes the element default. If the
+    /// two elements' defaults diverge, scaled output changes and the block
+    /// must pin `method` explicitly.
+    #[test]
+    fn scaling_method_default_matches_videoscale() {
+        init_gst();
+
+        let scale = gst::ElementFactory::make("videoscale").build().unwrap();
+        let convert_scale = gst::ElementFactory::make("videoconvertscale")
+            .build()
+            .unwrap();
+
+        let scale_method = scale.property_value("method");
+        let convert_scale_method = convert_scale.property_value("method");
+        assert_eq!(
+            format!("{:?}", scale_method),
+            format!("{:?}", convert_scale_method),
+            "videoscale and videoconvertscale disagree on the default scaling method; \
+             the block must pin `method` or the output change must be called out"
+        );
+    }
+
+    /// `configure_video_convert` must reach the conversion element, so that
+    /// both the converting and the scaling half are threaded.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn conversion_element_is_threaded() {
+        let result = build(&[("resolution", "1280x720"), ("format", "I420")]);
+        let convert = &result.elements[0].1;
+
+        assert!(
+            convert.has_property("n-threads"),
+            "the merged element must expose n-threads for configure_video_convert to reach"
+        );
+        assert_eq!(
+            convert.property::<u32>("n-threads"),
+            crate::gpu::video_convert_threads(),
+            "configure_video_convert did not reach the merged element"
+        );
+        assert!(
+            convert.property::<u32>("n-threads") > 1,
+            "n-threads left at the stock default of 1"
+        );
     }
 }

--- a/backend/src/blocks/builtin/videoformat.rs
+++ b/backend/src/blocks/builtin/videoformat.rs
@@ -14,7 +14,7 @@
 //! Unspecified properties allow passthrough - elements will not modify those aspects.
 
 use crate::blocks::{BlockBuildContext, BlockBuildError, BlockBuildResult, BlockBuilder};
-use crate::gpu::video_convert_mode;
+use crate::gpu::{self, video_convert_mode};
 use gstreamer as gst;
 use std::collections::HashMap;
 use strom_types::{
@@ -126,6 +126,7 @@ impl BlockBuilder for VideoFormatBuilder {
             .map_err(|e| {
                 BlockBuildError::ElementCreation(format!("{}: {}", convert_element_name, e))
             })?;
+        gpu::configure_video_convert(&videoconvert);
 
         // capsfilter with caps (only constraints specified properties)
         let caps = caps_str.parse::<gst::Caps>().map_err(|_| {

--- a/backend/src/blocks/builtin/vision_mixer/builder/pipeline_cpu.rs
+++ b/backend/src/blocks/builtin/vision_mixer/builder/pipeline_cpu.rs
@@ -109,6 +109,7 @@ pub(super) fn build_cpu_pipeline(
         // so that upstream GPU-memory sources (e.g. nvh264dec from efpsrt_input)
         // negotiate correctly against the CPU compositor backend.
         let videoconvert = elements::make_element(vc_factory, &vc_id_dsk)?;
+        gpu::configure_video_convert(&videoconvert);
 
         elems.push((q_id.clone(), queue));
         elems.push((vc_id_dsk.clone(), videoconvert));

--- a/backend/src/gpu.rs
+++ b/backend/src/gpu.rs
@@ -1,10 +1,13 @@
 //! GPU capability detection and video conversion mode selection.
 //!
-//! This module detects at startup whether GPU-accelerated video conversion
-//! with CUDA-GL interop is supported. On systems where it works (native Linux
-//! with X11 and NVIDIA drivers), we use `autovideoconvert` for better performance.
-//! On systems where it fails (WSL, headless/GBM, broken interop), we fall back
-//! to software `videoconvert`.
+//! The conversion mode is decided once at startup, per platform:
+//!
+//! * On CUDA platforms (Linux/Windows with NVIDIA) `autovideoconvert` gives a
+//!   real GPU path, but only where GL-CUDA interop actually works. NVENC's
+//!   presence is the gate for attempting that test, and the interop test is
+//!   the gate for using it. Where either fails we use software `videoconvert`.
+//! * On macOS there is no CUDA question to ask, so we do not ask it. See
+//!   `detect_convert_mode` for why macOS uses threaded software conversion.
 
 use gstreamer as gst;
 use gstreamer::prelude::*;
@@ -46,6 +49,7 @@ pub fn video_convert_mode() -> VideoConvertMode {
 }
 
 /// Check if running inside WSL (Windows Subsystem for Linux).
+#[cfg(not(target_os = "macos"))]
 fn is_wsl() -> bool {
     // Check WSL environment variable
     if std::env::var("WSL_DISTRO_NAME").is_ok() || std::env::var("WSL_INTEROP").is_ok() {
@@ -215,23 +219,49 @@ fn detect_gl_renderer() -> Option<GlRendererInfo> {
 
 /// Detect GPU capabilities and set the global video conversion mode.
 /// This should be called once at startup after GStreamer is initialized.
-///
-/// Detection strategy:
-/// 1. If running on WSL, skip GPU test (CUDA-GL interop is known broken)
-/// 2. If cudadownload element is unavailable, use software mode
-/// 3. Test GL→CUDA interop with a fast pipeline (no nvenc initialization)
 pub fn detect_gpu_capabilities() -> VideoConvertMode {
     // Probe GL renderer info early (best-effort, independent of CUDA-GL interop)
     let gl_info = detect_gl_renderer();
     let _ = GL_RENDERER_INFO.set(gl_info);
 
+    let mode = detect_convert_mode();
+    let _ = VIDEO_CONVERT_MODE.set(mode);
+    mode
+}
+
+/// Decide the conversion mode on macOS.
+///
+/// Do not add an NVENC check here: NVENC never exists on a Mac, so the probe
+/// could only ever return one answer.
+///
+/// `Software` is right for two reasons. `autovideoconvert` offers no GPU path
+/// for the frames these call sites see — given GL memory it picks
+/// `glcolorconvert`, but our blocks feed it system memory (the GL chains in
+/// this tree download at their boundary) and it then selects
+/// `videoconvertscale` on the CPU. And being a bin it exposes no `n-threads`,
+/// so it would forfeit the threading below, which is what moves the numbers.
+#[cfg(target_os = "macos")]
+fn detect_convert_mode() -> VideoConvertMode {
+    info!(
+        "macOS - using software video conversion with n-threads={} (autovideoconvert has no GPU path for system memory here)",
+        video_convert_threads()
+    );
+    VideoConvertMode::Software
+}
+
+/// Decide the conversion mode on CUDA-capable platforms (Linux, Windows).
+///
+/// Detection strategy, unchanged:
+/// 1. If running on WSL, skip GPU test (CUDA-GL interop is known broken)
+/// 2. If NVENC is unavailable there is no CUDA stack to test, use software mode
+/// 3. Test GL→CUDA interop with a fast pipeline (no nvenc initialization)
+#[cfg(not(target_os = "macos"))]
+fn detect_convert_mode() -> VideoConvertMode {
     // Fast path: WSL has broken CUDA-GL interop, skip expensive test
     if is_wsl() {
         info!("WSL detected - using software video conversion (CUDA-GL interop unsupported)");
         // deprioritize_nv_decoders();
-        let mode = VideoConvertMode::Software;
-        let _ = VIDEO_CONVERT_MODE.set(mode);
-        return mode;
+        return VideoConvertMode::Software;
     }
 
     // Check if nvh264enc is available (required for GPU-accelerated encoding)
@@ -242,14 +272,12 @@ pub fn detect_gpu_capabilities() -> VideoConvertMode {
 
     if !has_nvenc {
         info!("NVENC not available - using software video conversion");
-        let mode = VideoConvertMode::Software;
-        let _ = VIDEO_CONVERT_MODE.set(mode);
-        return mode;
+        return VideoConvertMode::Software;
     }
 
     debug!("Testing CUDA-GL interop (this may take a moment on first run)...");
 
-    let mode = match test_cuda_gl_interop() {
+    match test_cuda_gl_interop() {
         Ok(()) => {
             info!("CUDA-GL interop works - using GPU-accelerated video conversion");
             VideoConvertMode::GpuAccelerated
@@ -261,15 +289,217 @@ pub fn detect_gpu_capabilities() -> VideoConvertMode {
             );
             VideoConvertMode::Software
         }
-    };
+    }
+}
 
-    let _ = VIDEO_CONVERT_MODE.set(mode);
-    mode
+/// Sanity bound on the detected core count, not a performance policy: it sits
+/// above anything Apple silicon reports, and clamping is logged rather than
+/// silent. Deliberately loose, because the errors are asymmetric — overshooting
+/// the pool measured 1-2%, undershooting up to 24%.
+#[cfg(target_os = "macos")]
+const MAX_CONVERT_THREADS: u32 = 32;
+
+/// Sanity bound for the `STROM_VIDEOCONVERT_THREADS` override, so a typo cannot
+/// ask for thousands of threads.
+#[cfg(target_os = "macos")]
+const MAX_OVERRIDE_THREADS: u32 = 64;
+
+/// The override is only an escape hatch if it can exceed the sanity bound.
+#[cfg(target_os = "macos")]
+const _: () = assert!(MAX_OVERRIDE_THREADS > MAX_CONVERT_THREADS);
+
+/// Number of worker threads to give a software `videoconvert`.
+///
+/// The stock `n-threads=1` converts a whole frame on one core; a pool sized to
+/// the machine measured 24% faster end to end at 1080p on a 4+4 M2.
+///
+/// The pool counts every performance tier macOS reports except the efficiency
+/// one — 4 on an M2, 36 on an M5 Ultra. `videoconvert` cuts a frame into equal
+/// stripes and cannot emit until the slowest finishes, so an efficiency core
+/// becomes the straggler the whole frame waits on. Apple draws the same line,
+/// describing performance cores as joining the super cores for demanding
+/// multithreaded work while efficiency cores handle background tasks. Super and
+/// performance cores do still differ, so a wide machine is worth measuring with
+/// `STROM_VIDEOCONVERT_THREADS`.
+///
+/// Intel Macs report no tiers and fall back to the total logical CPU count,
+/// which is correct there since all cores are equivalent.
+#[cfg(target_os = "macos")]
+pub fn video_convert_threads() -> u32 {
+    static THREADS: OnceLock<u32> = OnceLock::new();
+    *THREADS.get_or_init(|| {
+        let detected = performance_core_count().unwrap_or_else(|| {
+            std::thread::available_parallelism()
+                .map(|n| n.get() as u32)
+                .unwrap_or(1)
+        });
+        let raw = std::env::var("STROM_VIDEOCONVERT_THREADS").ok();
+        resolve_thread_count(raw.as_deref(), detected)
+    })
+}
+
+/// Apply the override and the ceiling to a detected core count.
+///
+/// Split out from [`video_convert_threads`] so the parsing and clamping can be
+/// tested without the process-wide `OnceLock` or the environment, and so the
+/// behaviour on machines wider than this one is pinned by a test rather than
+/// left to inference.
+#[cfg(target_os = "macos")]
+fn resolve_thread_count(override_raw: Option<&str>, detected: u32) -> u32 {
+    if let Some(raw) = override_raw {
+        match raw.trim().parse::<u32>() {
+            // The override deliberately bypasses MAX_CONVERT_THREADS so a
+            // wider machine can be measured past the sanity bound without a
+            // rebuild.
+            Ok(n) if (1..=MAX_OVERRIDE_THREADS).contains(&n) => return n,
+            _ => warn!(
+                "ignoring STROM_VIDEOCONVERT_THREADS={:?} - expected an integer in 1..={}",
+                raw, MAX_OVERRIDE_THREADS
+            ),
+        }
+    }
+    if detected > MAX_CONVERT_THREADS {
+        warn!(
+            "detected {} fast cores, capping the videoconvert pool at {} - set STROM_VIDEOCONVERT_THREADS to override",
+            detected, MAX_CONVERT_THREADS
+        );
+    }
+    detected.clamp(1, MAX_CONVERT_THREADS)
+}
+
+/// Count the logical CPUs in every performance tier that is not an efficiency
+/// tier.
+///
+/// macOS numbers its core tiers fastest-first and names each. A part can have
+/// more than one fast tier — an M5 Ultra is 12 super cores plus 24 performance
+/// cores — so tier 0 alone would be 12 there and discard 24 fast cores.
+///
+/// Matching the tier to *exclude* is the durable form: "Efficiency" is stable
+/// while the fast tiers gain names. A rename fails open — efficiency
+/// cores get counted, costing the 1-2% that overshooting costs rather than most
+/// of the machine.
+///
+/// Returns `None` on Intel Macs, where these keys are absent.
+#[cfg(target_os = "macos")]
+fn performance_core_count() -> Option<u32> {
+    let levels = sysctl_u32("hw.nperflevels")?;
+    let tiers: Vec<(String, u32)> = (0..levels)
+        .map(|i| {
+            (
+                sysctl_string(&format!("hw.perflevel{}.name", i)).unwrap_or_default(),
+                sysctl_u32(&format!("hw.perflevel{}.logicalcpu", i)).unwrap_or(0),
+            )
+        })
+        .collect();
+
+    debug!("CPU performance tiers: {:?}", tiers);
+    let n = fast_cores_from_tiers(&tiers);
+    (n > 0).then_some(n)
+}
+
+/// Sum the tiers that are not efficiency tiers.
+///
+/// Split from the syscalls so the tier policy can be tested against machines
+/// that are not to hand.
+#[cfg(target_os = "macos")]
+fn fast_cores_from_tiers(tiers: &[(String, u32)]) -> u32 {
+    tiers
+        .iter()
+        .filter(|(name, _)| !name.to_ascii_lowercase().contains("efficiency"))
+        .map(|(_, count)| count)
+        .sum()
+}
+
+/// Read an integer sysctl by name.
+#[cfg(target_os = "macos")]
+fn sysctl_u32(name: &str) -> Option<u32> {
+    let cname = std::ffi::CString::new(name).ok()?;
+    let mut value: i32 = 0;
+    let mut size = std::mem::size_of::<i32>();
+    // SAFETY: `value` and `size` describe the same object, and `cname` is a
+    // NUL-terminated C string that outlives the call.
+    let rc = unsafe {
+        libc::sysctlbyname(
+            cname.as_ptr(),
+            &mut value as *mut i32 as *mut libc::c_void,
+            &mut size,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    (rc == 0 && value > 0).then_some(value as u32)
+}
+
+/// Read a string sysctl by name.
+#[cfg(target_os = "macos")]
+fn sysctl_string(name: &str) -> Option<String> {
+    let cname = std::ffi::CString::new(name).ok()?;
+    let mut size: usize = 0;
+
+    // SAFETY: a null data pointer asks sysctlbyname for the size only.
+    let rc = unsafe {
+        libc::sysctlbyname(
+            cname.as_ptr(),
+            std::ptr::null_mut(),
+            &mut size,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    if rc != 0 || size == 0 {
+        return None;
+    }
+
+    let mut buf = vec![0u8; size];
+    // SAFETY: `buf` has `size` bytes and `size` is updated with what was written.
+    let rc = unsafe {
+        libc::sysctlbyname(
+            cname.as_ptr(),
+            buf.as_mut_ptr() as *mut libc::c_void,
+            &mut size,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    if rc != 0 {
+        return None;
+    }
+
+    buf.truncate(size.min(buf.len()));
+    let end = buf.iter().position(|&b| b == 0).unwrap_or(buf.len());
+    Some(String::from_utf8_lossy(&buf[..end]).into_owned())
+}
+
+/// Apply tuning properties to a freshly created video conversion element.
+///
+/// `videoconvert` ships with `n-threads=1`, so a 1080p colour conversion runs
+/// on a single core however many the machine has. Every call site that builds a
+/// conversion element from [`VideoConvertMode::element_name`] routes through
+/// here, so the default is set in exactly one place.
+///
+/// This is macOS-only on purpose. The thread count above is an Apple-silicon
+/// heuristic. On Linux in particular a container's visible CPU count routinely
+/// overstates its cgroup quota, so picking a pool size there without measuring
+/// risks oversubscribing shared hosts. Elsewhere this is a no-op.
+pub fn configure_video_convert(element: &gst::Element) {
+    #[cfg(target_os = "macos")]
+    {
+        // Only plain `videoconvert` carries the property; `autovideoconvert` is
+        // a bin with nothing to forward it to.
+        if element.has_property("n-threads") {
+            element.set_property("n-threads", video_convert_threads());
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = element;
+    }
 }
 
 /// Test if true zero-copy GL-CUDA interop works with nvh264enc.
 /// Runs gst-launch-1.0 with GST_DEBUG to capture interop warnings.
 /// Returns Ok if zero-copy works, Err if fallback copy is used.
+#[cfg(not(target_os = "macos"))]
 fn test_cuda_gl_interop() -> Result<(), String> {
     use std::process::Command;
 
@@ -351,5 +581,213 @@ mod tests {
             "autovideoconvert"
         );
         assert_eq!(VideoConvertMode::Software.element_name(), "videoconvert");
+    }
+
+    /// `configure_video_convert` must raise the thread count off the stock
+    /// default of 1. Dropping the property, or a call site's use of this
+    /// helper, leaves `n-threads` at 1 and fails this test.
+    ///
+    /// macOS-only because the helper is deliberately a no-op elsewhere.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn configure_video_convert_sets_thread_count() {
+        gst::init().expect("gst init");
+
+        let convert = gst::ElementFactory::make("videoconvert")
+            .build()
+            .expect("videoconvert is in gst-plugins-base and must be present");
+
+        assert_eq!(
+            convert.property::<u32>("n-threads"),
+            1,
+            "upstream default changed; the premise of this fix needs rechecking"
+        );
+
+        configure_video_convert(&convert);
+
+        assert_eq!(
+            convert.property::<u32>("n-threads"),
+            video_convert_threads()
+        );
+        assert!(
+            video_convert_threads() > 1,
+            "every Mac this runs on is multi-core; a pool of 1 means detection failed"
+        );
+    }
+
+    /// The macOS choice of `Software` rests on `autovideoconvert` being a bin
+    /// that cannot forward a thread count to the converter it picks. If a
+    /// future GStreamer grows such a property, that trade-off is worth
+    /// re-measuring rather than silently keeping.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn autovideoconvert_cannot_be_threaded() {
+        gst::init().expect("gst init");
+
+        let auto = gst::ElementFactory::make("autovideoconvert")
+            .build()
+            .expect("autovideoconvert is in gst-plugins-base and must be present");
+
+        assert!(
+            !auto.has_property("n-threads"),
+            "autovideoconvert now exposes n-threads - re-measure Software vs GpuAccelerated on macOS"
+        );
+    }
+
+    /// The pool size must stay inside the documented bounds whichever branch
+    /// of `video_convert_threads` supplies it.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn video_convert_threads_is_bounded() {
+        let n = video_convert_threads();
+        assert!(
+            (1..=MAX_OVERRIDE_THREADS).contains(&n),
+            "thread count out of range: {}",
+            n
+        );
+    }
+
+    /// Pins what happens on machines wider than this one, which cannot
+    /// exercise these paths itself.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn thread_count_scales_with_cores() {
+        // The detected count is used as-is across the whole real Apple silicon
+        // range: M2 4, M3 Pro 6, M2 Max 8, M4 Pro 10, M3/M4 Max 12, M3 Ultra 24.
+        for cores in [4, 6, 8, 10, 12, 16, 24] {
+            assert_eq!(
+                resolve_thread_count(None, cores),
+                cores,
+                "a {}-P-core machine should use its cores, not a capped value",
+                cores
+            );
+        }
+
+        // The bound is a sanity check on the syscall, not a policy: it only
+        // engages past anything Apple silicon reports. An old Intel Mac Pro
+        // falling back to 56 logical CPUs is the realistic case that hits it.
+        assert_eq!(resolve_thread_count(None, 56), MAX_CONVERT_THREADS);
+        assert_eq!(resolve_thread_count(None, u32::MAX), MAX_CONVERT_THREADS);
+
+        // A nonsense detection still yields a usable pool.
+        assert_eq!(resolve_thread_count(None, 0), 1);
+    }
+
+    /// Pins the tier policy against real Apple silicon layouts, none of which
+    /// beyond this machine are to hand.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn fast_cores_counts_every_non_efficiency_tier() {
+        let m2 = [("Performance".into(), 4), ("Efficiency".into(), 4)];
+        assert_eq!(fast_cores_from_tiers(&m2), 4);
+
+        // M4: fewer performance cores than efficiency cores.
+        let m4 = [("Performance".into(), 4), ("Efficiency".into(), 6)];
+        assert_eq!(fast_cores_from_tiers(&m4), 4);
+
+        // M5 Ultra: 36 cores as 12 super + 24 performance, no efficiency tier.
+        // Taking level 0 alone would yield 12 and throw away 24 fast cores.
+        let m5_ultra = [("Super".into(), 12), ("Performance".into(), 24)];
+        assert_eq!(fast_cores_from_tiers(&m5_ultra), 36);
+
+        // M6: 2 super + 4 performance + 6 efficiency. All three tiers coexist,
+        // so "performance" is a tier in its own right and not efficiency
+        // renamed; only the efficiency tier is dropped.
+        let m6 = [
+            ("Super".into(), 2),
+            ("Performance".into(), 4),
+            ("Efficiency".into(), 6),
+        ];
+        assert_eq!(fast_cores_from_tiers(&m6), 6);
+    }
+
+    /// If Apple renames the efficiency tier the match fails open, including
+    /// those cores rather than discarding most of the machine. Overshooting the
+    /// pool costs ~1-2%; undershooting costs far more.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn fast_cores_fails_open_on_an_unrecognised_tier_name() {
+        let renamed = [("Performance".into(), 4), ("E-Core".into(), 4)];
+        assert_eq!(fast_cores_from_tiers(&renamed), 8);
+    }
+
+    /// The tier names really are readable on this machine, so the policy above
+    /// is driven by data rather than by an assumption about the sysctl.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn perflevel_names_are_readable() {
+        let levels = sysctl_u32("hw.nperflevels").expect("macOS reports hw.nperflevels");
+        assert!(levels >= 1);
+        let name = sysctl_string("hw.perflevel0.name").expect("perflevel0 has a name");
+        assert!(!name.is_empty(), "perflevel0.name was empty");
+    }
+
+    /// The override is the escape hatch for a machine wider than this one, so
+    /// it must beat the sanity bound — and must not be trusted blindly.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn thread_count_override_bypasses_the_bound() {
+        assert_eq!(resolve_thread_count(Some("16"), 4), 16);
+        assert_eq!(resolve_thread_count(Some(" 24 "), 4), 24);
+
+        // Past MAX_CONVERT_THREADS, which detection alone can never reach.
+        assert_eq!(
+            resolve_thread_count(Some(&MAX_OVERRIDE_THREADS.to_string()), 4),
+            MAX_OVERRIDE_THREADS
+        );
+
+        // Garbage, zero and absurd values fall back to detection rather than
+        // taking the process down or spawning thousands of threads.
+        for bad in ["", "  ", "no", "-1", "0", "65", "999999", "4.5"] {
+            assert_eq!(
+                resolve_thread_count(Some(bad), 4),
+                4,
+                "STROM_VIDEOCONVERT_THREADS={:?} should have been rejected",
+                bad
+            );
+        }
+    }
+
+    /// Tripwire for a VideoToolbox converter arriving in a future GStreamer.
+    ///
+    /// The macOS choice of `Software` rests on there being no hardware
+    /// converter for `autovideoconvert` to offer. `autovideoconvert` discovers
+    /// candidates by klass (`Filter/Converter/Video...`), and today no
+    /// applemedia element carries one — the plugin ships codecs, a source and a
+    /// sink, nothing that transforms raw video.
+    ///
+    /// That is a gap in GStreamer, not in the platform: Apple exposes
+    /// `VTPixelTransferSession`, which converts colour and scales, and nothing
+    /// upstream wraps it yet. If that changes, `autovideoconvert` will pick the
+    /// new element up automatically and `GpuAccelerated` becomes worth
+    /// re-measuring here — a VideoToolbox transfer session would keep frames in
+    /// `CVPixelBuffer`s and skip both the CPU stripe work and the GL round trip
+    /// that makes `glcolorconvert` unprofitable for system memory today.
+    ///
+    /// This test fails on the day that lands, so the decision gets revisited
+    /// deliberately instead of the constant above quietly going stale.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn no_applemedia_converter_to_reconsider() {
+        gst::init().expect("gst init");
+
+        let converters: Vec<String> = gst::Registry::get()
+            .features_by_plugin("applemedia")
+            .into_iter()
+            .filter_map(|f| f.downcast::<gst::ElementFactory>().ok())
+            .filter(|f| {
+                f.metadata(gst::ELEMENT_METADATA_KLASS)
+                    .map(|k| k.contains("Converter"))
+                    .unwrap_or(false)
+            })
+            .map(|f| f.name().to_string())
+            .collect();
+
+        assert!(
+            converters.is_empty(),
+            "applemedia now ships a video converter ({:?}) - autovideoconvert will \
+             discover it, so re-measure GpuAccelerated against threaded Software on macOS",
+            converters
+        );
     }
 }

--- a/backend/src/gpu.rs
+++ b/backend/src/gpu.rs
@@ -32,6 +32,21 @@ impl VideoConvertMode {
             VideoConvertMode::Software => "videoconvert",
         }
     }
+
+    /// Returns the element name for a stage that converts *and* scales.
+    ///
+    /// Use this instead of [`Self::element_name`] for a stage that needs
+    /// both: `videoconvertscale` does the two in a single walk of the frame.
+    ///
+    /// `autovideoconvert` covers both as well — it is
+    /// `Bin/Colorspace/Scale/Video/Converter` and autoplugs a scaler when the
+    /// caps ask for one.
+    pub fn convert_scale_element_name(&self) -> &'static str {
+        match self {
+            VideoConvertMode::GpuAccelerated => "autovideoconvert",
+            VideoConvertMode::Software => "videoconvertscale",
+        }
+    }
 }
 
 /// Global detected video convert mode, set once at startup.
@@ -474,8 +489,9 @@ fn sysctl_string(name: &str) -> Option<String> {
 ///
 /// `videoconvert` ships with `n-threads=1`, so a 1080p colour conversion runs
 /// on a single core however many the machine has. Every call site that builds a
-/// conversion element from [`VideoConvertMode::element_name`] routes through
-/// here, so the default is set in exactly one place.
+/// conversion element from [`VideoConvertMode::element_name`] or
+/// [`VideoConvertMode::convert_scale_element_name`] routes through here, so the
+/// default is set in exactly one place.
 ///
 /// This is macOS-only on purpose. The thread count above is an Apple-silicon
 /// heuristic. On Linux in particular a container's visible CPU count routinely
@@ -581,6 +597,33 @@ mod tests {
             "autovideoconvert"
         );
         assert_eq!(VideoConvertMode::Software.element_name(), "videoconvert");
+    }
+
+    /// The convert+scale variant must name elements that actually scale.
+    /// `videoconvert` here would silently drop the scaling half.
+    #[test]
+    fn convert_scale_element_name_scales() {
+        assert_eq!(
+            VideoConvertMode::Software.convert_scale_element_name(),
+            "videoconvertscale"
+        );
+        assert_eq!(
+            VideoConvertMode::GpuAccelerated.convert_scale_element_name(),
+            "autovideoconvert"
+        );
+
+        // autovideoconvert is only correct here because it autoplugs a scaler.
+        gst::init().expect("gst init");
+        let factory = gst::ElementFactory::find("autovideoconvert")
+            .expect("autovideoconvert is in gst-plugins-bad");
+        let klass = factory
+            .metadata(gst::ELEMENT_METADATA_KLASS)
+            .unwrap_or_default();
+        assert!(
+            klass.contains("Scale"),
+            "autovideoconvert does not advertise scaling (klass '{}'); the convert+scale call sites need a separate scaler",
+            klass
+        );
     }
 
     /// `configure_video_convert` must raise the thread count off the stock

--- a/backend/src/gst/thumbnail.rs
+++ b/backend/src/gst/thumbnail.rs
@@ -1,7 +1,7 @@
 //! Thumbnail capture error types.
 //!
 //! The actual thumbnail capture logic has moved to `thumbnail_tap.rs`, which
-//! uses GStreamer-native processing (autovideoconvert, videoscale) instead of
+//! uses GStreamer-native processing (videoconvertscale) instead of
 //! CPU-based pad probes. This module retains the shared error type.
 
 use thiserror::Error;


### PR DESCRIPTION
> Stacked on #726 — this branch is cut from `wagenet/macos-convert-mode`, so the diff includes that commit. Only the second commit belongs to this PR.

The Video Format block built `videoscale -> videoconvert -> capsfilter`, so a flow changing both resolution and pixel format walked every frame twice with an intermediate buffer between. `videoconvertscale` does both in one walk.

`autovideoconvert` already covers both passes — it is `Bin/Colorspace/Scale/Video/Converter` and autoplugs a scaler when the caps ask for one (verified with `gst-launch-1.0`: 1080p RGBA in, 720p I420 negotiated out). So the collapse applies in both convert modes, not just software. The new `VideoConvertMode::convert_scale_element_name()` picks the element per mode; `element_name()` is untouched, so the convert-only sites (NDI, videoenc, devicesrc, CPU vision mixer) don't gain a scaler.

## Measurements

M2, 4 performance cores, 1080p RGBA, 300 frames, within-pair order alternated. The noise floor here is ±11% on paired runs, and a fixed order has produced sign-flipping "wins" before.

Isolated stage, `gst-launch-1.0`, 20 pairs: 1.558 s → 0.589 s, **+62%**, 20/20 pairs, order-symmetric (+62.2% A-first, +62.0% B-first).

Full Strom flow ending in x264enc, fresh backend per measurement, 12 pairs: 2.104 s → 1.292 s, **+38%** (range 34–41%), 12/12 pairs, order-symmetric (+38.4%, +38.7%).

Format only, scaling passthrough (1080p RGBA → 1080p I420), 20 pairs: median **−0.9%**, 10/20 pairs. No measurable difference — a passthrough `videoscale` is free.

Most of that is not pass-merging. A third arm, `videoscale n-threads=4 ! videoconvert n-threads=4`, splits it: merging the passes is worth ~10% (median +10.5%, 17/20 pairs). The rest is that the scaling half is now threaded — `videoscale` has the same `n-threads` property and the same default of 1, but nothing ever set it, and the merged element goes through `configure_video_convert()`.

## Scaling method

Both elements share `GstVideoScaleMethod` and default to `1, "bilinear"` (GStreamer 1.28.6), so scaled output is unchanged and no `method` pin is needed. `scaling_method_default_matches_videoscale` fails if upstream diverges.

## External pads

Saved flows store links as `block_id:external_pad_name` and resolve them through the block definition at build time. `VideoFormat` doesn't override `get_external_pads()`, so it never persists `computed_external_pads` and nothing stale is baked into saved JSON. The risk is a definition naming an element the builder no longer creates, so the surviving element keeps the ID `videoscale` and `external_pads` is unchanged. That matches the convention already in the file: the ID names the role, not the factory, which is why the convert element was called `videoconvert` while being `autovideoconvert`.

Verified end to end — a flow linking `vfmt:video_in` and `vfmt:video_out` was created and started against the real backend, built `videoconvertscale -> capsfilter`, played, and reached EOS.

## Other videoscale sites

None. `videoformat.rs` was the only place building one, and `thumbnail_tap.rs` already uses `videoconvertscale`. A stale doc comment in `thumbnail.rs` naming elements that module no longer references is corrected here.

## Tests

- `builds_one_conversion_element_not_two` — two elements, one internal link, and the conversion element both converts and scales.
- `one_element_both_scales_and_converts` — 1080p RGBA into the block, 1280x720 I420 out.
- `conversion_element_is_threaded` (macOS) — `n-threads` reaches the merged element and is above the default of 1.
- `external_pads_resolve_to_built_elements` — every external pad resolves to an element the builder creates.
- `scaling_method_default_matches_videoscale`
- `gpu::convert_scale_element_name_scales` — the mode mapping, plus a guard that `autovideoconvert` still advertises `Scale`.

The first three were verified to fail against a temporary revert of `build()` to the old chain. The last three pass under that revert; they guard a future rename, future upstream drift, and a future mode-mapping mistake rather than this change.

All six use core and gst-plugins-base elements plus `autovideoconvert` from gst-plugins-bad, all installed in CI, so none skip.

Ran locally: full `cargo test` (552 lib tests plus all integration tests, including `pipeline_lifecycle_test`) green, with one pre-existing unrelated ignore (`test_jitterbuffer_stalls_without_drop_on_latency`); `cargo build` and `cargo clippy --all-targets -- -D warnings` clean.

Not run: Linux or Windows. macOS always resolves to `Software`, so the `autovideoconvert` branch of `convert_scale_element_name()` is never exercised here — it rests on the `gst-launch` check and the klass assertion, not a real GPU flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
