### PR TITLE
fix(whip): evaluate the inactivity watchdog per poll tick, not per timeout

### DIFF
--- a/backend/src/blocks/builtin/whip.rs
+++ b/backend/src/blocks/builtin/whip.rs
@@ -528,6 +528,41 @@ fn wait_until_deadline_or_stop(stop: &AtomicBool, deadline: Instant) -> bool {
     }
 }
 
+/// Block until the session has been idle for `timeout`, or until `stop` is set.
+///
+/// Returns `Some(idle_ms)` once the idle time crosses `timeout`, or `None` if a
+/// teardown path set `stop` first.
+///
+/// `last_buffer_ms` is the arrival time of the most recent buffer on any stream,
+/// as milliseconds since `epoch`; 0 means no buffer has arrived yet, in which case
+/// the session is still negotiating and the clock has not started.
+///
+/// Idle is re-evaluated on every `WATCHDOG_POLL` tick. The poll must stay finer than
+/// `timeout`: evaluating once per `timeout` puts detection anywhere between one and
+/// two full timeouts, since a drop landing just after a check goes unnoticed until
+/// the next one.
+fn wait_for_inactivity(
+    stop: &AtomicBool,
+    last_buffer_ms: &AtomicU64,
+    epoch: Instant,
+    timeout: std::time::Duration,
+) -> Option<u64> {
+    let timeout_ms = timeout.as_millis() as u64;
+    loop {
+        if wait_until_deadline_or_stop(stop, Instant::now() + WATCHDOG_POLL) {
+            return None;
+        }
+        let last = last_buffer_ms.load(Ordering::Relaxed);
+        if last == 0 {
+            continue;
+        }
+        let idle_ms = (epoch.elapsed().as_millis() as u64).saturating_sub(last);
+        if idle_ms >= timeout_ms {
+            return Some(idle_ms);
+        }
+    }
+}
+
 /// Create a new whipserversrc element for a single WHIP client session.
 ///
 /// Each session runs in its own isolated GStreamer pipeline to avoid
@@ -764,34 +799,25 @@ pub fn create_whipserversrc_for_session(
         std::thread::Builder::new()
             .name(format!("whip-watchdog-{}", port))
             .spawn(move || {
-                loop {
-                    let deadline = Instant::now() + INACTIVITY_TIMEOUT;
-                    if wait_until_deadline_or_stop(&cleanup_sent_watchdog, deadline) {
-                        // Another path (ICE callback, DELETE, flow stop) finished
-                        // with this session.
-                        break;
-                    }
-                    let last = last_buffer_ms_watchdog.load(Ordering::Relaxed);
-                    if last == 0 {
-                        // No buffer received yet — keep waiting (session might still be negotiating)
-                        continue;
-                    }
-                    let elapsed_ms = last_buffer_epoch.elapsed().as_millis() as u64;
-                    let idle_ms = elapsed_ms.saturating_sub(last);
-                    if idle_ms >= INACTIVITY_TIMEOUT.as_millis() as u64 {
-                        if !cleanup_sent_watchdog.swap(true, Ordering::SeqCst) {
-                            info!(
-                                "WHIP Input: Inactivity timeout ({}s idle) on port {}, triggering cleanup",
-                                idle_ms / 1000,
-                                port
-                            );
-                            let _ = cleanup_tx_watchdog.send(SessionCleanupRequest {
-                                port,
-                                reason: format!("inactivity ({}s idle)", idle_ms / 1000),
-                            });
-                        }
-                        break;
-                    }
+                // Returns None when another path (ICE callback, DELETE, flow stop)
+                // finished with this session first.
+                let Some(idle_ms) = wait_for_inactivity(
+                    &cleanup_sent_watchdog,
+                    &last_buffer_ms_watchdog,
+                    last_buffer_epoch,
+                    INACTIVITY_TIMEOUT,
+                ) else {
+                    return;
+                };
+                if !cleanup_sent_watchdog.swap(true, Ordering::SeqCst) {
+                    info!(
+                        "WHIP Input: Inactivity timeout ({}ms idle) on port {}, triggering cleanup",
+                        idle_ms, port
+                    );
+                    let _ = cleanup_tx_watchdog.send(SessionCleanupRequest {
+                        port,
+                        reason: format!("inactivity ({}ms idle)", idle_ms),
+                    });
                 }
             })
             .ok();
@@ -1870,6 +1896,78 @@ mod tests {
         assert!(
             Instant::now() >= deadline,
             "wait returned before its deadline"
+        );
+    }
+
+    /// A dead session must be detected one poll interval after the inactivity
+    /// threshold, not one whole extra timeout later.
+    ///
+    /// The last buffer here lands 150 ms after the epoch, so the threshold is crossed
+    /// at ~1150 ms — just *after* a once-per-timeout check at 1000 ms would have run,
+    /// and far enough past it that scheduler slop cannot blur the two. Evaluating once
+    /// per `timeout` instead of once per poll fails this test: it detects at ~2000 ms,
+    /// where polling detects at ~1250 ms.
+    #[test]
+    fn watchdog_detects_inactivity_within_one_poll_of_the_timeout() {
+        let timeout = std::time::Duration::from_millis(1000);
+        let stop = Arc::new(AtomicBool::new(false));
+        let epoch = Instant::now();
+        let last_buffer_ms = Arc::new(AtomicU64::new(150));
+
+        let started = Instant::now();
+        let idle_ms = wait_for_inactivity(&stop, &last_buffer_ms, epoch, timeout)
+            .expect("watchdog must report inactivity, not a stop");
+        let detection = started.elapsed();
+
+        // Slack over the expected 1250 ms covers scheduler jitter but stays well
+        // clear of the 2000 ms the once-per-timeout evaluation would take.
+        assert!(
+            detection < std::time::Duration::from_millis(1600),
+            "inactivity took {:?} to detect with a {:?} timeout — idle is being \
+             evaluated once per timeout, not once per poll",
+            detection,
+            timeout
+        );
+        assert!(
+            idle_ms < 2 * timeout.as_millis() as u64,
+            "reported idle time was {} ms for a {:?} timeout — the check is too coarse",
+            idle_ms,
+            timeout
+        );
+    }
+
+    /// The inactivity wait must abandon a session the moment a teardown path claims
+    /// it, even though the session never went idle.
+    #[test]
+    fn watchdog_inactivity_wait_gives_up_when_stopped() {
+        let stop = Arc::new(AtomicBool::new(false));
+        let epoch = Instant::now();
+        // Still negotiating: no buffer has arrived, so the idle clock never starts
+        // and only the stop flag can end the wait.
+        let last_buffer_ms = Arc::new(AtomicU64::new(0));
+
+        let setter = stop.clone();
+        std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(50));
+            setter.store(true, Ordering::SeqCst);
+        });
+
+        let started = Instant::now();
+        let result = wait_for_inactivity(
+            &stop,
+            &last_buffer_ms,
+            epoch,
+            std::time::Duration::from_secs(30),
+        );
+
+        assert!(
+            result.is_none(),
+            "a stopped wait must not report inactivity"
+        );
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(5),
+            "wait took {:?} — it is not polling the stop flag",
+            started.elapsed()
         );
     }
 


### PR DESCRIPTION
## The bug

`backend/src/blocks/builtin/whip.rs` — the WHIP inactivity watchdog slept a full
`INACTIVITY_TIMEOUT` (10s) and then evaluated idle time exactly once:

```rust
let deadline = Instant::now() + INACTIVITY_TIMEOUT;   // fresh 10s every iteration
if wait_until_deadline_or_stop(&cleanup_sent_watchdog, deadline) { break; }
```

A drop landing just after a check went unnoticed until the next one, so real detection
was 10-20s depending on where the drop fell in the cycle. A production
`Inactivity timeout (17s idle)` is only possible because of that coarseness — with
continuous evaluation the reported idle can never exceed the threshold by more than one
poll interval.

## Why it matters

This watchdog is the only time-driven path that reclaims a WHIP session, and a publisher
that dies without sending a WHIP DELETE — network loss, the common case — reaches no
other one: an abruptly killed peer leaves `webrtcbin` at `completed` until consent
freshness expires. Until it fires, the session's isolated pipeline (the libnice #52
workaround) holds its UDP sockets, threads and jitterbuffers; the slot stays occupied, so
a rejoining client gets `503 All session slots are occupied` (`max_sessions` is 1 per
endpoint); and the API keeps reporting a publisher that is gone.

## Relationship to the slot-takeover work

A separate change lets a new session displace a slot whose transport is already dead
(`whip_ingest.rs` `allocate_slot`). It covers the rejoin case and makes the 503 window
moot, but it is demand-driven and never runs when nobody reconnects — which is where this
watchdog stays the only reclamation path.

Takeover must decide a session is dead and then evict it, and a wrong predicate evicts a
*healthy* publisher during a transient stall, precisely what the 10s threshold exists to
prevent. That change can misfire; this one cannot, since it only makes an already-correct
teardown happen on schedule. That argues for landing this first.

## The fix

Extract the loop into `wait_for_inactivity`, which re-evaluates idle on every
`WATCHDOG_POLL` (250ms) tick — a constant that already existed in this file and was used
only to re-check the stop flag inside the wait.

`INACTIVITY_TIMEOUT` is deliberately unchanged at 10s: it guards against tearing down a
session during a brief network stall. The bug was that 10s silently meant up to 20s.

The log line now reports idle in milliseconds rather than truncated seconds. Nothing
parses that string.

## Measured

A headless `whipclientsink` publisher, `SIGKILL`ed to simulate network loss — a clean
`SIGINT` sends the WHIP DELETE and frees the slot instantly, which is not the case under
test. Media flow was confirmed by the `Pad video_0 ... → appsink → slot 0 appsrc` link
line, not by ICE state. Dwell is seconds of streaming before the kill, sweeping the drop
across a full watchdog cycle; the figure is the idle time the watchdog itself reports.

| dwell | before | after |
|---|---|---|
| 0s | 19198ms | 10076ms |
| 2s | 17165ms | 10058ms |
| 4s | 15176ms | 10206ms |
| 6s | 13145ms | 10219ms |
| 8s | 11187ms | 10222ms |
| 10s | 19188ms | 10229ms |

Before is a sawtooth from 19.2s down to 11.2s, wrapping — the production 17s sits on it.
After is flat at 10.06-10.23s, every sample within one `WATCHDOG_POLL` of the threshold.
Eight consecutive kill/rejoin cycles gave 10006-10197ms with zero 503s, each
re-allocating slot 0.

## Tests

`watchdog_detects_inactivity_within_one_poll_of_the_timeout` calls the real
`wait_for_inactivity` with the production `WATCHDOG_POLL`. It is a guard, not a
demonstration — reverting the one-line change and re-running gives:

```
inactivity took 2.015019458s to detect with a 1s timeout — idle is being
evaluated once per timeout, not once per poll
```

`watchdog_inactivity_wait_gives_up_when_stopped` covers the other exit: a teardown path
setting `cleanup_sent` must end the wait even though the session never went idle,
otherwise the watchdog outlives its session and asks the manager to clean up a port it no
longer knows.

Both are plain `std` timing with no GStreamer element, so they run in CI under
`cargo test --package strom`.

**Ran:** `cargo test --package strom` (543 lib + all integration tests, passing),
`cargo fmt --all`, `cargo clippy --all-targets`, plus the measurements above on macOS.
**Not run:** the Linux CI matrix.

## Scope

Watchdog only — no change to `allocate_slot` or the session manager, so this stays
independently reviewable from the takeover work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
