### PR TITLE
perf(macos): convert colour through Accelerate/vImage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6604,6 +6604,7 @@ dependencies = [
  "gst-plugins-lsp",
  "gstreamer",
  "gstreamer-app",
+ "gstreamer-base",
  "gstreamer-controller",
  "gstreamer-gl",
  "gstreamer-net",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ tower-http = { version = "0.7", features = ["fs", "cors", "trace"] }
 cairo-rs = { version = "0.22", features = ["v1_16"] }
 gstreamer = { version = "0.25", features = ["v1_22"] }
 gstreamer-app = { version = "0.25", features = ["v1_22"] }
+gstreamer-base = { version = "0.25", features = ["v1_22"] }
 gstreamer-controller = { version = "0.25", features = ["v1_22"] }
 gstreamer-net = { version = "0.25", features = ["v1_22"] }
 gstreamer-gl = { version = "0.25", features = ["v1_22"] }

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -136,6 +136,11 @@ hostname = "0.4"     # Cross-platform hostname detection
 strom-frontend = { path = "../frontend" }
 eframe = { workspace = true }
 
+[target.'cfg(target_os = "macos")'.dependencies]
+# Subclassing base for the vImage converter element in gst::vimage. Already a
+# transitive dependency of gstreamer-video, so naming it adds nothing to build.
+gstreamer-base.workspace = true
+
 [build-dependencies]
 chrono = "0.4"
 uuid = { version = "1.23", features = ["v4"] }

--- a/backend/src/blocks/builtin/devicesrc.rs
+++ b/backend/src/blocks/builtin/devicesrc.rs
@@ -79,7 +79,7 @@
 //! without changes here.
 
 use crate::blocks::{BlockBuildContext, BlockBuildError, BlockBuildResult, BlockBuilder};
-use crate::gpu::video_convert_mode;
+use crate::gpu::{self, video_convert_mode};
 use gstreamer as gst;
 use gstreamer::prelude::*;
 use std::collections::HashMap;
@@ -197,6 +197,7 @@ impl BlockBuilder for LocalInputBuilder {
                 .map_err(|e| {
                     BlockBuildError::ElementCreation(format!("{}: {}", convert_element_name, e))
                 })?;
+            gpu::configure_video_convert(&videoconvert);
 
             let video_caps = gst::Caps::builder("video/x-raw").build();
             let videocaps = gst::ElementFactory::make("capsfilter")

--- a/backend/src/blocks/builtin/ndi.rs
+++ b/backend/src/blocks/builtin/ndi.rs
@@ -5,7 +5,7 @@
 //! Requires the NDI SDK from NewTek/Vizrt to be installed.
 
 use crate::blocks::{BlockBuildContext, BlockBuildError, BlockBuildResult, BlockBuilder};
-use crate::gpu::video_convert_mode;
+use crate::gpu::{self, video_convert_mode};
 use gstreamer as gst;
 use gstreamer::prelude::*;
 use std::collections::HashMap;
@@ -217,6 +217,7 @@ impl BlockBuilder for NDIInputBuilder {
                     .map_err(|e| {
                         BlockBuildError::ElementCreation(format!("{}: {}", convert_element_name, e))
                     })?;
+                gpu::configure_video_convert(&videoconvert);
 
                 let video_caps = gst::Caps::builder("video/x-raw").build();
                 let videocaps = gst::ElementFactory::make("capsfilter")
@@ -304,6 +305,7 @@ impl BlockBuilder for NDIInputBuilder {
                     .map_err(|e| {
                         BlockBuildError::ElementCreation(format!("{}: {}", convert_element_name, e))
                     })?;
+                gpu::configure_video_convert(&videoconvert);
 
                 let caps = gst::Caps::builder("video/x-raw").build();
                 let capsfilter = gst::ElementFactory::make("capsfilter")
@@ -499,6 +501,7 @@ impl BlockBuilder for NDIOutputBuilder {
                     .map_err(|e| {
                         BlockBuildError::ElementCreation(format!("{}: {}", convert_element_name, e))
                     })?;
+                gpu::configure_video_convert(&videoconvert);
 
                 // Audio path
                 let audioconvert_id = format!("{}:audioconvert", instance_id);
@@ -585,6 +588,7 @@ impl BlockBuilder for NDIOutputBuilder {
                     .map_err(|e| {
                         BlockBuildError::ElementCreation(format!("{}: {}", convert_element_name, e))
                     })?;
+                gpu::configure_video_convert(&videoconvert);
 
                 let ndisink = gst::ElementFactory::make("ndisink")
                     .name(&ndisink_id)

--- a/backend/src/blocks/builtin/videoenc.rs
+++ b/backend/src/blocks/builtin/videoenc.rs
@@ -17,7 +17,7 @@
 //! - capsfilter: Sets output caps for proper codec negotiation
 
 use crate::blocks::{BlockBuildContext, BlockBuildError, BlockBuildResult, BlockBuilder};
-use crate::gpu::video_convert_mode;
+use crate::gpu::{self, video_convert_mode};
 use gstreamer as gst;
 use gstreamer::prelude::*;
 use std::collections::HashMap;
@@ -129,6 +129,7 @@ impl BlockBuilder for VideoEncBuilder {
             .map_err(|e| {
                 BlockBuildError::ElementCreation(format!("{}: {}", convert_element_name, e))
             })?;
+        gpu::configure_video_convert(&videoconvert);
 
         let encoder = gst::ElementFactory::make(&encoder_name)
             .name(&encoder_id)

--- a/backend/src/blocks/builtin/videoformat.rs
+++ b/backend/src/blocks/builtin/videoformat.rs
@@ -6,7 +6,7 @@
 //! - Color format (pixel format) - enforced by caps
 //!
 //! All properties are optional. The block creates a fixed chain of elements:
-//! videoscale -> videoconvert -> capsfilter
+//! videoconvertscale -> capsfilter
 //!
 //! TEMPORARY: videorate element removed to avoid frame duplication issues.
 //!
@@ -98,21 +98,18 @@ impl BlockBuilder for VideoFormatBuilder {
         let caps_str = caps_fields.join(",");
         info!("VideoFormat block caps: {}", caps_str);
 
-        // Always create all elements for consistent external pad references
-        // Elements will just pass through if their respective properties aren't set
-        let scale_id = format!("{}:videoscale", instance_id);
-        // Use detected video convert mode (autovideoconvert if GPU interop works, videoconvert otherwise)
-        // Note: We always use "videoconvert" as the element ID for consistent external pad references,
-        // even when the actual GStreamer element is "autovideoconvert"
-        let convert_mode = video_convert_mode();
-        let convert_element_name = convert_mode.element_name();
-        let convert_id = format!("{}:videoconvert", instance_id);
+        // `videoconvertscale` converts and scales in a single walk of the frame.
+        //
+        // The element ID is "videoscale": the block's external input pad
+        // resolves through that name (see `external_pads` below), and saved
+        // flows resolve their links through it at build time, so renaming it
+        // breaks every saved flow that links into this block. The ID names the
+        // role, not the factory.
+        let convert_id = format!("{}:videoscale", instance_id);
         let capsfilter_id = format!("{}:capsfilter", instance_id);
 
-        let videoscale = gst::ElementFactory::make("videoscale")
-            .name(&scale_id)
-            .build()
-            .map_err(|e| BlockBuildError::ElementCreation(format!("videoscale: {}", e)))?;
+        // videoconvertscale on the CPU; autovideoconvert scales as well as converts.
+        let convert_element_name = video_convert_mode().convert_scale_element_name();
 
         // TEMPORARY: videorate removed to avoid frame duplication issues
         // let videorate = gst::ElementFactory::make("videorate")
@@ -120,13 +117,15 @@ impl BlockBuilder for VideoFormatBuilder {
         //     .build()
         //     .map_err(|e| BlockBuildError::ElementCreation(format!("videorate: {}", e)))?;
 
-        let videoconvert = gst::ElementFactory::make(convert_element_name)
+        let convert_scale = gst::ElementFactory::make(convert_element_name)
             .name(&convert_id)
             .build()
             .map_err(|e| {
                 BlockBuildError::ElementCreation(format!("{}: {}", convert_element_name, e))
             })?;
-        gpu::configure_video_convert(&videoconvert);
+        // Raises `n-threads` off the stock default of 1, for both the
+        // converting and the scaling half.
+        gpu::configure_video_convert(&convert_scale);
 
         // capsfilter with caps (only constraints specified properties)
         let caps = caps_str.parse::<gst::Caps>().map_err(|_| {
@@ -139,26 +138,19 @@ impl BlockBuilder for VideoFormatBuilder {
             .build()
             .map_err(|e| BlockBuildError::ElementCreation(format!("capsfilter: {}", e)))?;
 
-        info!("VideoFormat block created (chain: videoscale -> {} -> capsfilter) [videorate TEMPORARILY REMOVED]", convert_element_name);
+        info!(
+            "VideoFormat block created (chain: {} -> capsfilter) [videorate TEMPORARILY REMOVED]",
+            convert_element_name
+        );
 
-        // Chain: videoscale -> videoconvert/autovideoconvert -> capsfilter (videorate temporarily removed)
-        let internal_links = vec![
-            (
-                ElementPadRef::pad(&scale_id, "src"),
-                ElementPadRef::pad(&convert_id, "sink"),
-            ),
-            (
-                ElementPadRef::pad(&convert_id, "src"),
-                ElementPadRef::pad(&capsfilter_id, "sink"),
-            ),
-        ];
+        // Chain: videoconvertscale/autovideoconvert -> capsfilter (videorate temporarily removed)
+        let internal_links = vec![(
+            ElementPadRef::pad(&convert_id, "src"),
+            ElementPadRef::pad(&capsfilter_id, "sink"),
+        )];
 
         Ok(BlockBuildResult {
-            elements: vec![
-                (scale_id, videoscale),
-                (convert_id, videoconvert),
-                (capsfilter_id, capsfilter),
-            ],
+            elements: vec![(convert_id, convert_scale), (capsfilter_id, capsfilter)],
             internal_links,
             bus_message_handler: None,
             pad_properties: HashMap::new(),
@@ -182,7 +174,7 @@ fn videoformat_definition() -> BlockDefinition {
             ExposedProperty {
                 name: "resolution".to_string(),
                 label: "Resolution".to_string(),
-                description: "Video resolution - creates videoscale element. Leave empty to pass through.".to_string(),
+                description: "Video resolution - applied by the videoconvertscale element. Leave empty to pass through.".to_string(),
                 property_type: PropertyType::Enum {
                     values: common_video_resolution_enum_values(true), // include empty "-" option
                 },
@@ -214,7 +206,7 @@ fn videoformat_definition() -> BlockDefinition {
             ExposedProperty {
                 name: "format".to_string(),
                 label: "Pixel Format".to_string(),
-                description: "Pixel format/color space - creates videoconvert element. Leave empty to pass through.".to_string(),
+                description: "Pixel format/color space - applied by the videoconvertscale element. Leave empty to pass through.".to_string(),
                 property_type: PropertyType::Enum {
                     values: common_video_pixel_format_enum_values(true),
                 },
@@ -251,5 +243,210 @@ fn videoformat_definition() -> BlockDefinition {
             height: Some(2.0),
             ..Default::default()
         }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::blocks::BlockBuildContext;
+    use gst::prelude::*;
+
+    fn init_gst() {
+        let _ = gst::init();
+        // video_convert_mode() panics until this has run.
+        crate::gpu::detect_gpu_capabilities();
+    }
+
+    fn props(pairs: &[(&str, &str)]) -> HashMap<String, PropertyValue> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), PropertyValue::String(v.to_string())))
+            .collect()
+    }
+
+    fn build(pairs: &[(&str, &str)]) -> BlockBuildResult {
+        init_gst();
+        let ctx = BlockBuildContext::new(Vec::new(), "all".to_string());
+        VideoFormatBuilder
+            .build("vf0", &props(pairs), &ctx)
+            .expect("VideoFormat block must build")
+    }
+
+    /// Guards external pad stability. Saved flows store links as
+    /// `block_id:external_pad_name` and resolve them through the block
+    /// definition's `internal_element_id` at build time, so a definition that
+    /// names an element the builder does not produce silently breaks every
+    /// saved flow linking into this block.
+    ///
+    /// Renaming the conversion element without updating `external_pads` (or
+    /// vice versa) fails here.
+    #[test]
+    fn external_pads_resolve_to_built_elements() {
+        let result = build(&[("resolution", "1280x720"), ("format", "I420")]);
+        let built: Vec<&str> = result.elements.iter().map(|(id, _)| id.as_str()).collect();
+
+        let definition = videoformat_definition();
+        let pads = definition
+            .external_pads
+            .inputs
+            .iter()
+            .chain(definition.external_pads.outputs.iter());
+
+        for pad in pads {
+            let resolved = format!("vf0:{}", pad.internal_element_id);
+            assert!(
+                built.contains(&resolved.as_str()),
+                "external pad '{}' resolves to element '{}', which the builder does not create. \
+                 Built elements: {:?}",
+                pad.name,
+                resolved,
+                built
+            );
+        }
+    }
+
+    /// The block builds exactly one conversion element plus the capsfilter.
+    /// Splitting the conversion back into separate scale and convert elements
+    /// fails this test.
+    #[test]
+    fn builds_one_conversion_element_not_two() {
+        let result = build(&[("resolution", "1280x720"), ("format", "I420")]);
+
+        assert_eq!(
+            result.elements.len(),
+            2,
+            "expected one conversion element plus the capsfilter, got {:?}",
+            result
+                .elements
+                .iter()
+                .map(|(id, _)| id.as_str())
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(
+            result.internal_links.len(),
+            1,
+            "a two-element chain has exactly one internal link"
+        );
+
+        let factory = result.elements[0]
+            .1
+            .factory()
+            .expect("built element has a factory")
+            .name()
+            .to_string();
+        assert!(
+            factory == "videoconvertscale" || factory == "autovideoconvert",
+            "conversion element must convert and scale in one pass, got '{}'",
+            factory
+        );
+    }
+
+    /// The single element must actually do both jobs: reject 1080p RGBA in,
+    /// 720p I420 out unless one element performed both the scale and the
+    /// colorspace conversion.
+    #[test]
+    fn one_element_both_scales_and_converts() {
+        let result = build(&[("resolution", "1280x720"), ("format", "I420")]);
+
+        let pipeline = gst::Pipeline::new();
+        let src = gst::ElementFactory::make("videotestsrc")
+            .property("num-buffers", 2i32)
+            .property("is-live", false)
+            .build()
+            .expect("videotestsrc is in gst-plugins-base");
+        let in_caps = gst::ElementFactory::make("capsfilter")
+            .property(
+                "caps",
+                "video/x-raw,width=1920,height=1080,format=RGBA,framerate=30/1"
+                    .parse::<gst::Caps>()
+                    .unwrap(),
+            )
+            .build()
+            .unwrap();
+        let sink = gst::ElementFactory::make("fakesink")
+            .property("sync", false)
+            .build()
+            .unwrap();
+
+        let convert = &result.elements[0].1;
+        let capsfilter = &result.elements[1].1;
+        pipeline
+            .add_many([&src, &in_caps, convert, capsfilter, &sink])
+            .unwrap();
+        gst::Element::link_many([&src, &in_caps, convert, capsfilter, &sink])
+            .expect("the block's single element must link 1080p RGBA to 720p I420");
+
+        pipeline.set_state(gst::State::Playing).unwrap();
+        let bus = pipeline.bus().unwrap();
+        let msg = bus.timed_pop_filtered(
+            gst::ClockTime::from_seconds(10),
+            &[gst::MessageType::Eos, gst::MessageType::Error],
+        );
+
+        let out_caps = capsfilter
+            .static_pad("src")
+            .unwrap()
+            .current_caps()
+            .expect("output caps must be negotiated");
+        pipeline.set_state(gst::State::Null).unwrap();
+
+        match msg {
+            Some(m) if m.type_() == gst::MessageType::Error => {
+                panic!("pipeline error: {:?}", m)
+            }
+            None => panic!("pipeline did not reach EOS"),
+            _ => {}
+        }
+
+        let s = out_caps.structure(0).unwrap();
+        assert_eq!(s.get::<i32>("width").unwrap(), 1280);
+        assert_eq!(s.get::<i32>("height").unwrap(), 720);
+        assert_eq!(s.get::<String>("format").unwrap(), "I420");
+    }
+
+    /// The block leaves `method` unset and takes the element default. If the
+    /// two elements' defaults diverge, scaled output changes and the block
+    /// must pin `method` explicitly.
+    #[test]
+    fn scaling_method_default_matches_videoscale() {
+        init_gst();
+
+        let scale = gst::ElementFactory::make("videoscale").build().unwrap();
+        let convert_scale = gst::ElementFactory::make("videoconvertscale")
+            .build()
+            .unwrap();
+
+        let scale_method = scale.property_value("method");
+        let convert_scale_method = convert_scale.property_value("method");
+        assert_eq!(
+            format!("{:?}", scale_method),
+            format!("{:?}", convert_scale_method),
+            "videoscale and videoconvertscale disagree on the default scaling method; \
+             the block must pin `method` or the output change must be called out"
+        );
+    }
+
+    /// `configure_video_convert` must reach the conversion element, so that
+    /// both the converting and the scaling half are threaded.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn conversion_element_is_threaded() {
+        let result = build(&[("resolution", "1280x720"), ("format", "I420")]);
+        let convert = &result.elements[0].1;
+
+        assert!(
+            convert.has_property("n-threads"),
+            "the merged element must expose n-threads for configure_video_convert to reach"
+        );
+        assert_eq!(
+            convert.property::<u32>("n-threads"),
+            crate::gpu::video_convert_threads(),
+            "configure_video_convert did not reach the merged element"
+        );
+        assert!(
+            convert.property::<u32>("n-threads") > 1,
+            "n-threads left at the stock default of 1"
+        );
     }
 }

--- a/backend/src/blocks/builtin/videoformat.rs
+++ b/backend/src/blocks/builtin/videoformat.rs
@@ -14,7 +14,7 @@
 //! Unspecified properties allow passthrough - elements will not modify those aspects.
 
 use crate::blocks::{BlockBuildContext, BlockBuildError, BlockBuildResult, BlockBuilder};
-use crate::gpu::video_convert_mode;
+use crate::gpu::{self, video_convert_mode};
 use gstreamer as gst;
 use std::collections::HashMap;
 use strom_types::{
@@ -126,6 +126,7 @@ impl BlockBuilder for VideoFormatBuilder {
             .map_err(|e| {
                 BlockBuildError::ElementCreation(format!("{}: {}", convert_element_name, e))
             })?;
+        gpu::configure_video_convert(&videoconvert);
 
         // capsfilter with caps (only constraints specified properties)
         let caps = caps_str.parse::<gst::Caps>().map_err(|_| {

--- a/backend/src/blocks/builtin/videoformat.rs
+++ b/backend/src/blocks/builtin/videoformat.rs
@@ -335,8 +335,13 @@ mod tests {
             .expect("built element has a factory")
             .name()
             .to_string();
+        // Every name here is a single element that converts *and* scales.
+        // `stromvimageconvert` does the scaling half through
+        // `GstVideoConverter`, which is what `videoconvertscale` is built on.
         assert!(
-            factory == "videoconvertscale" || factory == "autovideoconvert",
+            factory == "videoconvertscale"
+                || factory == "autovideoconvert"
+                || factory == video_convert_mode().convert_scale_element_name(),
             "conversion element must convert and scale in one pass, got '{}'",
             factory
         );

--- a/backend/src/blocks/builtin/vision_mixer/builder/pipeline_cpu.rs
+++ b/backend/src/blocks/builtin/vision_mixer/builder/pipeline_cpu.rs
@@ -109,6 +109,7 @@ pub(super) fn build_cpu_pipeline(
         // so that upstream GPU-memory sources (e.g. nvh264dec from efpsrt_input)
         // negotiate correctly against the CPU compositor backend.
         let videoconvert = elements::make_element(vc_factory, &vc_id_dsk)?;
+        gpu::configure_video_convert(&videoconvert);
 
         elems.push((q_id.clone(), queue));
         elems.push((vc_id_dsk.clone(), videoconvert));

--- a/backend/src/gpu.rs
+++ b/backend/src/gpu.rs
@@ -22,6 +22,11 @@ pub enum VideoConvertMode {
     GpuAccelerated,
     /// Use `videoconvert` - safe software fallback (interop broken or no GPU)
     Software,
+    /// Use `stromvimageconvert` - Accelerate/vImage on the format pairs it
+    /// covers, `GstVideoConverter` on the rest. macOS only, because the
+    /// element only exists there.
+    #[cfg(target_os = "macos")]
+    VImage,
 }
 
 impl VideoConvertMode {
@@ -30,6 +35,8 @@ impl VideoConvertMode {
         match self {
             VideoConvertMode::GpuAccelerated => "autovideoconvert",
             VideoConvertMode::Software => "videoconvert",
+            #[cfg(target_os = "macos")]
+            VideoConvertMode::VImage => crate::gst::vimage::ELEMENT_NAME,
         }
     }
 
@@ -41,10 +48,15 @@ impl VideoConvertMode {
     /// `autovideoconvert` covers both as well — it is
     /// `Bin/Colorspace/Scale/Video/Converter` and autoplugs a scaler when the
     /// caps ask for one.
+    ///
+    /// `stromvimageconvert` covers both too: a resize has no vImage path, so
+    /// it runs on `GstVideoConverter`, which is what `videoconvertscale` is.
     pub fn convert_scale_element_name(&self) -> &'static str {
         match self {
             VideoConvertMode::GpuAccelerated => "autovideoconvert",
             VideoConvertMode::Software => "videoconvertscale",
+            #[cfg(target_os = "macos")]
+            VideoConvertMode::VImage => crate::gst::vimage::ELEMENT_NAME,
         }
     }
 }
@@ -249,16 +261,41 @@ pub fn detect_gpu_capabilities() -> VideoConvertMode {
 /// Do not add an NVENC check here: NVENC never exists on a Mac, so the probe
 /// could only ever return one answer.
 ///
-/// `Software` is right for two reasons. `autovideoconvert` offers no GPU path
-/// for the frames these call sites see — given GL memory it picks
-/// `glcolorconvert`, but our blocks feed it system memory (the GL chains in
-/// this tree download at their boundary) and it then selects
-/// `videoconvertscale` on the CPU. And being a bin it exposes no `n-threads`,
-/// so it would forfeit the threading below, which is what moves the numbers.
+/// `autovideoconvert` is not a candidate. It offers no GPU path for the frames
+/// these call sites see — given GL memory it picks `glcolorconvert`, but our
+/// blocks feed it system memory (the GL chains in this tree download at their
+/// boundary) and it then selects `videoconvertscale` on the CPU. And being a
+/// bin it exposes no `n-threads`, so it would forfeit the threading that moved
+/// the numbers before vImage did.
+///
+/// That leaves `stromvimageconvert` against `videoconvert`. The vImage element
+/// wins where it has a path and is `GstVideoConverter` — the same code
+/// `videoconvert` runs — where it does not, so the only reasons to stay on
+/// `videoconvert` are the element failing to register or the
+/// `STROM_DISABLE_VIMAGE` escape hatch, which exists so the two can be
+/// benchmarked against each other from one binary.
 #[cfg(target_os = "macos")]
 fn detect_convert_mode() -> VideoConvertMode {
-    info!(
-        "macOS - using software video conversion with n-threads={} (autovideoconvert has no GPU path for system memory here)",
+    if std::env::var_os("STROM_DISABLE_VIMAGE").is_some() {
+        info!(
+            "macOS - STROM_DISABLE_VIMAGE set, using videoconvert with n-threads={}",
+            video_convert_threads()
+        );
+        return VideoConvertMode::Software;
+    }
+
+    if crate::gst::vimage::register() {
+        info!(
+            "macOS - using {} for video conversion (vImage where available, GstVideoConverter with n-threads={} otherwise)",
+            crate::gst::vimage::ELEMENT_NAME,
+            video_convert_threads()
+        );
+        return VideoConvertMode::VImage;
+    }
+
+    warn!(
+        "macOS - {} unavailable, falling back to videoconvert with n-threads={}",
+        crate::gst::vimage::ELEMENT_NAME,
         video_convert_threads()
     );
     VideoConvertMode::Software
@@ -500,8 +537,10 @@ fn sysctl_string(name: &str) -> Option<String> {
 pub fn configure_video_convert(element: &gst::Element) {
     #[cfg(target_os = "macos")]
     {
-        // Only plain `videoconvert` carries the property; `autovideoconvert` is
-        // a bin with nothing to forward it to.
+        // `videoconvert` and `stromvimageconvert` both carry the property;
+        // `autovideoconvert` is a bin with nothing to forward it to. On
+        // `stromvimageconvert` it sizes the `GstVideoConverter` fallback —
+        // the vImage path runs Accelerate's own pool and ignores it.
         if element.has_property("n-threads") {
             element.set_property("n-threads", video_convert_threads());
         }

--- a/backend/src/gpu.rs
+++ b/backend/src/gpu.rs
@@ -1,10 +1,13 @@
 //! GPU capability detection and video conversion mode selection.
 //!
-//! This module detects at startup whether GPU-accelerated video conversion
-//! with CUDA-GL interop is supported. On systems where it works (native Linux
-//! with X11 and NVIDIA drivers), we use `autovideoconvert` for better performance.
-//! On systems where it fails (WSL, headless/GBM, broken interop), we fall back
-//! to software `videoconvert`.
+//! The conversion mode is decided once at startup, per platform:
+//!
+//! * On CUDA platforms (Linux/Windows with NVIDIA) `autovideoconvert` gives a
+//!   real GPU path, but only where GL-CUDA interop actually works. NVENC's
+//!   presence is the gate for attempting that test, and the interop test is
+//!   the gate for using it. Where either fails we use software `videoconvert`.
+//! * On macOS there is no CUDA question to ask, so we do not ask it. See
+//!   `detect_convert_mode` for why macOS uses threaded software conversion.
 
 use gstreamer as gst;
 use gstreamer::prelude::*;
@@ -46,6 +49,7 @@ pub fn video_convert_mode() -> VideoConvertMode {
 }
 
 /// Check if running inside WSL (Windows Subsystem for Linux).
+#[cfg(not(target_os = "macos"))]
 fn is_wsl() -> bool {
     // Check WSL environment variable
     if std::env::var("WSL_DISTRO_NAME").is_ok() || std::env::var("WSL_INTEROP").is_ok() {
@@ -215,23 +219,49 @@ fn detect_gl_renderer() -> Option<GlRendererInfo> {
 
 /// Detect GPU capabilities and set the global video conversion mode.
 /// This should be called once at startup after GStreamer is initialized.
-///
-/// Detection strategy:
-/// 1. If running on WSL, skip GPU test (CUDA-GL interop is known broken)
-/// 2. If cudadownload element is unavailable, use software mode
-/// 3. Test GL→CUDA interop with a fast pipeline (no nvenc initialization)
 pub fn detect_gpu_capabilities() -> VideoConvertMode {
     // Probe GL renderer info early (best-effort, independent of CUDA-GL interop)
     let gl_info = detect_gl_renderer();
     let _ = GL_RENDERER_INFO.set(gl_info);
 
+    let mode = detect_convert_mode();
+    let _ = VIDEO_CONVERT_MODE.set(mode);
+    mode
+}
+
+/// Decide the conversion mode on macOS.
+///
+/// Do not add an NVENC check here: NVENC never exists on a Mac, so the probe
+/// could only ever return one answer.
+///
+/// `Software` is right for two reasons. `autovideoconvert` offers no GPU path
+/// for the frames these call sites see — given GL memory it picks
+/// `glcolorconvert`, but our blocks feed it system memory (the GL chains in
+/// this tree download at their boundary) and it then selects
+/// `videoconvertscale` on the CPU. And being a bin it exposes no `n-threads`,
+/// so it would forfeit the threading below, which is what moves the numbers.
+#[cfg(target_os = "macos")]
+fn detect_convert_mode() -> VideoConvertMode {
+    info!(
+        "macOS - using software video conversion with n-threads={} (autovideoconvert has no GPU path for system memory here)",
+        video_convert_threads()
+    );
+    VideoConvertMode::Software
+}
+
+/// Decide the conversion mode on CUDA-capable platforms (Linux, Windows).
+///
+/// Detection strategy, unchanged:
+/// 1. If running on WSL, skip GPU test (CUDA-GL interop is known broken)
+/// 2. If NVENC is unavailable there is no CUDA stack to test, use software mode
+/// 3. Test GL→CUDA interop with a fast pipeline (no nvenc initialization)
+#[cfg(not(target_os = "macos"))]
+fn detect_convert_mode() -> VideoConvertMode {
     // Fast path: WSL has broken CUDA-GL interop, skip expensive test
     if is_wsl() {
         info!("WSL detected - using software video conversion (CUDA-GL interop unsupported)");
         // deprioritize_nv_decoders();
-        let mode = VideoConvertMode::Software;
-        let _ = VIDEO_CONVERT_MODE.set(mode);
-        return mode;
+        return VideoConvertMode::Software;
     }
 
     // Check if nvh264enc is available (required for GPU-accelerated encoding)
@@ -242,14 +272,12 @@ pub fn detect_gpu_capabilities() -> VideoConvertMode {
 
     if !has_nvenc {
         info!("NVENC not available - using software video conversion");
-        let mode = VideoConvertMode::Software;
-        let _ = VIDEO_CONVERT_MODE.set(mode);
-        return mode;
+        return VideoConvertMode::Software;
     }
 
     debug!("Testing CUDA-GL interop (this may take a moment on first run)...");
 
-    let mode = match test_cuda_gl_interop() {
+    match test_cuda_gl_interop() {
         Ok(()) => {
             info!("CUDA-GL interop works - using GPU-accelerated video conversion");
             VideoConvertMode::GpuAccelerated
@@ -261,15 +289,217 @@ pub fn detect_gpu_capabilities() -> VideoConvertMode {
             );
             VideoConvertMode::Software
         }
-    };
+    }
+}
 
-    let _ = VIDEO_CONVERT_MODE.set(mode);
-    mode
+/// Sanity bound on the detected core count, not a performance policy: it sits
+/// above anything Apple silicon reports, and clamping is logged rather than
+/// silent. Deliberately loose, because the errors are asymmetric — overshooting
+/// the pool measured 1-2%, undershooting up to 24%.
+#[cfg(target_os = "macos")]
+const MAX_CONVERT_THREADS: u32 = 32;
+
+/// Sanity bound for the `STROM_VIDEOCONVERT_THREADS` override, so a typo cannot
+/// ask for thousands of threads.
+#[cfg(target_os = "macos")]
+const MAX_OVERRIDE_THREADS: u32 = 64;
+
+/// The override is only an escape hatch if it can exceed the sanity bound.
+#[cfg(target_os = "macos")]
+const _: () = assert!(MAX_OVERRIDE_THREADS > MAX_CONVERT_THREADS);
+
+/// Number of worker threads to give a software `videoconvert`.
+///
+/// The stock `n-threads=1` converts a whole frame on one core; a pool sized to
+/// the machine measured 24% faster end to end at 1080p on a 4+4 M2.
+///
+/// The pool counts every performance tier macOS reports except the efficiency
+/// one — 4 on an M2, 36 on an M5 Ultra. `videoconvert` cuts a frame into equal
+/// stripes and cannot emit until the slowest finishes, so an efficiency core
+/// becomes the straggler the whole frame waits on. Apple draws the same line,
+/// describing performance cores as joining the super cores for demanding
+/// multithreaded work while efficiency cores handle background tasks. Super and
+/// performance cores do still differ, so a wide machine is worth measuring with
+/// `STROM_VIDEOCONVERT_THREADS`.
+///
+/// Intel Macs report no tiers and fall back to the total logical CPU count,
+/// which is correct there since all cores are equivalent.
+#[cfg(target_os = "macos")]
+pub fn video_convert_threads() -> u32 {
+    static THREADS: OnceLock<u32> = OnceLock::new();
+    *THREADS.get_or_init(|| {
+        let detected = performance_core_count().unwrap_or_else(|| {
+            std::thread::available_parallelism()
+                .map(|n| n.get() as u32)
+                .unwrap_or(1)
+        });
+        let raw = std::env::var("STROM_VIDEOCONVERT_THREADS").ok();
+        resolve_thread_count(raw.as_deref(), detected)
+    })
+}
+
+/// Apply the override and the ceiling to a detected core count.
+///
+/// Split out from [`video_convert_threads`] so the parsing and clamping can be
+/// tested without the process-wide `OnceLock` or the environment, and so the
+/// behaviour on machines wider than this one is pinned by a test rather than
+/// left to inference.
+#[cfg(target_os = "macos")]
+fn resolve_thread_count(override_raw: Option<&str>, detected: u32) -> u32 {
+    if let Some(raw) = override_raw {
+        match raw.trim().parse::<u32>() {
+            // The override deliberately bypasses MAX_CONVERT_THREADS so a
+            // wider machine can be measured past the sanity bound without a
+            // rebuild.
+            Ok(n) if (1..=MAX_OVERRIDE_THREADS).contains(&n) => return n,
+            _ => warn!(
+                "ignoring STROM_VIDEOCONVERT_THREADS={:?} - expected an integer in 1..={}",
+                raw, MAX_OVERRIDE_THREADS
+            ),
+        }
+    }
+    if detected > MAX_CONVERT_THREADS {
+        warn!(
+            "detected {} fast cores, capping the videoconvert pool at {} - set STROM_VIDEOCONVERT_THREADS to override",
+            detected, MAX_CONVERT_THREADS
+        );
+    }
+    detected.clamp(1, MAX_CONVERT_THREADS)
+}
+
+/// Count the logical CPUs in every performance tier that is not an efficiency
+/// tier.
+///
+/// macOS numbers its core tiers fastest-first and names each. A part can have
+/// more than one fast tier — an M5 Ultra is 12 super cores plus 24 performance
+/// cores — so tier 0 alone would be 12 there and discard 24 fast cores.
+///
+/// Matching the tier to *exclude* is the durable form: "Efficiency" is stable
+/// while the fast tiers gain names. A rename fails open — efficiency
+/// cores get counted, costing the 1-2% that overshooting costs rather than most
+/// of the machine.
+///
+/// Returns `None` on Intel Macs, where these keys are absent.
+#[cfg(target_os = "macos")]
+fn performance_core_count() -> Option<u32> {
+    let levels = sysctl_u32("hw.nperflevels")?;
+    let tiers: Vec<(String, u32)> = (0..levels)
+        .map(|i| {
+            (
+                sysctl_string(&format!("hw.perflevel{}.name", i)).unwrap_or_default(),
+                sysctl_u32(&format!("hw.perflevel{}.logicalcpu", i)).unwrap_or(0),
+            )
+        })
+        .collect();
+
+    debug!("CPU performance tiers: {:?}", tiers);
+    let n = fast_cores_from_tiers(&tiers);
+    (n > 0).then_some(n)
+}
+
+/// Sum the tiers that are not efficiency tiers.
+///
+/// Split from the syscalls so the tier policy can be tested against machines
+/// that are not to hand.
+#[cfg(target_os = "macos")]
+fn fast_cores_from_tiers(tiers: &[(String, u32)]) -> u32 {
+    tiers
+        .iter()
+        .filter(|(name, _)| !name.to_ascii_lowercase().contains("efficiency"))
+        .map(|(_, count)| count)
+        .sum()
+}
+
+/// Read an integer sysctl by name.
+#[cfg(target_os = "macos")]
+fn sysctl_u32(name: &str) -> Option<u32> {
+    let cname = std::ffi::CString::new(name).ok()?;
+    let mut value: i32 = 0;
+    let mut size = std::mem::size_of::<i32>();
+    // SAFETY: `value` and `size` describe the same object, and `cname` is a
+    // NUL-terminated C string that outlives the call.
+    let rc = unsafe {
+        libc::sysctlbyname(
+            cname.as_ptr(),
+            &mut value as *mut i32 as *mut libc::c_void,
+            &mut size,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    (rc == 0 && value > 0).then_some(value as u32)
+}
+
+/// Read a string sysctl by name.
+#[cfg(target_os = "macos")]
+fn sysctl_string(name: &str) -> Option<String> {
+    let cname = std::ffi::CString::new(name).ok()?;
+    let mut size: usize = 0;
+
+    // SAFETY: a null data pointer asks sysctlbyname for the size only.
+    let rc = unsafe {
+        libc::sysctlbyname(
+            cname.as_ptr(),
+            std::ptr::null_mut(),
+            &mut size,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    if rc != 0 || size == 0 {
+        return None;
+    }
+
+    let mut buf = vec![0u8; size];
+    // SAFETY: `buf` has `size` bytes and `size` is updated with what was written.
+    let rc = unsafe {
+        libc::sysctlbyname(
+            cname.as_ptr(),
+            buf.as_mut_ptr() as *mut libc::c_void,
+            &mut size,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    if rc != 0 {
+        return None;
+    }
+
+    buf.truncate(size.min(buf.len()));
+    let end = buf.iter().position(|&b| b == 0).unwrap_or(buf.len());
+    Some(String::from_utf8_lossy(&buf[..end]).into_owned())
+}
+
+/// Apply tuning properties to a freshly created video conversion element.
+///
+/// `videoconvert` ships with `n-threads=1`, so a 1080p colour conversion runs
+/// on a single core however many the machine has. Every call site that builds a
+/// conversion element from [`VideoConvertMode::element_name`] routes through
+/// here, so the default is set in exactly one place.
+///
+/// This is macOS-only on purpose. The thread count above is an Apple-silicon
+/// heuristic. On Linux in particular a container's visible CPU count routinely
+/// overstates its cgroup quota, so picking a pool size there without measuring
+/// risks oversubscribing shared hosts. Elsewhere this is a no-op.
+pub fn configure_video_convert(element: &gst::Element) {
+    #[cfg(target_os = "macos")]
+    {
+        // Only plain `videoconvert` carries the property; `autovideoconvert` is
+        // a bin with nothing to forward it to.
+        if element.has_property("n-threads") {
+            element.set_property("n-threads", video_convert_threads());
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = element;
+    }
 }
 
 /// Test if true zero-copy GL-CUDA interop works with nvh264enc.
 /// Runs gst-launch-1.0 with GST_DEBUG to capture interop warnings.
 /// Returns Ok if zero-copy works, Err if fallback copy is used.
+#[cfg(not(target_os = "macos"))]
 fn test_cuda_gl_interop() -> Result<(), String> {
     use std::process::Command;
 
@@ -351,5 +581,213 @@ mod tests {
             "autovideoconvert"
         );
         assert_eq!(VideoConvertMode::Software.element_name(), "videoconvert");
+    }
+
+    /// `configure_video_convert` must raise the thread count off the stock
+    /// default of 1. Dropping the property, or a call site's use of this
+    /// helper, leaves `n-threads` at 1 and fails this test.
+    ///
+    /// macOS-only because the helper is deliberately a no-op elsewhere.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn configure_video_convert_sets_thread_count() {
+        gst::init().expect("gst init");
+
+        let convert = gst::ElementFactory::make("videoconvert")
+            .build()
+            .expect("videoconvert is in gst-plugins-base and must be present");
+
+        assert_eq!(
+            convert.property::<u32>("n-threads"),
+            1,
+            "upstream default changed; the premise of this fix needs rechecking"
+        );
+
+        configure_video_convert(&convert);
+
+        assert_eq!(
+            convert.property::<u32>("n-threads"),
+            video_convert_threads()
+        );
+        assert!(
+            video_convert_threads() > 1,
+            "every Mac this runs on is multi-core; a pool of 1 means detection failed"
+        );
+    }
+
+    /// The macOS choice of `Software` rests on `autovideoconvert` being a bin
+    /// that cannot forward a thread count to the converter it picks. If a
+    /// future GStreamer grows such a property, that trade-off is worth
+    /// re-measuring rather than silently keeping.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn autovideoconvert_cannot_be_threaded() {
+        gst::init().expect("gst init");
+
+        let auto = gst::ElementFactory::make("autovideoconvert")
+            .build()
+            .expect("autovideoconvert is in gst-plugins-base and must be present");
+
+        assert!(
+            !auto.has_property("n-threads"),
+            "autovideoconvert now exposes n-threads - re-measure Software vs GpuAccelerated on macOS"
+        );
+    }
+
+    /// The pool size must stay inside the documented bounds whichever branch
+    /// of `video_convert_threads` supplies it.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn video_convert_threads_is_bounded() {
+        let n = video_convert_threads();
+        assert!(
+            (1..=MAX_OVERRIDE_THREADS).contains(&n),
+            "thread count out of range: {}",
+            n
+        );
+    }
+
+    /// Pins what happens on machines wider than this one, which cannot
+    /// exercise these paths itself.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn thread_count_scales_with_cores() {
+        // The detected count is used as-is across the whole real Apple silicon
+        // range: M2 4, M3 Pro 6, M2 Max 8, M4 Pro 10, M3/M4 Max 12, M3 Ultra 24.
+        for cores in [4, 6, 8, 10, 12, 16, 24] {
+            assert_eq!(
+                resolve_thread_count(None, cores),
+                cores,
+                "a {}-P-core machine should use its cores, not a capped value",
+                cores
+            );
+        }
+
+        // The bound is a sanity check on the syscall, not a policy: it only
+        // engages past anything Apple silicon reports. An old Intel Mac Pro
+        // falling back to 56 logical CPUs is the realistic case that hits it.
+        assert_eq!(resolve_thread_count(None, 56), MAX_CONVERT_THREADS);
+        assert_eq!(resolve_thread_count(None, u32::MAX), MAX_CONVERT_THREADS);
+
+        // A nonsense detection still yields a usable pool.
+        assert_eq!(resolve_thread_count(None, 0), 1);
+    }
+
+    /// Pins the tier policy against real Apple silicon layouts, none of which
+    /// beyond this machine are to hand.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn fast_cores_counts_every_non_efficiency_tier() {
+        let m2 = [("Performance".into(), 4), ("Efficiency".into(), 4)];
+        assert_eq!(fast_cores_from_tiers(&m2), 4);
+
+        // M4: fewer performance cores than efficiency cores.
+        let m4 = [("Performance".into(), 4), ("Efficiency".into(), 6)];
+        assert_eq!(fast_cores_from_tiers(&m4), 4);
+
+        // M5 Ultra: 36 cores as 12 super + 24 performance, no efficiency tier.
+        // Taking level 0 alone would yield 12 and throw away 24 fast cores.
+        let m5_ultra = [("Super".into(), 12), ("Performance".into(), 24)];
+        assert_eq!(fast_cores_from_tiers(&m5_ultra), 36);
+
+        // M6: 2 super + 4 performance + 6 efficiency. All three tiers coexist,
+        // so "performance" is a tier in its own right and not efficiency
+        // renamed; only the efficiency tier is dropped.
+        let m6 = [
+            ("Super".into(), 2),
+            ("Performance".into(), 4),
+            ("Efficiency".into(), 6),
+        ];
+        assert_eq!(fast_cores_from_tiers(&m6), 6);
+    }
+
+    /// If Apple renames the efficiency tier the match fails open, including
+    /// those cores rather than discarding most of the machine. Overshooting the
+    /// pool costs ~1-2%; undershooting costs far more.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn fast_cores_fails_open_on_an_unrecognised_tier_name() {
+        let renamed = [("Performance".into(), 4), ("E-Core".into(), 4)];
+        assert_eq!(fast_cores_from_tiers(&renamed), 8);
+    }
+
+    /// The tier names really are readable on this machine, so the policy above
+    /// is driven by data rather than by an assumption about the sysctl.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn perflevel_names_are_readable() {
+        let levels = sysctl_u32("hw.nperflevels").expect("macOS reports hw.nperflevels");
+        assert!(levels >= 1);
+        let name = sysctl_string("hw.perflevel0.name").expect("perflevel0 has a name");
+        assert!(!name.is_empty(), "perflevel0.name was empty");
+    }
+
+    /// The override is the escape hatch for a machine wider than this one, so
+    /// it must beat the sanity bound — and must not be trusted blindly.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn thread_count_override_bypasses_the_bound() {
+        assert_eq!(resolve_thread_count(Some("16"), 4), 16);
+        assert_eq!(resolve_thread_count(Some(" 24 "), 4), 24);
+
+        // Past MAX_CONVERT_THREADS, which detection alone can never reach.
+        assert_eq!(
+            resolve_thread_count(Some(&MAX_OVERRIDE_THREADS.to_string()), 4),
+            MAX_OVERRIDE_THREADS
+        );
+
+        // Garbage, zero and absurd values fall back to detection rather than
+        // taking the process down or spawning thousands of threads.
+        for bad in ["", "  ", "no", "-1", "0", "65", "999999", "4.5"] {
+            assert_eq!(
+                resolve_thread_count(Some(bad), 4),
+                4,
+                "STROM_VIDEOCONVERT_THREADS={:?} should have been rejected",
+                bad
+            );
+        }
+    }
+
+    /// Tripwire for a VideoToolbox converter arriving in a future GStreamer.
+    ///
+    /// The macOS choice of `Software` rests on there being no hardware
+    /// converter for `autovideoconvert` to offer. `autovideoconvert` discovers
+    /// candidates by klass (`Filter/Converter/Video...`), and today no
+    /// applemedia element carries one — the plugin ships codecs, a source and a
+    /// sink, nothing that transforms raw video.
+    ///
+    /// That is a gap in GStreamer, not in the platform: Apple exposes
+    /// `VTPixelTransferSession`, which converts colour and scales, and nothing
+    /// upstream wraps it yet. If that changes, `autovideoconvert` will pick the
+    /// new element up automatically and `GpuAccelerated` becomes worth
+    /// re-measuring here — a VideoToolbox transfer session would keep frames in
+    /// `CVPixelBuffer`s and skip both the CPU stripe work and the GL round trip
+    /// that makes `glcolorconvert` unprofitable for system memory today.
+    ///
+    /// This test fails on the day that lands, so the decision gets revisited
+    /// deliberately instead of the constant above quietly going stale.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn no_applemedia_converter_to_reconsider() {
+        gst::init().expect("gst init");
+
+        let converters: Vec<String> = gst::Registry::get()
+            .features_by_plugin("applemedia")
+            .into_iter()
+            .filter_map(|f| f.downcast::<gst::ElementFactory>().ok())
+            .filter(|f| {
+                f.metadata(gst::ELEMENT_METADATA_KLASS)
+                    .map(|k| k.contains("Converter"))
+                    .unwrap_or(false)
+            })
+            .map(|f| f.name().to_string())
+            .collect();
+
+        assert!(
+            converters.is_empty(),
+            "applemedia now ships a video converter ({:?}) - autovideoconvert will \
+             discover it, so re-measure GpuAccelerated against threaded Software on macOS",
+            converters
+        );
     }
 }

--- a/backend/src/gpu.rs
+++ b/backend/src/gpu.rs
@@ -32,6 +32,21 @@ impl VideoConvertMode {
             VideoConvertMode::Software => "videoconvert",
         }
     }
+
+    /// Returns the element name for a stage that converts *and* scales.
+    ///
+    /// Use this instead of [`Self::element_name`] for a stage that needs
+    /// both: `videoconvertscale` does the two in a single walk of the frame.
+    ///
+    /// `autovideoconvert` covers both as well — it is
+    /// `Bin/Colorspace/Scale/Video/Converter` and autoplugs a scaler when the
+    /// caps ask for one.
+    pub fn convert_scale_element_name(&self) -> &'static str {
+        match self {
+            VideoConvertMode::GpuAccelerated => "autovideoconvert",
+            VideoConvertMode::Software => "videoconvertscale",
+        }
+    }
 }
 
 /// Global detected video convert mode, set once at startup.
@@ -474,8 +489,9 @@ fn sysctl_string(name: &str) -> Option<String> {
 ///
 /// `videoconvert` ships with `n-threads=1`, so a 1080p colour conversion runs
 /// on a single core however many the machine has. Every call site that builds a
-/// conversion element from [`VideoConvertMode::element_name`] routes through
-/// here, so the default is set in exactly one place.
+/// conversion element from [`VideoConvertMode::element_name`] or
+/// [`VideoConvertMode::convert_scale_element_name`] routes through here, so the
+/// default is set in exactly one place.
 ///
 /// This is macOS-only on purpose. The thread count above is an Apple-silicon
 /// heuristic. On Linux in particular a container's visible CPU count routinely
@@ -581,6 +597,33 @@ mod tests {
             "autovideoconvert"
         );
         assert_eq!(VideoConvertMode::Software.element_name(), "videoconvert");
+    }
+
+    /// The convert+scale variant must name elements that actually scale.
+    /// `videoconvert` here would silently drop the scaling half.
+    #[test]
+    fn convert_scale_element_name_scales() {
+        assert_eq!(
+            VideoConvertMode::Software.convert_scale_element_name(),
+            "videoconvertscale"
+        );
+        assert_eq!(
+            VideoConvertMode::GpuAccelerated.convert_scale_element_name(),
+            "autovideoconvert"
+        );
+
+        // autovideoconvert is only correct here because it autoplugs a scaler.
+        gst::init().expect("gst init");
+        let factory = gst::ElementFactory::find("autovideoconvert")
+            .expect("autovideoconvert is in gst-plugins-bad");
+        let klass = factory
+            .metadata(gst::ELEMENT_METADATA_KLASS)
+            .unwrap_or_default();
+        assert!(
+            klass.contains("Scale"),
+            "autovideoconvert does not advertise scaling (klass '{}'); the convert+scale call sites need a separate scaler",
+            klass
+        );
     }
 
     /// `configure_video_convert` must raise the thread count off the stock

--- a/backend/src/gst/mod.rs
+++ b/backend/src/gst/mod.rs
@@ -17,6 +17,9 @@ pub mod thumbnail_tap;
 pub mod transitions;
 pub(crate) mod underlay;
 pub mod video_frame;
+/// vImage-backed video conversion. macOS only: the element wraps Accelerate.
+#[cfg(target_os = "macos")]
+pub mod vimage;
 pub mod volume_ramp;
 pub mod whep_probe;
 

--- a/backend/src/gst/thumbnail.rs
+++ b/backend/src/gst/thumbnail.rs
@@ -1,7 +1,7 @@
 //! Thumbnail capture error types.
 //!
 //! The actual thumbnail capture logic has moved to `thumbnail_tap.rs`, which
-//! uses GStreamer-native processing (autovideoconvert, videoscale) instead of
+//! uses GStreamer-native processing (videoconvertscale) instead of
 //! CPU-based pad probes. This module retains the shared error type.
 
 use thiserror::Error;

--- a/backend/src/gst/vimage/accelerate.rs
+++ b/backend/src/gst/vimage/accelerate.rs
@@ -1,0 +1,237 @@
+//! Raw FFI declarations for the vImage entry points this element uses.
+//!
+//! Only the handful of symbols needed by [`super::plan`] are declared. The
+//! shapes are transcribed from the macOS SDK headers
+//! (`Accelerate.framework/Frameworks/vImage.framework/Headers/{Conversion,vImage_Types}.h`);
+//! the layout of every struct here is fixed public ABI.
+//!
+//! Everything in this module is `unsafe` to call. The safe wrappers live in
+//! [`super::plan`], which is the only place allowed to build the buffer
+//! descriptors.
+
+#![allow(non_camel_case_types, non_upper_case_globals, non_snake_case)]
+
+use std::ffi::c_void;
+
+/// `vImagePixelCount` — `unsigned long`, 64-bit on every Mac we build for.
+pub type vImagePixelCount = usize;
+/// `vImage_Error` — `ssize_t`. Negative values are errors, `0` is success.
+pub type vImage_Error = isize;
+/// `vImage_Flags` — `uint32_t`.
+pub type vImage_Flags = u32;
+
+/// Default behaviour, which includes vImage's own internal multithreading.
+/// That is where the speed comes from: vImage tiles the image across the
+/// cores itself, so the element does not manage a pool of its own.
+pub const kvImageNoFlags: vImage_Flags = 0;
+pub const kvImageNoError: vImage_Error = 0;
+
+/// Not a vImage code: this element's own marker for "GStreamer would not hand
+/// us a plane we expected", so the one error path can carry a single type.
+/// Kept clear of vImage's own range, which runs from -21772 downwards.
+pub const K_PLANE_UNAVAILABLE: vImage_Error = -1;
+
+/// `vImageARGBType::kvImageARGB8888` — any 8-bit four-channel interleaved
+/// buffer. Channel order is carried by the permute map, not by this value.
+pub const kvImageARGB8888: u32 = 0;
+
+/// `vImageYpCbCrType` discriminants for the four Y'CbCr layouts we map onto.
+pub const kvImage422CbYpCrYp8: u32 = 0; // UYVY
+pub const kvImage422YpCbYpCr8: u32 = 1; // YUY2
+pub const kvImage420Yp8_Cb8_Cr8: u32 = 3; // I420 / YV12
+pub const kvImage420Yp8_CbCr8: u32 = 4; // NV12
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct vImage_Buffer {
+    pub data: *mut c_void,
+    pub height: vImagePixelCount,
+    pub width: vImagePixelCount,
+    pub rowBytes: usize,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct vImage_YpCbCrPixelRange {
+    pub Yp_bias: i32,
+    pub CbCr_bias: i32,
+    pub YpRangeMax: i32,
+    pub CbCrRangeMax: i32,
+    pub YpMax: i32,
+    pub YpMin: i32,
+    pub CbCrMax: i32,
+    pub CbCrMin: i32,
+}
+
+/// Opaque 128-byte, 16-byte-aligned conversion state. Apple documents these as
+/// reusable across threads once generated, which is why the element builds one
+/// per caps negotiation and then shares it for every frame.
+#[repr(C, align(16))]
+#[derive(Clone, Copy)]
+pub struct vImage_ARGBToYpCbCr {
+    pub opaque: [u8; 128],
+}
+
+#[repr(C, align(16))]
+#[derive(Clone, Copy)]
+pub struct vImage_YpCbCrToARGB {
+    pub opaque: [u8; 128],
+}
+
+// The generated conversion state is plain bytes with no interior pointers into
+// caller memory, and Apple documents it as safe to use concurrently from
+// several threads. That is what lets `State` sit behind a shared reference
+// while streaming threads read it.
+unsafe impl Send for vImage_ARGBToYpCbCr {}
+unsafe impl Sync for vImage_ARGBToYpCbCr {}
+unsafe impl Send for vImage_YpCbCrToARGB {}
+unsafe impl Sync for vImage_YpCbCrToARGB {}
+
+#[repr(C)]
+pub struct vImage_ARGBToYpCbCrMatrix {
+    _private: [f32; 8],
+}
+
+#[repr(C)]
+pub struct vImage_YpCbCrToARGBMatrix {
+    _private: [f32; 5],
+}
+
+#[link(name = "Accelerate", kind = "framework")]
+extern "C" {
+    pub static kvImage_ARGBToYpCbCrMatrix_ITU_R_601_4: *const vImage_ARGBToYpCbCrMatrix;
+    pub static kvImage_ARGBToYpCbCrMatrix_ITU_R_709_2: *const vImage_ARGBToYpCbCrMatrix;
+    pub static kvImage_YpCbCrToARGBMatrix_ITU_R_601_4: *const vImage_YpCbCrToARGBMatrix;
+    pub static kvImage_YpCbCrToARGBMatrix_ITU_R_709_2: *const vImage_YpCbCrToARGBMatrix;
+
+    pub fn vImageConvert_ARGBToYpCbCr_GenerateConversion(
+        matrix: *const vImage_ARGBToYpCbCrMatrix,
+        pixelRange: *const vImage_YpCbCrPixelRange,
+        outInfo: *mut vImage_ARGBToYpCbCr,
+        inARGBType: u32,
+        outYpCbCrType: u32,
+        flags: vImage_Flags,
+    ) -> vImage_Error;
+
+    pub fn vImageConvert_YpCbCrToARGB_GenerateConversion(
+        matrix: *const vImage_YpCbCrToARGBMatrix,
+        pixelRange: *const vImage_YpCbCrPixelRange,
+        outInfo: *mut vImage_YpCbCrToARGB,
+        inYpCbCrType: u32,
+        outARGBType: u32,
+        flags: vImage_Flags,
+    ) -> vImage_Error;
+
+    // RGB -> Y'CbCr
+    pub fn vImageConvert_ARGB8888To420Yp8_CbCr8(
+        src: *const vImage_Buffer,
+        destYp: *const vImage_Buffer,
+        destCbCr: *const vImage_Buffer,
+        info: *const vImage_ARGBToYpCbCr,
+        permuteMap: *const u8,
+        flags: vImage_Flags,
+    ) -> vImage_Error;
+
+    pub fn vImageConvert_ARGB8888To420Yp8_Cb8_Cr8(
+        src: *const vImage_Buffer,
+        destYp: *const vImage_Buffer,
+        destCb: *const vImage_Buffer,
+        destCr: *const vImage_Buffer,
+        info: *const vImage_ARGBToYpCbCr,
+        permuteMap: *const u8,
+        flags: vImage_Flags,
+    ) -> vImage_Error;
+
+    pub fn vImageConvert_ARGB8888To422CbYpCrYp8(
+        src: *const vImage_Buffer,
+        dest: *const vImage_Buffer,
+        info: *const vImage_ARGBToYpCbCr,
+        permuteMap: *const u8,
+        flags: vImage_Flags,
+    ) -> vImage_Error;
+
+    pub fn vImageConvert_ARGB8888To422YpCbYpCr8(
+        src: *const vImage_Buffer,
+        dest: *const vImage_Buffer,
+        info: *const vImage_ARGBToYpCbCr,
+        permuteMap: *const u8,
+        flags: vImage_Flags,
+    ) -> vImage_Error;
+
+    // Y'CbCr -> RGB
+    pub fn vImageConvert_420Yp8_CbCr8ToARGB8888(
+        srcYp: *const vImage_Buffer,
+        srcCbCr: *const vImage_Buffer,
+        dest: *const vImage_Buffer,
+        info: *const vImage_YpCbCrToARGB,
+        permuteMap: *const u8,
+        alpha: u8,
+        flags: vImage_Flags,
+    ) -> vImage_Error;
+
+    pub fn vImageConvert_420Yp8_Cb8_Cr8ToARGB8888(
+        srcYp: *const vImage_Buffer,
+        srcCb: *const vImage_Buffer,
+        srcCr: *const vImage_Buffer,
+        dest: *const vImage_Buffer,
+        info: *const vImage_YpCbCrToARGB,
+        permuteMap: *const u8,
+        alpha: u8,
+        flags: vImage_Flags,
+    ) -> vImage_Error;
+
+    pub fn vImageConvert_422CbYpCrYp8ToARGB8888(
+        src: *const vImage_Buffer,
+        dest: *const vImage_Buffer,
+        info: *const vImage_YpCbCrToARGB,
+        permuteMap: *const u8,
+        alpha: u8,
+        flags: vImage_Flags,
+    ) -> vImage_Error;
+
+    pub fn vImageConvert_422YpCbYpCr8ToARGB8888(
+        src: *const vImage_Buffer,
+        dest: *const vImage_Buffer,
+        info: *const vImage_YpCbCrToARGB,
+        permuteMap: *const u8,
+        alpha: u8,
+        flags: vImage_Flags,
+    ) -> vImage_Error;
+
+    // Channel shuffling and plane interleaving
+    pub fn vImagePermuteChannels_ARGB8888(
+        src: *const vImage_Buffer,
+        dest: *const vImage_Buffer,
+        permuteMap: *const u8,
+        flags: vImage_Flags,
+    ) -> vImage_Error;
+
+    pub fn vImageConvert_ChunkyToPlanar8(
+        srcChannels: *const *const c_void,
+        destPlanarBuffers: *const *const vImage_Buffer,
+        channelCount: u32,
+        srcStrideBytes: usize,
+        srcWidth: vImagePixelCount,
+        srcHeight: vImagePixelCount,
+        srcRowBytes: usize,
+        flags: vImage_Flags,
+    ) -> vImage_Error;
+
+    pub fn vImageConvert_PlanarToChunky8(
+        srcPlanarBuffers: *const *const vImage_Buffer,
+        destChannels: *const *mut c_void,
+        channelCount: u32,
+        destStrideBytes: usize,
+        destWidth: vImagePixelCount,
+        destHeight: vImagePixelCount,
+        destRowBytes: usize,
+        flags: vImage_Flags,
+    ) -> vImage_Error;
+
+    pub fn vImageCopyBuffer(
+        src: *const vImage_Buffer,
+        dest: *const vImage_Buffer,
+        pixelSize: usize,
+        flags: vImage_Flags,
+    ) -> vImage_Error;
+}

--- a/backend/src/gst/vimage/bench.rs
+++ b/backend/src/gst/vimage/bench.rs
@@ -1,0 +1,262 @@
+//! A measurement harness for the vImage path. Not a guard.
+//!
+//! Nothing here asserts anything about performance — a timing assertion would
+//! be flaky on a shared machine and would fail for reasons that have nothing
+//! to do with this code. It exists so the numbers in the pull request can be
+//! reproduced, and it is `#[ignore]`d so it never runs in CI.
+//!
+//! Run it through `.ab-bench/vimage-bench.sh`, which drives the chunking
+//! described below. A single experiment can also be run directly:
+//!
+//! ```text
+//! STROM_BENCH_PAIRS=10 cargo test --lib gst::vimage::bench::ab_vimage \
+//!     -- --ignored --nocapture --test-threads=1
+//! ```
+//!
+//! Method, which matters more than the numbers:
+//!
+//! * Arms are **paired**: both run back to back on the same host state, so a
+//!   load spike hits both halves of a pair rather than one arm.
+//! * Pair order is **counterbalanced and shuffled** — half the pairs run A
+//!   first, half B first, in random order. Strict alternation is wrong here:
+//!   it is a fixed ABBA schedule, so each arm permanently occupies one phase
+//!   of the host's autocorrelated noise, and an A/A control run that way
+//!   returns a significant difference where the truth is exactly zero.
+//! * An **A/A control** with byte-identical arms runs alongside the A/B. Only
+//!   the control licenses reading the A/B as a real effect rather than as
+//!   harness bias.
+//!
+//! * Each experiment is a **separate test**, run in **short chunks of fresh
+//!   processes**. macOS moves a windowless process into the background QoS
+//!   band about thirty seconds after launch — priority 4, efficiency cores,
+//!   throttled clock — and a test binary is exactly that shape. Ten pairs per
+//!   process keeps every measurement inside that window. Both arms of a pair
+//!   are always in the same process, so chunking adds between-process variance
+//!   to the arms but none to the paired difference.
+//!
+//! Output is CSV on stdout (`pair,a_first,a_ms,b_ms`) so the statistics can be
+//! redone without re-running the measurement.
+
+use std::time::Instant;
+
+use gstreamer as gst;
+use gstreamer::prelude::*;
+
+/// Frames per run. Matches the figure the work was scoped against.
+const FRAMES: u32 = 300;
+const WIDTH: u32 = 1920;
+const HEIGHT: u32 = 1080;
+
+/// Pairs per process. Small enough that a chunk finishes before macOS App Nap
+/// would demote the process; the driver script runs several chunks to reach
+/// the pair count the statistics need. At the ~5.6% per-pair spread measured
+/// on this class of host, 40 pairs put roughly +/-1.8% around the mean.
+fn pairs() -> usize {
+    std::env::var("STROM_BENCH_PAIRS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(10)
+}
+
+/// One discarded pair before measurement starts, so neither arm pays for the
+/// first-touch page faults and registry warm-up. Deliberately just one: a
+/// longer warm-up would spend the App Nap window on runs that get thrown away.
+const WARMUP: usize = 1;
+
+/// A deterministic generator, so a reported seed reproduces the exact
+/// schedule. Only used to shuffle the counterbalanced order.
+struct XorShift(u64);
+
+impl XorShift {
+    fn next(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.0 = x;
+        x
+    }
+}
+
+/// Time one pass of `frames` buffers through `converter`, from the pipeline
+/// reaching PLAYING to end of stream.
+///
+/// `converter` is a `gst-launch`-style fragment so an arm can be a single
+/// element, a configured element, or nothing at all. `tail` is everything
+/// after it — usually a capsfilter pinning the output format, but for the
+/// encoder experiment a real encoder with its own format preferences.
+fn run_once(converter: &str, tail: &str) -> f64 {
+    let description = format!(
+        "videotestsrc num-buffers={FRAMES} is-live=false pattern=smpte \
+         ! video/x-raw,format=RGBA,width={WIDTH},height={HEIGHT},framerate=30/1 \
+         {converter} {tail} \
+         ! fakesink sync=false"
+    );
+
+    let pipeline = gst::parse::launch(&description)
+        .unwrap_or_else(|e| panic!("pipeline {description:?}: {e}"))
+        .downcast::<gst::Pipeline>()
+        .expect("parse::launch returns a pipeline");
+
+    // Reach PLAYING before starting the clock: state changes allocate and
+    // negotiate, and neither is what is being measured.
+    pipeline.set_state(gst::State::Playing).expect("play");
+    let _ = pipeline.state(gst::ClockTime::from_seconds(10));
+
+    let start = Instant::now();
+    let bus = pipeline.bus().expect("pipeline bus");
+    let message = bus.timed_pop_filtered(
+        gst::ClockTime::from_seconds(120),
+        &[gst::MessageType::Eos, gst::MessageType::Error],
+    );
+    let elapsed = start.elapsed();
+
+    if let Some(gst::MessageView::Error(err)) = message.as_ref().map(|m| m.view()) {
+        panic!("pipeline {description:?} failed: {}", err.error());
+    }
+    assert!(message.is_some(), "pipeline {description:?} never finished");
+
+    pipeline.set_state(gst::State::Null).expect("null");
+    elapsed.as_secs_f64() * 1000.0
+}
+
+/// Run one paired experiment and print its rows as CSV.
+fn experiment(label: &str, arm_a: &str, arm_b: &str, tail: &str, seed: u64) {
+    // Counterbalance: exactly half the pairs put A first, then shuffle which.
+    let n = pairs();
+    let mut order: Vec<bool> = (0..n).map(|i| i < n / 2).collect();
+    let mut rng = XorShift(seed | 1);
+    for i in (1..order.len()).rev() {
+        let j = (rng.next() % (i as u64 + 1)) as usize;
+        order.swap(i, j);
+    }
+
+    for _ in 0..WARMUP {
+        run_once(arm_a, tail);
+        run_once(arm_b, tail);
+    }
+
+    println!("# experiment={label} seed={seed} frames={FRAMES} size={WIDTH}x{HEIGHT}");
+    println!("# arm_a={arm_a:?} arm_b={arm_b:?} tail={tail:?}");
+    println!("{label},pair,a_first,a_ms,b_ms");
+    for (pair, &a_first) in order.iter().enumerate() {
+        let (a_ms, b_ms) = if a_first {
+            let a = run_once(arm_a, tail);
+            let b = run_once(arm_b, tail);
+            (a, b)
+        } else {
+            let b = run_once(arm_b, tail);
+            let a = run_once(arm_a, tail);
+            (a, b)
+        };
+        println!("{label},{pair},{a_first},{a_ms:.3},{b_ms:.3}");
+    }
+}
+
+/// The pinned-format tail: what the Video Format block builds when an operator
+/// sets an output format, which is where the vImage path is actually reached.
+const NV12_TAIL: &str = "! video/x-raw,format=NV12 ";
+
+/// The unpinned tail: a real VideoToolbox encoder, left to state its own
+/// format preference. Strom's Video Encoder block builds exactly this when no
+/// format has been pinned upstream, and neither converter picks NV12 from the
+/// menu it offers — both expand to a 16-bit intermediate. This experiment
+/// exists to show the change does not make that path worse.
+const VTENC_TAIL: &str = "! vtenc_h264_hw ! h264parse ";
+
+/// Shared setup: initialise GStreamer, register the element, and resolve the
+/// seed. A fixed `STROM_BENCH_SEED` reproduces a chunk's exact schedule.
+fn setup() -> u64 {
+    gst::init().expect("gst init");
+    assert!(super::register(), "the vImage plugin must register");
+    std::env::var("STROM_BENCH_SEED")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or_else(|| {
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock after epoch")
+                .as_nanos() as u64
+        })
+}
+
+/// The arm to beat is what production does today: `videoconvert` with the
+/// thread pool `configure_video_convert` gives it.
+fn threaded_videoconvert() -> String {
+    format!(
+        "! videoconvert n-threads={} ",
+        crate::gpu::video_convert_threads()
+    )
+}
+
+/// Source and sink with a passthrough where the converter goes, so the
+/// converter cost can be reported net of the rest of the pipeline. Both arms
+/// are the same fragment, which makes this a second A/A control.
+#[test]
+#[ignore = "measurement harness, not a test; see the module docs to run it"]
+fn baseline() {
+    let seed = setup();
+    experiment(
+        "baseline",
+        "! identity ",
+        "! identity ",
+        "! video/x-raw,format=RGBA ",
+        seed,
+    );
+}
+
+/// The A/A control: byte-identical arms. Whatever this returns is the
+/// harness's own bias, and the A/B has to beat it to mean anything.
+#[test]
+#[ignore = "measurement harness, not a test; see the module docs to run it"]
+fn aa_control() {
+    let seed = setup();
+    let arm = threaded_videoconvert();
+    experiment("aa-control", &arm, &arm, NV12_TAIL, seed);
+}
+
+/// The same comparison against *stock* `videoconvert`, which is what this ran
+/// on before #726 raised the thread count. Only here to complete the table;
+/// the number that matters for this change is [`ab_vimage`].
+#[test]
+#[ignore = "measurement harness, not a test; see the module docs to run it"]
+fn ab_stock() {
+    let seed = setup();
+    experiment(
+        "ab-stock",
+        "! videoconvert n-threads=1 ",
+        &format!("! {} ", super::ELEMENT_NAME),
+        NV12_TAIL,
+        seed,
+    );
+}
+
+/// The unpinned encoder path, where neither converter reaches vImage. Guards
+/// against the change regressing what it cannot speed up.
+#[test]
+#[ignore = "measurement harness, not a test; see the module docs to run it"]
+fn ab_vtenc() {
+    let seed = setup();
+    experiment(
+        "ab-vtenc",
+        &threaded_videoconvert(),
+        &format!("! {} ", super::ELEMENT_NAME),
+        VTENC_TAIL,
+        seed,
+    );
+}
+
+/// The comparison that matters: today's threaded `videoconvert` against the
+/// vImage element, both converting RGBA to NV12.
+#[test]
+#[ignore = "measurement harness, not a test; see the module docs to run it"]
+fn ab_vimage() {
+    let seed = setup();
+    experiment(
+        "ab-vimage",
+        &threaded_videoconvert(),
+        &format!("! {} ", super::ELEMENT_NAME),
+        NV12_TAIL,
+        seed,
+    );
+}

--- a/backend/src/gst/vimage/convert.rs
+++ b/backend/src/gst/vimage/convert.rs
@@ -1,0 +1,320 @@
+//! Executing a [`Plan`] against one pair of mapped frames.
+//!
+//! This is the per-buffer hot path. It does no allocation, takes no locks and
+//! makes exactly one or two vImage calls; every decision was made in
+//! [`Plan::build`](super::plan::Plan::build) at negotiation time.
+
+use gstreamer as gst;
+use gstreamer_video::prelude::*;
+use gstreamer_video::VideoFrameRef;
+
+use super::accelerate as acc;
+use super::plan::{plane_buffer, Plan, YuvKind};
+
+type SrcFrame<'a> = VideoFrameRef<&'a gst::BufferRef>;
+type DstFrame<'a> = VideoFrameRef<&'a mut gst::BufferRef>;
+
+/// Alpha written into packed RGB destinations. `videoconvert` writes opaque
+/// for a Y'CbCr source too, so this matches it.
+const OPAQUE_ALPHA: u8 = 255;
+
+/// Read-only plane pointer plus its stride.
+fn src_plane(frame: &SrcFrame<'_>, plane: u32) -> Option<(*mut u8, i32)> {
+    let stride = *frame.plane_stride().get(plane as usize)?;
+    let data = frame.plane_data(plane).ok()?;
+    // Cast away const: every vImage_Buffer field is `void *`, and the source
+    // descriptors are only ever passed to parameters the headers declare
+    // `const vImage_Buffer *`.
+    Some((data.as_ptr() as *mut u8, stride))
+}
+
+/// Writable plane pointer plus its stride.
+///
+/// The stride is read before the mutable borrow so both can be returned; the
+/// borrow itself ends here, and the pointer stays valid for as long as the
+/// mapped frame does.
+fn dst_plane(frame: &mut DstFrame<'_>, plane: u32) -> Option<(*mut u8, i32)> {
+    let stride = *frame.plane_stride().get(plane as usize)?;
+    let data = frame.plane_data_mut(plane).ok()?;
+    Some((data.as_mut_ptr(), stride))
+}
+
+/// The destination plane descriptors for a Y'CbCr layout, in the order the
+/// matching vImage entry point wants them.
+enum YuvPlanes {
+    /// Y plus interleaved CbCr.
+    Biplanar {
+        y: acc::vImage_Buffer,
+        cbcr: acc::vImage_Buffer,
+    },
+    /// Y plus separate Cb and Cr.
+    Triplanar {
+        y: acc::vImage_Buffer,
+        cb: acc::vImage_Buffer,
+        cr: acc::vImage_Buffer,
+    },
+    /// One packed 4:2:2 plane.
+    Packed(acc::vImage_Buffer),
+}
+
+/// Build the plane descriptors for a Y'CbCr frame, whichever side it is on.
+///
+/// `plane` yields `(pointer, stride)` for a plane index; the caller supplies
+/// the read or write variant.
+fn yuv_planes(
+    kind: YuvKind,
+    width: u32,
+    height: u32,
+    mut plane: impl FnMut(u32) -> Option<(*mut u8, i32)>,
+) -> Option<YuvPlanes> {
+    let (y_ptr, y_stride) = plane(0)?;
+    let y = plane_buffer(y_ptr, width, height, y_stride);
+    match kind {
+        YuvKind::Nv12 => {
+            let (uv_ptr, uv_stride) = plane(1)?;
+            Some(YuvPlanes::Biplanar {
+                y,
+                // One sample of this plane is a Cb/Cr pair, so its width is
+                // half the luma width even though it occupies as many bytes.
+                cbcr: plane_buffer(uv_ptr, width / 2, height / 2, uv_stride),
+            })
+        }
+        YuvKind::Planar420 { cb_plane, cr_plane } => {
+            let (cb_ptr, cb_stride) = plane(cb_plane)?;
+            let (cr_ptr, cr_stride) = plane(cr_plane)?;
+            Some(YuvPlanes::Triplanar {
+                y,
+                cb: plane_buffer(cb_ptr, width / 2, height / 2, cb_stride),
+                cr: plane_buffer(cr_ptr, width / 2, height / 2, cr_stride),
+            })
+        }
+        // 4:2:2 packed formats are a single plane; the luma descriptor built
+        // above already names it with the full pixel width.
+        YuvKind::Uyvy | YuvKind::Yuy2 => Some(YuvPlanes::Packed(y)),
+    }
+}
+
+/// Run one frame through the planned vImage call.
+///
+/// Returns the vImage error code on failure so the caller can log it once and
+/// push an error rather than silently emitting a garbage frame.
+pub(super) fn run(
+    plan: &Plan,
+    inframe: &SrcFrame<'_>,
+    outframe: &mut DstFrame<'_>,
+) -> Result<(), acc::vImage_Error> {
+    let width = inframe.width();
+    let height = inframe.height();
+    let missing = || -> acc::vImage_Error { acc::K_PLANE_UNAVAILABLE };
+
+    match plan {
+        Plan::RgbToYuv {
+            info,
+            permute,
+            dest,
+        } => {
+            let (src_ptr, src_stride) = src_plane(inframe, 0).ok_or_else(missing)?;
+            let src = plane_buffer(src_ptr, width, height, src_stride);
+            let planes =
+                yuv_planes(*dest, width, height, |p| dst_plane(outframe, p)).ok_or_else(missing)?;
+            // SAFETY: every descriptor points into a frame this function holds
+            // mapped, with the sample dimensions and stride GStreamer reports
+            // for that plane. `info` was generated for exactly this Y'CbCr
+            // layout in `Plan::build`, and `permute` is a permutation of 0..4.
+            let err = unsafe {
+                match planes {
+                    YuvPlanes::Biplanar { y, cbcr } => acc::vImageConvert_ARGB8888To420Yp8_CbCr8(
+                        &src,
+                        &y,
+                        &cbcr,
+                        info,
+                        permute.as_ptr(),
+                        acc::kvImageNoFlags,
+                    ),
+                    YuvPlanes::Triplanar { y, cb, cr } => {
+                        acc::vImageConvert_ARGB8888To420Yp8_Cb8_Cr8(
+                            &src,
+                            &y,
+                            &cb,
+                            &cr,
+                            info,
+                            permute.as_ptr(),
+                            acc::kvImageNoFlags,
+                        )
+                    }
+                    YuvPlanes::Packed(dst) if *dest == YuvKind::Uyvy => {
+                        acc::vImageConvert_ARGB8888To422CbYpCrYp8(
+                            &src,
+                            &dst,
+                            info,
+                            permute.as_ptr(),
+                            acc::kvImageNoFlags,
+                        )
+                    }
+                    YuvPlanes::Packed(dst) => acc::vImageConvert_ARGB8888To422YpCbYpCr8(
+                        &src,
+                        &dst,
+                        info,
+                        permute.as_ptr(),
+                        acc::kvImageNoFlags,
+                    ),
+                }
+            };
+            check(err)
+        }
+
+        Plan::YuvToRgb { info, permute, src } => {
+            let (dst_ptr, dst_stride) = dst_plane(outframe, 0).ok_or_else(missing)?;
+            let dst = plane_buffer(dst_ptr, width, height, dst_stride);
+            let planes =
+                yuv_planes(*src, width, height, |p| src_plane(inframe, p)).ok_or_else(missing)?;
+            // SAFETY: as above, with the roles of the frames exchanged.
+            let err = unsafe {
+                match planes {
+                    YuvPlanes::Biplanar { y, cbcr } => acc::vImageConvert_420Yp8_CbCr8ToARGB8888(
+                        &y,
+                        &cbcr,
+                        &dst,
+                        info,
+                        permute.as_ptr(),
+                        OPAQUE_ALPHA,
+                        acc::kvImageNoFlags,
+                    ),
+                    YuvPlanes::Triplanar { y, cb, cr } => {
+                        acc::vImageConvert_420Yp8_Cb8_Cr8ToARGB8888(
+                            &y,
+                            &cb,
+                            &cr,
+                            &dst,
+                            info,
+                            permute.as_ptr(),
+                            OPAQUE_ALPHA,
+                            acc::kvImageNoFlags,
+                        )
+                    }
+                    YuvPlanes::Packed(packed) if *src == YuvKind::Uyvy => {
+                        acc::vImageConvert_422CbYpCrYp8ToARGB8888(
+                            &packed,
+                            &dst,
+                            info,
+                            permute.as_ptr(),
+                            OPAQUE_ALPHA,
+                            acc::kvImageNoFlags,
+                        )
+                    }
+                    YuvPlanes::Packed(packed) => acc::vImageConvert_422YpCbYpCr8ToARGB8888(
+                        &packed,
+                        &dst,
+                        info,
+                        permute.as_ptr(),
+                        OPAQUE_ALPHA,
+                        acc::kvImageNoFlags,
+                    ),
+                }
+            };
+            check(err)
+        }
+
+        Plan::RgbPermute { permute } => {
+            let (src_ptr, src_stride) = src_plane(inframe, 0).ok_or_else(missing)?;
+            let src = plane_buffer(src_ptr, width, height, src_stride);
+            let (dst_ptr, dst_stride) = dst_plane(outframe, 0).ok_or_else(missing)?;
+            let dst = plane_buffer(dst_ptr, width, height, dst_stride);
+            // SAFETY: both descriptors name a mapped single-plane frame of the
+            // same size, and `permute` is a permutation of 0..4.
+            let err = unsafe {
+                acc::vImagePermuteChannels_ARGB8888(
+                    &src,
+                    &dst,
+                    permute.as_ptr(),
+                    acc::kvImageNoFlags,
+                )
+            };
+            check(err)
+        }
+
+        Plan::ChromaInterleave { cb_plane, cr_plane } => {
+            copy_luma(inframe, outframe, width, height)?;
+            let (cb_ptr, cb_stride) = src_plane(inframe, *cb_plane).ok_or_else(missing)?;
+            let (cr_ptr, cr_stride) = src_plane(inframe, *cr_plane).ok_or_else(missing)?;
+            let (uv_ptr, uv_stride) = dst_plane(outframe, 1).ok_or_else(missing)?;
+            let cb = plane_buffer(cb_ptr, width / 2, height / 2, cb_stride);
+            let cr = plane_buffer(cr_ptr, width / 2, height / 2, cr_stride);
+            let sources: [*const acc::vImage_Buffer; 2] = [&cb, &cr];
+            // SAFETY: `destChannels` names the first byte of each interleaved
+            // component within the destination plane, which is why the second
+            // entry is offset by one; `destStrideBytes` of 2 tells vImage how
+            // far apart consecutive samples of one component are.
+            let err = unsafe {
+                let destinations: [*mut std::ffi::c_void; 2] = [
+                    uv_ptr as *mut std::ffi::c_void,
+                    uv_ptr.add(1) as *mut std::ffi::c_void,
+                ];
+                acc::vImageConvert_PlanarToChunky8(
+                    sources.as_ptr(),
+                    destinations.as_ptr(),
+                    2,
+                    2,
+                    (width / 2) as acc::vImagePixelCount,
+                    (height / 2) as acc::vImagePixelCount,
+                    uv_stride as usize,
+                    acc::kvImageNoFlags,
+                )
+            };
+            check(err)
+        }
+
+        Plan::ChromaDeinterleave { cb_plane, cr_plane } => {
+            copy_luma(inframe, outframe, width, height)?;
+            let (uv_ptr, uv_stride) = src_plane(inframe, 1).ok_or_else(missing)?;
+            let (cb_ptr, cb_stride) = dst_plane(outframe, *cb_plane).ok_or_else(missing)?;
+            let (cr_ptr, cr_stride) = dst_plane(outframe, *cr_plane).ok_or_else(missing)?;
+            let cb = plane_buffer(cb_ptr, width / 2, height / 2, cb_stride);
+            let cr = plane_buffer(cr_ptr, width / 2, height / 2, cr_stride);
+            let destinations: [*const acc::vImage_Buffer; 2] = [&cb, &cr];
+            // SAFETY: mirror of the interleave case above.
+            let err = unsafe {
+                let sources: [*const std::ffi::c_void; 2] = [
+                    uv_ptr as *const std::ffi::c_void,
+                    uv_ptr.add(1) as *const std::ffi::c_void,
+                ];
+                acc::vImageConvert_ChunkyToPlanar8(
+                    sources.as_ptr(),
+                    destinations.as_ptr(),
+                    2,
+                    2,
+                    (width / 2) as acc::vImagePixelCount,
+                    (height / 2) as acc::vImagePixelCount,
+                    uv_stride as usize,
+                    acc::kvImageNoFlags,
+                )
+            };
+            check(err)
+        }
+    }
+}
+
+/// Copy the luma plane unchanged, honouring a stride difference between the
+/// two frames.
+fn copy_luma(
+    inframe: &SrcFrame<'_>,
+    outframe: &mut DstFrame<'_>,
+    width: u32,
+    height: u32,
+) -> Result<(), acc::vImage_Error> {
+    let (src_ptr, src_stride) = src_plane(inframe, 0).ok_or(acc::K_PLANE_UNAVAILABLE)?;
+    let (dst_ptr, dst_stride) = dst_plane(outframe, 0).ok_or(acc::K_PLANE_UNAVAILABLE)?;
+    let src = plane_buffer(src_ptr, width, height, src_stride);
+    let dst = plane_buffer(dst_ptr, width, height, dst_stride);
+    // SAFETY: both descriptors name the mapped luma plane of a frame of this
+    // size; a luma sample is one byte.
+    check(unsafe { acc::vImageCopyBuffer(&src, &dst, 1, acc::kvImageNoFlags) })
+}
+
+fn check(err: acc::vImage_Error) -> Result<(), acc::vImage_Error> {
+    if err == acc::kvImageNoError {
+        Ok(())
+    } else {
+        Err(err)
+    }
+}

--- a/backend/src/gst/vimage/imp.rs
+++ b/backend/src/gst/vimage/imp.rs
@@ -1,0 +1,602 @@
+//! The `stromvimageconvert` element.
+//!
+//! A drop-in replacement for `videoconvert`/`videoconvertscale` that runs the
+//! conversion through Accelerate's vImage where vImage has a direct path, and
+//! through `GstVideoConverter` — the very code `videoconvert` runs — where it
+//! does not. Both are chosen once per caps negotiation, so the streaming path
+//! never has to ask which it is.
+
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{LazyLock, Mutex};
+
+use gstreamer as gst;
+use gstreamer::glib;
+use gstreamer::prelude::*;
+use gstreamer::subclass::prelude::*;
+use gstreamer_base as gst_base;
+use gstreamer_base::subclass::prelude::*;
+use gstreamer_video as gst_video;
+use gstreamer_video::subclass::prelude::*;
+use gstreamer_video::{VideoFormat, VideoFormatInfo, VideoFrameRef, VideoInfo};
+
+use super::convert;
+use super::plan::Plan;
+
+pub(super) static CAT: LazyLock<gst::DebugCategory> = LazyLock::new(|| {
+    gst::DebugCategory::new(
+        super::ELEMENT_NAME,
+        gst::DebugColorFlags::empty(),
+        Some("vImage-backed video converter and scaler"),
+    )
+});
+
+/// Matches `videoconvert`'s own default, so `gpu::configure_video_convert`
+/// raising it off 1 means the same thing here as it does there.
+const DEFAULT_N_THREADS: u32 = 1;
+
+/// Fields a conversion is allowed to change. Everything else — framerate above
+/// all — has to survive untouched, because this element cannot alter it.
+const CONVERTIBLE_FIELDS: [&str; 6] = [
+    "format",
+    "colorimetry",
+    "chroma-site",
+    "width",
+    "height",
+    "pixel-aspect-ratio",
+];
+
+/// Value of the read-only `conversion-path` property before any caps have
+/// been negotiated.
+pub(super) const PATH_UNNEGOTIATED: &str = "unnegotiated";
+/// Value of `conversion-path` while the vImage kernels are in use.
+pub(super) const PATH_VIMAGE: &str = "vimage";
+/// Value of `conversion-path` while `GstVideoConverter` is in use.
+pub(super) const PATH_FALLBACK: &str = "fallback";
+
+/// Which of the two conversion engines the negotiated caps resolved to.
+enum Path {
+    /// vImage has a direct call for this format pair.
+    VImage(Plan),
+    /// It does not, so run `GstVideoConverter` exactly as `videoconvert` would.
+    Fallback(gst_video::VideoConverter),
+}
+
+impl Path {
+    fn name(&self) -> &'static str {
+        match self {
+            Path::VImage(_) => PATH_VIMAGE,
+            Path::Fallback(_) => PATH_FALLBACK,
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct VImageConvert {
+    /// Thread count handed to the `GstVideoConverter` fallback. vImage runs
+    /// its own internal thread pool and takes no such hint.
+    n_threads: AtomicU32,
+    state: Mutex<Option<Path>>,
+}
+
+#[glib::object_subclass]
+impl ObjectSubclass for VImageConvert {
+    const NAME: &'static str = "StromVImageConvert";
+    type Type = super::VImageConvert;
+    type ParentType = gst_video::VideoFilter;
+
+    fn new() -> Self {
+        Self {
+            n_threads: AtomicU32::new(DEFAULT_N_THREADS),
+            state: Mutex::new(None),
+        }
+    }
+}
+
+impl ObjectImpl for VImageConvert {
+    fn properties() -> &'static [glib::ParamSpec] {
+        static PROPERTIES: LazyLock<Vec<glib::ParamSpec>> = LazyLock::new(|| {
+            vec![
+                glib::ParamSpecUInt::builder("n-threads")
+                    .nick("Threads")
+                    .blurb(
+                        "Maximum number of threads the software fallback may use \
+                         (0 = one per core). The vImage path manages its own pool.",
+                    )
+                    .default_value(DEFAULT_N_THREADS)
+                    .mutable_ready()
+                    .build(),
+                // Read-only, and the only way to tell from outside which
+                // engine the negotiated caps actually landed on. Without it a
+                // silent fall back to GstVideoConverter looks exactly like a
+                // working vImage path.
+                glib::ParamSpecString::builder("conversion-path")
+                    .nick("Conversion path")
+                    .blurb(
+                        "Which engine the negotiated caps resolved to: \
+                         \"vimage\", \"fallback\", or \"unnegotiated\"",
+                    )
+                    .default_value(Some(PATH_UNNEGOTIATED))
+                    .read_only()
+                    .build(),
+            ]
+        });
+        PROPERTIES.as_ref()
+    }
+
+    fn set_property(&self, _id: usize, value: &glib::Value, pspec: &glib::ParamSpec) {
+        match pspec.name() {
+            "n-threads" => self
+                .n_threads
+                .store(value.get().expect("n-threads is a uint"), Ordering::Relaxed),
+            other => unimplemented!("no such property {}", other),
+        }
+    }
+
+    fn property(&self, _id: usize, pspec: &glib::ParamSpec) -> glib::Value {
+        match pspec.name() {
+            "n-threads" => self.n_threads.load(Ordering::Relaxed).to_value(),
+            "conversion-path" => self
+                .state
+                .lock()
+                .unwrap()
+                .as_ref()
+                .map_or(PATH_UNNEGOTIATED, Path::name)
+                .to_value(),
+            other => unimplemented!("no such property {}", other),
+        }
+    }
+}
+
+impl GstObjectImpl for VImageConvert {}
+
+impl ElementImpl for VImageConvert {
+    fn metadata() -> Option<&'static gst::subclass::ElementMetadata> {
+        static METADATA: LazyLock<gst::subclass::ElementMetadata> = LazyLock::new(|| {
+            gst::subclass::ElementMetadata::new(
+                "vImage video converter and scaler",
+                "Filter/Converter/Video/Scaler",
+                "Converts video formats through Accelerate/vImage on macOS, \
+                 falling back to GstVideoConverter for pairs vImage cannot do",
+                "Strom contributors",
+            )
+        });
+        Some(&*METADATA)
+    }
+
+    fn pad_templates() -> &'static [gst::PadTemplate] {
+        static TEMPLATES: LazyLock<Vec<gst::PadTemplate>> = LazyLock::new(|| {
+            // The full raw format set, matching `videoconvertscale`: whatever
+            // vImage declines still has the fallback behind it, so narrowing
+            // the templates would only turn a slower conversion into a failed
+            // link.
+            let caps = gst_video::VideoCapsBuilder::new().build();
+            vec![
+                gst::PadTemplate::new(
+                    "sink",
+                    gst::PadDirection::Sink,
+                    gst::PadPresence::Always,
+                    &caps,
+                )
+                .expect("static sink template"),
+                gst::PadTemplate::new(
+                    "src",
+                    gst::PadDirection::Src,
+                    gst::PadPresence::Always,
+                    &caps,
+                )
+                .expect("static src template"),
+            ]
+        });
+        TEMPLATES.as_ref()
+    }
+}
+
+impl BaseTransformImpl for VImageConvert {
+    const MODE: gst_base::subclass::BaseTransformMode =
+        gst_base::subclass::BaseTransformMode::NeverInPlace;
+    const PASSTHROUGH_ON_SAME_CAPS: bool = true;
+    const TRANSFORM_IP_ON_PASSTHROUGH: bool = false;
+
+    /// Advertise the incoming caps unchanged first, then a copy with every
+    /// convertible field dropped.
+    ///
+    /// Order matters: with the unchanged caps first, a peer that would accept
+    /// them wins the intersection and `BaseTransform` goes passthrough instead
+    /// of converting a frame into its own format.
+    fn transform_caps(
+        &self,
+        _direction: gst::PadDirection,
+        caps: &gst::Caps,
+        filter: Option<&gst::Caps>,
+    ) -> Option<gst::Caps> {
+        let mut relaxed = caps.copy();
+        {
+            let relaxed = relaxed.make_mut();
+            for idx in 0..relaxed.size() {
+                if let Some(s) = relaxed.structure_mut(idx) {
+                    s.remove_fields(CONVERTIBLE_FIELDS);
+                }
+            }
+        }
+
+        let mut result = caps.copy();
+        result.make_mut().append(relaxed);
+
+        if let Some(filter) = filter {
+            result = filter.intersect_with_mode(&result, gst::CapsIntersectMode::First);
+        }
+        Some(result)
+    }
+
+    /// Pin the other pad's caps, preferring no conversion at all.
+    ///
+    /// Format is chosen by the loss score in [`conversion_loss`]; size and
+    /// pixel aspect ratio are pulled towards the input so that a stage asked
+    /// only to convert does not silently rescale.
+    fn fixate_caps(
+        &self,
+        _direction: gst::PadDirection,
+        caps: &gst::Caps,
+        othercaps: gst::Caps,
+    ) -> gst::Caps {
+        let Some(in_s) = caps.structure(0) else {
+            let mut othercaps = othercaps;
+            othercaps.fixate();
+            return othercaps;
+        };
+
+        let in_format = in_s
+            .get::<&str>("format")
+            .ok()
+            .and_then(|f| f.parse::<VideoFormat>().ok());
+
+        let candidates = othercaps.to_string();
+        let mut result = choose_format(&othercaps, in_format);
+
+        {
+            let result = result.make_mut();
+            if let Some(s) = result.structure_mut(0) {
+                fixate_int(s, "width", in_s.get::<i32>("width").ok());
+                fixate_int(s, "height", in_s.get::<i32>("height").ok());
+                let par = in_s
+                    .get::<gst::Fraction>("pixel-aspect-ratio")
+                    .unwrap_or_else(|_| gst::Fraction::new(1, 1));
+                if s.has_field("pixel-aspect-ratio") {
+                    s.fixate_field_nearest_fraction(
+                        "pixel-aspect-ratio",
+                        (par.numer(), par.denom()),
+                    );
+                } else {
+                    s.set("pixel-aspect-ratio", par);
+                }
+            }
+        }
+        result.fixate();
+
+        gst::debug!(
+            CAT,
+            imp = self,
+            "fixated {} against candidates {} to {}",
+            caps,
+            candidates,
+            result
+        );
+        result
+    }
+
+    fn stop(&self) -> Result<(), gst::ErrorMessage> {
+        *self.state.lock().unwrap() = None;
+        Ok(())
+    }
+}
+
+impl VideoFilterImpl for VImageConvert {
+    fn set_info(
+        &self,
+        incaps: &gst::Caps,
+        in_info: &VideoInfo,
+        outcaps: &gst::Caps,
+        out_info: &VideoInfo,
+    ) -> Result<(), gst::LoggableError> {
+        let path = match Plan::build(in_info, out_info) {
+            Some(plan) => {
+                gst::info!(
+                    CAT,
+                    imp = self,
+                    "vImage path ({}) for {:?} -> {:?} at {}x{}",
+                    plan.describe(),
+                    in_info.format(),
+                    out_info.format(),
+                    in_info.width(),
+                    in_info.height()
+                );
+                Path::VImage(plan)
+            }
+            None => {
+                let mut config = gst_video::VideoConverterConfig::new();
+                config.set_threads(self.n_threads.load(Ordering::Relaxed));
+                let converter = gst_video::VideoConverter::new(in_info, out_info, Some(config))
+                    .map_err(|e| {
+                        gst::loggable_error!(CAT, "no conversion for these caps: {}", e)
+                    })?;
+                gst::info!(
+                    CAT,
+                    imp = self,
+                    "no vImage path for {:?} {}x{} -> {:?} {}x{}, using GstVideoConverter",
+                    in_info.format(),
+                    in_info.width(),
+                    in_info.height(),
+                    out_info.format(),
+                    out_info.width(),
+                    out_info.height()
+                );
+                Path::Fallback(converter)
+            }
+        };
+
+        *self.state.lock().unwrap() = Some(path);
+        self.parent_set_info(incaps, in_info, outcaps, out_info)
+    }
+
+    fn transform_frame(
+        &self,
+        inframe: &VideoFrameRef<&gst::BufferRef>,
+        outframe: &mut VideoFrameRef<&mut gst::BufferRef>,
+    ) -> Result<gst::FlowSuccess, gst::FlowError> {
+        let state = self.state.lock().unwrap();
+        let Some(path) = state.as_ref() else {
+            return Err(gst::FlowError::NotNegotiated);
+        };
+
+        match path {
+            Path::VImage(plan) => convert::run(plan, inframe, outframe).map_err(|err| {
+                gst::error!(CAT, imp = self, "vImage conversion failed: error {}", err);
+                gst::FlowError::Error
+            })?,
+            Path::Fallback(converter) => converter.frame_ref(inframe, outframe),
+        }
+
+        Ok(gst::FlowSuccess::Ok)
+    }
+}
+
+/// Fixate an integer field towards the input's value, adding it outright when
+/// [`BaseTransformImpl::transform_caps`] dropped it.
+fn fixate_int(s: &mut gst::StructureRef, name: &str, target: Option<i32>) {
+    let Some(target) = target else { return };
+    if s.has_field(name) {
+        s.fixate_field_nearest_int(name, target);
+    } else {
+        s.set(name, target);
+    }
+}
+
+/// Reduce candidate caps to a single structure with a fixed format.
+///
+/// Ties keep the earliest candidate, so where two formats cost the same the
+/// peer's own preference order decides.
+fn choose_format(othercaps: &gst::Caps, in_format: Option<VideoFormat>) -> gst::Caps {
+    let mut best: Option<(u32, usize, VideoFormat)> = None;
+
+    for idx in 0..othercaps.size() {
+        let Some(s) = othercaps.structure(idx) else {
+            continue;
+        };
+        for format in formats_of(s) {
+            let loss = conversion_loss(in_format, format);
+            if best.is_none_or(|(best_loss, _, _)| loss < best_loss) {
+                best = Some((loss, idx, format));
+            }
+        }
+    }
+
+    let Some((_, idx, format)) = best else {
+        let mut caps = othercaps.copy();
+        caps.truncate();
+        return caps;
+    };
+
+    let mut structure = othercaps
+        .structure(idx)
+        .expect("index came from this caps")
+        .to_owned();
+    structure.set("format", format.to_str());
+
+    let features = othercaps.features(idx).map(|f| f.to_owned());
+    let mut caps = gst::Caps::new_empty();
+    caps.make_mut().append_structure_full(structure, features);
+    caps
+}
+
+/// Every video format a caps structure's `format` field allows.
+fn formats_of(s: &gst::StructureRef) -> Vec<VideoFormat> {
+    if let Ok(name) = s.get::<&str>("format") {
+        return name.parse::<VideoFormat>().into_iter().collect();
+    }
+    if let Ok(list) = s.get::<gst::List>("format") {
+        return list
+            .iter()
+            .filter_map(|v| v.get::<&str>().ok())
+            .filter_map(|name| name.parse::<VideoFormat>().ok())
+            .collect();
+    }
+    Vec::new()
+}
+
+/// Penalty for a candidate deeper than the input, set above every other
+/// penalty combined so that a same-or-shallower format always wins when one
+/// exists — while still allowing a deeper one when it is the only option.
+///
+/// This is the one place the scoring deliberately parts company with
+/// `videoconvert`. Feeding `vtenc_h264_hw` from RGBA, the encoder offers
+/// `{ AYUV64, UYVY, NV12, I420, P010_10LE, ARGB64_BE, RGBA64_LE }` and
+/// `videoconvert` takes AYUV64 — sixteen bits per component for an eight-bit
+/// source, which the encoder then converts again. Measured over 40 pairs at
+/// 1080p, picking the deeper format cost 15.7% end to end against picking
+/// UYVY. Widening cannot add information, and it doubles the bytes touched on
+/// every frame.
+const SCORE_DEPTH_INCREASE: u32 = 128;
+
+/// How much a conversion to `out` costs, in the spirit of `videoconvert`'s own
+/// scoring: identity is free, and each way the output can represent less than
+/// the input costs far more than the reverse.
+///
+/// This is deliberately a smaller model than `gst_video_convert`'s
+/// `score_value` — it ranks colour space, alpha, bit depth and chroma
+/// subsampling and stops there. The case that matters most, "the input format
+/// is on the menu, take it", is exact; beyond that the ordering only has to be
+/// sensible, and ties defer to the peer.
+fn conversion_loss(in_format: Option<VideoFormat>, out: VideoFormat) -> u32 {
+    let Some(in_format) = in_format else {
+        // Nothing to compare against, so let caps order decide alone.
+        return 0;
+    };
+    if in_format == out {
+        return 0;
+    }
+
+    let i = VideoFormatInfo::from_format(in_format);
+    let o = VideoFormatInfo::from_format(out);
+
+    // Changing format at all costs something, so an identical format always
+    // wins even against an otherwise lossless alternative.
+    let mut loss = 1;
+
+    if i.is_rgb() != o.is_rgb() || i.is_yuv() != o.is_yuv() || i.is_gray() != o.is_gray() {
+        loss += 2;
+    }
+    if i.has_alpha() && !o.has_alpha() {
+        loss += 8;
+    } else if o.has_alpha() && !i.has_alpha() {
+        loss += 1;
+    }
+    if o.has_palette() && !i.has_palette() {
+        loss += 64;
+    }
+
+    let depth = |info: &VideoFormatInfo| info.depth().iter().copied().max().unwrap_or(8);
+    let (in_depth, out_depth) = (depth(&i), depth(&o));
+    if out_depth < in_depth {
+        loss += 4 * (in_depth - out_depth);
+    } else if out_depth > in_depth {
+        loss += SCORE_DEPTH_INCREASE;
+    }
+
+    let sub = |values: &[u32]| values.iter().copied().max().unwrap_or(0);
+    if sub(o.w_sub()) > sub(i.w_sub()) {
+        loss += 16;
+    } else if sub(o.w_sub()) < sub(i.w_sub()) {
+        loss += 1;
+    }
+    if sub(o.h_sub()) > sub(i.h_sub()) {
+        loss += 32;
+    } else if sub(o.h_sub()) < sub(i.h_sub()) {
+        loss += 1;
+    }
+
+    loss
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn init() {
+        gst::init().expect("gst init");
+    }
+
+    /// The one case that must be exact: if the peer will take the input format
+    /// unchanged, nothing else may outscore it.
+    #[test]
+    fn identity_beats_every_alternative() {
+        init();
+        for candidate in [
+            VideoFormat::I420,
+            VideoFormat::Nv12,
+            VideoFormat::Bgra,
+            VideoFormat::Uyvy,
+        ] {
+            assert!(
+                conversion_loss(Some(VideoFormat::Rgba), candidate)
+                    > conversion_loss(Some(VideoFormat::Rgba), VideoFormat::Rgba),
+                "{:?} should cost more than staying in RGBA",
+                candidate
+            );
+        }
+    }
+
+    /// Dropping alpha is a real loss; gaining an alpha channel is not.
+    #[test]
+    fn losing_alpha_costs_more_than_gaining_it() {
+        init();
+        let losing = conversion_loss(Some(VideoFormat::Rgba), VideoFormat::Rgbx);
+        let gaining = conversion_loss(Some(VideoFormat::Rgbx), VideoFormat::Rgba);
+        assert!(
+            losing > gaining,
+            "losing alpha scored {losing}, gaining scored {gaining}"
+        );
+    }
+
+    /// Subsampling chroma away costs more than keeping it.
+    #[test]
+    fn subsampling_costs_more_than_staying_full_chroma() {
+        init();
+        let to_420 = conversion_loss(Some(VideoFormat::Rgba), VideoFormat::I420);
+        let to_uyvy = conversion_loss(Some(VideoFormat::Rgba), VideoFormat::Uyvy);
+        assert!(
+            to_420 > to_uyvy,
+            "4:2:0 scored {to_420}, 4:2:2 scored {to_uyvy}"
+        );
+    }
+
+    /// The measured case: from 8-bit RGBA, an 8-bit target must beat every
+    /// 16-bit one on the menu `vtenc_h264_hw` offers. Scoring the deeper
+    /// format first cost 15.7% end to end.
+    #[test]
+    fn an_eight_bit_target_beats_every_deeper_one() {
+        init();
+        let menu = [
+            VideoFormat::Ayuv64,
+            VideoFormat::Uyvy,
+            VideoFormat::Nv12,
+            VideoFormat::I420,
+            VideoFormat::P01010le,
+            VideoFormat::Argb64Be,
+            VideoFormat::Rgba64Le,
+        ];
+        let best = menu
+            .iter()
+            .min_by_key(|&&f| conversion_loss(Some(VideoFormat::Rgba), f))
+            .copied()
+            .expect("menu is not empty");
+        assert_eq!(
+            best,
+            VideoFormat::Uyvy,
+            "an 8-bit source must not be widened when an 8-bit target exists"
+        );
+    }
+
+    /// A deeper format is still chosen when nothing shallower is offered —
+    /// the penalty orders candidates, it does not veto them.
+    #[test]
+    fn a_deeper_target_is_still_chosen_when_it_is_the_only_option() {
+        init();
+        let only_deep = [VideoFormat::Argb64Be, VideoFormat::Ayuv64];
+        let best = only_deep
+            .iter()
+            .min_by_key(|&&f| conversion_loss(Some(VideoFormat::Rgba), f))
+            .copied()
+            .expect("menu is not empty");
+        assert_eq!(best, VideoFormat::Argb64Be);
+    }
+
+    #[test]
+    fn format_list_is_read_from_caps() {
+        init();
+        let caps = gst::Caps::builder("video/x-raw")
+            .field("format", gst::List::new(["NV12", "I420"]))
+            .build();
+        let formats = formats_of(caps.structure(0).unwrap());
+        assert_eq!(formats, vec![VideoFormat::Nv12, VideoFormat::I420]);
+    }
+}

--- a/backend/src/gst/vimage/mod.rs
+++ b/backend/src/gst/vimage/mod.rs
@@ -1,0 +1,89 @@
+//! A vImage-backed video converter for macOS.
+//!
+//! Colour conversion is the largest fixed cost in Strom's macOS pipelines:
+//! every encoder, compositor and WebRTC sink wants Y'CbCr while the sources
+//! and the HTML renderer produce packed RGB. `videoconvert` does that on the
+//! CPU; Accelerate's vImage does the same work through hand-tuned NEON kernels
+//! across its own thread pool.
+//!
+//! The element registered here, `stromvimageconvert`, is a drop-in for
+//! `videoconvert` and `videoconvertscale`. It exposes the same `n-threads`
+//! property, so [`crate::gpu::configure_video_convert`] reaches it unchanged,
+//! and it never fails a conversion `videoconvert` would have managed: format
+//! pairs without a vImage path — and every resize — run on
+//! `GstVideoConverter`, which is the code `videoconvert` itself is built on.
+//!
+//! Registration is static and idempotent; see [`register`].
+
+mod accelerate;
+mod convert;
+mod imp;
+mod plan;
+
+#[cfg(test)]
+mod bench;
+#[cfg(test)]
+mod tests;
+
+use std::sync::OnceLock;
+
+use gstreamer as gst;
+use gstreamer::glib;
+use gstreamer::prelude::*;
+use gstreamer_base as gst_base;
+use gstreamer_video as gst_video;
+use tracing::warn;
+
+/// The GStreamer factory name. Prefixed because this element lives in Strom's
+/// tree rather than in `gst-plugins-rs`; the prefix keeps it from ever
+/// colliding with an upstream element of the obvious name.
+pub const ELEMENT_NAME: &str = "stromvimageconvert";
+
+glib::wrapper! {
+    pub struct VImageConvert(ObjectSubclass<imp::VImageConvert>)
+        @extends gst_video::VideoFilter, gst_base::BaseTransform, gst::Element, gst::Object;
+}
+
+fn plugin_init(plugin: &gst::Plugin) -> Result<(), glib::BoolError> {
+    // Rank NONE: this element is selected by name through
+    // `VideoConvertMode`, never autoplugged.
+    gst::Element::register(
+        Some(plugin),
+        ELEMENT_NAME,
+        gst::Rank::NONE,
+        VImageConvert::static_type(),
+    )
+}
+
+gst::plugin_define!(
+    stromvimage,
+    "vImage-backed video conversion for macOS",
+    plugin_init,
+    env!("CARGO_PKG_VERSION"),
+    "MIT/X11",
+    "strom",
+    "strom",
+    "https://github.com/Eyevinn/strom"
+);
+
+/// Register the plugin with the GStreamer registry, once per process.
+///
+/// Returns whether `stromvimageconvert` is available afterwards. A `false`
+/// here is not fatal: [`crate::gpu::detect_convert_mode`] treats it as "stay
+/// on `videoconvert`", which is exactly the behaviour before this element
+/// existed.
+///
+/// Callers must have initialised GStreamer first.
+pub fn register() -> bool {
+    static REGISTERED: OnceLock<bool> = OnceLock::new();
+    *REGISTERED.get_or_init(|| match plugin_register_static() {
+        Ok(()) => true,
+        Err(e) => {
+            warn!(
+                "could not register the {} plugin, staying on videoconvert: {}",
+                ELEMENT_NAME, e
+            );
+            false
+        }
+    })
+}

--- a/backend/src/gst/vimage/plan.rs
+++ b/backend/src/gst/vimage/plan.rs
@@ -1,0 +1,386 @@
+//! Deciding, once per caps negotiation, whether vImage can do a conversion —
+//! and if so, exactly which call to make for each frame.
+//!
+//! [`Plan::build`] is the gate. It returns `None` for anything vImage has no
+//! direct path for; the element then falls back to `GstVideoConverter`, the
+//! same code `videoconvert` runs. Nothing here allocates or fails at streaming
+//! time: every decision, including the generated colour matrices, is resolved
+//! in `build` and reused for every frame.
+
+use gstreamer_video::{VideoColorMatrix, VideoColorRange, VideoFormat, VideoInfo};
+
+use super::accelerate as acc;
+
+/// Which Y'CbCr layout a plan reads or writes, together with everything
+/// needed to find its planes in a `VideoFrameRef`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum YuvKind {
+    /// Y plane + interleaved CbCr plane (`NV12`).
+    Nv12,
+    /// Y plane + separate Cb and Cr planes. `I420` and `YV12` differ only in
+    /// which plane index holds which chroma component, so both land here.
+    Planar420 { cb_plane: u32, cr_plane: u32 },
+    /// `UYVY` — Cb Y Cr Y in memory (vImage's `422CbYpCrYp8`).
+    Uyvy,
+    /// `YUY2` — Y Cb Y Cr in memory (vImage's `422YpCbYpCr8`).
+    Yuy2,
+}
+
+impl YuvKind {
+    fn vimage_type(self) -> u32 {
+        match self {
+            YuvKind::Nv12 => acc::kvImage420Yp8_CbCr8,
+            YuvKind::Planar420 { .. } => acc::kvImage420Yp8_Cb8_Cr8,
+            YuvKind::Uyvy => acc::kvImage422CbYpCrYp8,
+            YuvKind::Yuy2 => acc::kvImage422YpCbYpCr8,
+        }
+    }
+
+    /// Chroma subsampling constraints vImage imposes on the frame size.
+    fn requires_even(self) -> (bool, bool) {
+        match self {
+            YuvKind::Nv12 | YuvKind::Planar420 { .. } => (true, true),
+            YuvKind::Uyvy | YuvKind::Yuy2 => (true, false),
+        }
+    }
+}
+
+/// The single vImage call a negotiated caps pair resolves to.
+pub(super) enum Plan {
+    RgbToYuv {
+        info: acc::vImage_ARGBToYpCbCr,
+        /// Gather map: `canonical_ARGB[i] = src_pixel[permute[i]]`.
+        permute: [u8; 4],
+        dest: YuvKind,
+    },
+    YuvToRgb {
+        info: acc::vImage_YpCbCrToARGB,
+        /// Scatter map: `dest_pixel[i] = canonical_ARGB[permute[i]]`.
+        permute: [u8; 4],
+        src: YuvKind,
+    },
+    /// Packed 8-bit four-channel to packed 8-bit four-channel.
+    RgbPermute { permute: [u8; 4] },
+    /// `I420`/`YV12` to `NV12`: copy Y, interleave the two chroma planes.
+    ChromaInterleave { cb_plane: u32, cr_plane: u32 },
+    /// `NV12` to `I420`/`YV12`: copy Y, split the chroma plane in two.
+    ChromaDeinterleave { cb_plane: u32, cr_plane: u32 },
+}
+
+impl Plan {
+    /// A short name for the chosen path, for the one log line per negotiation.
+    pub(super) fn describe(&self) -> &'static str {
+        match self {
+            Plan::RgbToYuv { .. } => "RGB to Y'CbCr",
+            Plan::YuvToRgb { .. } => "Y'CbCr to RGB",
+            Plan::RgbPermute { .. } => "RGB channel permute",
+            Plan::ChromaInterleave { .. } => "chroma interleave",
+            Plan::ChromaDeinterleave { .. } => "chroma deinterleave",
+        }
+    }
+
+    /// Decide whether vImage can perform this conversion.
+    ///
+    /// Returns `None` — meaning "use the `GstVideoConverter` fallback" — for
+    /// a resize, an odd frame size against a subsampled format, a colour
+    /// matrix or range vImage's generated conversions do not cover, and every
+    /// format pair not enumerated below.
+    pub(super) fn build(in_info: &VideoInfo, out_info: &VideoInfo) -> Option<Self> {
+        // vImage's converters do not resize. A scaling stage stays on
+        // `GstVideoConverter`, which fuses convert and scale in one pass.
+        if in_info.width() != out_info.width() || in_info.height() != out_info.height() {
+            return None;
+        }
+        // Interlaced content needs field-aware chroma handling that these
+        // frame-at-a-time calls do not provide.
+        if in_info.is_interlaced() || out_info.is_interlaced() {
+            return None;
+        }
+
+        let src = in_info.format();
+        let dst = out_info.format();
+        let size_ok = |kind: YuvKind| {
+            let (even_w, even_h) = kind.requires_even();
+            !(even_w && !in_info.width().is_multiple_of(2)
+                || even_h && !in_info.height().is_multiple_of(2))
+        };
+
+        match (rgb32_layout(src), yuv_kind(dst)) {
+            // Packed RGB -> Y'CbCr, the headline path.
+            (Some(layout), Some(kind)) if size_ok(kind) => {
+                let range = yuv_pixel_range(out_info)?;
+                let matrix = rgb_to_yuv_matrix(out_info)?;
+                require_full_range_rgb(in_info)?;
+                let mut info = acc::vImage_ARGBToYpCbCr { opaque: [0; 128] };
+                // SAFETY: `matrix` is one of Accelerate's own static matrices,
+                // `range` is a fully initialised value type, and `info` is a
+                // correctly sized and aligned output slot.
+                let err = unsafe {
+                    acc::vImageConvert_ARGBToYpCbCr_GenerateConversion(
+                        matrix,
+                        &range,
+                        &mut info,
+                        acc::kvImageARGB8888,
+                        kind.vimage_type(),
+                        acc::kvImageNoFlags,
+                    )
+                };
+                if err != acc::kvImageNoError {
+                    return None;
+                }
+                return Some(Plan::RgbToYuv {
+                    info,
+                    permute: layout,
+                    dest: kind,
+                });
+            }
+            _ => {}
+        }
+
+        match (yuv_kind(src), rgb32_layout(dst)) {
+            (Some(kind), Some(layout)) if size_ok(kind) => {
+                let range = yuv_pixel_range(in_info)?;
+                let matrix = yuv_to_rgb_matrix(in_info)?;
+                require_full_range_rgb(out_info)?;
+                let mut info = acc::vImage_YpCbCrToARGB { opaque: [0; 128] };
+                // SAFETY: as above — static matrix, initialised range, sized
+                // and aligned output slot.
+                let err = unsafe {
+                    acc::vImageConvert_YpCbCrToARGB_GenerateConversion(
+                        matrix,
+                        &range,
+                        &mut info,
+                        kind.vimage_type(),
+                        acc::kvImageARGB8888,
+                        acc::kvImageNoFlags,
+                    )
+                };
+                if err != acc::kvImageNoError {
+                    return None;
+                }
+                return Some(Plan::YuvToRgb {
+                    info,
+                    permute: invert_permute(layout),
+                    src: kind,
+                });
+            }
+            _ => {}
+        }
+
+        // The remaining paths move bytes without touching colour, so they are
+        // only correct when both sides agree on range and matrix.
+        if in_info.colorimetry() != out_info.colorimetry() {
+            return None;
+        }
+
+        if let (Some(src_layout), Some(dst_layout)) = (rgb32_layout(src), rgb32_layout(dst)) {
+            // A source without alpha cannot supply one: `videoconvert` writes
+            // opaque 0xff there, and a straight permute would copy padding.
+            if out_info.format_info().has_alpha() && !in_info.format_info().has_alpha() {
+                return None;
+            }
+            return Some(Plan::RgbPermute {
+                permute: permute_between(src_layout, dst_layout),
+            });
+        }
+
+        match (yuv_kind(src), yuv_kind(dst)) {
+            (Some(YuvKind::Planar420 { cb_plane, cr_plane }), Some(YuvKind::Nv12))
+                if size_ok(YuvKind::Nv12) =>
+            {
+                Some(Plan::ChromaInterleave { cb_plane, cr_plane })
+            }
+            (Some(YuvKind::Nv12), Some(YuvKind::Planar420 { cb_plane, cr_plane }))
+                if size_ok(YuvKind::Nv12) =>
+            {
+                Some(Plan::ChromaDeinterleave { cb_plane, cr_plane })
+            }
+            _ => None,
+        }
+    }
+}
+
+/// Byte offsets of A, R, G and B within one pixel of a packed 8-bit
+/// four-channel format, or `None` if the format is not one.
+///
+/// The `x` variants are listed with their padding byte in the alpha slot:
+/// on the RGB-to-Y'CbCr path alpha is never read, and on the reverse path
+/// vImage writes a caller-supplied constant there.
+fn rgb32_layout(format: VideoFormat) -> Option<[u8; 4]> {
+    match format {
+        VideoFormat::Rgba | VideoFormat::Rgbx => Some([3, 0, 1, 2]),
+        VideoFormat::Bgra | VideoFormat::Bgrx => Some([3, 2, 1, 0]),
+        VideoFormat::Argb | VideoFormat::Xrgb => Some([0, 1, 2, 3]),
+        VideoFormat::Abgr | VideoFormat::Xbgr => Some([0, 3, 2, 1]),
+        _ => None,
+    }
+}
+
+fn yuv_kind(format: VideoFormat) -> Option<YuvKind> {
+    match format {
+        VideoFormat::Nv12 => Some(YuvKind::Nv12),
+        VideoFormat::I420 => Some(YuvKind::Planar420 {
+            cb_plane: 1,
+            cr_plane: 2,
+        }),
+        // YV12 is I420 with the chroma planes swapped, so the same vImage
+        // call works once the plane indices are exchanged.
+        VideoFormat::Yv12 => Some(YuvKind::Planar420 {
+            cb_plane: 2,
+            cr_plane: 1,
+        }),
+        VideoFormat::Uyvy => Some(YuvKind::Uyvy),
+        VideoFormat::Yuy2 => Some(YuvKind::Yuy2),
+        _ => None,
+    }
+}
+
+/// Invert a gather map into a scatter map (they are inverse permutations).
+fn invert_permute(map: [u8; 4]) -> [u8; 4] {
+    let mut out = [0u8; 4];
+    for (canonical, &offset) in map.iter().enumerate() {
+        out[offset as usize] = canonical as u8;
+    }
+    out
+}
+
+/// Build the map that `vImagePermuteChannels_ARGB8888` wants for a
+/// source-to-destination channel reorder: `dest[i] = src[map[i]]`.
+fn permute_between(src: [u8; 4], dst: [u8; 4]) -> [u8; 4] {
+    let mut out = [0u8; 4];
+    for canonical in 0..4 {
+        out[dst[canonical] as usize] = src[canonical];
+    }
+    out
+}
+
+/// vImage's `ARGB8888` is full-range by definition, so a Y'CbCr conversion is
+/// only equivalent to `videoconvert`'s when the RGB side is full-range too.
+fn require_full_range_rgb(info: &VideoInfo) -> Option<()> {
+    match info.colorimetry().range() {
+        VideoColorRange::Range0_255 | VideoColorRange::Unknown => Some(()),
+        _ => None,
+    }
+}
+
+/// Map the caps' colour range onto vImage's pixel-range description.
+///
+/// The clamps are set wide open (`0..=255`) deliberately: `videoconvert` does
+/// not pre-clamp to legal range either, so clamping here would be a visible
+/// difference rather than a fidelity improvement.
+fn yuv_pixel_range(info: &VideoInfo) -> Option<acc::vImage_YpCbCrPixelRange> {
+    match info.colorimetry().range() {
+        VideoColorRange::Range16_235 => Some(acc::vImage_YpCbCrPixelRange {
+            Yp_bias: 16,
+            CbCr_bias: 128,
+            YpRangeMax: 235,
+            CbCrRangeMax: 240,
+            YpMax: 255,
+            YpMin: 0,
+            CbCrMax: 255,
+            CbCrMin: 0,
+        }),
+        VideoColorRange::Range0_255 => Some(acc::vImage_YpCbCrPixelRange {
+            Yp_bias: 0,
+            CbCr_bias: 128,
+            YpRangeMax: 255,
+            CbCrRangeMax: 255,
+            YpMax: 255,
+            YpMin: 0,
+            CbCrMax: 255,
+            CbCrMin: 0,
+        }),
+        _ => None,
+    }
+}
+
+fn rgb_to_yuv_matrix(info: &VideoInfo) -> Option<*const acc::vImage_ARGBToYpCbCrMatrix> {
+    // SAFETY: reading the address of an Accelerate global. The pointees are
+    // immutable framework constants that outlive the process.
+    match info.colorimetry().matrix() {
+        VideoColorMatrix::Bt601 => Some(unsafe { acc::kvImage_ARGBToYpCbCrMatrix_ITU_R_601_4 }),
+        VideoColorMatrix::Bt709 => Some(unsafe { acc::kvImage_ARGBToYpCbCrMatrix_ITU_R_709_2 }),
+        _ => None,
+    }
+}
+
+fn yuv_to_rgb_matrix(info: &VideoInfo) -> Option<*const acc::vImage_YpCbCrToARGBMatrix> {
+    // SAFETY: as above.
+    match info.colorimetry().matrix() {
+        VideoColorMatrix::Bt601 => Some(unsafe { acc::kvImage_YpCbCrToARGBMatrix_ITU_R_601_4 }),
+        VideoColorMatrix::Bt709 => Some(unsafe { acc::kvImage_YpCbCrToARGBMatrix_ITU_R_709_2 }),
+        _ => None,
+    }
+}
+
+/// A `vImage_Buffer` pointing at one plane of a mapped frame.
+///
+/// `width` is in samples of that plane, not bytes, which is what every vImage
+/// entry point expects; for the interleaved `CbCr` plane of NV12 a sample is
+/// the Cb/Cr pair.
+pub(super) fn plane_buffer(
+    data: *mut u8,
+    width: u32,
+    height: u32,
+    stride: i32,
+) -> acc::vImage_Buffer {
+    acc::vImage_Buffer {
+        data: data as *mut std::ffi::c_void,
+        height: height as acc::vImagePixelCount,
+        width: width as acc::vImagePixelCount,
+        rowBytes: stride as usize,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gather_and_scatter_maps_are_inverses() {
+        for format in [
+            VideoFormat::Rgba,
+            VideoFormat::Bgra,
+            VideoFormat::Argb,
+            VideoFormat::Abgr,
+        ] {
+            let gather = rgb32_layout(format).expect("packed 8-bit four-channel format");
+            let scatter = invert_permute(gather);
+            // Gathering then scattering must reproduce the original offsets.
+            for canonical in 0..4 {
+                assert_eq!(scatter[gather[canonical] as usize], canonical as u8);
+            }
+        }
+    }
+
+    /// The permute map is what stops BGRA arriving as RGBA with the channels
+    /// rotated, so pin the two orders the compositor path actually uses.
+    #[test]
+    fn rgba_to_bgra_swaps_red_and_blue_and_keeps_alpha() {
+        let rgba = rgb32_layout(VideoFormat::Rgba).unwrap();
+        let bgra = rgb32_layout(VideoFormat::Bgra).unwrap();
+        // dest[i] = src[map[i]]: B at dest 0 comes from src offset 2, and so on.
+        assert_eq!(permute_between(rgba, bgra), [2, 1, 0, 3]);
+        assert_eq!(permute_between(bgra, rgba), [2, 1, 0, 3]);
+        // Identity must stay identity.
+        assert_eq!(permute_between(rgba, rgba), [0, 1, 2, 3]);
+    }
+
+    #[test]
+    fn yv12_is_i420_with_the_chroma_planes_exchanged() {
+        assert_eq!(
+            yuv_kind(VideoFormat::I420),
+            Some(YuvKind::Planar420 {
+                cb_plane: 1,
+                cr_plane: 2
+            })
+        );
+        assert_eq!(
+            yuv_kind(VideoFormat::Yv12),
+            Some(YuvKind::Planar420 {
+                cb_plane: 2,
+                cr_plane: 1
+            })
+        );
+    }
+}

--- a/backend/src/gst/vimage/tests.rs
+++ b/backend/src/gst/vimage/tests.rs
@@ -1,0 +1,417 @@
+//! Correctness and negotiation tests for `stromvimageconvert`.
+//!
+//! The load-bearing test is [`vimage_output_matches_videoconvert`]: it pushes
+//! the same frame through this element and through stock `videoconvert` and
+//! compares the two outputs pixel for pixel. Everything about the vImage path
+//! — permute maps, plane dimensions, colour matrices, pixel ranges — is only
+//! as good as that comparison, and nothing else in the tree would catch a
+//! channel swap or a half-height chroma plane.
+//!
+//! These tests need no element beyond `gst-plugins-base`, so they run in CI on
+//! macOS runners without extra packages. They are macOS-only because the module
+//! they test is.
+
+use gstreamer as gst;
+use gstreamer::prelude::*;
+use gstreamer_app as gst_app;
+use gstreamer_video as gst_video;
+use gstreamer_video::prelude::*;
+use gstreamer_video::{VideoFormat, VideoInfo};
+
+use super::imp::{PATH_FALLBACK, PATH_VIMAGE};
+use super::plan::Plan;
+
+fn init() {
+    gst::init().expect("gst init");
+    assert!(super::register(), "the vImage plugin must register");
+}
+
+/// Chroma is averaged over a 2x2 block, so `videoconvert` and vImage can
+/// legitimately disagree by a rounding step; anything larger is a real bug.
+/// Luma is a per-pixel matrix multiply, so it agrees far more tightly.
+const MAX_DELTA: i32 = 2;
+
+/// A deterministic, chroma-heavy test frame. Flat colour would hide a
+/// red/blue swap against a bad permute map, and a smooth ramp would hide a
+/// chroma plane written at the wrong stride, so this does both: hard vertical
+/// colour bars over a diagonal luminance gradient.
+fn fill_test_pattern(data: &mut [u8], width: usize, height: usize, stride: usize) {
+    const BARS: [[u8; 3]; 8] = [
+        [255, 255, 255],
+        [255, 255, 0],
+        [0, 255, 255],
+        [0, 255, 0],
+        [255, 0, 255],
+        [255, 0, 0],
+        [0, 0, 255],
+        [16, 16, 16],
+    ];
+    for y in 0..height {
+        for x in 0..width {
+            let bar = BARS[(x * BARS.len()) / width];
+            let shade = ((x + y) % 64) as u16;
+            let px = y * stride + x * 4;
+            for c in 0..3 {
+                data[px + c] = ((bar[c] as u16 * (192 + shade)) / 255).min(255) as u8;
+            }
+            // A varying alpha would be dropped by every YUV target anyway;
+            // keeping it varied still exercises the RGB permute path.
+            data[px + 3] = (x % 256) as u8;
+        }
+    }
+}
+
+/// What one run of [`convert_one`] produced.
+struct Converted {
+    buffer: gst::Buffer,
+    info: VideoInfo,
+    /// The converter's `conversion-path` property, read while the caps were
+    /// still negotiated. `None` for elements that do not have the property.
+    path: Option<String>,
+}
+
+/// Run one buffer of `in_caps` through `element` and return the output buffer
+/// together with the negotiated output info.
+fn convert_one(
+    element_name: &str,
+    in_caps: &gst::Caps,
+    out_caps: &gst::Caps,
+    input: &gst::Buffer,
+) -> Converted {
+    let pipeline = gst::Pipeline::new();
+    let src = gst_app::AppSrc::builder()
+        .caps(in_caps)
+        .format(gst::Format::Time)
+        .build();
+    let convert = gst::ElementFactory::make(element_name)
+        .build()
+        .unwrap_or_else(|e| panic!("{element_name} must be present: {e}"));
+    let capsfilter = gst::ElementFactory::make("capsfilter")
+        .property("caps", out_caps)
+        .build()
+        .expect("capsfilter");
+    let sink = gst_app::AppSink::builder().sync(false).build();
+
+    pipeline
+        .add_many([
+            src.upcast_ref::<gst::Element>(),
+            &convert,
+            &capsfilter,
+            sink.upcast_ref(),
+        ])
+        .expect("add elements");
+    gst::Element::link_many([
+        src.upcast_ref::<gst::Element>(),
+        &convert,
+        &capsfilter,
+        sink.upcast_ref(),
+    ])
+    .expect("link elements");
+
+    pipeline.set_state(gst::State::Playing).expect("play");
+    src.push_buffer(input.clone()).expect("push");
+    src.end_of_stream().expect("eos");
+
+    let sample = sink
+        .try_pull_sample(gst::ClockTime::from_seconds(10))
+        .unwrap_or_else(|| panic!("{element_name} produced no output"));
+    let buffer = sample.buffer().expect("sample buffer").copy();
+    let info = VideoInfo::from_caps(sample.caps().expect("sample caps")).expect("output info");
+    // Read before NULL: `stop()` drops the negotiated state.
+    let path = convert
+        .has_property("conversion-path")
+        .then(|| convert.property::<String>("conversion-path"));
+
+    pipeline.set_state(gst::State::Null).expect("null");
+    Converted { buffer, info, path }
+}
+
+/// Compare every plane of two frames of the same format, reporting where and
+/// by how much they first diverge.
+fn assert_frames_match(
+    label: &str,
+    info: &VideoInfo,
+    mine: &gst::Buffer,
+    reference: &gst::Buffer,
+    max_delta: i32,
+) {
+    let mine =
+        gst_video::VideoFrameRef::from_buffer_ref_readable(mine.as_ref(), info).expect("map ours");
+    let theirs = gst_video::VideoFrameRef::from_buffer_ref_readable(reference.as_ref(), info)
+        .expect("map reference");
+
+    let mut worst = 0i32;
+    let mut worst_at = (0u32, 0usize, 0usize);
+    for plane in 0..info.n_planes() {
+        let a = mine.plane_data(plane).expect("our plane");
+        let b = theirs.plane_data(plane).expect("reference plane");
+        let stride = mine.plane_stride()[plane as usize] as usize;
+        let rows = mine.plane_height(plane) as usize;
+        // Compare only the active bytes of each row; padding is undefined.
+        let row_bytes = (info.width() as usize
+            * info.format_info().pixel_stride()[plane as usize] as usize)
+            .min(stride);
+        for row in 0..rows {
+            for col in 0..row_bytes {
+                let idx = row * stride + col;
+                if idx >= a.len() || idx >= b.len() {
+                    continue;
+                }
+                let delta = (a[idx] as i32 - b[idx] as i32).abs();
+                if delta > worst {
+                    worst = delta;
+                    worst_at = (plane, row, col);
+                }
+            }
+        }
+    }
+
+    assert!(
+        worst <= max_delta,
+        "{label}: vImage and videoconvert differ by {worst} \
+         (plane {}, row {}, byte {}), which is more than the {max_delta} a \
+         chroma rounding difference can explain",
+        worst_at.0,
+        worst_at.1,
+        worst_at.2
+    );
+}
+
+fn packed_rgb_buffer(info: &VideoInfo) -> gst::Buffer {
+    let mut buffer = gst::Buffer::with_size(info.size()).expect("allocate");
+    {
+        let buffer = buffer.get_mut().unwrap();
+        let mut map = buffer.map_writable().expect("map writable");
+        let stride = info.stride()[0] as usize;
+        fill_test_pattern(
+            map.as_mut_slice(),
+            info.width() as usize,
+            info.height() as usize,
+            stride,
+        );
+    }
+    gst_video::VideoMeta::add(
+        buffer.get_mut().unwrap(),
+        gst_video::VideoFrameFlags::empty(),
+        info.format(),
+        info.width(),
+        info.height(),
+    )
+    .ok();
+    buffer
+}
+
+/// Every format pair the vImage path claims must produce what `videoconvert`
+/// produces. A wrong permute map, a chroma plane described at the wrong size,
+/// or the wrong colour matrix all show up here and nowhere else.
+#[test]
+fn vimage_output_matches_videoconvert() {
+    init();
+
+    // Second half of each pair is what a real flow asks for; the RGB source
+    // formats are the ones Strom's HTML and compositor paths produce.
+    let pairs: &[(VideoFormat, VideoFormat)] = &[
+        (VideoFormat::Rgba, VideoFormat::Nv12),
+        (VideoFormat::Rgba, VideoFormat::I420),
+        (VideoFormat::Bgra, VideoFormat::Nv12),
+        (VideoFormat::Bgra, VideoFormat::I420),
+        (VideoFormat::Bgra, VideoFormat::Yv12),
+        (VideoFormat::Rgba, VideoFormat::Uyvy),
+        (VideoFormat::Rgba, VideoFormat::Yuy2),
+        (VideoFormat::Rgba, VideoFormat::Bgra),
+        (VideoFormat::Bgrx, VideoFormat::Rgbx),
+        (VideoFormat::I420, VideoFormat::Nv12),
+        (VideoFormat::Nv12, VideoFormat::I420),
+    ];
+
+    // 4:2:0 needs even dimensions, and a non-square frame catches width and
+    // height being transposed in a plane descriptor.
+    let (width, height) = (128, 64);
+
+    for &(src, dst) in pairs {
+        let in_info = VideoInfo::builder(src, width, height)
+            .fps(gst::Fraction::new(30, 1))
+            .build()
+            .expect("input info");
+        let out_info = VideoInfo::builder(dst, width, height)
+            .fps(gst::Fraction::new(30, 1))
+            .build()
+            .expect("output info");
+
+        assert!(
+            Plan::build(&in_info, &out_info).is_some(),
+            "{src:?} -> {dst:?} is listed here as a vImage pair but Plan::build declined it"
+        );
+
+        let in_caps = in_info.to_caps().expect("input caps");
+        let out_caps = out_info.to_caps().expect("output caps");
+        let input = source_buffer(&in_info);
+
+        let ours = convert_one(super::ELEMENT_NAME, &in_caps, &out_caps, &input);
+        let reference = convert_one("videoconvert", &in_caps, &out_caps, &input);
+
+        // Without this the comparison is vacuous: if negotiation quietly chose
+        // the fallback, both sides would be running GstVideoConverter and the
+        // pixels would match no matter how wrong the vImage code was.
+        assert_eq!(
+            ours.path.as_deref(),
+            Some(PATH_VIMAGE),
+            "{src:?} -> {dst:?} did not take the vImage path"
+        );
+
+        assert_frames_match(
+            &format!("{src:?} -> {dst:?}"),
+            &ours.info,
+            &ours.buffer,
+            &reference.buffer,
+            MAX_DELTA,
+        );
+    }
+}
+
+/// Build the input frame for a pair, generating the non-RGB sources by letting
+/// `videoconvert` produce them from the RGBA pattern.
+fn source_buffer(info: &VideoInfo) -> gst::Buffer {
+    if info.format_info().is_rgb() {
+        return packed_rgb_buffer(info);
+    }
+
+    let rgba = VideoInfo::builder(VideoFormat::Rgba, info.width(), info.height())
+        .fps(gst::Fraction::new(30, 1))
+        .build()
+        .expect("rgba info");
+    convert_one(
+        "videoconvert",
+        &rgba.to_caps().expect("rgba caps"),
+        &info.to_caps().expect("caps"),
+        &packed_rgb_buffer(&rgba),
+    )
+    .buffer
+}
+
+/// A pair with no vImage path must still convert, through the fallback. If
+/// this ever fails the element has stopped being a drop-in replacement.
+#[test]
+fn unsupported_pair_falls_back_and_still_converts() {
+    init();
+
+    // 10-bit 4:2:2 has no vImage entry point in this module, and GRAY8 has no
+    // colour at all — both must land on GstVideoConverter.
+    for target in [VideoFormat::V210, VideoFormat::Gray8] {
+        let in_info = VideoInfo::builder(VideoFormat::Rgba, 128, 64)
+            .fps(gst::Fraction::new(30, 1))
+            .build()
+            .expect("input info");
+        let out_info = VideoInfo::builder(target, 128, 64)
+            .fps(gst::Fraction::new(30, 1))
+            .build()
+            .expect("output info");
+
+        assert!(
+            Plan::build(&in_info, &out_info).is_none(),
+            "{target:?} is not a vImage path and must not claim to be one"
+        );
+
+        let ours = convert_one(
+            super::ELEMENT_NAME,
+            &in_info.to_caps().expect("in caps"),
+            &out_info.to_caps().expect("out caps"),
+            &packed_rgb_buffer(&in_info),
+        );
+        let reference = convert_one(
+            "videoconvert",
+            &in_info.to_caps().expect("in caps"),
+            &out_info.to_caps().expect("out caps"),
+            &packed_rgb_buffer(&in_info),
+        );
+
+        assert_eq!(ours.path.as_deref(), Some(PATH_FALLBACK));
+
+        // The fallback *is* GstVideoConverter, so this should be exact.
+        assert_frames_match(
+            &format!("fallback RGBA -> {target:?}"),
+            &ours.info,
+            &ours.buffer,
+            &reference.buffer,
+            0,
+        );
+    }
+}
+
+/// A resize has no vImage path, but the element still has to do it — this is
+/// the case `videoformat.rs` hits whenever a resolution is set.
+#[test]
+fn resize_goes_through_the_fallback_and_produces_the_requested_size() {
+    init();
+
+    let in_info = VideoInfo::builder(VideoFormat::Rgba, 128, 64)
+        .fps(gst::Fraction::new(30, 1))
+        .build()
+        .expect("input info");
+    let out_info = VideoInfo::builder(VideoFormat::I420, 64, 32)
+        .fps(gst::Fraction::new(30, 1))
+        .build()
+        .expect("output info");
+
+    assert!(
+        Plan::build(&in_info, &out_info).is_none(),
+        "a resize must not take the vImage path"
+    );
+
+    let ours = convert_one(
+        super::ELEMENT_NAME,
+        &in_info.to_caps().expect("in caps"),
+        &out_info.to_caps().expect("out caps"),
+        &packed_rgb_buffer(&in_info),
+    );
+    assert_eq!(ours.path.as_deref(), Some(PATH_FALLBACK));
+    assert_eq!((ours.info.width(), ours.info.height()), (64, 32));
+    assert_eq!(ours.info.format(), VideoFormat::I420);
+}
+
+/// `gpu::configure_video_convert` reaches the element only through
+/// `has_property("n-threads")`. Losing that property would silently drop the
+/// fallback back to single-threaded conversion.
+#[test]
+fn element_exposes_n_threads_for_configure_video_convert() {
+    init();
+
+    let element = gst::ElementFactory::make(super::ELEMENT_NAME)
+        .build()
+        .expect("element must be registered");
+    assert!(element.has_property("n-threads"));
+    assert_eq!(
+        element.property::<u32>("n-threads"),
+        1,
+        "the default must match videoconvert's, or configure_video_convert \
+         would be raising it from a different baseline"
+    );
+
+    crate::gpu::configure_video_convert(&element);
+    assert_eq!(
+        element.property::<u32>("n-threads"),
+        crate::gpu::video_convert_threads()
+    );
+}
+
+/// Negotiation must prefer leaving the format alone. If this regresses, an
+/// element asked only to pass frames through starts converting them.
+#[test]
+fn identical_caps_negotiate_without_conversion() {
+    init();
+
+    let info = VideoInfo::builder(VideoFormat::Nv12, 128, 64)
+        .fps(gst::Fraction::new(30, 1))
+        .build()
+        .expect("info");
+    let caps = info.to_caps().expect("caps");
+
+    let ours = convert_one(
+        super::ELEMENT_NAME,
+        &caps,
+        &gst::Caps::builder("video/x-raw").build(),
+        &source_buffer(&info),
+    );
+    assert_eq!(ours.info.format(), VideoFormat::Nv12);
+    assert_eq!((ours.info.width(), ours.info.height()), (128, 64));
+}


### PR DESCRIPTION
> Stacked on #731 (which is itself stacked on #726). Review the last commit only; the first two belong to those PRs. Merge them first.

## What this adds

`stromvimageconvert` — a GStreamer element that converts colour through Accelerate/vImage on macOS. It lives in `backend/src/gst/vimage/`, registers itself statically the first time `detect_gpu_capabilities()` runs, and is selected by a new macOS-only `VideoConvertMode::VImage`.

**No call site changed.** The element carries the same `n-threads` property as `videoconvert`, so `configure_video_convert()` from #726 reaches it unchanged and all five sites pick it up through `element_name()` / `convert_scale_element_name()`.

Four modules, one job each: `accelerate.rs` (FFI), `plan.rs` (decide, once per negotiation, whether vImage can do the pair), `convert.rs` (execute, per frame), `imp.rs` (the element and its caps negotiation).

## Fallback

The element never fails a conversion `videoconvert` would have managed. Anything vImage has no path for — an unlisted format pair, a resize, interlaced content, a colour matrix outside BT.601/BT.709 — is built as a `GstVideoConverter`, which is the code `videoconvert` and `videoconvertscale` are themselves built on, configured with the same thread count. A new read-only `conversion-path` property reports `vimage` / `fallback` / `unnegotiated`.

vImage paths: packed RGB32 (`RGBA`/`BGRA`/`ARGB`/`ABGR` and their `x` variants) to and from `NV12`, `I420`, `YV12`, `UYVY`, `YUY2`; RGB32 to RGB32; and `NV12` to and from `I420`/`YV12`.

## Which pairs Strom actually negotiates

Checked against a running backend with `GST_DEBUG=stromvimageconvert:5`, driving `videotestsrc → Video Format → Video Encoder → fakesink`:

| Configuration | Negotiated | Path |
|---|---|---|
| Video Format with an output format set | `RGBA→NV12`, `RGBA→I420`, `RGBA→UYVY`, `BGRA→NV12` | vImage |
| Video Format left unset, `vtenc_h264_hw` downstream | `RGBA→UYVY` (was `RGBA→ARGB64_BE`) | vImage |
| Second converter, format already pinned | `NV12→NV12` etc. | passthrough |

So the headline `RGBA→NV12` is real, but only when an output format is pinned. **Unpinned, the encoder's own preference decides, and that turned out to be worth reporting on its own:** `vtenc_h264_hw` offers `{ AYUV64, UYVY, NV12, I420, P010_10LE, ARGB64_BE, RGBA64_LE }`, and stock `videoconvert` picks `AYUV64` — sixteen bits per component for an eight-bit source, which the encoder then converts again. That is pre-existing behaviour, not something this PR introduced.

## The one deliberate divergence from `videoconvert`

My first fixation scored the same menu and picked `ARGB64_BE`, also 16-bit. Measured end to end that cost **15.7%** against picking an 8-bit target (t = −163, n = 40). So a bit-depth *increase* now outweighs every other penalty combined: a same-or-shallower format always wins when one exists, and a deeper one is still chosen when it is the only option. Widening cannot add information and it doubles the bytes touched per frame. The element picks `UYVY` there, the regression goes to zero, and that path now reaches vImage too.

`fixate_caps` is otherwise a smaller model than `gst_video_convert`'s `score_value` — colour space, alpha, depth, chroma subsampling, ties to the peer's order. The case that matters most, "the input format is on the menu, take it", is exact.

## Numbers

M4 Max (12P+4E, 64 GB), 1080p RGBA→NV12, 300 frames, **40 counterbalanced pairs** per experiment (half each order, shuffled — not alternating), run in chunks of fresh processes so macOS App Nap cannot reach them. Host load average 2.5–9 across the run, recorded per chunk in the CSV. Debug build, which if anything favours the C-heavy `videoconvert` arm.

| Experiment | Arm A | Arm B | Net of source | t |
|---|---|---|---|---|
| **baseline** (identity vs identity) | 237.9 ms | 238.0 ms | — | −0.20 |
| **A/A control** (`videoconvert` vs itself) | 472.0 ms | 444.7 ms | 1.01× | 0.60 † |
| **A/B** (`videoconvert n-threads=12` vs vImage) | 186.2 ms | **54.3 ms** | **3.43×** | 33.6 |
| **vs stock** (`videoconvert n-threads=1` vs vImage) | 738.2 ms | 53.1 ms | **13.91×** | 791.8 |
| **unpinned** (`vtenc_h264_hw` downstream) | 444.5 ms | 444.2 ms | 1.00× | 5.96 |

† The A/A figure shown is from the clean run (+0.4%). The repeat run caught a load spike and returned +5.8%, t = 1.26 — also not significant, which is the point. Both A/B runs agreed at 3.43× and 3.44×.

Against the figures this work was scoped from: 3.4× vs a predicted 3.6× over the threaded path, and 13.9× vs a predicted ~14× over stock. Different machine (M4 Max, not M2), same conclusion.

The harness is committed as `#[ignore]`d tests in `bench.rs` with the method documented, so the numbers are reproducible. It asserts nothing about timing.

## Tests

`cargo test` — **566 lib tests + all integration binaries pass**, run in full. `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` clean.

The load-bearing test is `vimage_output_matches_videoconvert`: for all eleven claimed pairs it pushes one frame through this element and through stock `videoconvert` and compares pixel for pixel, tolerating ±2 for chroma rounding. It asserts via `conversion-path` that the vImage path was actually taken — without that the comparison would pass vacuously whenever negotiation quietly chose the fallback.

I verified it bites, rather than assuming it: swapping the red and blue entries of the RGBA permute map fails it by 149; treating limited-range Y'CbCr as full range fails it by 20. Both restored afterwards.

Also covered: unsupported pairs and resizes take the fallback and match `videoconvert` exactly; `n-threads` is exposed and `configure_video_convert` moves it; identical caps negotiate without converting; the depth-increase rule and its "only option" escape.

### Where these tests run

**Locally on macOS only. None of the 14 new tests execute in PR CI.** The module is `#[cfg(target_os = "macos")]` throughout, and `build-macos` in `ci.yml` is gated on `github.event_name == 'workflow_dispatch'`, so the Linux jobs compile the whole thing out. They will run on a manual dispatch with `platforms: macos` (or `both`), and they need no new package — everything used is in `gst-plugins-base`.

This is a pre-existing property of the repo's CI rather than something this PR introduces: the macOS-only tests #726 added to `gpu.rs` are in the same position. Worth deciding separately whether a macOS test job should run on PRs; I have not changed CI here.

What CI did verify on this PR: Linux x86_64 and ARM64 builds, `Check (Linux)` (clippy plus `cargo test` with the module cfg'd out), the WASM build, and the API contract check — all green. **Windows is built by no job on a PR either, so it is unverified by anyone**; the non-macOS code paths it shares with Linux are identical.

`gstreamer-base` is a macOS-only dependency and already transitive via `gstreamer-video`, so nothing new compiles anywhere.

## Not done

Scaling has no vImage path — `vImageScale` plus a convert would be two passes, so a resize stays on `GstVideoConverter`. `NV21`, 10-bit and `v210` are not covered. Worth revisiting if a flow turns out to need them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
