### PR TITLE
chore(release): bump version to 0.6.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6575,7 +6575,7 @@ dependencies = [
 
 [[package]]
 name = "strom"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6652,7 +6652,7 @@ dependencies = [
 
 [[package]]
 name = "strom-frontend"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -6688,7 +6688,7 @@ dependencies = [
 
 [[package]]
 name = "strom-mcp-server"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "anyhow",
  "reqwest 0.13.4",
@@ -6702,7 +6702,7 @@ dependencies = [
 
 [[package]]
 name = "strom-types"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "garde",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["types", "backend", "frontend", "mcp-server"]
 default-members = ["backend"]
 
 [workspace.package]
-version = "0.6.7"
+version = "0.6.8"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Per Enstedt <per.enstedt@eyevinn.se>"]

--- a/openapi.json
+++ b/openapi.json
@@ -10,7 +10,7 @@
     "license": {
       "name": "MIT OR Apache-2.0"
     },
-    "version": "0.6.7"
+    "version": "0.6.8"
   },
   "paths": {
     "/api/auth/status": {


### PR DESCRIPTION
## Description

Release version bump from 0.6.7 to 0.6.8, following the same shape as #716.

- **`Cargo.toml`** — `[workspace.package] version` 0.6.7 → 0.6.8. All member crates (backend, frontend, types, mcp-server) inherit it with `version.workspace = true`, so no member manifest needed editing.
- **`Cargo.lock`** — refreshed with `cargo update --workspace --offline`. The diff is only the four strom crates' own version lines; no third-party dependency moved.
- **`openapi.json`** — `info.version` 0.6.7 → 0.6.8, matching what the generator produces from the backend's `CARGO_PKG_VERSION`. The snapshot test strips `info.version` before comparing, so nothing enforces this — it is kept in sync by hand to stop the drift #716 had to repair.

### What 0.6.8 carries over 0.6.7

#738, which makes a set-but-empty `STROM_*` variable count as unset.

That matters for the published Docker image specifically. 0.6.7 exits 1 with `error with configuration: relative URL without a base` when handed `STROM_DATABASE_URL=""` — which is what Eyevinn Open Source Cloud forwards for an instance with no `DatabaseUrl` configured, an optional field in its service schema. The OSC fork carries an `osc-entrypoint` script purely to unset that variable before `exec`.

Once this version is tagged and `docker-publish.yml` has run, that workaround can go and the fork's `Dockerfile.osc` can be replaced with `FROM eyevinntechnology/strom:latest` instead of maintaining its own drifted copy of the build. That fork change is prepared but deliberately not merged until this release exists.

## Related Issue

None — release chore.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Release chore

## Tests

No new tests — a version bump has no behaviour to guard. What was run locally (macOS, Rust 1.97.1 per `rust-toolchain.toml`):

- `cargo test --test openapi_test` — passes, so the spec snapshot still matches the generator
- `cargo test --workspace` — 541 backend unit + 58 strom-types + all integration tests pass; 1 pre-existing ignored test (`jitterbuffer_mute_test`)
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- `cargo run -- --version` — reports `strom 0.6.8`, confirming the bump reaches the binary and not just the manifests

## Checklist

- [x] I have run `cargo fmt --all`
- [x] I have run `cargo clippy --workspace --all-targets -- -D warnings`
- [x] I have run `cargo test --workspace`
- [x] I have updated documentation as needed (none applies)
- [x] I have added tests for new functionality (none applies)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
