### PR TITLE
fix(whip): stop slots without a publisher holding the pipeline out of PLAYING

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Cache apt packages
         uses: awalsh128/cache-apt-pkgs-action@v1.6.1
         with:
-          packages: libunwind-dev libssl-dev libcairo2-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-bad1.0-dev gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-libav pkg-config cmake libclang-dev
+          packages: libunwind-dev libssl-dev libcairo2-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-bad1.0-dev gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-libav gstreamer1.0-nice pkg-config cmake libclang-dev
           version: 1.5
 
       # cache-apt-pkgs-action restores package files but does not run postinst,
@@ -306,7 +306,7 @@ jobs:
       - name: Install GStreamer (cached)
         uses: awalsh128/cache-apt-pkgs-action@v1.6.1
         with:
-          packages: libunwind-dev libssl-dev libcairo2-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-bad1.0-dev gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-libav pkg-config cmake libclang-dev
+          packages: libunwind-dev libssl-dev libcairo2-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-bad1.0-dev gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-libav gstreamer1.0-nice pkg-config cmake libclang-dev
           version: 1.5
 
       - name: Download frontend dist
@@ -416,7 +416,7 @@ jobs:
       - name: Install GStreamer (cached)
         uses: awalsh128/cache-apt-pkgs-action@v1.6.1
         with:
-          packages: libunwind-dev libssl-dev libcairo2-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-bad1.0-dev gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-libav pkg-config cmake libclang-dev
+          packages: libunwind-dev libssl-dev libcairo2-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-bad1.0-dev gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-libav gstreamer1.0-nice pkg-config cmake libclang-dev
           version: 1.5
 
       - name: Download frontend dist

--- a/backend/src/blocks/builtin/whip.rs
+++ b/backend/src/blocks/builtin/whip.rs
@@ -165,6 +165,24 @@ fn parse_do_retransmission(properties: &HashMap<String, PropertyValue>) -> bool 
         .unwrap_or(true)
 }
 
+/// Keep a slot with no publisher from holding the pipeline out of PLAYING.
+///
+/// A `decodebin` cannot complete READY->PAUSED until data arrives and it can
+/// typefind, and a pipeline with any child still ASYNC never completes its own
+/// transition. Two guards, for the two moments this bites:
+/// - Locked state keeps an idle slot out of the pipeline's state changes
+///   entirely: it sits in NULL and contributes nothing to the aggregated state.
+/// - `async-handling` makes the decodebin absorb its own ASYNC once unlocked,
+///   so a slot claimed by a session that then sends no media cannot pull a
+///   running pipeline back out of PLAYING.
+///
+/// Neither hides a real preroll failure: a decodebin that errors still posts
+/// its ERROR to the pipeline bus.
+fn prepare_idle_decodebin(decodebin: &gst::Element) {
+    decodebin.set_property("async-handling", true);
+    decodebin.set_locked_state(true);
+}
+
 /// Build WHIP Input per-slot output chains.
 ///
 /// At build time, per-slot chains are created in the main pipeline:
@@ -179,24 +197,6 @@ fn parse_do_retransmission(properties: &HashMap<String, PropertyValue>) -> bool 
 /// A slot's `decodebin` starts with its state locked (see
 /// `prepare_idle_decodebin`); `WhipEndpointConfig::allocate_slot` unlocks it
 /// when a session claims the slot.
-/// Keep a slot with no publisher from holding the pipeline out of PLAYING.
-///
-/// A `decodebin` cannot complete READY->PAUSED until data arrives and it can
-/// typefind, and a pipeline with any child still ASYNC never completes its own
-/// transition. Two guards, for the two moments that bites:
-/// - Locked state keeps an idle slot out of the pipeline's state changes
-///   entirely: it sits in NULL and contributes nothing to the aggregated state.
-/// - `async-handling` makes the decodebin absorb its own ASYNC once unlocked,
-///   so a slot claimed by a session that then sends no media cannot pull a
-///   running pipeline back out of PLAYING.
-///
-/// Neither hides a real preroll failure: a decodebin that errors still posts
-/// its ERROR to the pipeline bus.
-fn prepare_idle_decodebin(decodebin: &gst::Element) {
-    decodebin.set_property("async-handling", true);
-    decodebin.set_locked_state(true);
-}
-
 fn build_whipserversrc(
     instance_id: &str,
     properties: &HashMap<String, PropertyValue>,

--- a/backend/src/blocks/builtin/whip.rs
+++ b/backend/src/blocks/builtin/whip.rs
@@ -175,6 +175,28 @@ fn parse_do_retransmission(properties: &HashMap<String, PropertyValue>) -> bool 
 /// The actual whipserversrc elements are created dynamically per-session
 /// by `create_whipserversrc_for_session` when clients connect. Each session
 /// is assigned a slot and its appsink feeds the slot's appsrc.
+///
+/// A slot's `decodebin` starts with its state locked (see
+/// `prepare_idle_decodebin`); `WhipEndpointConfig::allocate_slot` unlocks it
+/// when a session claims the slot.
+/// Keep a slot with no publisher from holding the pipeline out of PLAYING.
+///
+/// A `decodebin` cannot complete READY->PAUSED until data arrives and it can
+/// typefind, and a pipeline with any child still ASYNC never completes its own
+/// transition. Two guards, for the two moments that bites:
+/// - Locked state keeps an idle slot out of the pipeline's state changes
+///   entirely: it sits in NULL and contributes nothing to the aggregated state.
+/// - `async-handling` makes the decodebin absorb its own ASYNC once unlocked,
+///   so a slot claimed by a session that then sends no media cannot pull a
+///   running pipeline back out of PLAYING.
+///
+/// Neither hides a real preroll failure: a decodebin that errors still posts
+/// its ERROR to the pipeline bus.
+fn prepare_idle_decodebin(decodebin: &gst::Element) {
+    decodebin.set_property("async-handling", true);
+    decodebin.set_locked_state(true);
+}
+
 fn build_whipserversrc(
     instance_id: &str,
     properties: &HashMap<String, PropertyValue>,
@@ -250,6 +272,9 @@ fn build_whipserversrc(
     let mut internal_links: Vec<(ElementPadRef, ElementPadRef)> = Vec::new();
     let mut slot_audio_appsrcs: Vec<gst_app::AppSrc> = Vec::new();
     let mut slot_video_appsrcs: Vec<gst_app::AppSrc> = Vec::new();
+    // Per-slot decodebins, locked until a session claims the slot. Weak refs:
+    // the pipeline owns them.
+    let mut slot_decodebins: Vec<Vec<gst::glib::WeakRef<gst::Element>>> = Vec::new();
 
     // One flag per slot, set when decodebin exposes that slot's video pad.
     // A session stops asking the publisher for keyframes once its flag flips.
@@ -257,6 +282,8 @@ fn build_whipserversrc(
         Arc::new((0..max_sessions).map(|_| AtomicBool::new(false)).collect());
 
     for slot in 0..max_sessions {
+        let mut decodebins_for_slot: Vec<gst::glib::WeakRef<gst::Element>> = Vec::new();
+
         // Audio chain for this slot
         if mode.has_audio() {
             let appsrc_id = format!("{}:appsrc_audio_{}", instance_id, slot);
@@ -292,6 +319,9 @@ fn build_whipserversrc(
                     .map_err(|e| {
                         BlockBuildError::ElementCreation(format!("decodebin_audio_{}: {}", slot, e))
                     })?;
+
+                prepare_idle_decodebin(&decodebin);
+                decodebins_for_slot.push(decodebin.downgrade());
 
                 let audioconvert = gst::ElementFactory::make("audioconvert")
                     .name(&audioconvert_id)
@@ -395,6 +425,9 @@ fn build_whipserversrc(
                         BlockBuildError::ElementCreation(format!("decodebin_video_{}: {}", slot, e))
                     })?;
 
+                prepare_idle_decodebin(&decodebin);
+                decodebins_for_slot.push(decodebin.downgrade());
+
                 let videoconvert = gst::ElementFactory::make("videoconvert")
                     .name(&videoconvert_id)
                     .build()
@@ -455,6 +488,8 @@ fn build_whipserversrc(
             elements.push((appsrc_id, appsrc.upcast()));
             elements.push((video_out_tee_id, video_out_tee));
         }
+
+        slot_decodebins.push(decodebins_for_slot);
     }
 
     let stun_server = ctx.stun_server();
@@ -490,6 +525,7 @@ fn build_whipserversrc(
             max_sessions,
             slot_audio_appsrcs,
             slot_video_appsrcs,
+            slot_decodebins,
             slot_assignments,
         },
     );

--- a/backend/src/whip_session_manager.rs
+++ b/backend/src/whip_session_manager.rs
@@ -57,6 +57,11 @@ pub struct WhipEndpointConfig {
     pub slot_audio_appsrcs: Vec<gst_app::AppSrc>,
     /// Per-slot video appsrc elements (main pipeline side, created at build time)
     pub slot_video_appsrcs: Vec<gst_app::AppSrc>,
+    /// Per-slot `decodebin` elements (main pipeline side, created at build
+    /// time), indexed by slot. Locked while the slot has no publisher so it
+    /// cannot hold the pipeline short of PLAYING; `allocate_slot` unlocks them.
+    /// Empty when the endpoint runs with `decode=false`.
+    pub slot_decodebins: Vec<Vec<gst::glib::WeakRef<gst::Element>>>,
     /// Slot assignments: slot index → Option<resource_id>
     /// Protected by RwLock for concurrent access from HTTP handlers.
     pub slot_assignments: Arc<RwLock<Vec<Option<String>>>>,
@@ -66,18 +71,61 @@ impl WhipEndpointConfig {
     /// Allocate a free slot for a new session.
     /// Returns the slot index, or None if all slots are occupied.
     pub fn allocate_slot(&self, resource_id: &str) -> Option<usize> {
-        let mut slots = self.slot_assignments.write().unwrap();
-        for (i, slot) in slots.iter_mut().enumerate() {
-            if slot.is_none() {
-                *slot = Some(resource_id.to_string());
-                info!(
-                    "WhipEndpointConfig: Allocated slot {} for session '{}'",
-                    i, resource_id
+        let allocated = {
+            let mut slots = self.slot_assignments.write().unwrap();
+            let mut allocated = None;
+            for (i, slot) in slots.iter_mut().enumerate() {
+                if slot.is_none() {
+                    *slot = Some(resource_id.to_string());
+                    info!(
+                        "WhipEndpointConfig: Allocated slot {} for session '{}'",
+                        i, resource_id
+                    );
+                    allocated = Some(i);
+                    break;
+                }
+            }
+            allocated
+        };
+
+        // A publisher is on its way, so the slot's decode chain can join the
+        // pipeline's state changes. The SDP exchange is well ahead of the first
+        // RTP packet: ICE and DTLS still have to complete before media arrives.
+        if let Some(slot) = allocated {
+            self.activate_slot_decoders(slot);
+        }
+        allocated
+    }
+
+    /// Bring a slot's `decodebin` elements into the running pipeline.
+    ///
+    /// They are built with their state locked (see `prepare_idle_decodebin` in
+    /// the WHIP block builder). Idempotent: a slot reused by a later session
+    /// re-syncs a decodebin that is already running.
+    fn activate_slot_decoders(&self, slot: usize) {
+        let Some(decodebins) = self.slot_decodebins.get(slot) else {
+            return;
+        };
+        for weak in decodebins {
+            let Some(decodebin) = weak.upgrade() else {
+                // Pipeline already torn down.
+                continue;
+            };
+            decodebin.set_locked_state(false);
+            if let Err(e) = decodebin.sync_state_with_parent() {
+                warn!(
+                    "WhipEndpointConfig: Failed to sync {} with pipeline state: {}",
+                    decodebin.name(),
+                    e
                 );
-                return Some(i);
+            } else {
+                debug!(
+                    "WhipEndpointConfig: Activated {} for slot {}",
+                    decodebin.name(),
+                    slot
+                );
             }
         }
-        None
     }
 
     /// Release a slot when a session disconnects.

--- a/backend/tests/whip_idle_slot_test.rs
+++ b/backend/tests/whip_idle_slot_test.rs
@@ -30,6 +30,10 @@ const REQUIRED: &[&str] = &[
     "h264parse",
     "appsink",
     "fakesink",
+    // Not used by the test directly: `WHIPInputBuilder::build` refuses to build
+    // without ICE, so a host missing libnice fails every test here.
+    "nicesrc",
+    "nicesink",
 ];
 
 /// Skipping on a missing element passes green and guards nothing, so CI sets

--- a/backend/tests/whip_idle_slot_test.rs
+++ b/backend/tests/whip_idle_slot_test.rs
@@ -1,0 +1,346 @@
+//! A WHIP Input block builds one decode chain per session slot at flow start,
+//! whether or not anyone is publishing to that slot. A `decodebin` cannot
+//! complete READY->PAUSED until data arrives and it can typefind, and a
+//! pipeline with any child still ASYNC never completes its own transition, so
+//! a slot with no publisher can hold the whole flow short of PLAYING.
+//!
+//! The first two tests are a pair: one asserts idle slots do not block PLAYING,
+//! the other that a slot claimed by a session still decodes. Either alone could
+//! be satisfied by a change that breaks the other.
+
+use std::collections::HashMap;
+use strom::blocks::builtin::whip::WHIPInputBuilder;
+use strom::blocks::{BlockBuildContext, BlockBuilder};
+use strom_types::element::ElementPadRef;
+use strom_types::PropertyValue;
+
+use gstreamer as gst;
+use gstreamer::prelude::*;
+
+/// Elements these tests need beyond core GStreamer. Missing on a bare CI image.
+const REQUIRED: &[&str] = &[
+    "appsrc",
+    "decodebin",
+    "videoconvert",
+    "audioconvert",
+    "audioresample",
+    "tee",
+    "videotestsrc",
+    "x264enc",
+    "h264parse",
+    "appsink",
+    "fakesink",
+];
+
+/// Skipping on a missing element passes green and guards nothing, so CI sets
+/// `STROM_REQUIRE_GST_PLUGINS=1` to turn a skip into a failure.
+fn plugins_available() -> bool {
+    let missing: Vec<&str> = REQUIRED
+        .iter()
+        .copied()
+        .filter(|e| gst::ElementFactory::find(e).is_none())
+        .collect();
+    if missing.is_empty() {
+        return true;
+    }
+    assert!(
+        strom_types::env::var_opt("STROM_REQUIRE_GST_PLUGINS").is_none(),
+        "STROM_REQUIRE_GST_PLUGINS is set but these elements are missing: {}",
+        missing.join(", ")
+    );
+    false
+}
+
+/// Resolve one side of a block's declared internal link to a pad.
+fn resolve_pad(
+    by_id: &HashMap<String, gst::Element>,
+    reference: &ElementPadRef,
+    request: bool,
+) -> gst::Pad {
+    let element = by_id.get(&reference.element_id).unwrap_or_else(|| {
+        panic!(
+            "block declares a link to unknown element {}",
+            reference.element_id
+        )
+    });
+    let pad_name = reference.pad_name.as_deref().unwrap_or("src");
+    element
+        .static_pad(pad_name)
+        .or_else(|| {
+            if request {
+                element.request_pad_simple(pad_name)
+            } else {
+                None
+            }
+        })
+        .unwrap_or_else(|| panic!("{} has no pad {}", reference.element_id, pad_name))
+}
+
+/// Build `inputs` WHIP Input blocks through the real block builder and wire up
+/// the internal links they declare, exactly as the pipeline manager does.
+///
+/// Returns the pipeline, the elements by ID, and the build contexts (which own
+/// the endpoint configs the session manager later takes).
+fn build_whip_inputs(
+    inputs: usize,
+) -> (
+    gst::Pipeline,
+    HashMap<String, gst::Element>,
+    Vec<BlockBuildContext>,
+) {
+    let pipeline = gst::Pipeline::new();
+    let mut by_id: HashMap<String, gst::Element> = HashMap::new();
+    let mut contexts = Vec::new();
+
+    for input in 0..inputs {
+        let instance_id = format!("whip_p{}", input + 1);
+
+        let mut props: HashMap<String, PropertyValue> = HashMap::new();
+        props.insert(
+            "endpoint_id".to_string(),
+            PropertyValue::String(format!("p{}", input + 1)),
+        );
+        props.insert(
+            "mode".to_string(),
+            PropertyValue::String("audio_video".to_string()),
+        );
+        props.insert("max_sessions".to_string(), PropertyValue::Int(1));
+        props.insert("decode".to_string(), PropertyValue::Bool(true));
+
+        let ctx = BlockBuildContext::new(vec![], "all".to_string());
+        let built = WHIPInputBuilder
+            .build(&instance_id, &props, &ctx)
+            .expect("WHIP Input block builds");
+
+        for (id, element) in &built.elements {
+            pipeline.add(element).expect("add block element");
+            by_id.insert(id.clone(), element.clone());
+        }
+        for (from, to) in &built.internal_links {
+            let src = resolve_pad(&by_id, from, true);
+            let sink = resolve_pad(&by_id, to, true);
+            src.link(&sink)
+                .unwrap_or_else(|e| panic!("link {:?} -> {:?}: {:?}", from, to, e));
+        }
+        contexts.push(ctx);
+    }
+
+    (pipeline, by_id, contexts)
+}
+
+/// Wait for the pipeline to settle and report the state it settled in.
+fn wait_for_playing(pipeline: &gst::Pipeline, secs: u64) -> (gst::StateChangeSuccess, gst::State) {
+    let (result, current, _pending) = pipeline.state(gst::ClockTime::from_seconds(secs));
+    let success = result.unwrap_or_else(|e| panic!("pipeline state change failed: {:?}", e));
+    (success, current)
+}
+
+/// Decodebins still short of PLAYING, so a failure names the culprits.
+fn stuck_decodebins(by_id: &HashMap<String, gst::Element>) -> Vec<String> {
+    by_id
+        .iter()
+        .filter(|(id, _)| id.contains("decodebin"))
+        .filter_map(|(id, element)| {
+            let (_, current, pending) = element.state(gst::ClockTime::ZERO);
+            (current != gst::State::Playing)
+                .then(|| format!("{} (current {:?}, pending {:?})", id, current, pending))
+        })
+        .collect()
+}
+
+/// Five WHIP inputs, nobody publishing: the pipeline must still reach PLAYING.
+///
+/// The flow shape this guards is a production with several remote presenters,
+/// where the mixer and the recorders must run before all of them connect.
+#[test]
+fn idle_whip_slots_do_not_block_playing() {
+    gst::init().expect("gstreamer init");
+    if !plugins_available() {
+        eprintln!("skipping: required GStreamer elements missing");
+        return;
+    }
+
+    let (pipeline, by_id, _contexts) = build_whip_inputs(5);
+
+    pipeline
+        .set_state(gst::State::Playing)
+        .expect("pipeline accepts PLAYING");
+
+    let (success, current) = wait_for_playing(&pipeline, 10);
+    let stuck = stuck_decodebins(&by_id);
+    pipeline
+        .set_state(gst::State::Null)
+        .expect("pipeline to NULL");
+
+    assert_eq!(
+        (success, current),
+        (gst::StateChangeSuccess::Success, gst::State::Playing),
+        "five idle WHIP slots held the pipeline out of PLAYING; still short of it: {:?}",
+        stuck
+    );
+}
+
+/// A slot claimed by a session must actually decode.
+///
+/// Counterpart to the test above: keeping every `decodebin` out of the pipeline
+/// for good would satisfy that one and break WHIP input entirely.
+#[test]
+fn allocated_slot_decodes_incoming_media() {
+    gst::init().expect("gstreamer init");
+    if !plugins_available() {
+        eprintln!("skipping: required GStreamer elements missing");
+        return;
+    }
+
+    let (pipeline, by_id, contexts) = build_whip_inputs(2);
+
+    // Tap the first input's video output tee, where decoded frames come out.
+    let tee = by_id
+        .get("whip_p1:video_out_tee_0")
+        .expect("the first WHIP input has a video output tee");
+    let sink = gst::ElementFactory::make("fakesink")
+        .name("probe_sink")
+        .property("sync", false)
+        // Not `async`: an unprerolled sink would hold the pipeline ASYNC by
+        // itself and mask what this test is measuring.
+        .property("async", false)
+        .property("signal-handoffs", true)
+        .build()
+        .expect("fakesink");
+    let frames = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let frames_for_handoff = frames.clone();
+    sink.connect("handoff", false, move |_| {
+        frames_for_handoff.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        None
+    });
+    pipeline.add(&sink).expect("add probe sink");
+    tee.link(&sink).expect("link tee -> probe sink");
+
+    pipeline
+        .set_state(gst::State::Playing)
+        .expect("pipeline accepts PLAYING");
+    let (success, current) = wait_for_playing(&pipeline, 10);
+    assert_eq!(
+        (success, current),
+        (gst::StateChangeSuccess::Success, gst::State::Playing),
+        "pipeline did not reach PLAYING with idle slots; still short of it: {:?}",
+        stuck_decodebins(&by_id)
+    );
+
+    // A publisher arrives: the session manager claims a slot on the endpoint
+    // config the block registered, which is what brings the slot's decode
+    // chain into the running pipeline.
+    let configs = contexts[0].take_whip_endpoint_configs();
+    let (_, config) = configs
+        .into_iter()
+        .next()
+        .expect("the first WHIP input registered an endpoint config");
+    let slot = config.allocate_slot("test-session").expect("a free slot");
+    assert_eq!(slot, 0);
+
+    // Feed it real H.264, the way a session's appsink bridge does.
+    let feeder = gst::parse::launch(
+        "videotestsrc is-live=true ! video/x-raw,width=320,height=240,framerate=30/1 \
+         ! x264enc tune=zerolatency key-int-max=15 ! h264parse \
+         ! appsink name=out emit-signals=true sync=false",
+    )
+    .expect("feeder pipeline");
+    let appsink = feeder
+        .downcast_ref::<gst::Bin>()
+        .unwrap()
+        .by_name("out")
+        .unwrap()
+        .downcast::<gstreamer_app::AppSink>()
+        .unwrap();
+    let slot_appsrc = config.slot_video_appsrcs[slot].clone();
+    appsink.set_callbacks(
+        gstreamer_app::AppSinkCallbacks::builder()
+            .new_sample(move |sink| {
+                let sample = sink.pull_sample().map_err(|_| gst::FlowError::Eos)?;
+                let _ = slot_appsrc.push_sample(&sample);
+                Ok(gst::FlowSuccess::Ok)
+            })
+            .build(),
+    );
+    feeder.set_state(gst::State::Playing).expect("feeder plays");
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(20);
+    while std::time::Instant::now() < deadline
+        && frames.load(std::sync::atomic::Ordering::Relaxed) == 0
+    {
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+    let decoded = frames.load(std::sync::atomic::Ordering::Relaxed);
+    let (_, still_playing, _) = pipeline.state(gst::ClockTime::ZERO);
+
+    feeder.set_state(gst::State::Null).expect("feeder to NULL");
+    pipeline
+        .set_state(gst::State::Null)
+        .expect("pipeline to NULL");
+
+    assert!(
+        decoded > 0,
+        "the slot claimed by the session decoded nothing; decodebins: {:?}",
+        stuck_decodebins(&by_id)
+    );
+    assert_eq!(
+        still_playing,
+        gst::State::Playing,
+        "pipeline left PLAYING after a session claimed a slot"
+    );
+}
+
+/// A session that claims a slot and then sends nothing must not stall a
+/// pipeline that is already running.
+///
+/// Unlocking a slot's `decodebin` hands it back to the pipeline's state
+/// management, and it goes ASYNC again the moment it is asked for PAUSED with
+/// nothing to typefind. `async-handling` is what keeps an abandoned WHIP
+/// negotiation, or a publisher whose video never negotiates, from pulling a
+/// live pipeline back out of PLAYING.
+#[test]
+fn allocated_slot_without_media_does_not_stall_a_running_pipeline() {
+    gst::init().expect("gstreamer init");
+    if !plugins_available() {
+        eprintln!("skipping: required GStreamer elements missing");
+        return;
+    }
+
+    let (pipeline, by_id, contexts) = build_whip_inputs(2);
+
+    pipeline
+        .set_state(gst::State::Playing)
+        .expect("pipeline accepts PLAYING");
+    let (success, current) = wait_for_playing(&pipeline, 10);
+    assert_eq!(
+        (success, current),
+        (gst::StateChangeSuccess::Success, gst::State::Playing),
+        "pipeline did not reach PLAYING with idle slots; still short of it: {:?}",
+        stuck_decodebins(&by_id)
+    );
+
+    let configs = contexts[0].take_whip_endpoint_configs();
+    let (_, config) = configs
+        .into_iter()
+        .next()
+        .expect("the first WHIP input registered an endpoint config");
+    config.allocate_slot("test-session").expect("a free slot");
+
+    // No media follows. Give the decodebins time to go ASYNC and, if the guard
+    // is missing, to take the pipeline down with them.
+    std::thread::sleep(std::time::Duration::from_secs(2));
+    let (result, current, pending) = pipeline.state(gst::ClockTime::ZERO);
+
+    pipeline
+        .set_state(gst::State::Null)
+        .expect("pipeline to NULL");
+
+    assert_eq!(
+        (result.expect("pipeline state readable"), current),
+        (gst::StateChangeSuccess::Success, gst::State::Playing),
+        "a slot claimed but never fed pulled the pipeline out of PLAYING \
+         (pending {:?}); decodebins: {:?}",
+        pending,
+        stuck_decodebins(&by_id)
+    );
+}


### PR DESCRIPTION
## The stall

A WHIP Input block builds one decode chain per session slot at flow start — `appsrc -> decodebin -> convert -> tee` — whether or not anyone is publishing to that slot. A `decodebin` cannot complete READY->PAUSED until data arrives and it can typefind, and a pipeline with any child still ASYNC never completes its own transition.

A single slot with no publisher therefore held the whole flow one state short of PLAYING. In a production with five remote presenter inputs and one publisher connected, the mixer never composited, the recorders never left READY, and the input that *was* publishing decoded into a pipeline that was not running. Under `GST_DEBUG=GST_STATES:5` all ten decodebins (5 inputs x video+audio) sat at `current READY pending PAUSED, desired next PLAYING`.

## The fix

Each slot's `decodebin` gets two guards. Locked state keeps an idle slot out of the pipeline's state changes entirely: it sits in NULL, holds no resources, and contributes nothing to the aggregated state. `async-handling=true` makes it absorb its own ASYNC once unlocked, so a slot claimed by a session that then sends no media — an abandoned negotiation, a publisher whose video never negotiates — cannot pull a running pipeline back out of PLAYING.

`WhipEndpointConfig::allocate_slot` unlocks a slot's decodebins when a session claims it, during the SDP exchange and well ahead of the first RTP packet. Unlocking is idempotent, so a slot reused by a later session re-syncs a decodebin that is already running.

Neither guard hides a real preroll failure: a `decodebin` that errors still posts its ERROR to the pipeline bus.

## Verification

Headless backend, five WHIP inputs, one publisher on `p1`:

| | before | after |
|---|---|---|
| `gst_state` from `GET /api/flows/{id}` | `Paused`, indefinitely | `Playing` |
| recording | 0 bytes | grew 10.8 MB -> 14.8 MB while watched |

`GST_STATES:5` on the fixed run shows exactly two decodebins unlocking, at the moment slot 0 is allocated; the other eight stay locked in NULL.

## Tests

`backend/tests/whip_idle_slot_test.rs` builds real WHIP Input blocks through `WHIPInputBuilder` and wires up the internal links they declare, rather than reconstructing the topology by hand:

- `idle_whip_slots_do_not_block_playing` — five inputs, nobody publishing, pipeline must reach PLAYING.
- `allocated_slot_decodes_incoming_media` — a slot claimed through `allocate_slot`, then fed real H.264, must produce decoded frames at that input's output tee. Without it, locking every decodebin for good would satisfy the first test and break WHIP input entirely.
- `allocated_slot_without_media_does_not_stall_a_running_pipeline` — covers the `async-handling` guard.

Removing both guards fails all three; removing only `async-handling` fails the two allocation tests.

The tests honour `STROM_REQUIRE_GST_PLUGINS`, so a missing element fails rather than skips. `WHIPInputBuilder::build` gates on `require_ice_elements`, and the Linux jobs had no package for it: `05b1456` adds `gstreamer1.0-nice` to all three, and `nicesrc`/`nicesink` are declared in the test's `REQUIRED` list so the dependency stops being silent if that package ever drops out again.

Ran locally on macOS: the three new tests at the current head, under `STROM_REQUIRE_GST_PLUGINS=1`. `pipeline_lifecycle_test`, `jitterbuffer_mute_test`, `failed_start_teardown_test`, `pipeline_start_failure_test` and `openapi_test` were run on the fix commit; the two commits since touch only a doc comment and the test's element list.

## Not fixed here: recorders with no data

The same flow has a second, independent cause of the same symptom, fixed separately in #750. With the WHIP slots fixed, a flow with a recorder per input still reports `Paused`: the `splitmuxsink` of every recorder whose input is not publishing sits at READY with no data to preroll, and sinks hold the pipeline by design. `async-handling=true` on `splitmuxsink` lets media flow (the fed recorder grew to 5.8 MB) but leaves the pipeline reporting `Paused`, so the recorder needs the same locked-until-data treatment rather than a one-line property.

The verification above therefore used a flow with a recorder on the publishing input only. Against a flow with a recorder on every input, this branch alone still shows `Paused`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
