### PR TITLE
fix(macos): keep the headless server out of App Nap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6618,6 +6618,7 @@ dependencies = [
  "network-interface",
  "notify",
  "nvml-wrapper",
+ "objc2-foundation 0.3.2",
  "parking_lot",
  "reqwest 0.13.4",
  "rust-embed",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -140,6 +140,15 @@ eframe = { workspace = true }
 chrono = "0.4"
 uuid = { version = "1.23", features = ["v4"] }
 
+[target.'cfg(target_os = "macos")'.dependencies]
+# App Nap opt-out: see backend/src/macos_app_nap.rs. Already in the tree via
+# eframe, so this adds no new crate.
+objc2-foundation = { version = "0.3", default-features = false, features = [
+    "std",
+    "NSProcessInfo",
+    "NSString",
+] }
+
 [target.'cfg(windows)'.build-dependencies]
 winresource = "0.1"
 

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -31,6 +31,7 @@ pub mod gst;
 pub mod gui;
 pub mod json_rejection;
 pub mod layout;
+pub mod macos_app_nap;
 pub mod mcp;
 pub mod network;
 pub mod openapi;

--- a/backend/src/macos_app_nap.rs
+++ b/backend/src/macos_app_nap.rs
@@ -1,0 +1,53 @@
+//! Keep macOS from putting the server into the background QoS band.
+//!
+//! Headless Strom registers with LaunchServices as a `Foreground` app but never
+//! opens a window, and macOS App-Naps that shape ~32 s after launch: every thread
+//! drops to scheduling priority 4, which on Apple Silicon means efficiency cores
+//! at a throttled clock, and pipelines run ~7x slower for the rest of the
+//! process's life. `gst-launch-1.0` is exempt because it registers as
+//! `UIElement`; what makes Strom `Foreground` is not known.
+//!
+//! `beginActivityWithOptions:reason:` is the documented opt-out, and works
+//! regardless of activation policy.
+//!
+//! Only headless mode needs this. In GUI mode the window keeps the app out of App
+//! Nap.
+
+/// Take a user-initiated activity assertion that lasts as long as the process.
+///
+/// Safe to call more than once; each call takes its own assertion.
+#[cfg(target_os = "macos")]
+pub fn hold_activity_for_process_lifetime() {
+    use objc2_foundation::{NSActivityOptions, NSProcessInfo, NSString};
+
+    // `UserInitiatedAllowingIdleSystemSleep` rather than `UserInitiated`: both opt
+    // out of App Nap, but the plain variant also blocks system idle sleep, and a
+    // media server has no business keeping the machine awake. `LatencyCritical`
+    // also opts out of timer coalescing.
+    let options = NSActivityOptions::UserInitiatedAllowingIdleSystemSleep
+        | NSActivityOptions::LatencyCritical;
+    let reason = NSString::from_str("Strom is running media pipelines");
+    let activity = NSProcessInfo::processInfo().beginActivityWithOptions_reason(options, &reason);
+
+    // The assertion lasts as long as the token, and we want it for the whole
+    // process, so leaking it is deliberate.
+    std::mem::forget(activity);
+
+    tracing::info!("macOS: holding a user-initiated activity assertion (App Nap opt-out)");
+}
+
+/// No-op away from macOS.
+#[cfg(not(target_os = "macos"))]
+pub fn hold_activity_for_process_lifetime() {}
+
+#[cfg(all(test, target_os = "macos"))]
+mod tests {
+    /// Catches a wrong selector or option constant, which aborts the process
+    /// rather than failing an assertion. `tests/macos_app_nap_test.rs` is the
+    /// actual guard.
+    #[test]
+    fn taking_the_activity_assertion_does_not_abort() {
+        super::hold_activity_for_process_lifetime();
+        super::hold_activity_for_process_lifetime();
+    }
+}

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -565,6 +565,11 @@ fn run_headless_entry(
     log_reload_handle: strom::state::LogReloadHandle,
     default_log_filter: String,
 ) -> anyhow::Result<()> {
+    // Before the CFRunLoop starts: without this the process is App-Napped into the
+    // background QoS band ~32 s in, and every pipeline after that runs on
+    // efficiency cores.
+    strom::macos_app_nap::hold_activity_for_process_lifetime();
+
     #[cfg(target_os = "macos")]
     {
         gstreamer::macos_main(move || {

--- a/backend/tests/macos_app_nap_test.rs
+++ b/backend/tests/macos_app_nap_test.rs
@@ -1,0 +1,176 @@
+//! Guards for the App Nap opt-out in `macos_app_nap`.
+//!
+//! ~32 s after launch macOS moves headless Strom into the background QoS band and
+//! every thread drops to scheduling priority 4 — on Apple Silicon, efficiency
+//! cores at a throttled clock, which costs a 1080p x264 flow ~7x its wall clock.
+//! The server holds an `NSProcessInfo` activity assertion to opt out.
+//!
+//! Two failure modes, tested separately because they cost three orders of
+//! magnitude apart: the call going missing from `run_headless_entry` (the
+//! realistic regression, caught in well under a second), and macOS ceasing to
+//! honour the assertion (only observable by waiting out the demotion window, so
+//! opt-in and run by hand).
+#![cfg(target_os = "macos")]
+
+use std::io::Read;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+/// Logged by `hold_activity_for_process_lifetime`. Asserted below, so treat it as
+/// part of the contract rather than a message to reword freely.
+const MARKER: &str = "App Nap opt-out";
+
+/// Logged well after the assertion is taken. Once this appears, the marker either
+/// arrived or never will, so the test can fail immediately instead of waiting out
+/// the deadline.
+const READY: &str = "Server listening on";
+
+/// Darwin's QoS classes map onto scheduling priorities: 46-47 user-interactive,
+/// 37 user-initiated, 31 default, 20 utility, 4 background.
+const BACKGROUND_PRIORITY: u32 = 4;
+
+struct Server {
+    child: std::process::Child,
+    log: tempfile::NamedTempFile,
+    _dir: tempfile::TempDir,
+}
+
+impl Server {
+    fn spawn() -> Self {
+        let dir = tempfile::tempdir().expect("create a data directory");
+        let log = tempfile::NamedTempFile::new().expect("create a log file");
+        // Port 0 lets the OS pick, so concurrent tests cannot collide.
+        let child = Command::new(env!("CARGO_BIN_EXE_strom"))
+            .args(["--headless", "--port", "0", "--data-dir"])
+            .arg(dir.path())
+            .stdout(log.reopen().expect("reopen the log for stdout"))
+            .stderr(log.reopen().expect("reopen the log for stderr"))
+            .stdin(Stdio::null())
+            .spawn()
+            .expect("spawn the headless server");
+        Self {
+            child,
+            log,
+            _dir: dir,
+        }
+    }
+
+    fn log_contains(&self, needle: &str) -> bool {
+        let mut text = String::new();
+        self.log
+            .reopen()
+            .expect("reopen the log")
+            .read_to_string(&mut text)
+            .ok();
+        text.contains(needle)
+    }
+}
+
+impl Drop for Server {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+/// The wiring test. Fails if the call in `run_headless_entry` is removed.
+#[test]
+fn headless_entry_takes_the_activity_assertion() {
+    let server = Server::spawn();
+
+    let deadline = Instant::now() + Duration::from_secs(90);
+    let mut started = false;
+    while Instant::now() < deadline {
+        if server.log_contains(MARKER) {
+            return;
+        }
+        if server.log_contains(READY) {
+            started = true;
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+
+    assert!(
+        started,
+        "the headless server never got as far as logging {READY:?}, so this says \
+         nothing about the activity assertion"
+    );
+    panic!(
+        "the headless server reached {READY:?} without logging {MARKER:?}: nothing \
+         took an NSProcessInfo activity assertion, so macOS will App-Nap the process \
+         into the background QoS band about thirty seconds in and every pipeline \
+         after that will run on efficiency cores"
+    );
+}
+
+/// `ps -M` prints one row per thread. Priority is the only column that is digits
+/// followed by the scheduling-policy letter (`31T`, `4T`, `50R`) — %CPU has a
+/// dot, TIME has colons, STAT has no digits.
+fn priority_of_row(row: &str) -> Option<u32> {
+    row.split_whitespace().find_map(|token| {
+        if !token.is_ascii() || token.len() < 2 {
+            return None;
+        }
+        let (digits, policy) = token.split_at(token.len() - 1);
+        if !policy.chars().all(|c| c.is_ascii_uppercase()) {
+            return None;
+        }
+        digits.parse().ok()
+    })
+}
+
+fn max_thread_priority(pid: u32) -> Option<u32> {
+    let out = Command::new("ps")
+        .arg("-M")
+        .arg(pid.to_string())
+        .output()
+        .ok()?;
+    String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .skip(1)
+        .filter_map(priority_of_row)
+        .max()
+}
+
+/// The behavioural check: does macOS still honour the assertion?
+///
+/// Opt-in, because the demotion lands at ~32 s and cannot be observed without
+/// waiting past it. Run by hand on a real Mac after touching this module or
+/// upgrading macOS or `objc2-foundation`:
+///
+/// ```text
+/// STROM_TEST_APP_NAP=1 cargo test --test macos_app_nap_test -- --ignored
+/// ```
+///
+/// Not wired into CI: the GitHub macOS runner is a headless VM and it is
+/// unverified whether it App-Naps at all.
+#[test]
+#[ignore = "waits ~50 s for the App Nap window; set STROM_TEST_APP_NAP=1"]
+fn server_is_not_demoted_to_background_qos() {
+    if std::env::var_os("STROM_TEST_APP_NAP").is_none() {
+        eprintln!("skipped: set STROM_TEST_APP_NAP=1 to run");
+        return;
+    }
+    let settle = Duration::from_secs(50);
+    let mut server = Server::spawn();
+
+    std::thread::sleep(settle);
+
+    let exited = server.child.try_wait().expect("poll the server");
+    let observed = max_thread_priority(server.child.id());
+
+    assert!(
+        exited.is_none(),
+        "the server exited before the priority could be read ({exited:?})"
+    );
+    let highest = observed.expect("read thread priorities from `ps -M`");
+    assert!(
+        highest > BACKGROUND_PRIORITY,
+        "every thread sits at scheduling priority {highest} after {}s: the process \
+         has been App-Napped into the background QoS band and its pipelines will \
+         run on efficiency cores. The NSProcessInfo activity assertion is no longer \
+         effective.",
+        settle.as_secs()
+    );
+}


### PR DESCRIPTION
## Problem

Once a headless Strom process is ~32 s old, macOS moves the whole task into the
background QoS band and leaves it there: every thread drops to scheduling priority
4, which on Apple Silicon means efficiency cores at a throttled clock. CPU-bound
work slows down accordingly — a 1080p x264 encode takes 7.4x longer, measured
below.

This tracks process age, not work done. A backend that sat idle and then ran its
first cycle is already slow if it is old enough, and a restart resets it for
another 32 s.

## Cause

Headless Strom registers with LaunchServices as a `Foreground` app and never opens
a window. `gst-launch-1.0` has the same runtime shape — `gst_macos_main`, a
main-thread CFRunLoop, an `NSEventThread`, no window — but registers as
`UIElement` and is never demoted. Read it with `lsappinfo info -pid <pid>`.

| process | type | priority while idle |
| --- | --- | --- |
| `gst-launch-1.0 udpsrc port=N ! fakesink` | `UIElement` | 46, held 200 s |
| `gst-launch-1.0 videotestsrc ! fakesink` | `UIElement` | 46, held 200 s |
| headless Strom, unpatched | `Foreground` | 4, from ~32 s |

Workload does not discriminate: the `udpsrc` pipeline waits on packets that never
arrive at zero CPU and keeps priority 46. Activation policy does. Forcing the
unpatched server to the accessory policy with `setActivationPolicy:`, while taking
no activity assertion, held it at 46 for 162 s against a `Foreground` control
demoted on schedule.

What registers Strom as `Foreground` is unknown. Ruled out by measurement:
`gst_macos_main` and `gst_macos_main_simple` (C probes of both register
`UIElement`), load-time AppKit linkage, creating `NSApplication` before
`gst_macos_main`, winit/eframe (a `--features no-gui` build still demotes), and
CEF (`cefsrc` is not installed on the measuring machine). The assertion opts out
whichever it turns out to be.

## Fix

Hold a user-initiated activity for the life of the process.
`UserInitiatedAllowingIdleSystemSleep` rather than `UserInitiated`, because the
plain variant also blocks system idle sleep; `LatencyCritical` also opts out of
timer coalescing. `objc2-foundation` already ships via eframe, so no new crate.
Only `run_headless_entry` takes the assertion, so GUI mode is untouched.

## Verification

12 paired reps: counterbalanced randomised order, a fresh server per rep, a 50 s
settle so both arms age equally, and one binary with an environment variable
gating only the assertion call. Each rep records its own `ps -M` priority and host
load. Workload is 600 frames of 1080p `videotestsrc ! capsfilter ! x264enc !
fakesink`, timed from `Paused -> Playing` to end-of-stream in the server log.

| | patched | unpatched |
| --- | --- | --- |
| median | 3.62 s | 26.68 s |
| range | 3.52-3.66 s | 23.0-29.7 s |
| priority | 50 / 56 | 4 |

Geometric mean 7.41x, 95% CI 7.16-7.67, 12/12 pairs, t = +114.4, p = 2.9e-18.
Order effect is 7.36x patched-first against 7.53x unpatched-first (5 and 7 pairs).

A/A control, both arms patched, same schedule and analysis: 0.994x, CI
0.987-1.002, p = 0.15. Per-pair spread is 1.25% there against 6.06% in the A/B,
the difference being variability in the demoted arm.

Demotion threshold, six servers sampled once a second: 31.7-32.5 s, median 32.1 s.

M-series laptop, AC power, host load 1.9-5.8 across the reps. Battery is untested.

## Tests

- `headless_entry_takes_the_activity_assertion` catches the call going missing
  from `run_headless_entry`, by watching for the line it logs. 0.5 s.
- `server_is_not_demoted_to_background_qos` checks that macOS still honours the
  assertion, which needs the full demotion window, so it is `#[ignore]`d:
  `STROM_TEST_APP_NAP=1 cargo test --test macos_app_nap_test -- --ignored`. Not
  wired into CI, where the runner is a VM that may not App-Nap at all.

A unit test in `macos_app_nap.rs` catches a wrong selector on every macOS
`cargo test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
