### PR TITLE
fix(vision mixer): keep per-pixel alpha on keyed pads with an alpha-less output_format

### DIFF
--- a/backend/src/blocks/builtin/vision_mixer/builder/mod.rs
+++ b/backend/src/blocks/builtin/vision_mixer/builder/mod.rs
@@ -13,6 +13,7 @@ use super::properties;
 use crate::blocks::{BlockBuildContext, BlockBuildError, BlockBuildResult, BlockBuilder};
 use gstreamer as gst;
 use gstreamer_app as gst_app;
+use gstreamer_video as gst_video;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use strom_types::vision_mixer;
@@ -239,36 +240,76 @@ impl<'a> PipelineParams<'a> {
         format!("{}:{}", self.instance_id, name)
     }
 
-    /// Build PGM output caps with resolution, framerate, and optional pixel format.
-    pub(super) fn pgm_caps(&self) -> gst::Caps {
+    /// Raw video caps with resolution, framerate and an optional pixel format.
+    fn raw_caps(&self, w: u32, h: u32, framerate: (i32, i32), format: Option<&str>) -> gst::Caps {
         let mut builder = gst::Caps::builder("video/x-raw")
-            .field("width", self.pgm_w as i32)
-            .field("height", self.pgm_h as i32)
-            .field(
-                "framerate",
-                gst::Fraction::new(self.pgm_framerate.0, self.pgm_framerate.1),
-            )
+            .field("width", w as i32)
+            .field("height", h as i32)
+            .field("framerate", gst::Fraction::new(framerate.0, framerate.1))
             .field("pixel-aspect-ratio", gst::Fraction::new(1, 1));
-        if let Some(ref fmt) = self.output_format {
-            builder = builder.field("format", fmt.as_str());
+        if let Some(fmt) = format {
+            builder = builder.field("format", fmt);
         }
         builder.build()
     }
 
+    /// Build PGM output caps with resolution, framerate, and optional pixel format.
+    pub(super) fn pgm_caps(&self) -> gst::Caps {
+        self.raw_caps(
+            self.pgm_w,
+            self.pgm_h,
+            self.pgm_framerate,
+            self.output_format.as_deref(),
+        )
+    }
+
     /// Build multiview output caps with resolution, framerate, and optional pixel format.
     pub(super) fn mv_caps(&self) -> gst::Caps {
-        let mut builder = gst::Caps::builder("video/x-raw")
-            .field("width", self.mv_w as i32)
-            .field("height", self.mv_h as i32)
-            .field(
-                "framerate",
-                gst::Fraction::new(self.mv_framerate.0, self.mv_framerate.1),
-            )
-            .field("pixel-aspect-ratio", gst::Fraction::new(1, 1));
-        if let Some(ref fmt) = self.output_format {
-            builder = builder.field("format", fmt.as_str());
+        self.raw_caps(
+            self.mv_w,
+            self.mv_h,
+            self.mv_framerate,
+            self.output_format.as_deref(),
+        )
+    }
+
+    /// PGM caps with `format` instead of `output_format` — the software
+    /// compositor's blend space, see [`Self::alpha_blend_format`].
+    pub(super) fn pgm_blend_caps(&self, format: &str) -> gst::Caps {
+        self.raw_caps(self.pgm_w, self.pgm_h, self.pgm_framerate, Some(format))
+    }
+
+    /// Multiview caps with `format` instead of `output_format` — the software
+    /// compositor's blend space, see [`Self::alpha_blend_format`].
+    pub(super) fn mv_blend_caps(&self, format: &str) -> gst::Caps {
+        self.raw_caps(self.mv_w, self.mv_h, self.mv_framerate, Some(format))
+    }
+
+    /// The format the software compositor has to blend in so that keyed pads
+    /// keep their per-pixel alpha, or `None` when `output_format` needs no
+    /// substitute.
+    ///
+    /// `compositor` blends in its own output format and converts every sink
+    /// pad to it first, so an alpha-less `output_format` (I420, NV12, RGB, ...)
+    /// strips the alpha of DSK graphics, the multiview overlay and the border
+    /// underlays. Blending in the alpha-carrying counterpart and converting
+    /// once on the way out keeps the key and still hands `output_format`
+    /// downstream. Alpha-carrying and unknown formats are left alone.
+    pub(super) fn alpha_blend_format(&self) -> Option<&'static str> {
+        let fmt = self.output_format.as_deref()?;
+        let format = fmt.parse::<gst_video::VideoFormat>().ok()?;
+        let info = gst_video::VideoFormatInfo::from_format(format);
+        if info.has_alpha() {
+            return None;
         }
-        builder.build()
+        // Match the chroma subsampling of the requested format so the extra
+        // hop costs nothing the output would not have cost anyway.
+        Some(match fmt {
+            "YUY2" | "UYVY" => "A422",
+            "v210" => "A422_10LE",
+            _ if info.is_rgb() || info.is_gray() => "RGBA",
+            _ => "A420",
+        })
     }
 
     /// Build PGM output caps for the GL-memory passthrough path.

--- a/backend/src/blocks/builtin/vision_mixer/builder/pipeline_cpu.rs
+++ b/backend/src/blocks/builtin/vision_mixer/builder/pipeline_cpu.rs
@@ -18,6 +18,9 @@ pub(super) fn build_cpu_pipeline(
     let mut elems: Vec<(String, gst::Element)> = Vec::new();
     let mut links: Vec<(ElementPadRef, ElementPadRef)> = Vec::new();
 
+    // Conversion element for this host — see the DSK chain below for why.
+    let vc_factory = gpu::video_convert_mode().element_name();
+
     let dist_comp = elements::make_dist_compositor(p.backend, p.latency_ms, p.min_upstream_ms)?;
     let mv_comp = elements::make_mv_compositor(p.backend, p.latency_ms, p.min_upstream_ms)?;
 
@@ -65,10 +68,55 @@ pub(super) fn build_cpu_pipeline(
     elems.push((tee_pgm_id.clone(), tee_pgm));
     elems.push((q_dist_out_id.clone(), queue_dist_out));
 
-    links.push((
-        ElementPadRef::pad(&mixer_id, "src"),
-        ElementPadRef::pad(&cf_dist_id, "sink"),
-    ));
+    // Keyed pads on the dist compositor: DSK graphics, and the border
+    // underlays that carry #RRGGBBAA colors. When they are present and
+    // output_format cannot hold alpha, blend in the alpha-carrying
+    // counterpart and convert to output_format after the mixer — pinning
+    // output_format on the mixer itself would flatten the key.
+    let dist_keyed = p.num_dsk_inputs > 0 || p.num_pips > 0;
+    let dist_blend_format = if dist_keyed {
+        p.alpha_blend_format()
+    } else {
+        None
+    };
+    if let Some(blend_fmt) = dist_blend_format {
+        let cf_blend_id = p.id("capsfilter_dist_blend");
+        let capsfilter_blend = gst::ElementFactory::make("capsfilter")
+            .name(&cf_blend_id)
+            .property("caps", p.pgm_blend_caps(blend_fmt))
+            .build()
+            .map_err(|e| {
+                BlockBuildError::ElementCreation(format!("capsfilter_dist_blend: {}", e))
+            })?;
+        let vc_dist_out_id = p.id("videoconvert_dist_out");
+        let videoconvert_dist_out = elements::make_element(vc_factory, &vc_dist_out_id)?;
+        elems.push((cf_blend_id.clone(), capsfilter_blend));
+        elems.push((vc_dist_out_id.clone(), videoconvert_dist_out));
+        info!(
+            "Vision mixer {}: blending in {} for keyed pads, converting to {} on output",
+            p.instance_id,
+            blend_fmt,
+            p.output_format.as_deref().unwrap_or("auto")
+        );
+
+        links.push((
+            ElementPadRef::pad(&mixer_id, "src"),
+            ElementPadRef::pad(&cf_blend_id, "sink"),
+        ));
+        links.push((
+            ElementPadRef::pad(&cf_blend_id, "src"),
+            ElementPadRef::pad(&vc_dist_out_id, "sink"),
+        ));
+        links.push((
+            ElementPadRef::pad(&vc_dist_out_id, "src"),
+            ElementPadRef::pad(&cf_dist_id, "sink"),
+        ));
+    } else {
+        links.push((
+            ElementPadRef::pad(&mixer_id, "src"),
+            ElementPadRef::pad(&cf_dist_id, "sink"),
+        ));
+    }
     links.push((
         ElementPadRef::pad(&cf_dist_id, "src"),
         ElementPadRef::pad(&tee_pgm_id, "sink"),
@@ -98,7 +146,6 @@ pub(super) fn build_cpu_pipeline(
     elems.push((cf_pgm_mv_id.clone(), capsfilter_pgm_mv));
 
     // DSK input element chains (links to mixer added later after video inputs)
-    let vc_factory = gpu::video_convert_mode().element_name();
     for i in 0..p.num_dsk_inputs {
         let q_id = p.id(&format!("queue_dsk_{}", i));
         let vc_id_dsk = p.id(&format!("videoconvert_dsk_{}", i));
@@ -118,27 +165,12 @@ pub(super) fn build_cpu_pipeline(
             ElementPadRef::pad(&vc_id_dsk, "sink"),
         ));
 
-        // When output_format is specified, force DSK inputs to match — same as video inputs.
-        if let Some(ref fmt) = p.output_format {
-            let cf_dsk_id = p.id(&format!("capsfilter_dsk_{}", i));
-            let capsfilter_dsk = gst::ElementFactory::make("capsfilter")
-                .name(&cf_dsk_id)
-                .property(
-                    "caps",
-                    gst::Caps::builder("video/x-raw")
-                        .field("format", fmt.as_str())
-                        .build(),
-                )
-                .build()
-                .map_err(|e| {
-                    BlockBuildError::ElementCreation(format!("capsfilter_dsk_{}: {}", i, e))
-                })?;
-            elems.push((cf_dsk_id.clone(), capsfilter_dsk));
-            links.push((
-                ElementPadRef::pad(&vc_id_dsk, "src"),
-                ElementPadRef::pad(&cf_dsk_id, "sink"),
-            ));
-        }
+        // No output_format capsfilter here. A DSK is a keyer: forcing an
+        // alpha-less format (I420/NV12) ahead of the compositor silently
+        // flattens the graphic's per-pixel alpha and paints its RGB opaquely
+        // over the program. Video inputs need the pin because their tee feeds
+        // two independently negotiating compositors; a DSK links straight to
+        // one compositor pad, so its convert pad handles the conversion.
     }
 
     // --- Multiview output chain (no gldownload needed for CPU) ---
@@ -159,10 +191,39 @@ pub(super) fn build_cpu_pipeline(
     elems.push((tee_mv_id.clone(), tee_mv));
     elems.push((q_mv_out_id.clone(), queue_mv_out));
 
-    links.push((
-        ElementPadRef::pad(&mv_comp_id, "src"),
-        ElementPadRef::pad(&cf_mv_id, "sink"),
-    ));
+    // The multiview overlay (labels, VU meters, tallies) is an RGBA pad on
+    // mv_comp, so the multiview always has a keyed pad — same treatment as the
+    // dist compositor above.
+    if let Some(blend_fmt) = p.alpha_blend_format() {
+        let cf_blend_id = p.id("capsfilter_mv_blend");
+        let capsfilter_blend = gst::ElementFactory::make("capsfilter")
+            .name(&cf_blend_id)
+            .property("caps", p.mv_blend_caps(blend_fmt))
+            .build()
+            .map_err(|e| BlockBuildError::ElementCreation(format!("capsfilter_mv_blend: {}", e)))?;
+        let vc_mv_out_id = p.id("videoconvert_mv_out");
+        let videoconvert_mv_out = elements::make_element(vc_factory, &vc_mv_out_id)?;
+        elems.push((cf_blend_id.clone(), capsfilter_blend));
+        elems.push((vc_mv_out_id.clone(), videoconvert_mv_out));
+
+        links.push((
+            ElementPadRef::pad(&mv_comp_id, "src"),
+            ElementPadRef::pad(&cf_blend_id, "sink"),
+        ));
+        links.push((
+            ElementPadRef::pad(&cf_blend_id, "src"),
+            ElementPadRef::pad(&vc_mv_out_id, "sink"),
+        ));
+        links.push((
+            ElementPadRef::pad(&vc_mv_out_id, "src"),
+            ElementPadRef::pad(&cf_mv_id, "sink"),
+        ));
+    } else {
+        links.push((
+            ElementPadRef::pad(&mv_comp_id, "src"),
+            ElementPadRef::pad(&cf_mv_id, "sink"),
+        ));
+    }
     links.push((
         ElementPadRef::pad(&cf_mv_id, "src"),
         ElementPadRef::pad(&tee_mv_id, "sink"),
@@ -200,45 +261,18 @@ pub(super) fn build_cpu_pipeline(
     elems.push((q_overlay_id.clone(), queue_overlay));
     elems.push((vc_overlay_id.clone(), videoconvert_overlay));
 
-    // Optional capsfilter to match compositor output format
-    let overlay_last_id = if let Some(ref fmt) = p.output_format {
-        let cf_overlay_id = p.id("capsfilter_overlay");
-        let capsfilter_overlay = gst::ElementFactory::make("capsfilter")
-            .name(&cf_overlay_id)
-            .property(
-                "caps",
-                gst::Caps::builder("video/x-raw")
-                    .field("format", fmt.as_str())
-                    .build(),
-            )
-            .build()
-            .map_err(|e| BlockBuildError::ElementCreation(format!("capsfilter_overlay: {}", e)))?;
-        elems.push((cf_overlay_id.clone(), capsfilter_overlay));
-
-        links.push((
-            ElementPadRef::pad(&appsrc_overlay_id, "src"),
-            ElementPadRef::pad(&q_overlay_id, "sink"),
-        ));
-        links.push((
-            ElementPadRef::pad(&q_overlay_id, "src"),
-            ElementPadRef::pad(&vc_overlay_id, "sink"),
-        ));
-        links.push((
-            ElementPadRef::pad(&vc_overlay_id, "src"),
-            ElementPadRef::pad(&cf_overlay_id, "sink"),
-        ));
-        cf_overlay_id
-    } else {
-        links.push((
-            ElementPadRef::pad(&appsrc_overlay_id, "src"),
-            ElementPadRef::pad(&q_overlay_id, "sink"),
-        ));
-        links.push((
-            ElementPadRef::pad(&q_overlay_id, "src"),
-            ElementPadRef::pad(&vc_overlay_id, "sink"),
-        ));
-        vc_overlay_id.clone()
-    };
+    // No output_format capsfilter here either: the overlay is RGBA with
+    // per-pixel alpha, and pinning it to an alpha-less format would composite
+    // its transparent areas opaquely over the multiview.
+    links.push((
+        ElementPadRef::pad(&appsrc_overlay_id, "src"),
+        ElementPadRef::pad(&q_overlay_id, "sink"),
+    ));
+    links.push((
+        ElementPadRef::pad(&q_overlay_id, "src"),
+        ElementPadRef::pad(&vc_overlay_id, "sink"),
+    ));
+    let overlay_last_id = vc_overlay_id;
     // Link to mv_comp is added AFTER all other mv_comp links (pad ordering matters)
 
     // --- Border underlay sources ---
@@ -404,11 +438,7 @@ pub(super) fn build_cpu_pipeline(
         ));
     }
     for i in 0..p.num_dsk_inputs {
-        let last_dsk_elem = if p.output_format.is_some() {
-            p.id(&format!("capsfilter_dsk_{}", i))
-        } else {
-            p.id(&format!("videoconvert_dsk_{}", i))
-        };
+        let last_dsk_elem = p.id(&format!("videoconvert_dsk_{}", i));
         links.push((
             ElementPadRef::pad(&last_dsk_elem, "src"),
             ElementPadRef::pad(&mixer_id, format!("sink_{}", p.num_inputs + i)),

--- a/backend/src/blocks/builtin/vision_mixer/builder/pipeline_gpu.rs
+++ b/backend/src/blocks/builtin/vision_mixer/builder/pipeline_gpu.rs
@@ -55,6 +55,13 @@ pub(super) fn build_gpu_pipeline(
     // With gl_download=false: mixer → queue_post_dist → tee_pgm → capsfilter(GLMemory) → queue_dist_out
     // The capsfilter on the false path enforces pgm_framerate/resolution while
     // keeping memory in GL — without it, the framerate property is silently ignored.
+    //
+    // These capsfilters carry output_format (see pgm_caps/mv_caps), and keyed
+    // pads still keep their alpha: glvideomixer is a bin whose own converter
+    // absorbs the pin, so the blend stays RGBA in GL memory. Keep a converting
+    // element between the mixer and any format pin — a mixer converts every
+    // sink pad to its own src format, so an alpha-less pin on mixer:src strips
+    // the alpha of every DSK graphic and border underlay feeding it.
     let q_post_dist_id = p.id("queue_post_dist");
     let queue_post_dist = elements::make_queue(&q_post_dist_id)?;
     let tee_pgm_id = p.id("tee_pgm");

--- a/backend/tests/vision_mixer_keyed_alpha_test.rs
+++ b/backend/tests/vision_mixer_keyed_alpha_test.rs
@@ -191,10 +191,12 @@ fn build_flow(block_id: &str, output_format: &str) -> Flow {
     flow
 }
 
-/// Mean luma of a horizontal band of an RGBA frame. White reads high, red
-/// mid, black low — enough to tell "background shows through" from "graphic
-/// painted opaquely".
-fn mean_luma(sample: &gstreamer::Sample, x0: usize, x1: usize) -> f64 {
+/// Fraction of red and of white pixels in a horizontal band of an RGBA frame.
+///
+/// Colour fractions rather than mean luma: an all-black startup frame is dark
+/// the way an opaque-keyed frame is dark, so a brightness threshold cannot
+/// tell "the graphic is up" from "nothing is composited yet".
+fn band_colors(sample: &gstreamer::Sample, x0: usize, x1: usize) -> (f64, f64) {
     use gstreamer_video::{VideoFormat, VideoFrameRef, VideoInfo};
     let caps = sample.caps().expect("caps");
     let info = VideoInfo::from_caps(caps).expect("video info from caps");
@@ -208,26 +210,30 @@ fn mean_luma(sample: &gstreamer::Sample, x0: usize, x1: usize) -> f64 {
     let h = info.height() as usize;
     let stride = info.stride()[0] as usize;
     let data = frame.plane_data(0).expect("plane 0");
-    let mut sum = 0u64;
-    let mut n = 0u64;
+    let (mut red, mut white, mut n) = (0u64, 0u64, 0u64);
     for y in (h / 4)..(3 * h / 4) {
         let row = &data[y * stride..];
         for x in x0..x1 {
             let o = x * 4;
-            let (r, g, b) = (row[o] as u64, row[o + 1] as u64, row[o + 2] as u64);
-            sum += (r * 299 + g * 587 + b * 114) / 1000;
+            let (r, g, b) = (row[o], row[o + 1], row[o + 2]);
+            if r > 150 && g < 80 && b < 80 {
+                red += 1;
+            } else if r > 200 && g > 200 && b > 200 {
+                white += 1;
+            }
             n += 1;
         }
     }
-    sum as f64 / n as f64
+    (red as f64 / n as f64, white as f64 / n as f64)
 }
 
 /// What one run of the flow observed.
 struct Measured {
-    /// Mean luma of the opaque (red) half of the keyed DSK graphic.
-    dsk_left: f64,
-    /// Mean luma of the transparent half — the program background must show.
-    dsk_right: f64,
+    /// Fraction of red pixels in the opaque half of the keyed DSK graphic.
+    dsk_left_red: f64,
+    /// Fraction of white pixels in the transparent half — the program
+    /// background must show through there.
+    dsk_right_white: f64,
     /// Fraction of near-white pixels in the multiview frame. The multiview
     /// overlay is a full-canvas keyed RGBA pad; if its alpha is dropped the
     /// multiview is the overlay's own black RGB and this goes to ~0.
@@ -325,7 +331,7 @@ fn run_flow(block_id: &str, output_format: &str) -> Measured {
     // alpha change takes effect a frame or two after set_dsk_enabled), then
     // measure that frame.
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(20);
-    let (dsk_left, dsk_right) = loop {
+    let (dsk_left_red, dsk_right_white) = loop {
         assert!(
             std::time::Instant::now() < deadline,
             "DSK graphic never appeared in PGM within 20s"
@@ -334,11 +340,12 @@ fn run_flow(block_id: &str, output_format: &str) -> Measured {
         else {
             continue;
         };
-        let left = mean_luma(&sample, W / 8, 3 * W / 8);
-        let right = mean_luma(&sample, 5 * W / 8, 7 * W / 8);
-        // The left half turning from white to red means the keyer is live.
-        if left < 150.0 {
-            break (left, right);
+        let (left_red, _) = band_colors(&sample, W / 8, 3 * W / 8);
+        let (_, right_white) = band_colors(&sample, 5 * W / 8, 7 * W / 8);
+        // Wait for the graphic's opaque half to actually be red: early frames
+        // are still black everywhere, and a keyed-opaque failure is black too.
+        if left_red > 0.8 {
+            break (left_red, right_white);
         }
     };
 
@@ -382,8 +389,8 @@ fn run_flow(block_id: &str, output_format: &str) -> Measured {
     manager.stop().expect("stop");
     drop(manager);
     Measured {
-        dsk_left,
-        dsk_right,
+        dsk_left_red,
+        dsk_right_white,
         mv_bright,
         pgm_format,
     }
@@ -396,23 +403,24 @@ fn run_flow(block_id: &str, output_format: &str) -> Measured {
 async fn keyed_pads_keep_alpha_with_alpha_less_output_format() {
     let m = run_flow("vmk_nv12", "NV12");
     eprintln!(
-        "NV12 output_format: dsk left {:.1}, dsk right {:.1}, mv bright {:.3}, pgm format {}",
-        m.dsk_left, m.dsk_right, m.mv_bright, m.pgm_format
+        "NV12 output_format: dsk left red {:.3}, dsk right white {:.3}, mv bright {:.3}, \
+         pgm format {}",
+        m.dsk_left_red, m.dsk_right_white, m.mv_bright, m.pgm_format
     );
     assert_eq!(
         m.pgm_format, "NV12",
         "output_format must still pin the mixer output"
     );
     assert!(
-        m.dsk_left < 150.0,
-        "opaque half of the DSK graphic should be red, luma {:.1}",
-        m.dsk_left
+        m.dsk_left_red > 0.8,
+        "opaque half of the DSK graphic should be red, {:.3} red",
+        m.dsk_left_red
     );
     assert!(
-        m.dsk_right > 180.0,
-        "transparent half of the DSK graphic must show the white background, luma {:.1} \
+        m.dsk_right_white > 0.8,
+        "transparent half of the DSK graphic must show the white background, {:.3} white \
          (alpha flattened before blending)",
-        m.dsk_right
+        m.dsk_right_white
     );
     assert!(
         m.mv_bright > 0.05,
@@ -427,18 +435,19 @@ async fn keyed_pads_keep_alpha_with_alpha_less_output_format() {
 async fn keyed_pads_keep_alpha_with_auto_output_format() {
     let m = run_flow("vmk_auto", "");
     eprintln!(
-        "auto output_format: dsk left {:.1}, dsk right {:.1}, mv bright {:.3}, pgm format {}",
-        m.dsk_left, m.dsk_right, m.mv_bright, m.pgm_format
+        "auto output_format: dsk left red {:.3}, dsk right white {:.3}, mv bright {:.3}, \
+         pgm format {}",
+        m.dsk_left_red, m.dsk_right_white, m.mv_bright, m.pgm_format
     );
     assert!(
-        m.dsk_left < 150.0,
-        "opaque half should be red, luma {:.1}",
-        m.dsk_left
+        m.dsk_left_red > 0.8,
+        "opaque half should be red, {:.3} red",
+        m.dsk_left_red
     );
     assert!(
-        m.dsk_right > 180.0,
-        "transparent half must show the white background, luma {:.1}",
-        m.dsk_right
+        m.dsk_right_white > 0.8,
+        "transparent half must show the white background, {:.3} white",
+        m.dsk_right_white
     );
     assert!(
         m.mv_bright > 0.05,

--- a/backend/tests/vision_mixer_keyed_alpha_test.rs
+++ b/backend/tests/vision_mixer_keyed_alpha_test.rs
@@ -1,0 +1,448 @@
+//! Regression test: an alpha-less `output_format` must not destroy the
+//! per-pixel alpha of a DSK (downstream keyer) input.
+//!
+//! Builds a real vision mixer flow through `PipelineManager` on the CPU
+//! (software compositor) backend with `output_format=NV12`, feeds DSK 0 a
+//! half-transparent RGBA graphic, and asserts the transparent half still
+//! shows the program background. Before the fix the builder inserted an
+//! NV12 capsfilter between the DSK input and the compositor, which flattened
+//! the alpha and painted the graphic's black RGB over the background.
+
+use gstreamer::prelude::*;
+use std::collections::HashMap;
+use strom::blocks::BlockRegistry;
+use strom::events::EventBroadcaster;
+use strom::gst::pipeline::PipelineManager;
+use strom_types::{Flow, PropertyValue as PV};
+use tempfile::NamedTempFile;
+
+const W: usize = 320;
+const H: usize = 180;
+
+fn elem(id: &str, ty: &str, props: Vec<(&str, PV)>) -> strom_types::Element {
+    strom_types::Element {
+        id: id.to_string(),
+        element_type: ty.to_string(),
+        properties: props.into_iter().map(|(k, v)| (k.to_string(), v)).collect(),
+        position: [0.0, 0.0].into(),
+        pad_properties: HashMap::new(),
+    }
+}
+
+/// Flow: a white program input on video_in_0, and on dsk_in_0 a graphic whose
+/// left half is opaque red and whose right half is fully transparent
+/// (videobox pads the 160-wide red source out to 320 with border-alpha=0).
+fn build_flow(block_id: &str, output_format: &str) -> Flow {
+    let mut flow = Flow::new(format!("vm_keyed_alpha_{}", block_id));
+    flow.blocks.push(strom_types::BlockInstance {
+        id: block_id.to_string(),
+        block_definition_id: "builtin.vision_mixer".to_string(),
+        name: None,
+        properties: {
+            let mut p = HashMap::new();
+            p.insert(
+                "compositor_preference".to_string(),
+                PV::String("cpu".to_string()),
+            );
+            p.insert("num_inputs".to_string(), PV::UInt(2));
+            p.insert("num_dsk_inputs".to_string(), PV::String("1".to_string()));
+            p.insert(
+                "output_format".to_string(),
+                PV::String(output_format.to_string()),
+            );
+            p.insert(
+                "pgm_resolution".to_string(),
+                PV::String(format!("{}x{}", W, H)),
+            );
+            p.insert(
+                "multiview_resolution".to_string(),
+                PV::String(format!("{}x{}", W, H)),
+            );
+            p
+        },
+        position: strom_types::block::Position { x: 100.0, y: 100.0 },
+        runtime_data: None,
+        computed_external_pads: None,
+    });
+
+    flow.elements.push(elem(
+        "bg",
+        "videotestsrc",
+        vec![
+            ("pattern", PV::String("white".into())),
+            ("is-live", PV::Bool(true)),
+        ],
+    ));
+    flow.elements.push(elem(
+        "bgcaps",
+        "capsfilter",
+        vec![(
+            "caps",
+            PV::String(format!(
+                "video/x-raw,width={},height={},framerate=30/1",
+                W, H
+            )),
+        )],
+    ));
+    flow.elements.push(elem(
+        "gfx",
+        "videotestsrc",
+        vec![
+            ("pattern", PV::String("red".into())),
+            ("is-live", PV::Bool(true)),
+        ],
+    ));
+    flow.elements.push(elem(
+        "gfxcaps",
+        "capsfilter",
+        vec![(
+            "caps",
+            PV::String(format!(
+                "video/x-raw,format=RGBA,width={},height={},framerate=30/1",
+                W / 2,
+                H
+            )),
+        )],
+    ));
+    // Pad the red source out to full width with a fully transparent border.
+    flow.elements.push(elem(
+        "gfxbox",
+        "videobox",
+        vec![
+            ("right", PV::Int(-((W / 2) as i64))),
+            ("border-alpha", PV::Float(0.0)),
+        ],
+    ));
+    flow.elements.push(elem(
+        "gfxout",
+        "capsfilter",
+        vec![(
+            "caps",
+            PV::String(format!(
+                "video/x-raw,format=RGBA,width={},height={},framerate=30/1",
+                W, H
+            )),
+        )],
+    ));
+    // Measure in RGBA regardless of what the mixer output negotiated: with
+    // output_format=Auto the CPU compositor can settle on exotic formats
+    // (GBRA_12LE here). Converting after the mixer cannot restore alpha that
+    // was already flattened upstream, so it does not mask the bug.
+    flow.elements.push(elem("pgmconv", "videoconvert", vec![]));
+    flow.elements.push(elem(
+        "pgmcaps",
+        "capsfilter",
+        vec![("caps", PV::String("video/x-raw,format=RGBA".into()))],
+    ));
+    flow.elements.push(elem(
+        "pgmsink",
+        "appsink",
+        vec![
+            ("sync", PV::Bool(false)),
+            ("max-buffers", PV::UInt(1)),
+            ("drop", PV::Bool(true)),
+        ],
+    ));
+    // Same for the multiview, whose overlay (labels, VU meters, tallies) is a
+    // keyed RGBA pad covering the whole canvas.
+    flow.elements.push(elem("mvconv", "videoconvert", vec![]));
+    flow.elements.push(elem(
+        "mvcaps",
+        "capsfilter",
+        vec![("caps", PV::String("video/x-raw,format=RGBA".into()))],
+    ));
+    flow.elements.push(elem(
+        "mvsink",
+        "appsink",
+        vec![
+            ("sync", PV::Bool(false)),
+            ("max-buffers", PV::UInt(1)),
+            ("drop", PV::Bool(true)),
+        ],
+    ));
+
+    // DSK pads are dynamic (num_dsk_inputs), so the flow needs the computed
+    // pad set the API normally fills in before validation.
+    for block in &mut flow.blocks {
+        if let Some(builder) = strom::blocks::builtin::get_builder(&block.block_definition_id) {
+            block.computed_external_pads = builder.get_external_pads(&block.properties);
+        }
+    }
+
+    for (from, to) in [
+        ("bg:src".to_string(), "bgcaps:sink".to_string()),
+        ("bgcaps:src".to_string(), format!("{}:video_in_0", block_id)),
+        ("gfx:src".to_string(), "gfxcaps:sink".to_string()),
+        ("gfxcaps:src".to_string(), "gfxbox:sink".to_string()),
+        ("gfxbox:src".to_string(), "gfxout:sink".to_string()),
+        ("gfxout:src".to_string(), format!("{}:dsk_in_0", block_id)),
+        (format!("{}:pgm_out", block_id), "pgmconv:sink".to_string()),
+        ("pgmconv:src".to_string(), "pgmcaps:sink".to_string()),
+        ("pgmcaps:src".to_string(), "pgmsink:sink".to_string()),
+        (
+            format!("{}:multiview_out", block_id),
+            "mvconv:sink".to_string(),
+        ),
+        ("mvconv:src".to_string(), "mvcaps:sink".to_string()),
+        ("mvcaps:src".to_string(), "mvsink:sink".to_string()),
+    ] {
+        flow.links.push(strom_types::Link { from, to });
+    }
+    flow
+}
+
+/// Mean luma of a horizontal band of an RGBA frame. White reads high, red
+/// mid, black low — enough to tell "background shows through" from "graphic
+/// painted opaquely".
+fn mean_luma(sample: &gstreamer::Sample, x0: usize, x1: usize) -> f64 {
+    use gstreamer_video::{VideoFormat, VideoFrameRef, VideoInfo};
+    let caps = sample.caps().expect("caps");
+    let info = VideoInfo::from_caps(caps).expect("video info from caps");
+    assert_eq!(
+        info.format(),
+        VideoFormat::Rgba,
+        "PGM sample should be RGBA"
+    );
+    let buffer = sample.buffer().expect("buffer");
+    let frame = VideoFrameRef::from_buffer_ref_readable(buffer, &info).expect("map frame");
+    let h = info.height() as usize;
+    let stride = info.stride()[0] as usize;
+    let data = frame.plane_data(0).expect("plane 0");
+    let mut sum = 0u64;
+    let mut n = 0u64;
+    for y in (h / 4)..(3 * h / 4) {
+        let row = &data[y * stride..];
+        for x in x0..x1 {
+            let o = x * 4;
+            let (r, g, b) = (row[o] as u64, row[o + 1] as u64, row[o + 2] as u64);
+            sum += (r * 299 + g * 587 + b * 114) / 1000;
+            n += 1;
+        }
+    }
+    sum as f64 / n as f64
+}
+
+/// What one run of the flow observed.
+struct Measured {
+    /// Mean luma of the opaque (red) half of the keyed DSK graphic.
+    dsk_left: f64,
+    /// Mean luma of the transparent half — the program background must show.
+    dsk_right: f64,
+    /// Fraction of near-white pixels in the multiview frame. The multiview
+    /// overlay is a full-canvas keyed RGBA pad; if its alpha is dropped the
+    /// multiview is the overlay's own black RGB and this goes to ~0.
+    mv_bright: f64,
+    /// Pixel format the mixer output actually negotiated, i.e. what
+    /// `output_format` delivers to whatever consumes PGM.
+    pgm_format: String,
+}
+
+/// Fraction of pixels in an RGBA frame that are near-white. The multiview is
+/// mostly black canvas, so a mean is a poor signal; what matters is whether
+/// the white input's thumbnails and preview survive under the overlay.
+fn bright_fraction(sample: &gstreamer::Sample) -> f64 {
+    use gstreamer_video::{VideoFrameRef, VideoInfo};
+    let caps = sample.caps().expect("caps");
+    let info = VideoInfo::from_caps(caps).expect("video info from caps");
+    let buffer = sample.buffer().expect("buffer");
+    let frame = VideoFrameRef::from_buffer_ref_readable(buffer, &info).expect("map frame");
+    let (w, h) = (info.width() as usize, info.height() as usize);
+    let stride = info.stride()[0] as usize;
+    let data = frame.plane_data(0).expect("plane 0");
+    let mut bright = 0u64;
+    for y in 0..h {
+        let row = &data[y * stride..];
+        for x in 0..w {
+            let o = x * 4;
+            if row[o] > 200 && row[o + 1] > 200 && row[o + 2] > 200 {
+                bright += 1;
+            }
+        }
+    }
+    bright as f64 / (w * h) as f64
+}
+
+fn run_flow(block_id: &str, output_format: &str) -> Measured {
+    gstreamer::init().unwrap();
+    // The builder picks its videoconvert factory from the detected GPU
+    // capabilities; without this the first lookup panics.
+    strom::gpu::detect_gpu_capabilities();
+
+    let temp_file = NamedTempFile::new().unwrap();
+    let registry = BlockRegistry::new(temp_file.path());
+    let events = EventBroadcaster::new(10);
+
+    let flow = build_flow(block_id, output_format);
+    let mut manager = PipelineManager::new(
+        &flow,
+        events,
+        &registry,
+        vec![],
+        "all".to_string(),
+        None,
+        std::env::temp_dir(),
+        std::sync::Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+    )
+    .expect("build CPU pipeline");
+
+    // Count overlay frames so the multiview is only measured once the overlay
+    // is actually being composited — before its first push the multiview looks
+    // healthy whether or not its alpha survives.
+    let overlay_frames = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    {
+        let counter = std::sync::Arc::clone(&overlay_frames);
+        manager
+            .pipeline()
+            .by_name(&format!("{}:appsrc_overlay", block_id))
+            .expect("overlay appsrc in pipeline")
+            .static_pad("src")
+            .expect("overlay appsrc src pad")
+            .add_probe(gstreamer::PadProbeType::BUFFER, move |_, _| {
+                counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                gstreamer::PadProbeReturn::Ok
+            });
+    }
+
+    manager.start().expect("start CPU pipeline");
+
+    // DSK pads are built hidden (alpha=0) — key the graphic in.
+    manager
+        .set_dsk_enabled(block_id, 0, 2, true)
+        .expect("enable DSK 0");
+
+    let sink = |name: &str| {
+        manager
+            .pipeline()
+            .by_name(name)
+            .unwrap_or_else(|| panic!("{} in pipeline", name))
+            .downcast::<gstreamer_app::AppSink>()
+            .expect("appsink type")
+    };
+    let pgm_sink = sink("pgmsink");
+    let mv_sink = sink("mvsink");
+
+    // Pull PGM frames until the keyed graphic is actually on screen (the pad
+    // alpha change takes effect a frame or two after set_dsk_enabled), then
+    // measure that frame.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(20);
+    let (dsk_left, dsk_right) = loop {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "DSK graphic never appeared in PGM within 20s"
+        );
+        let Some(sample) = pgm_sink.try_pull_sample(gstreamer::ClockTime::from_mseconds(500))
+        else {
+            continue;
+        };
+        let left = mean_luma(&sample, W / 8, 3 * W / 8);
+        let right = mean_luma(&sample, 5 * W / 8, 7 * W / 8);
+        // The left half turning from white to red means the keyer is live.
+        if left < 150.0 {
+            break (left, right);
+        }
+    };
+
+    // Wait for the overlay renderer to push (it starts after the appsrc
+    // reaches PLAYING), then drop the frames composited before it appeared.
+    let mv_deadline = std::time::Instant::now() + std::time::Duration::from_secs(20);
+    while overlay_frames.load(std::sync::atomic::Ordering::Relaxed) < 3 {
+        assert!(
+            std::time::Instant::now() < mv_deadline,
+            "overlay renderer never pushed a frame within 20s"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    // Watch the multiview until a frame shows picture, keeping the best
+    // reading. When the overlay's alpha is flattened, the overlay's own black
+    // covers the whole canvas and picture never appears.
+    let mut mv_bright: f64 = 0.0;
+    let watch_until = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    while std::time::Instant::now() < watch_until {
+        let Some(sample) = mv_sink.try_pull_sample(gstreamer::ClockTime::from_mseconds(500)) else {
+            continue;
+        };
+        mv_bright = mv_bright.max(bright_fraction(&sample));
+        if mv_bright > 0.05 {
+            break;
+        }
+    }
+
+    // What the mixer output negotiated, read at the block's own output
+    // capsfilter rather than at the test's RGBA measurement tap.
+    let pgm_format = manager
+        .pipeline()
+        .by_name(&format!("{}:capsfilter_dist", block_id))
+        .expect("capsfilter_dist in pipeline")
+        .static_pad("src")
+        .expect("capsfilter_dist src pad")
+        .current_caps()
+        .and_then(|c| c.structure(0).and_then(|s| s.get::<String>("format").ok()))
+        .expect("negotiated PGM format");
+
+    manager.stop().expect("stop");
+    drop(manager);
+    Measured {
+        dsk_left,
+        dsk_right,
+        mv_bright,
+        pgm_format,
+    }
+}
+
+/// With an alpha-less `output_format`, a keyed DSK graphic and the multiview
+/// overlay must keep their per-pixel alpha — and PGM must still come out in
+/// the requested format.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn keyed_pads_keep_alpha_with_alpha_less_output_format() {
+    let m = run_flow("vmk_nv12", "NV12");
+    eprintln!(
+        "NV12 output_format: dsk left {:.1}, dsk right {:.1}, mv bright {:.3}, pgm format {}",
+        m.dsk_left, m.dsk_right, m.mv_bright, m.pgm_format
+    );
+    assert_eq!(
+        m.pgm_format, "NV12",
+        "output_format must still pin the mixer output"
+    );
+    assert!(
+        m.dsk_left < 150.0,
+        "opaque half of the DSK graphic should be red, luma {:.1}",
+        m.dsk_left
+    );
+    assert!(
+        m.dsk_right > 180.0,
+        "transparent half of the DSK graphic must show the white background, luma {:.1} \
+         (alpha flattened before blending)",
+        m.dsk_right
+    );
+    assert!(
+        m.mv_bright > 0.05,
+        "multiview shows no picture ({:.3} of pixels bright) — the overlay's \
+         transparent areas were composited opaquely",
+        m.mv_bright
+    );
+}
+
+/// Baseline: the same flow with `output_format=Auto`, which was never broken.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn keyed_pads_keep_alpha_with_auto_output_format() {
+    let m = run_flow("vmk_auto", "");
+    eprintln!(
+        "auto output_format: dsk left {:.1}, dsk right {:.1}, mv bright {:.3}, pgm format {}",
+        m.dsk_left, m.dsk_right, m.mv_bright, m.pgm_format
+    );
+    assert!(
+        m.dsk_left < 150.0,
+        "opaque half should be red, luma {:.1}",
+        m.dsk_left
+    );
+    assert!(
+        m.dsk_right > 180.0,
+        "transparent half must show the white background, luma {:.1}",
+        m.dsk_right
+    );
+    assert!(
+        m.mv_bright > 0.05,
+        "multiview shows no picture ({:.3} of pixels bright)",
+        m.mv_bright
+    );
+}

--- a/backend/tests/vision_mixer_keyed_alpha_test.rs
+++ b/backend/tests/vision_mixer_keyed_alpha_test.rs
@@ -399,16 +399,19 @@ fn run_flow(block_id: &str, output_format: &str) -> Measured {
 /// With an alpha-less `output_format`, a keyed DSK graphic and the multiview
 /// overlay must keep their per-pixel alpha — and PGM must still come out in
 /// the requested format.
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn keyed_pads_keep_alpha_with_alpha_less_output_format() {
-    let m = run_flow("vmk_nv12", "NV12");
+///
+/// `blend` is the space `alpha_blend_format` substitutes for this
+/// `output_format`; it has to be one `compositor` will blend in, and one that
+/// converts to the requested format on the way out.
+fn assert_keyed_alpha_survives(block_id: &str, output_format: &str, blend: &str) {
+    let m = run_flow(block_id, output_format);
     eprintln!(
-        "NV12 output_format: dsk left red {:.3}, dsk right white {:.3}, mv bright {:.3}, \
-         pgm format {}",
-        m.dsk_left_red, m.dsk_right_white, m.mv_bright, m.pgm_format
+        "{} output_format (blends in {}): dsk left red {:.3}, dsk right white {:.3}, \
+         mv bright {:.3}, pgm format {}",
+        output_format, blend, m.dsk_left_red, m.dsk_right_white, m.mv_bright, m.pgm_format
     );
     assert_eq!(
-        m.pgm_format, "NV12",
+        m.pgm_format, output_format,
         "output_format must still pin the mixer output"
     );
     assert!(
@@ -428,6 +431,28 @@ async fn keyed_pads_keep_alpha_with_alpha_less_output_format() {
          transparent areas were composited opaquely",
         m.mv_bright
     );
+}
+
+/// One test per branch of `alpha_blend_format`, so a format that loses its key
+/// is named by the failure rather than hidden behind the first one to break.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn keyed_pads_keep_alpha_with_nv12_output_format() {
+    assert_keyed_alpha_survives("vmk_nv12", "NV12", "A420");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn keyed_pads_keep_alpha_with_yuy2_output_format() {
+    assert_keyed_alpha_survives("vmk_yuy2", "YUY2", "A422");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn keyed_pads_keep_alpha_with_v210_output_format() {
+    assert_keyed_alpha_survives("vmk_v210", "v210", "A422_10LE");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn keyed_pads_keep_alpha_with_rgb_output_format() {
+    assert_keyed_alpha_survives("vmk_rgb", "RGB", "RGBA");
 }
 
 /// Baseline: the same flow with `output_format=Auto`, which was never broken.


### PR DESCRIPTION
## The bug

The vision mixer's `output_format` property offers alpha-less formats (I420, NV12, RGB, ...). Setting one on the CPU path destroyed the per-pixel alpha of every keyed pad: a DSK graphic's transparent areas composited as the graphic's own black instead of the program picture, and the full-canvas multiview overlay turned the whole multiview black. There is a standing incentive to set the property: unpinned RGBA into `vtenc_h264_hw` negotiates AYUV64 rather than NV12.

## Cause

Two places, one mechanism.

The builder inserted `output_format` capsfilters on the DSK chains and on the overlay appsrc chain, flattening alpha before the compositor saw it. Removing those alone does not fix it — measured, not assumed. `compositor` blends in its *own output format* and converts every sink pad to that format first, so pinning an alpha-less format on the compositor's src caps makes its sink pads alpha-less too:

```
compositor ! video/x-raw,format=NV12   # RGBA input: not-negotiated
compositor ! videoconvert ! video/x-raw,format=NV12   # RGBA input: key survives
```

The hazard was already known in this file — the border underlays pin RGBA with a comment saying an alpha-less `output_format` "would silently drop the alpha of #RRGGBBAA border colors" — but the conclusion was never applied to the compositor's own output.

## Fix

When a compositor has keyed pads and `output_format` cannot carry alpha, blend in the alpha-carrying counterpart of the requested format and convert to `output_format` after the mixer. `output_format` still pins what leaves the block; it no longer dictates the blend space. The dist compositor gets this when DSK inputs or PiP border underlays exist; the multiview always does, since its overlay is a full-canvas RGBA pad. The DSK and overlay capsfilters are dropped; the video-input capsfilters stay, since their tee feeds two independently negotiating compositors.

**Cost, for the reviewer to weigh.** Both compositor outputs gain a full-frame conversion per frame, where the compositor previously blended straight into `output_format`. That is inherent to the fix and a real cost in a block being optimised elsewhere. The blend space matches the requested chroma subsampling, so the added hop is an alpha strip, not a resample. Only flows with a keyed pad and a non-`Auto` `output_format` pay it.

**The GPU path.** `builder/pipeline_gpu.rs` is unchanged, but not because it ignores `output_format` — it pins it at `capsfilter_dist` and `capsfilter_mv`. Keyed pads survive there because `glvideomixer` is a *bin* whose internal converter absorbs the pin, so the blend stays RGBA in GL memory. Verified by reading the internal mixer's src caps with an NV12 pin downstream: still `format=(string)RGBA` on `GstGLVideoMixer:m-mixer`. The general invariant now sits as a comment there: keep a converting element between a mixer and any format pin.

## Tests

New `backend/tests/vision_mixer_keyed_alpha_test.rs` builds a real flow through `PipelineManager` (following `vision_mixer_fx_test.rs`): a white program input and a DSK graphic that is opaque red on the left half and fully transparent on the right, CPU backend. One test per branch of `alpha_blend_format`, so a format that loses its key is named by the failure rather than hidden behind the first one to break.

| `output_format` | blend space | transparent half white, fix reverted | with fix |
|---|---|---|---|
| NV12 | A420 | 0.000 | 1.000 |
| YUY2 | A422 | 0.000 | 1.000 |
| v210 | A422_10LE | 0.000 | 1.000 |
| RGB | RGBA | 0.000 | 1.000 |
| Auto | none | 1.000 | 1.000 |

Each also asserts the requested format negotiates at `capsfilter_dist` and that the multiview shows picture. Reverting the blend substitution turns all four red and leaves `Auto` green. `A422` and `A422_10LE` are on `compositor`'s src pad template (checked with `gst-inspect-1.0` against gst-plugins-base 1.28.6), and each blend-to-output pair negotiates through `videoconvert`. `UYVY` shares the `A422` branch with `YUY2`, so it is covered by code path but has no flow test of its own.

Two things the measurement has to get right, both of which produced a green test that guarded nothing until fixed. The multiview reading is gated on a buffer probe counting overlay appsrc pushes, so it cannot pass by measuring a multiview the overlay has not reached yet. And readiness is detected by colour, not brightness: an all-black startup frame is dark in exactly the way an opaque-keyed failure is dark.

Run locally on macOS (Apple silicon, GStreamer 1.28.6): the full `cargo test` suite green, plus `cargo clippy --all-targets -D warnings`. The new test has no skip path and needs only `compositor` and `videobox`, both already in the CI package list on every platform. Not run: NVIDIA/CUDA paths, and the GPU path's flow behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
