### PR TITLE
fix(compositor): honour force_live on the CPU mixer path

### DIFF
--- a/backend/src/blocks/builtin/compositor.rs
+++ b/backend/src/blocks/builtin/compositor.rs
@@ -462,20 +462,17 @@ fn build_software_compositor(
     let mixer_id = format!("{}:mixer", instance_id);
     let mixer = gst::ElementFactory::make("compositor")
         .name(&mixer_id)
+        .property("force-live", force_live)
         .build()
         .map_err(|e| BlockBuildError::ElementCreation(format!("compositor: {}", e)))?;
 
-    info!("CPU mixer created");
+    info!("CPU mixer created with force-live={}", force_live);
 
     // Set mixer properties
     // Note: compositor element uses different property names than glvideomixerelement
     if mixer.has_property("background") {
         mixer.set_property_from_str("background", background);
     }
-
-    // Note: compositor element has force-live as read-only (unlike glvideomixerelement)
-    // so we don't set it here - it defaults based on whether live sources are connected
-    let _ = force_live; // Acknowledge parameter even though we can't use it for CPU backend
 
     // Set latency properties
     set_mixer_latency_properties(&mixer, properties);
@@ -1210,5 +1207,65 @@ fn compositor_definition() -> BlockDefinition {
             height: Some(2.5),
             ..Default::default()
         }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a CPU compositor block with the given `force_live` value.
+    ///
+    /// `compositor_preference = "cpu"` pins the backend so the test exercises
+    /// `build_software_compositor` regardless of whether GL is available on the
+    /// host — otherwise `Auto` would pick the GL path on most dev machines.
+    fn build_cpu_compositor(force_live: bool) -> BlockBuildResult {
+        let _ = gst::init();
+
+        let mut properties = HashMap::new();
+        properties.insert(
+            "compositor_preference".to_string(),
+            PropertyValue::String("cpu".to_string()),
+        );
+        properties.insert("num_inputs".to_string(), PropertyValue::Int(2));
+        properties.insert("force_live".to_string(), PropertyValue::Bool(force_live));
+
+        let ctx = BlockBuildContext::new(Vec::new(), "all".to_string());
+        CompositorBuilder
+            .build("test_comp", &properties, &ctx)
+            .expect("CPU compositor should build")
+    }
+
+    /// Read `force-live` off the mixer element in a build result.
+    fn mixer_force_live(result: &BlockBuildResult) -> bool {
+        let (_, mixer) = result
+            .elements
+            .iter()
+            .find(|(id, _)| id.as_str() == "test_comp:mixer")
+            .expect("build result must contain the mixer element");
+        mixer.property::<bool>("force-live")
+    }
+
+    /// `force-live` on `compositor` is construct-only: it must be passed to
+    /// `ElementFactory::make(...).property(...)`, not set afterwards. Setting it
+    /// after `build()` silently leaves the element at its `false` default, so
+    /// this asserts the property actually took.
+    #[test]
+    fn cpu_mixer_honours_force_live_true() {
+        let result = build_cpu_compositor(true);
+        assert!(
+            mixer_force_live(&result),
+            "CPU mixer must report force-live=true when the block is built with force_live true"
+        );
+    }
+
+    /// The counterpart: `force_live=false` must not be silently upgraded.
+    #[test]
+    fn cpu_mixer_honours_force_live_false() {
+        let result = build_cpu_compositor(false);
+        assert!(
+            !mixer_force_live(&result),
+            "CPU mixer must report force-live=false when the block is built with force_live false"
+        );
     }
 }


### PR DESCRIPTION
## The bug

`build_software_compositor` in `backend/src/blocks/builtin/compositor.rs` discarded its
`force_live` parameter, justified by this comment:

```rust
// Note: compositor element has force-live as read-only (unlike glvideomixerelement)
// so we don't set it here - it defaults based on whether live sources are connected
let _ = force_live; // Acknowledge parameter even though we can't use it for CPU backend
```

That is factually wrong. `gst-inspect-1.0 compositor` reports:

```
force-live          : Always operate in live mode and aggregate on timeout regardless of
                      whether any live sources are linked upstream
                      flags: readable, writable, can be set only at object construction time
                      Boolean. Default: false
```

Construct-only, not read-only — the same flags as `glvideomixerelement`. The code built the
element first and only then tried to set properties, which is why it concluded the property was
unusable.

Net effect before this change: the CPU mixer always ran with `force-live=false`, while the GL
path received the caller's value. The parameter was silently dropped for CPU.

## The fix

Set it at construction, the pattern already used in `vision_mixer/elements.rs`, which even
documents it: *"force-live is construct-only and must be set via
`ElementFactory::make().property()`"*.

```rust
let mixer = gst::ElementFactory::make("compositor")
    .name(&mixer_id)
    .property("force-live", force_live)
    .build()
```

The incorrect comment and the `let _ = force_live;` line are removed, and the `info!` now reports
the value the way the GL path already does. The GL path is otherwise unchanged.

## What this does NOT do

**This is a correctness fix, not a behaviour fix. It does not fix the vision mixer cold-start
stall.** That was tested specifically. Isolated `gst-launch-1.0` runs show a compositor with
linked-but-never-negotiating sink pads keeps producing frames in every configuration tried:

- CPU and GL backends
- `force-live` true and false
- `ignore-inactive-pads` true and false
- silent upstream both live (`udpsrc`) and non-live (`appsrc`)
- 2 pads with 1 live, and 5 pads with 1 live
- with and without queues

All produced ~294–297 frames per 10s at 30fps, against a ~295 frame all-live control.

Also worth recording, and deliberately not built on here: `glvideomixerelement` has no
`ignore-inactive-pads` property at all — that escape hatch is CPU-only.

## Tests

Two tests in a new `mod tests` in `compositor.rs`. They drive the public
`CompositorBuilder::build()` with `compositor_preference = "cpu"` — pinning the backend so the
test exercises the CPU path regardless of whether the host has GL — and then read `force-live`
back off the built mixer element.

- `cpu_mixer_honours_force_live_true` — **the guard.** Reverting the one-line fix makes it fail,
  because a `compositor` built without the construct-time property stays at its `false` default,
  and being construct-only nothing downstream can change it afterwards. Verified by actually
  reverting the line locally and re-running: it failed with *"CPU mixer must report
  force-live=true when the block is built with force_live true"*, then passed again on restore.
- `cpu_mixer_honours_force_live_false` — the counterpart. It does not fail on revert, so it is
  not the guard; it earns its place because `parse_force_live` defaults to `true`, so a wrong
  property key would make this one fail. It pins the key name and the plumbing.

`compositor` ships in `gst-plugins-base`, already in the CI package list
(`.github/workflows/ci.yml`), so these tests execute in CI rather than skipping.

### Commands actually run

| Command | Result |
| --- | --- |
| `gst-inspect-1.0 compositor` | Confirmed the construct-only flags quoted above |
| `cargo fmt --all -- --check` | Passed |
| `cargo clippy --workspace --all-targets -- -D warnings` | Passed |
| `cargo test --lib blocks::builtin::compositor` | 2 passed, 0 failed |
| Same test with the fix line reverted | 1 passed, 1 failed — the guard fired |
| Pre-commit hook (fmt + clippy + secret scan) | Passed; `--no-verify` not used |

All runs used the dev profile with `CARGO_PROFILE_DEV_DEBUG=0` and `CARGO_INCREMENTAL=0`.

### Not run

- `cargo test --workspace` — **not run.** The build volume was nearly full for this work, and a
  full workspace test build did not fit. Only the two tests above were executed.
- No runtime verification in the running app. This change alters only which value a
  construct-time property receives, and the assertion reads that property back directly.
- Nothing was run against the GL path; it is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
