### PR TITLE
docs(agent): require linked refs and one line per item in the onward message

### DIFF
--- a/scripts/agent/README.md
+++ b/scripts/agent/README.md
@@ -71,6 +71,14 @@ useful if the runtime changes and safe to read in public.
   same commit.
 - **`SUMMARY.md` puts JSON before prose** so the human table cannot disagree with the record,
   and so a run's state survives without re-reading a long comment thread.
+- **Reference form is destination-dependent, and that asymmetry is deliberate.** `#738` is
+  right in the summary comment, which is posted in this repository and autolinks it. It is
+  wrong in the onward message, where nothing autolinks and a reader has to search for every
+  item by hand. Do not unify the two on the shorter form to remove the special case; the
+  special case is the whole point. `SUMMARY.md` also carried a blanket "never a remote URL"
+  rule that made bare refs the only option — it now bans the URLs that actually matter
+  (credentials, endpoints, anything outside this repository) and requires the ones that do
+  not.
 
 ## Changing the protocol
 

--- a/scripts/agent/SUMMARY.md
+++ b/scripts/agent/SUMMARY.md
@@ -105,8 +105,8 @@ Under the JSON, at most **1200 characters**, in this order and nothing else:
     ## Done
     | # | Verdict | Radius | Conf | CI |
     |---|---|---|---|---|
-    | [#721](url) | Comment | GLOBAL | HIGH | linux green, mac/win skipped |
-    | [#725](url) | Approve | SHARED | HIGH | green, new tests ran |
+    | #721 | Comment | GLOBAL | HIGH | linux green, mac/win skipped |
+    | #725 | Approve | SHARED | HIGH | green, new tests ran |
 
     Skipped: #726 #723 #700 (drafts), #698 #696 (dep bumps).
     Left by cap: #700.
@@ -125,6 +125,38 @@ Finish by rewriting the `state:begin`/`state:end` block in the issue body.
 ## Reporting onward
 
 If the task definition gives you somewhere else to report, render that message from
-`needs_human` and the item lists — never from a second pass over the run. Keep it to five
-lines. Never put a credential, a remote URL or a raw log excerpt in it. If the run did
+`needs_human` and the item lists — never from a second pass over the run. If the run did
 nothing, say that in one line rather than staying silent.
+
+**Every reference is a full URL, and every item is its own line.** A bare `#721` autolinks
+only inside this repository's own issues and pull requests. Everywhere else it is four
+characters a reader has to go look up by hand, so a message that names six items costs six
+searches. Write `<https://github.com/Eyevinn/strom/issues/721|#721>` for a destination that
+takes that link form, `https://github.com/Eyevinn/strom/issues/721` where it does not, and
+`#721` only in the rendered half above, which is posted here. The `/issues/` path serves pull
+requests too, so one form covers both and you never have to know which an item is.
+
+One line per item, numbered under each heading. Do not merge two items into a sentence,
+and do not write the message as prose — a paragraph naming four pull requests and their
+verdicts is the shape this section exists to prevent.
+
+    *Agent triage* — 2026-08-31T08:00Z, main@1c06c37, 4 items
+
+    *Needs you*
+    1. <https://github.com/Eyevinn/strom/issues/721|#721> — platform builds never compiled the new FFI path
+       `gh workflow run ci.yml --ref wagenet/685-hdrext -f platforms=both`
+    2. <https://github.com/Eyevinn/strom/issues/700|#700> — draft, needs `/agent-fix` to reach class A
+
+    *Reviewed*
+    1. <https://github.com/Eyevinn/strom/issues/721|#721> — Comment, GLOBAL, HIGH
+    2. <https://github.com/Eyevinn/strom/issues/725|#725> — Approve, SHARED, HIGH
+
+    Skipped 5, left by cap 1. Queue: 6 candidates, 1 claimed, 8 awaiting reply, 1 untriaged.
+
+Cap the item lines at twelve. Past that, keep every `needs_human` line and collapse the rest
+into the trailing count — the onward message is a prompt to act, and the full record is in
+the summary comment.
+
+Links into this repository are required, not merely allowed. What must never appear: a
+credential or token, a service endpoint or instance hostname, a log excerpt, or a link to
+anything outside this repository.


### PR DESCRIPTION
## Description

The onward message — the one the agents render for a destination outside GitHub — came out as prose naming several items by bare number. Both halves of that are hard to act on: `#721` autolinks only inside this repository, so anywhere else each reference is four characters someone has to go look up by hand, and a message naming six items costs six searches.

**The old rule caused it.** `SUMMARY.md` § *Reporting onward* said:

> Keep it to five lines. Never put a credential, a remote URL or a raw log excerpt in it.

That banned the very links that make the message useful, leaving bare refs as the only option — and a five-line ceiling with no worked example pushed items together into sentences to fit.

## What changes

- **Every reference is a full URL.** Both link forms are given, since the destination is deployment configuration and this file deliberately does not know which one it is. The `/issues/` path resolves pull requests too, so one form covers both and a run never has to determine which an item is.
- **Every item is its own numbered line**, under a heading. Explicitly: do not merge two items into a sentence, and do not write the message as prose.
- **The URL ban now names what actually must not appear** — credentials, service endpoints or instance hostnames, log excerpts, links outside this repository. Links *into* this repository are required rather than merely allowed.
- **The ceiling becomes twelve item lines** instead of five total, with every `needs_human` line kept whole and the rest collapsed into the trailing count. The onward message is a prompt to act; the full record is in the summary comment.
- **A worked example**, because `README.md` is right that a rule describing a shape drifts and an example does not. The absence of one here is most of why this drifted.

Also dropped the `[#721](url)` placeholder from the rendered-half table. That half is posted in this repository, where `#721` autolinks on its own, and leaving a fake URL there contradicted the new rule about where each form belongs.

## Why the asymmetry is recorded in README.md

`#721` is correct in the summary comment and wrong in the onward message. That is a special case, and a future cleanup would be tempted to unify both on the shorter form. `README.md`'s design notes now say why not — the special case is the point.

## What is deliberately not here

The destination is not named. `README.md` states that nothing about where the agents report belongs in this directory — that is deployment configuration, and keeping it out is what makes these files safe to read in public and durable if the runtime changes. The rule is written against the *capability* (a destination that takes `<url|text>`, or one that does not) rather than the product.

Happy to name it explicitly instead if you would rather the file be blunt about it — it is a one-line change either way.

## Related Issue

None — reported directly.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Tests

`scripts/agent/test-agent-scripts.sh` — **40 passed, 0 failed**, unchanged before and after. This commit touches no script, so no test needed adding; the ceilings `verify-citations.sh` enforces come in via `--max-chars` and are not affected.

No mechanical check enforces the new format. `README.md` argues that mechanical checks are what actually stop model drift, so that is a fair thing to want here — a "no bare `#\d+` in the onward message" check would be cheap. I left it out because the onward message is never written to a file that the verifier sees, so wiring it up is a plumbing change rather than a rule change, and `README.md`'s own prescription for a drifted shape is a worked example. Say the word and I will add the check and its test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
