### PR TITLE
feat(blocks): add builtin.audioenc, an audio encoder block

### DIFF
--- a/backend/src/blocks/builtin/audioenc.rs
+++ b/backend/src/blocks/builtin/audioenc.rs
@@ -1,0 +1,445 @@
+//! Audio encoder block. Codecs: AAC (default), Opus, MP3, AC-3.
+//!
+//! Chain: audioconvert -> audioresample -> capsfilter -> encoder -> parser -> capsfilter
+//!
+//! The rate capsfilter pins sample rate and channels when configured, the parser gives
+//! downstream muxers framed data, and the final capsfilter pins the output codec.
+
+use crate::blocks::{BlockBuildContext, BlockBuildError, BlockBuildResult, BlockBuilder};
+use gstreamer as gst;
+use gstreamer::prelude::*;
+use std::collections::HashMap;
+use strom_types::{block::*, element::ElementPadRef, EnumValue, PropertyValue, *};
+use tracing::{info, warn};
+
+/// Audio Encoder block builder.
+pub struct AudioEncBuilder;
+
+/// Default target bitrate in kbps.
+const DEFAULT_BITRATE_KBPS: u32 = 128;
+
+/// Default output sample rate. WebRTC ingest is 48 kHz and Opus accepts only a fixed
+/// set of rates, so 48000 keeps every codec negotiable.
+const DEFAULT_SAMPLE_RATE: &str = "48000";
+
+/// Sample rates Opus can encode. Anything else has to be resampled first.
+const OPUS_SAMPLE_RATES: [i32; 5] = [8000, 12000, 16000, 24000, 48000];
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum Codec {
+    Aac,
+    Opus,
+    Mp3,
+    Ac3,
+}
+
+impl BlockBuilder for AudioEncBuilder {
+    fn build(
+        &self,
+        instance_id: &str,
+        properties: &HashMap<String, PropertyValue>,
+        _ctx: &BlockBuildContext,
+    ) -> Result<BlockBuildResult, BlockBuildError> {
+        info!("Building AudioEncoder block instance: {}", instance_id);
+
+        let codec = parse_codec(properties)?;
+        let bitrate_kbps = parse_bitrate(properties);
+        let sample_rate = parse_sample_rate(properties)?;
+        let channels = parse_channels(properties)?;
+
+        // Catch this here rather than as a not-negotiated error on a running flow.
+        if codec == Codec::Opus {
+            if let Some(rate) = sample_rate {
+                if !OPUS_SAMPLE_RATES.contains(&rate) {
+                    return Err(BlockBuildError::InvalidConfiguration(format!(
+                        "Opus cannot encode at {} Hz — supported rates are {:?}",
+                        rate, OPUS_SAMPLE_RATES
+                    )));
+                }
+            }
+        }
+
+        let encoder_name = select_encoder(codec)?;
+        info!(
+            "Selected encoder '{}' for codec {:?} at {} kbps",
+            encoder_name, codec, bitrate_kbps
+        );
+
+        let convert_id = format!("{}:audioconvert", instance_id);
+        let resample_id = format!("{}:audioresample", instance_id);
+        let rate_caps_id = format!("{}:rate_caps", instance_id);
+        let encoder_id = format!("{}:encoder", instance_id);
+        let parser_id = format!("{}:parser", instance_id);
+        let capsfilter_id = format!("{}:capsfilter", instance_id);
+
+        let audioconvert = gst::ElementFactory::make("audioconvert")
+            .name(&convert_id)
+            .build()
+            .map_err(|e| BlockBuildError::ElementCreation(format!("audioconvert: {}", e)))?;
+
+        let audioresample = gst::ElementFactory::make("audioresample")
+            .name(&resample_id)
+            .build()
+            .map_err(|e| BlockBuildError::ElementCreation(format!("audioresample: {}", e)))?;
+
+        let rate_caps = gst::ElementFactory::make("capsfilter")
+            .name(&rate_caps_id)
+            .property("caps", build_raw_caps(sample_rate, channels))
+            .build()
+            .map_err(|e| BlockBuildError::ElementCreation(format!("capsfilter: {}", e)))?;
+
+        let encoder = gst::ElementFactory::make(&encoder_name)
+            .name(&encoder_id)
+            .build()
+            .map_err(|e| BlockBuildError::ElementCreation(format!("{}: {}", encoder_name, e)))?;
+
+        set_encoder_bitrate(&encoder, &encoder_name, bitrate_kbps);
+
+        let parser_name = get_parser_name(codec);
+        let parser = gst::ElementFactory::make(parser_name)
+            .name(&parser_id)
+            .build()
+            .map_err(|e| BlockBuildError::ElementCreation(format!("{}: {}", parser_name, e)))?;
+
+        let caps_str = get_codec_caps_string(codec);
+        let caps = caps_str.parse::<gst::Caps>().map_err(|_| {
+            BlockBuildError::InvalidConfiguration(format!("Invalid caps: {}", caps_str))
+        })?;
+
+        let capsfilter = gst::ElementFactory::make("capsfilter")
+            .name(&capsfilter_id)
+            .property("caps", &caps)
+            .build()
+            .map_err(|e| BlockBuildError::ElementCreation(format!("capsfilter: {}", e)))?;
+
+        info!(
+            "AudioEncoder block created (chain: audioconvert -> audioresample -> capsfilter -> {} -> {} -> capsfilter [{}])",
+            encoder_name, parser_name, caps_str
+        );
+
+        let internal_links = vec![
+            (
+                ElementPadRef::pad(&convert_id, "src"),
+                ElementPadRef::pad(&resample_id, "sink"),
+            ),
+            (
+                ElementPadRef::pad(&resample_id, "src"),
+                ElementPadRef::pad(&rate_caps_id, "sink"),
+            ),
+            (
+                ElementPadRef::pad(&rate_caps_id, "src"),
+                ElementPadRef::pad(&encoder_id, "sink"),
+            ),
+            (
+                ElementPadRef::pad(&encoder_id, "src"),
+                ElementPadRef::pad(&parser_id, "sink"),
+            ),
+            (
+                ElementPadRef::pad(&parser_id, "src"),
+                ElementPadRef::pad(&capsfilter_id, "sink"),
+            ),
+        ];
+
+        Ok(BlockBuildResult {
+            elements: vec![
+                (convert_id, audioconvert),
+                (resample_id, audioresample),
+                (rate_caps_id, rate_caps),
+                (encoder_id, encoder),
+                (parser_id, parser),
+                (capsfilter_id, capsfilter),
+            ],
+            internal_links,
+            bus_message_handler: None,
+            pad_properties: HashMap::new(),
+        })
+    }
+}
+
+/// Build the raw-audio caps that pin sample rate and channel count.
+///
+/// Fields the caller left as "source" are omitted, so upstream keeps whatever it had.
+fn build_raw_caps(sample_rate: Option<i32>, channels: Option<i32>) -> gst::Caps {
+    let mut builder = gst::Caps::builder("audio/x-raw");
+    if let Some(rate) = sample_rate {
+        builder = builder.field("rate", rate);
+    }
+    if let Some(ch) = channels {
+        builder = builder.field("channels", ch);
+    }
+    builder.build()
+}
+
+/// Encoders to try for the given codec, best first.
+fn get_encoder_priority_list(codec: Codec) -> Vec<&'static str> {
+    match codec {
+        // fdkaacenc has the best quality but is not always packaged.
+        Codec::Aac => vec!["fdkaacenc", "avenc_aac", "voaacenc", "faac"],
+        Codec::Opus => vec!["opusenc"],
+        Codec::Mp3 => vec!["lamemp3enc"],
+        Codec::Ac3 => vec!["avenc_ac3"],
+    }
+}
+
+/// Pick the first available encoder for the codec.
+fn select_encoder(codec: Codec) -> Result<String, BlockBuildError> {
+    let candidates = get_encoder_priority_list(codec);
+
+    for encoder_name in &candidates {
+        if let Some(factory) = gst::ElementFactory::find(encoder_name) {
+            // Respect GST_PLUGIN_FEATURE_RANK=element:0, which is how an element
+            // gets taken out of play without uninstalling it.
+            if factory.rank() == gst::Rank::NONE {
+                info!("Audio encoder disabled (rank=0): {}", encoder_name);
+                continue;
+            }
+            return Ok((*encoder_name).to_string());
+        }
+        info!("Audio encoder not available: {}", encoder_name);
+    }
+
+    Err(BlockBuildError::InvalidConfiguration(format!(
+        "No encoder available for {:?} (tried {})",
+        codec,
+        candidates.join(", ")
+    )))
+}
+
+/// Apply the target bitrate, accounting for each encoder's units.
+///
+/// Uses `set_property_from_str` throughout so a property whose type differs between
+/// encoders cannot panic the build.
+fn set_encoder_bitrate(encoder: &gst::Element, encoder_name: &str, bitrate_kbps: u32) {
+    if encoder_name == "lamemp3enc" {
+        // lamemp3enc takes kbps, and only honours it when target is "bitrate"
+        // (it optimises for quality otherwise).
+        if encoder.has_property("target") {
+            encoder.set_property_from_str("target", "bitrate");
+        }
+        encoder.set_property_from_str("bitrate", &bitrate_kbps.to_string());
+        return;
+    }
+
+    // Everything else takes bits per second.
+    if encoder.has_property("bitrate") {
+        encoder.set_property_from_str("bitrate", &(bitrate_kbps * 1000).to_string());
+    } else {
+        warn!(
+            "Audio encoder {} has no bitrate property, using its default",
+            encoder_name
+        );
+    }
+}
+
+/// Parser element for the codec, so downstream muxers get properly framed data.
+fn get_parser_name(codec: Codec) -> &'static str {
+    match codec {
+        Codec::Aac => "aacparse",
+        Codec::Opus => "opusparse",
+        Codec::Mp3 => "mpegaudioparse",
+        Codec::Ac3 => "ac3parse",
+    }
+}
+
+/// Output caps for the codec.
+///
+/// `stream-format` is deliberately left unpinned for AAC: aacparse converts between
+/// raw and adts, and pinning either one here would break the muxers that want the other.
+fn get_codec_caps_string(codec: Codec) -> &'static str {
+    match codec {
+        Codec::Aac => "audio/mpeg,mpegversion=4",
+        Codec::Opus => "audio/x-opus",
+        Codec::Mp3 => "audio/mpeg,mpegversion=1,layer=3",
+        Codec::Ac3 => "audio/x-ac3",
+    }
+}
+
+/// Parse codec from properties.
+fn parse_codec(properties: &HashMap<String, PropertyValue>) -> Result<Codec, BlockBuildError> {
+    let codec_str = properties
+        .get("codec")
+        .and_then(|v| match v {
+            PropertyValue::String(s) => Some(s.as_str()),
+            _ => None,
+        })
+        .unwrap_or("aac");
+
+    match codec_str {
+        "aac" => Ok(Codec::Aac),
+        "opus" => Ok(Codec::Opus),
+        "mp3" => Ok(Codec::Mp3),
+        "ac3" => Ok(Codec::Ac3),
+        _ => Err(BlockBuildError::InvalidConfiguration(format!(
+            "Invalid codec: {}",
+            codec_str
+        ))),
+    }
+}
+
+/// Parse target bitrate in kbps.
+fn parse_bitrate(properties: &HashMap<String, PropertyValue>) -> u32 {
+    properties
+        .get("bitrate")
+        .and_then(|v| match v {
+            PropertyValue::UInt(u) => Some(*u as u32),
+            PropertyValue::Int(i) if *i > 0 => Some(*i as u32),
+            _ => None,
+        })
+        .unwrap_or(DEFAULT_BITRATE_KBPS)
+}
+
+/// Parse sample rate. `None` means "leave it to upstream".
+fn parse_sample_rate(
+    properties: &HashMap<String, PropertyValue>,
+) -> Result<Option<i32>, BlockBuildError> {
+    parse_source_or_number(properties, "sample_rate", DEFAULT_SAMPLE_RATE)
+}
+
+/// Parse channel count. `None` means "leave it to upstream".
+fn parse_channels(
+    properties: &HashMap<String, PropertyValue>,
+) -> Result<Option<i32>, BlockBuildError> {
+    parse_source_or_number(properties, "channels", "source")
+}
+
+/// Shared parsing for the enums whose values are either "source" or a number.
+fn parse_source_or_number(
+    properties: &HashMap<String, PropertyValue>,
+    name: &str,
+    default: &str,
+) -> Result<Option<i32>, BlockBuildError> {
+    let value = properties
+        .get(name)
+        .and_then(|v| match v {
+            PropertyValue::String(s) => Some(s.as_str()),
+            _ => None,
+        })
+        .unwrap_or(default);
+
+    if value == "source" {
+        return Ok(None);
+    }
+
+    value
+        .parse::<i32>()
+        .map(Some)
+        .map_err(|_| BlockBuildError::InvalidConfiguration(format!("Invalid {}: {}", name, value)))
+}
+
+/// Get all audio encoder block definitions.
+pub fn get_blocks() -> Vec<BlockDefinition> {
+    vec![audioenc_definition()]
+}
+
+fn audioenc_definition() -> BlockDefinition {
+    BlockDefinition {
+        id: "builtin.audioenc".to_string(),
+        name: "Audio Encoder".to_string(),
+        description: "Encodes raw audio to AAC, Opus, MP3, or AC-3. Place it before any block that requires pre-encoded audio, such as the Recorder.".to_string(),
+        category: "Audio".to_string(),
+        exposed_properties: vec![
+            ExposedProperty {
+                name: "codec".to_string(),
+                label: "Codec".to_string(),
+                description: "Audio codec to encode to. AAC is the safe choice for MP4 recordings.".to_string(),
+                property_type: PropertyType::Enum {
+                    values: vec![
+                        EnumValue { value: "aac".to_string(), label: Some("AAC".to_string()) },
+                        EnumValue { value: "opus".to_string(), label: Some("Opus".to_string()) },
+                        EnumValue { value: "mp3".to_string(), label: Some("MP3".to_string()) },
+                        EnumValue { value: "ac3".to_string(), label: Some("AC-3".to_string()) },
+                    ],
+                },
+                default_value: Some(PropertyValue::String("aac".to_string())),
+                mapping: PropertyMapping {
+                    element_id: "_block".to_string(),
+                    property_name: "codec".to_string(),
+                    transform: None,
+                },
+                live: false,
+                persist: None,
+            },
+            ExposedProperty {
+                name: "bitrate".to_string(),
+                label: "Bitrate (kbps)".to_string(),
+                description: "Target bitrate in kilobits per second. 128 is transparent enough for speech and music at 48 kHz stereo.".to_string(),
+                property_type: PropertyType::UInt,
+                default_value: Some(PropertyValue::UInt(DEFAULT_BITRATE_KBPS as u64)),
+                mapping: PropertyMapping {
+                    element_id: "_block".to_string(),
+                    property_name: "bitrate".to_string(),
+                    transform: None,
+                },
+                live: false,
+                persist: None,
+            },
+            ExposedProperty {
+                name: "sample_rate".to_string(),
+                label: "Sample Rate".to_string(),
+                description: "Output sample rate. \"Match source\" passes upstream's rate through, which Opus rejects unless it is one of 8/12/16/24/48 kHz.".to_string(),
+                property_type: PropertyType::Enum {
+                    values: vec![
+                        EnumValue { value: "48000".to_string(), label: Some("48 kHz".to_string()) },
+                        EnumValue { value: "44100".to_string(), label: Some("44.1 kHz".to_string()) },
+                        EnumValue { value: "32000".to_string(), label: Some("32 kHz".to_string()) },
+                        EnumValue { value: "source".to_string(), label: Some("Match source".to_string()) },
+                    ],
+                },
+                default_value: Some(PropertyValue::String(DEFAULT_SAMPLE_RATE.to_string())),
+                mapping: PropertyMapping {
+                    element_id: "_block".to_string(),
+                    property_name: "sample_rate".to_string(),
+                    transform: None,
+                },
+                live: false,
+                persist: None,
+            },
+            ExposedProperty {
+                name: "channels".to_string(),
+                label: "Channels".to_string(),
+                description: "Output channel count. \"Match source\" passes upstream's layout through.".to_string(),
+                property_type: PropertyType::Enum {
+                    values: vec![
+                        EnumValue { value: "source".to_string(), label: Some("Match source".to_string()) },
+                        EnumValue { value: "1".to_string(), label: Some("Mono".to_string()) },
+                        EnumValue { value: "2".to_string(), label: Some("Stereo".to_string()) },
+                    ],
+                },
+                default_value: Some(PropertyValue::String("source".to_string())),
+                mapping: PropertyMapping {
+                    element_id: "_block".to_string(),
+                    property_name: "channels".to_string(),
+                    transform: None,
+                },
+                live: false,
+                persist: None,
+            },
+        ],
+        external_pads: ExternalPads {
+            inputs: vec![ExternalPad {
+                label: None,
+                name: "audio_in".to_string(),
+                media_type: MediaType::Audio,
+                internal_element_id: "audioconvert".to_string(),
+                internal_pad_name: "sink".to_string(),
+            }],
+            outputs: vec![ExternalPad {
+                label: None,
+                name: "encoded_out".to_string(),
+                media_type: MediaType::Audio,
+                internal_element_id: "capsfilter".to_string(),
+                internal_pad_name: "src".to_string(),
+            }],
+        },
+        built_in: true,
+        ui_metadata: Some(BlockUIMetadata {
+            icon: Some("🎚".to_string()),
+            width: Some(1.5),
+            height: Some(2.5),
+            ..Default::default()
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/backend/src/blocks/builtin/audioenc.rs
+++ b/backend/src/blocks/builtin/audioenc.rs
@@ -376,7 +376,7 @@ fn audioenc_definition() -> BlockDefinition {
             ExposedProperty {
                 name: "sample_rate".to_string(),
                 label: "Sample Rate".to_string(),
-                description: "Output sample rate. \"Match source\" passes upstream's rate through, which Opus rejects unless it is one of 8/12/16/24/48 kHz.".to_string(),
+                description: "Output sample rate. \"Match source\" pins no rate, letting the resampler settle on one the encoder accepts. Opus encodes only at 8/12/16/24/48 kHz, so pinning 44.1 or 32 kHz with Opus is rejected at build time.".to_string(),
                 property_type: PropertyType::Enum {
                     values: vec![
                         EnumValue { value: "48000".to_string(), label: Some("48 kHz".to_string()) },

--- a/backend/src/blocks/builtin/audioenc/tests.rs
+++ b/backend/src/blocks/builtin/audioenc/tests.rs
@@ -1,0 +1,213 @@
+//! Tests for the audio encoder block.
+//!
+//! Encoder selection and caps are pure functions and are tested unconditionally.
+//! The build test needs a real GStreamer element, so it is skipped when no encoder
+//! for the codec is installed.
+
+use super::*;
+use gstreamer as gst;
+
+fn init_gst() {
+    let _ = gst::init();
+}
+
+fn props(pairs: &[(&str, PropertyValue)]) -> HashMap<String, PropertyValue> {
+    pairs
+        .iter()
+        .map(|(k, v)| (k.to_string(), v.clone()))
+        .collect()
+}
+
+#[test]
+fn test_codec_parsing_default() {
+    let codec = parse_codec(&HashMap::new()).expect("should have a default codec");
+    assert_eq!(codec, Codec::Aac, "default codec should be AAC");
+}
+
+#[test]
+fn test_codec_parsing_valid() {
+    for (s, expected) in [
+        ("aac", Codec::Aac),
+        ("opus", Codec::Opus),
+        ("mp3", Codec::Mp3),
+        ("ac3", Codec::Ac3),
+    ] {
+        let p = props(&[("codec", PropertyValue::String(s.to_string()))]);
+        assert_eq!(parse_codec(&p).expect("should parse"), expected);
+    }
+}
+
+#[test]
+fn test_codec_parsing_invalid() {
+    let p = props(&[("codec", PropertyValue::String("flac".to_string()))]);
+    assert!(parse_codec(&p).is_err(), "unknown codec should error");
+}
+
+#[test]
+fn test_every_codec_has_a_parser_and_caps() {
+    init_gst();
+    for codec in [Codec::Aac, Codec::Opus, Codec::Mp3, Codec::Ac3] {
+        let caps_str = get_codec_caps_string(codec);
+        assert!(
+            caps_str.parse::<gst::Caps>().is_ok(),
+            "caps for {:?} should parse: {}",
+            codec,
+            caps_str
+        );
+        assert!(
+            !get_encoder_priority_list(codec).is_empty(),
+            "{:?} should have at least one candidate encoder",
+            codec
+        );
+    }
+}
+
+#[test]
+fn test_aac_caps_leave_stream_format_open() {
+    init_gst();
+
+    // aacparse converts between raw and adts. Pinning either here would break the
+    // muxers that want the other, so the field must stay absent.
+    let caps: gst::Caps = get_codec_caps_string(Codec::Aac)
+        .parse()
+        .expect("aac caps should parse");
+    let s = caps.structure(0).expect("caps should have a structure");
+    assert!(
+        s.get::<String>("stream-format").is_err(),
+        "AAC output caps must not pin stream-format"
+    );
+}
+
+#[test]
+fn test_bitrate_default_and_override() {
+    assert_eq!(parse_bitrate(&HashMap::new()), DEFAULT_BITRATE_KBPS);
+    let p = props(&[("bitrate", PropertyValue::UInt(192))]);
+    assert_eq!(parse_bitrate(&p), 192);
+}
+
+#[test]
+fn test_sample_rate_parsing() {
+    assert_eq!(
+        parse_sample_rate(&HashMap::new()).expect("default should parse"),
+        Some(48000),
+        "default sample rate should be 48 kHz"
+    );
+
+    let p = props(&[("sample_rate", PropertyValue::String("source".to_string()))]);
+    assert_eq!(
+        parse_sample_rate(&p).expect("source should parse"),
+        None,
+        "\"source\" should leave the rate unconstrained"
+    );
+
+    let p = props(&[("sample_rate", PropertyValue::String("44100".to_string()))]);
+    assert_eq!(parse_sample_rate(&p).expect("should parse"), Some(44100));
+
+    let p = props(&[("sample_rate", PropertyValue::String("banana".to_string()))]);
+    assert!(parse_sample_rate(&p).is_err(), "garbage should error");
+}
+
+#[test]
+fn test_channels_default_is_source() {
+    assert_eq!(
+        parse_channels(&HashMap::new()).expect("default should parse"),
+        None
+    );
+    let p = props(&[("channels", PropertyValue::String("2".to_string()))]);
+    assert_eq!(parse_channels(&p).expect("should parse"), Some(2));
+}
+
+#[test]
+fn test_raw_caps_omit_unset_fields() {
+    init_gst();
+
+    let caps = build_raw_caps(None, None);
+    let s = caps.structure(0).expect("caps should have a structure");
+    assert!(s.get::<i32>("rate").is_err(), "rate should be absent");
+    assert!(
+        s.get::<i32>("channels").is_err(),
+        "channels should be absent"
+    );
+
+    let caps = build_raw_caps(Some(48000), Some(2));
+    let s = caps.structure(0).expect("caps should have a structure");
+    assert_eq!(s.get::<i32>("rate").expect("rate should be set"), 48000);
+    assert_eq!(s.get::<i32>("channels").expect("channels should be set"), 2);
+}
+
+#[test]
+fn test_opus_rejects_illegal_sample_rate_at_build_time() {
+    init_gst();
+
+    let p = props(&[
+        ("codec", PropertyValue::String("opus".to_string())),
+        ("sample_rate", PropertyValue::String("44100".to_string())),
+    ]);
+    let ctx = BlockBuildContext::new(Vec::new(), "all".to_string());
+    let err = match AudioEncBuilder.build("test:audioenc", &p, &ctx) {
+        Err(e) => e,
+        Ok(_) => panic!("Opus at 44.1 kHz should be rejected"),
+    };
+
+    let msg = format!("{:?}", err);
+    assert!(
+        msg.contains("44100"),
+        "error should name the offending rate, got: {}",
+        msg
+    );
+}
+
+#[test]
+fn test_build_produces_the_full_chain() {
+    init_gst();
+
+    // Only run where an AAC encoder actually exists.
+    if select_encoder(Codec::Aac).is_err() {
+        eprintln!("skipping: no AAC encoder available");
+        return;
+    }
+
+    let ctx = BlockBuildContext::new(Vec::new(), "all".to_string());
+    let result = AudioEncBuilder
+        .build("test:audioenc", &HashMap::new(), &ctx)
+        .expect("default AAC build should succeed");
+
+    let ids: Vec<&str> = result.elements.iter().map(|(id, _)| id.as_str()).collect();
+    for expected in [
+        "test:audioenc:audioconvert",
+        "test:audioenc:audioresample",
+        "test:audioenc:rate_caps",
+        "test:audioenc:encoder",
+        "test:audioenc:parser",
+        "test:audioenc:capsfilter",
+    ] {
+        assert!(
+            ids.contains(&expected),
+            "chain should contain {}, got {:?}",
+            expected,
+            ids
+        );
+    }
+
+    assert_eq!(
+        result.internal_links.len(),
+        5,
+        "six elements should be joined by five links"
+    );
+}
+
+#[test]
+fn test_definition_pads_point_at_real_elements() {
+    // The external pads name elements by their un-prefixed id. If the build renames
+    // one, links into and out of the block silently stop resolving.
+    let def = audioenc_definition();
+    assert_eq!(def.id, "builtin.audioenc");
+
+    let input = &def.external_pads.inputs[0];
+    assert_eq!(input.internal_element_id, "audioconvert");
+    assert_eq!(input.media_type, MediaType::Audio);
+
+    let output = &def.external_pads.outputs[0];
+    assert_eq!(output.internal_element_id, "capsfilter");
+    assert_eq!(output.media_type, MediaType::Audio);
+}

--- a/backend/src/blocks/builtin/audioenc/tests.rs
+++ b/backend/src/blocks/builtin/audioenc/tests.rs
@@ -163,6 +163,10 @@ fn test_build_produces_the_full_chain() {
 
     // Only run where an AAC encoder actually exists.
     if select_encoder(Codec::Aac).is_err() {
+        assert!(
+            strom_types::env::var_opt("STROM_REQUIRE_GST_PLUGINS").is_none(),
+            "STROM_REQUIRE_GST_PLUGINS is set but no AAC encoder is available"
+        );
         eprintln!("skipping: no AAC encoder available");
         return;
     }

--- a/backend/src/blocks/builtin/mod.rs
+++ b/backend/src/blocks/builtin/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod aes67;
 pub mod audioanalyzer;
+pub mod audioenc;
 pub mod audioformat;
 pub mod audiogain;
 pub mod audiorouter;
@@ -115,6 +116,9 @@ pub fn get_all_builtin_blocks() -> Vec<BlockDefinition> {
     // Add Time Offset block (generic timestamp shifter)
     blocks.extend(time_offset::get_blocks());
 
+    // Add AudioEncoder blocks
+    blocks.extend(audioenc::get_blocks());
+
     // Add VideoEncoder blocks
     blocks.extend(videoenc::get_blocks());
 
@@ -143,6 +147,7 @@ pub fn get_builder(block_definition_id: &str) -> Option<Arc<dyn BlockBuilder>> {
         "builtin.aes67_input" => Some(Arc::new(aes67::AES67InputBuilder)),
         "builtin.aes67_output" => Some(Arc::new(aes67::AES67OutputBuilder)),
         "builtin.audioanalyzer" => Some(Arc::new(audioanalyzer::AudioAnalyzerBuilder)),
+        "builtin.audioenc" => Some(Arc::new(audioenc::AudioEncBuilder)),
         "builtin.audioformat" => Some(Arc::new(audioformat::AudioFormatBuilder)),
         "builtin.audiogain" => Some(Arc::new(audiogain::AudioGainBuilder)),
         "builtin.audiorouter" => Some(Arc::new(audiorouter::AudioRouterBuilder)),


### PR DESCRIPTION
## What

Adds `builtin.audioenc`, an audio encoder block, as the counterpart to the existing `builtin.videoenc`.

The Recorder only accepts pre-encoded audio, and the only audio encoders in the tree were buried inside the SRT and WHIP output blocks. A raw audio pad — a decoded WHIP input feeding a vision mixer, say — therefore could not be recorded at all.

The block builds the chain:

```
audioconvert -> audioresample -> capsfilter -> encoder -> parser -> capsfilter
```

Codecs: AAC (default), Opus, MP3, AC-3, with `bitrate`, `sample_rate` and `channels` properties. `sample_rate` and `channels` both accept `"source"` to leave the upstream value untouched.

## Details worth review

- The encoder is the first available candidate for the codec, skipping any factory whose rank is NONE, so `GST_PLUGIN_FEATURE_RANK=element:0` still works as the way to take an encoder out of play.
- Bitrate is applied with `set_property_from_str` throughout, avoiding the enum-property panic class. `lamemp3enc` is special-cased: it takes kbps rather than bps, and only honours the value when `target=bitrate`.
- Opus accepts only 8/12/16/24/48 kHz. An illegal rate is rejected at build time with a message naming the rate, rather than surfacing later as a not-negotiated error on a running flow.
- AAC output caps deliberately leave `stream-format` unpinned, since `aacparse` converts between raw and adts and pinning either breaks the muxers wanting the other.

## Testing

Which commands actually ran, and where. All of the below ran against `7b2ab3b`, the current head, on macOS:

- `cargo clippy --workspace --all-targets -- -D warnings` — **passed**. `--all-targets` covers the lib-test target, so the block and its test module both typecheck.
- `cargo fmt --all -- --check` — **passed**.
- The 12 `audioenc` unit tests — **12 passed**. This includes `test_build_produces_the_full_chain`, which really executed rather than skipping: an AAC encoder is present on this machine. An earlier revision of this section said it had been skipped here; that was wrong.
- `openapi_test` — **1 passed**. `pipeline_lifecycle_test` — **3 passed**.
- The skip guard was exercised deliberately: with `GST_PLUGIN_FEATURE_RANK=fdkaacenc:0,avenc_aac:0,voaacenc:0,faac:0` and `STROM_REQUIRE_GST_PLUGINS=1`, `test_build_produces_the_full_chain` fails on the new assertion instead of returning early. Without the env var it skips with a message, as intended.

No end-to-end flow was run through the new block on real media. The evidence above is compile-level plus unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
