### PR TITLE
fix(vision-mixer): join overlay timer threads before the process exits

### DIFF
--- a/backend/src/blocks/builtin/vision_mixer/overlay.rs
+++ b/backend/src/blocks/builtin/vision_mixer/overlay.rs
@@ -12,8 +12,9 @@ use gstreamer as gst;
 use gstreamer::prelude::*;
 use gstreamer_app as gst_app;
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, AtomicU8, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, AtomicU8, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
+use std::thread::JoinHandle;
 use std::time::{Instant, SystemTime};
 use strom_types::vision_mixer::{self, Zone, TIMEZONE_REFRESH_SECS};
 use tracing::{debug, warn};
@@ -1034,6 +1035,56 @@ pub fn unregister_overlay_renderer(block_id: &str) {
     }
 }
 
+/// Join handles for every overlay timer thread started in this process.
+fn overlay_timer_handles() -> &'static Mutex<Vec<JoinHandle<()>>> {
+    static INSTANCE: OnceLock<Mutex<Vec<JoinHandle<()>>>> = OnceLock::new();
+    INSTANCE.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+/// Makes every overlay timer thread leave its loop at the next tick,
+/// regardless of registry state.
+static OVERLAY_TIMERS_SHUTDOWN: AtomicBool = AtomicBool::new(false);
+
+/// Timer threads currently inside their loop.
+static OVERLAY_TIMERS_RUNNING: AtomicUsize = AtomicUsize::new(0);
+
+/// Number of overlay timer threads currently running.
+pub fn overlay_timers_running() -> usize {
+    OVERLAY_TIMERS_RUNNING.load(Ordering::SeqCst)
+}
+
+/// Stop every overlay timer thread and wait for it to exit.
+///
+/// Must run before `main` returns: these threads call cairo, and pixman frees
+/// its global implementation chain from a `__cxa_atexit` destructor while other
+/// threads are still running, so cairo entered after `exit()` walks freed heap.
+///
+/// Terminal, and bounded by one frame interval plus one render. The appsrc is
+/// leaky and non-blocking, so a render in flight cannot stall the join.
+pub fn shutdown_overlay_timers() {
+    OVERLAY_TIMERS_SHUTDOWN.store(true, Ordering::SeqCst);
+    let handles: Vec<JoinHandle<()>> = match overlay_timer_handles().lock() {
+        Ok(mut h) => std::mem::take(&mut *h),
+        Err(mut poisoned) => std::mem::take(&mut **poisoned.get_mut()),
+    };
+    let count = handles.len();
+    for handle in handles {
+        if let Err(e) = handle.join() {
+            warn!("Overlay timer thread panicked during shutdown: {:?}", e);
+        }
+    }
+    if count > 0 {
+        debug!("Joined {} overlay timer thread(s)", count);
+    }
+}
+
+/// Clear the shutdown flag so a later test in the same process can start
+/// another overlay timer.
+#[cfg(test)]
+pub fn reset_overlay_timers_shutdown_for_test() {
+    OVERLAY_TIMERS_SHUTDOWN.store(false, Ordering::SeqCst);
+}
+
 /// Trigger an immediate overlay re-render (called from API on state changes).
 pub fn trigger_overlay_update(block_id: &str) {
     if let Some(renderer) = get_overlay_renderer(block_id) {
@@ -1060,7 +1111,9 @@ pub fn trigger_overlay_update(block_id: &str) {
 /// Pushes at the multiview framerate so the compositor always has a current
 /// buffer on the overlay pad. Only re-renders when state actually changes
 /// (PGM/PVW switch, clock tick); otherwise re-pushes the last sample.
-/// The thread stops when the renderer is unregistered (flow stop).
+///
+/// Stops when the renderer is unregistered (flow stop) or on
+/// [`shutdown_overlay_timers`] (process exit), which joins the kept handle.
 pub fn start_overlay_timer(
     block_id: String,
     renderer: Arc<Mutex<OverlayRenderer>>,
@@ -1069,12 +1122,27 @@ pub fn start_overlay_timer(
     let frame_interval = std::time::Duration::from_nanos(
         (mv_framerate.1 as u64 * 1_000_000_000) / mv_framerate.0.max(1) as u64,
     );
-    std::thread::Builder::new()
+    // Reap finished handles so they do not accumulate across flow restarts.
+    if let Ok(mut handles) = overlay_timer_handles().lock() {
+        handles.retain(|h| !h.is_finished());
+    }
+
+    OVERLAY_TIMERS_RUNNING.fetch_add(1, Ordering::SeqCst);
+    let spawned = std::thread::Builder::new()
         .name(format!(
             "overlay-timer-{}",
             &block_id[..8.min(block_id.len())]
         ))
         .spawn(move || {
+            // Decrements on every exit path, including a panic.
+            struct RunningGuard;
+            impl Drop for RunningGuard {
+                fn drop(&mut self) {
+                    OVERLAY_TIMERS_RUNNING.fetch_sub(1, Ordering::SeqCst);
+                }
+            }
+            let _running = RunningGuard;
+
             debug!("Overlay timer started for {}", block_id);
             // Wait for pipeline to reach PLAYING before pushing first frame.
             // The appsrc needs caps negotiation to complete first.
@@ -1083,6 +1151,9 @@ pub fn start_overlay_timer(
             // thread observes the unregistration — presence alone would keep
             // the old thread (and its strong AppSrc ref) alive forever.
             let still_mine = |r: &Arc<Mutex<OverlayRenderer>>| {
+                if OVERLAY_TIMERS_SHUTDOWN.load(Ordering::SeqCst) {
+                    return false;
+                }
                 get_overlay_renderer(&block_id)
                     .map(|cur| Arc::ptr_eq(&cur, r))
                     .unwrap_or(false)
@@ -1103,8 +1174,10 @@ pub fn start_overlay_timer(
                 return;
             }
             debug!("Overlay appsrc PLAYING, pushing initial frame");
-            if let Ok(mut r) = renderer.lock() {
-                r.render_if_dirty();
+            if still_mine(&renderer) {
+                if let Ok(mut r) = renderer.lock() {
+                    r.render_if_dirty();
+                }
             }
             // Deadline-based loop: advance by frame_interval per tick so that
             // render/push time doesn't accumulate as drift.
@@ -1128,12 +1201,20 @@ pub fn start_overlay_timer(
                     r.render_if_dirty();
                 }
             }
-        })
-        .unwrap_or_else(|e| {
-            warn!("Failed to start overlay timer: {}", e);
-            // Return a dummy handle — the overlay just won't update the clock
-            std::thread::spawn(|| {})
         });
+
+    match spawned {
+        Ok(handle) => {
+            if let Ok(mut handles) = overlay_timer_handles().lock() {
+                handles.push(handle);
+            }
+        }
+        Err(e) => {
+            // Thread never ran, so its guard never will.
+            OVERLAY_TIMERS_RUNNING.fetch_sub(1, Ordering::SeqCst);
+            warn!("Failed to start overlay timer: {}", e);
+        }
+    }
 }
 
 /// Collect the input indices that contribute to a PiP composition (background

--- a/backend/src/blocks/builtin/vision_mixer/tests.rs
+++ b/backend/src/blocks/builtin/vision_mixer/tests.rs
@@ -348,3 +348,99 @@ fn overlay_registries_round_trip() {
         "renderer must be cleaned (otherwise overlay-timer-* thread leaks)"
     );
 }
+
+/// `shutdown_overlay_timers` must wait until the timer thread has left cairo,
+/// not just signal it: a thread still painting while `exit()` frees pixman's
+/// globals is the `overlay-timer-*` SIGSEGV on graceful shutdown.
+#[test]
+fn shutdown_overlay_timers_joins_running_timer() {
+    use super::overlay::{
+        overlay_timers_running, register_overlay_renderer, register_overlay_state,
+        shutdown_overlay_timers, start_overlay_timer, unregister_overlay_renderer,
+        unregister_overlay_state, OverlayRenderer, VisionMixerOverlayState,
+    };
+    use gstreamer as gst;
+    use gstreamer::prelude::ElementExt;
+    use gstreamer_app as gst_app;
+    use std::sync::{Arc, Mutex};
+    use std::time::{Duration, Instant};
+
+    gst::init().unwrap();
+
+    let block_id = "test-vm-overlay-timer-shutdown-block-id";
+
+    let lo = layout::compute_layout(1280, 720, 4, 0, ASPECT_16_9, false);
+    let state = Arc::new(VisionMixerOverlayState::new(
+        4,
+        0,
+        0,
+        1,
+        vec!["A".into(), "B".into(), "C".into(), "D".into()],
+        lo,
+        1920,
+        1080,
+        false,
+        super::overlay::PipInitialState::default(),
+    ));
+
+    let caps = gst::Caps::builder("video/x-raw")
+        .field("format", "BGRA")
+        .field("width", 1280i32)
+        .field("height", 720i32)
+        .field("framerate", gst::Fraction::new(50, 1))
+        .build();
+    // Mirror production: leaky and non-blocking, so a render in flight cannot
+    // stall the join.
+    let appsrc = gst_app::AppSrc::builder()
+        .caps(&caps)
+        .format(gst::Format::Time)
+        .is_live(false)
+        .do_timestamp(true)
+        .max_buffers(2)
+        .leaky_type(gst_app::AppLeakyType::Upstream)
+        .build();
+    // The timer only enters its render loop once the appsrc reports PLAYING.
+    appsrc
+        .set_state(gst::State::Playing)
+        .expect("appsrc should reach PLAYING");
+
+    let renderer = Arc::new(Mutex::new(OverlayRenderer::new(
+        appsrc.clone(),
+        caps,
+        Arc::clone(&state),
+        1280,
+        720,
+    )));
+
+    register_overlay_state(block_id, Arc::clone(&state));
+    register_overlay_renderer(block_id, Arc::clone(&renderer));
+
+    let before = overlay_timers_running();
+    start_overlay_timer(block_id.to_string(), Arc::clone(&renderer), (50, 1));
+
+    // Wait for a real render, so shutdown interrupts a thread inside cairo
+    // rather than one waiting for PLAYING.
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while appsrc.current_level_buffers() == 0 && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    assert!(
+        appsrc.current_level_buffers() > 0,
+        "overlay timer should have rendered and pushed a frame before shutdown"
+    );
+
+    shutdown_overlay_timers();
+
+    // No sleep, no retry: the thread must be gone once the call returns.
+    assert_eq!(
+        overlay_timers_running(),
+        before,
+        "shutdown_overlay_timers must join the timer thread, not just signal it"
+    );
+
+    let _ = appsrc.set_state(gst::State::Null);
+    unregister_overlay_state(block_id);
+    unregister_overlay_renderer(block_id);
+    // The flag is process-global and terminal; clear it for later tests.
+    super::overlay::reset_overlay_timers_shutdown_for_test();
+}

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -582,6 +582,9 @@ fn run_with_gui(
         error!("GUI error: {:?}", e);
     }
 
+    // Must run before library destructors; see `shutdown_overlay_timers`.
+    strom::blocks::builtin::vision_mixer::overlay::shutdown_overlay_timers();
+
     Ok(())
 }
 
@@ -763,7 +766,12 @@ async fn run_headless(
         handle_for_signal.graceful_shutdown(Some(Duration::from_secs(10)));
     });
 
-    serve_with_tls(addr, app, handle, tls_config).await?;
+    let serve_result = serve_with_tls(addr, app, handle, tls_config).await;
+
+    // Must run before library destructors; see `shutdown_overlay_timers`.
+    strom::blocks::builtin::vision_mixer::overlay::shutdown_overlay_timers();
+
+    serve_result?;
 
     Ok(())
 }


### PR DESCRIPTION
## Cause

Two SIGSEGVs on macOS/arm64 in six graceful shutdowns of v0.6.8, both on thread `overlay-timer-vmix`, both inside `pixman_fill` under `render_if_dirty`.

The overlay timer thread is spawned detached, and its only stop condition is renderer unregistration, which the headless SIGTERM path never triggers. The thread therefore runs until the process dies.

It calls cairo, which draws through pixman. Pixman frees its global implementation chain from a destructor registered with `__cxa_atexit`, and `exit()` runs that destructor while other threads are still running, without clearing the global that points at the chain. Cairo entered after that point walks freed heap in `_pixman_implementation_fill`. This puts the fault deep inside pixman rather than at the Rust call site, and produces no panic or error line.

The `unsafe impl Send`/`Sync` on `OverlayRenderer` is sound: the mutex covers every path to the surface and context, and the `cairooverlay` callback does not touch this renderer. The surface is cairo-owned and held alive by the `Arc` the thread holds. This is teardown ordering, not a data race or a lifetime bug.

## Fix

Keep each timer's `JoinHandle`, add a process-shutdown flag the loop checks once per tick, and call `shutdown_overlay_timers()` on both exit paths in `main` before library destructors run.

The join is bounded by one frame interval plus one render, since the flag is checked in both the wait loop and the render loop. The overlay appsrc is leaky and non-blocking, so a render in flight cannot stall it. Finished handles are reaped on each spawn. The six `process::exit(1)` sites are startup failures that run before any flow exists.

## Reproduction

The crash itself was not reproduced. 11 shutdown cycles on the reporter's flow with 5 live WHIP publishers produced zero segfaults against the reporter's 2 in 6, so this is unremarkable, but the crash was never observed directly and the fix is reasoned rather than confirmed to that extent.

The precondition the crash requires is reproducible on both sides of the change. Same flow, one SIGTERM each:

| | cairo renders after SIGTERM | timer at exit |
|---|---|---|
| without the fix | 17, the last 625 ms after SIGTERM | still painting; log stops mid-loop |
| with the fix | 0 | `Joined 2 overlay timer thread(s)`, ~200 µs |

Two timer threads were live when `main` returned, and nothing stops them without this change. The log ending mid-render-loop matches the reported symptom.

## Tests

`shutdown_overlay_timers_joins_running_timer` starts a timer against a real `AppSrc`, waits until a frame has been rendered and pushed so shutdown interrupts a thread inside cairo, then asserts the thread count is back to baseline the instant `shutdown_overlay_timers()` returns.

Verified to fail by reverting each half of the fix:
- discarding the `JoinHandle`: fails, `left: 1, right: 0`
- removing the shutdown flag but keeping the join: `join()` blocks forever, test hangs

## Commands run

```
cargo clippy --all-targets --workspace   # clean
cargo test --workspace                   # 657 passed, 0 failed
```

No `stop_flow()` pipeline-survival ERROR in any shutdown log.

End-to-end runs used a debug build of this branch against the reporter's flow with the 5 `builtin.audioenc` blocks and their recorders removed, since `builtin.audioenc` does not exist upstream; the mixer, overlay, WHIP inputs and WHEP output are unchanged. The 11 shutdown cycles used the unmodified flow and the release binary that produced the original crashes.

Not run: any non-macOS platform. `lldb` was unusable on the test machine (`system.privilege.taskport.debug` unavailable), so the evidence is log-based rather than a debugger thread dump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
