### PR TITLE
fix(whip): detect a dropped ingest sooner and retry with backoff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,6 +221,30 @@ jobs:
           base: openapi-base.json
           revision: openapi-current.json
 
+  # The static pages under backend/static are served to browsers and never touched
+  # by cargo, so nothing else in this workflow would notice a break in them.
+  static-js:
+    name: Static JS Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+
+      # A parse gate over every served script. It is all the coverage three of
+      # them have - they are DOM-driven end to end and cannot be loaded outside a
+      # browser - so it catches a syntax error, nothing more.
+      - name: Syntax check
+        run: find backend/static -name '*.js' -not -path '*/tests/*' -print0 | xargs -0 -n1 node --check
+
+      # Expanded by the shell, not by node: a bare directory is read as a module
+      # path, and node's own glob handling is version-dependent.
+      - name: Unit tests
+        run: node --test backend/static/tests/*.test.js
+
   # Linux x86_64 build
   build-linux-x86_64:
     name: Build (Linux x86_64)

--- a/backend/static/tests/whip_reconnect.test.js
+++ b/backend/static/tests/whip_reconnect.test.js
@@ -1,0 +1,122 @@
+// Unit tests for the WHIP ingest reconnect backoff.
+//
+// whip.js is a classic browser script; the `typeof module` guard at its foot is
+// what makes it require()able here. The assertions read the production constants
+// instead of restating them, so a wider MAX_RECONNECT_ATTEMPTS or an edited
+// RECONNECT_DELAYS stays covered without touching this file.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const {
+    ICE_DISCONNECT_GRACE_MS,
+    RECONNECT_DELAYS,
+    MAX_RECONNECT_ATTEMPTS,
+    whipReconnectDelay,
+} = require('../whip/whip.js');
+
+// backend/src/blocks/builtin/whip.rs INACTIVITY_TIMEOUT. Mirrored by hand, since
+// a JS test cannot read a Rust const: keep it in step with the Rust one.
+const SERVER_INACTIVITY_TIMEOUT_MS = 10000;
+
+test('every attempt within the retry budget has a delay', () => {
+    for (let attempt = 1; attempt <= MAX_RECONNECT_ATTEMPTS; attempt++) {
+        const delay = whipReconnectDelay(attempt);
+        assert.equal(
+            typeof delay, 'number',
+            `attempt ${attempt} produced ${delay} instead of a number`,
+        );
+        assert.ok(Number.isFinite(delay) && delay > 0, `attempt ${attempt} -> ${delay}`);
+    }
+});
+
+test('attempts past the end of the list clamp to the last delay', () => {
+    const last = RECONNECT_DELAYS[RECONNECT_DELAYS.length - 1];
+    for (const attempt of [RECONNECT_DELAYS.length, RECONNECT_DELAYS.length + 1, 100]) {
+        assert.equal(whipReconnectDelay(attempt), last, `attempt ${attempt}`);
+    }
+});
+
+test('the delays are the schedule the page advertises', () => {
+    const schedule = [];
+    for (let attempt = 1; attempt <= RECONNECT_DELAYS.length; attempt++) {
+        schedule.push(whipReconnectDelay(attempt));
+    }
+    assert.deepEqual(schedule, RECONNECT_DELAYS);
+});
+
+test('the backoff grows', () => {
+    // Strictly, not merely non-decreasing: a flat schedule satisfies every other
+    // assertion here while retrying at a fixed interval forever.
+    for (let attempt = 2; attempt <= MAX_RECONNECT_ATTEMPTS; attempt++) {
+        assert.ok(
+            whipReconnectDelay(attempt) >= whipReconnectDelay(attempt - 1),
+            `attempt ${attempt} is shorter than attempt ${attempt - 1}`,
+        );
+    }
+    assert.ok(
+        whipReconnectDelay(MAX_RECONNECT_ATTEMPTS) > whipReconnectDelay(1),
+        'the schedule is flat - it does not back off',
+    );
+});
+
+test('the first retry beats the server freeing the slot', () => {
+    // An abrupt drop stops media, and the server frees the ingest slot
+    // SERVER_INACTIVITY_TIMEOUT_MS later. The page spends ICE_DISCONNECT_GRACE_MS
+    // deciding the transport is dead and then waits for the first retry, so those
+    // two together have to fit inside the server's window - otherwise the POST
+    // always arrives after the slot is gone and the page can never get it back.
+    const firstPost = ICE_DISCONNECT_GRACE_MS + whipReconnectDelay(1);
+    assert.ok(
+        firstPost < SERVER_INACTIVITY_TIMEOUT_MS,
+        `first reconnect POST lands at ${firstPost}ms, at or past the server's ` +
+        `${SERVER_INACTIVITY_TIMEOUT_MS}ms slot timeout`,
+    );
+});
+
+test('the retry budget covers a long outage', () => {
+    // Currently 331s across 15 attempts. The bound is loose on purpose: backing
+    // off early must not shorten the total recovery window.
+    let total = 0;
+    for (let attempt = 1; attempt <= MAX_RECONNECT_ATTEMPTS; attempt++) {
+        total += whipReconnectDelay(attempt);
+    }
+    assert.ok(total >= 300000, `retries span only ${total / 1000}s`);
+});
+
+test('the browser path still works', () => {
+    // ingest.html pulls whip.js in with a plain <script src>, where `module` does
+    // not exist. Run it the same way: the export guard at the foot has to stay
+    // inert and the reconnect globals have to land in the page's scope. Separate
+    // runInContext calls share one global lexical scope, as classic scripts on a
+    // page do, so this is also how the inline script reaches these names.
+    const src = fs.readFileSync(path.join(__dirname, '..', 'whip', 'whip.js'), 'utf8');
+    const context = vm.createContext({ console });
+    vm.runInContext(src, context);
+
+    assert.equal(vm.runInContext('typeof module', context), 'undefined');
+    assert.equal(vm.runInContext('typeof whipReconnectDelay', context), 'function');
+    // Compared as JSON: the vm context has its own Array, and a cross-realm array
+    // never passes a strict deep-equal.
+    assert.equal(
+        vm.runInContext('JSON.stringify(RECONNECT_DELAYS)', context),
+        JSON.stringify(RECONNECT_DELAYS),
+    );
+    assert.equal(vm.runInContext('MAX_RECONNECT_ATTEMPTS', context), MAX_RECONNECT_ATTEMPTS);
+});
+
+test('ingest.html does not redeclare the shared reconnect globals', () => {
+    // whip.js and the inline script share one global lexical scope, so a second
+    // top-level declaration of either name is a parse error that takes the whole
+    // page down rather than just the reconnect path.
+    const html = fs.readFileSync(path.join(__dirname, '..', 'whip', 'ingest.html'), 'utf8');
+    for (const name of ['RECONNECT_DELAYS', 'MAX_RECONNECT_ATTEMPTS']) {
+        assert.ok(
+            !new RegExp(`(?:const|let|var)\\s+${name}\\b`).test(html),
+            `${name} is declared in ingest.html as well as whip.js`,
+        );
+    }
+});

--- a/backend/static/whip/ingest.html
+++ b/backend/static/whip/ingest.html
@@ -113,13 +113,8 @@
         let reconnectAttempt = 0;
         let reconnectTimer = null;
         let activeEndpoint = null;
-        const MAX_RECONNECT_ATTEMPTS = 15;
-        // Backoff between reconnect attempts, in ms; attempts past the list use the
-        // last value. The first retry is deliberately early: the server decides an
-        // abruptly dropped publisher is gone a couple of seconds after its media
-        // stops, and holds an arriving POST while it decides, so an early retry is
-        // answered rather than refused.
-        const RECONNECT_DELAYS = [1000, 2000, 4000, 8000, 16000, 30000];
+        // MAX_RECONNECT_ATTEMPTS, RECONNECT_DELAYS and whipReconnectDelay() are
+        // globals from whip.js, which is loaded above.
 
         // Elements
         const endpointSelect = document.getElementById('endpointSelect');
@@ -290,7 +285,7 @@
                 return;
             }
             reconnectAttempt++;
-            const delay = RECONNECT_DELAYS[Math.min(reconnectAttempt, RECONNECT_DELAYS.length) - 1];
+            const delay = whipReconnectDelay(reconnectAttempt);
             log('Reconnecting in ' + (delay / 1000) + 's (attempt ' + reconnectAttempt + '/' + MAX_RECONNECT_ATTEMPTS + ')... Reason: ' + reason, 'warning');
             setStatus('status', 'Reconnecting in ' + (delay / 1000) + 's (attempt ' + reconnectAttempt + ')...', 'connecting');
             reconnectTimer = setTimeout(() => {
@@ -573,7 +568,7 @@
                 onIceState: () => {},
             });
 
-            log('WHIP ingest client v11');
+            log('WHIP ingest client v12');
             whipClient.connect(stream);
         }
 

--- a/backend/static/whip/ingest.html
+++ b/backend/static/whip/ingest.html
@@ -114,7 +114,12 @@
         let reconnectTimer = null;
         let activeEndpoint = null;
         const MAX_RECONNECT_ATTEMPTS = 15;
-        const RECONNECT_DELAY = 10000;
+        // Backoff between reconnect attempts, in ms; attempts past the list use the
+        // last value. The first retry is deliberately early: the server decides an
+        // abruptly dropped publisher is gone a couple of seconds after its media
+        // stops, and holds an arriving POST while it decides, so an early retry is
+        // answered rather than refused.
+        const RECONNECT_DELAYS = [1000, 2000, 4000, 8000, 16000, 30000];
 
         // Elements
         const endpointSelect = document.getElementById('endpointSelect');
@@ -285,12 +290,13 @@
                 return;
             }
             reconnectAttempt++;
-            log('Reconnecting in ' + (RECONNECT_DELAY / 1000) + 's (attempt ' + reconnectAttempt + '/' + MAX_RECONNECT_ATTEMPTS + ')... Reason: ' + reason, 'warning');
-            setStatus('status', 'Reconnecting in ' + (RECONNECT_DELAY / 1000) + 's (attempt ' + reconnectAttempt + ')...', 'connecting');
+            const delay = RECONNECT_DELAYS[Math.min(reconnectAttempt, RECONNECT_DELAYS.length) - 1];
+            log('Reconnecting in ' + (delay / 1000) + 's (attempt ' + reconnectAttempt + '/' + MAX_RECONNECT_ATTEMPTS + ')... Reason: ' + reason, 'warning');
+            setStatus('status', 'Reconnecting in ' + (delay / 1000) + 's (attempt ' + reconnectAttempt + ')...', 'connecting');
             reconnectTimer = setTimeout(() => {
                 reconnectTimer = null;
                 if (wantConnected) doReconnect();
-            }, RECONNECT_DELAY);
+            }, delay);
         }
 
         function cancelReconnect() {
@@ -567,7 +573,7 @@
                 onIceState: () => {},
             });
 
-            log('WHIP ingest client v10');
+            log('WHIP ingest client v11');
             whipClient.connect(stream);
         }
 

--- a/backend/static/whip/whip.js
+++ b/backend/static/whip/whip.js
@@ -1,5 +1,12 @@
 // WHIP Client - WebRTC-HTTP Ingestion Protocol client for browser-based sending.
 
+// How long ICE 'disconnected' is given to recover before the session is treated
+// as dead. It fires on a couple of missed consent checks and often recovers, so
+// tearing down at once costs a needless renegotiation; waiting too long is worse,
+// because the publisher keeps encoding into a dead transport and the server cannot
+// free the slot for the reconnect until this expires.
+const ICE_DISCONNECT_GRACE_MS = 4000;
+
 // Global debug mode flag - toggle via UI or setWhipDebugMode(true/false)
 let whipDebugMode = false;
 
@@ -224,8 +231,8 @@ class WhipClient {
                     }
                 } else if (state === 'disconnected') {
                     // ICE 'disconnected' is transient — it can recover to 'connected'.
-                    // Wait 10s before treating it as a real disconnect.
-                    this._logAlways('ICE disconnected (waiting 10s for recovery...)', 'warning');
+                    this._logAlways('ICE disconnected (waiting ' + (ICE_DISCONNECT_GRACE_MS / 1000) +
+                        's for recovery...)', 'warning');
                     if (!this._disconnectTimer) {
                         this._disconnectTimer = setTimeout(() => {
                             this._disconnectTimer = null;
@@ -237,7 +244,7 @@ class WhipClient {
                                     this.callbacks.onDisconnected();
                                 }
                             }
-                        }, 10000);
+                        }, ICE_DISCONNECT_GRACE_MS);
                     }
                 }
             };

--- a/backend/static/whip/whip.js
+++ b/backend/static/whip/whip.js
@@ -7,6 +7,20 @@
 // free the slot for the reconnect until this expires.
 const ICE_DISCONNECT_GRACE_MS = 4000;
 
+// Reconnect backoff for the ingest page, in ms. Attempts past the end of the list
+// reuse the last delay. The first retry is deliberately early: the server decides
+// an abruptly dropped publisher is gone a couple of seconds after its media stops,
+// and holds an arriving POST while it decides, so an early retry is answered
+// rather than refused.
+const RECONNECT_DELAYS = [1000, 2000, 4000, 8000, 16000, 30000];
+const MAX_RECONNECT_ATTEMPTS = 15;
+
+// Delay before reconnect attempt `attempt`, which is 1-based: the first retry is
+// attempt 1. Lives here rather than in the page so CI can exercise it.
+function whipReconnectDelay(attempt) {
+    return RECONNECT_DELAYS[Math.min(attempt, RECONNECT_DELAYS.length) - 1];
+}
+
 // Global debug mode flag - toggle via UI or setWhipDebugMode(true/false)
 let whipDebugMode = false;
 
@@ -600,4 +614,16 @@ class WhipClient {
             return null;
         }
     }
+}
+
+// The browser loads this file as a classic script, where `module` is undefined and
+// this block is skipped. Node's test runner require()s it, which supplies `module`
+// and hands the pure logic to the unit tests in ../tests/.
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = {
+        ICE_DISCONNECT_GRACE_MS,
+        RECONNECT_DELAYS,
+        MAX_RECONNECT_ATTEMPTS,
+        whipReconnectDelay,
+    };
 }


### PR DESCRIPTION
## Problem

The WHIP ingest page is slow to come back after its transport dies. Two timers stack up: ICE `disconnected` gets 10 s to recover (`whip.js`), then every retry waits a flat 10 s (`ingest.html`). On top of that Chrome takes ~6 s to notice at all, so the first reconnect attempt lands ~26 s after the drop.

The server frees the seat long before that. The inactivity watchdog reclaims it at 10 s, and #753 will hand it over as soon as ~2 s. Neither helps while the page is not asking.

## What this does

`ICE_DISCONNECT_GRACE_MS = 4000` — `disconnected` is genuinely transient and often recovers, so it still gets a grace period, just a shorter one. Tearing down early costs a needless renegotiation; waiting costs the publisher, who keeps encoding into a dead transport meanwhile.

`RECONNECT_DELAYS = [1000, 2000, 4000, 8000, 16000, 30000]` replaces the flat 10 s, last value repeating. Better on both axes: first attempt at 1 s instead of 10 s, and 15 attempts now cover 331 s instead of 150 s.

`RECONNECT_DELAYS`, `MAX_RECONNECT_ATTEMPTS` and the delay lookup live in `whip.js` rather than inline in `ingest.html`, so CI can reach them. The page picks them up as globals from the script tag it already had.

The first retry is early on purpose. With #753 the server holds an arriving POST for up to 3 s while it decides whether the sitting session is dead, so a retry that lands before the seat is free is answered rather than refused. Without #753 it collects a 503 and the next attempt is 2 s later.

## Verification

Playwright drives the real page in Chromium with a fake camera and mic, waits for media to reach the server (`Pad video_0`), then issues a WHIP DELETE for the session **from outside the browser**. The page is not told — from its point of view the server has vanished, which is what network loss looks like. Same rig, same drop, before and after:

| | v10 (before) | v11 (after) |
| --- | --- | --- |
| Chrome reports ICE `disconnected` | +6.2 s | +6.3 s |
| first re-POST reaches the server | +26.4 s | **+11.6 s** |
| media flowing again | +27.4 s | **+12.1 s** |

Backoff sequence and grace value read out of the page source and stepped through all 15 attempts: `1, 2, 4, 8, 16, 30 × 10`, no `undefined` at the boundary. Both files pass `node --check` (the inline script extracted from the HTML).

Server was built from `main` — no #753 — so this measures the client timing on its own.

The table was measured against client v11. v12 moves the constants into `whip.js` without changing a value, which the unit tests below assert.

## What this does not fix

**Chrome's ~6 s detection is now the floor**, and a page cannot shorten it. That keeps the first re-POST at ~11.6 s, still past the 10 s watchdog, so #753's takeover window remains out of reach for this page even after this change. Getting under it means detecting the drop ourselves — polling `getStats()` for outbound RTP with no returning RTCP — rather than waiting for the browser's ICE state. Worth doing, not here.

**`whep/player.html` still has the flat 10 s reconnect** and is deliberately untouched. It is a subscriber, not a publisher, so it is not racing the ingest watchdog and the fix is not the same one. Separate change.

## Risk

An ICE blip that would have recovered between 4 s and 10 s now causes a full renegotiation instead: new POST, new session, new keyframe wait, a second or two of black. The measurements above put Chrome's own detection at ~6 s, so a blip has to be quite specifically timed to land in that band.

## Tests

New `Static JS Tests` job in `.github/workflows/ci.yml`, **green on this head**. Runs on `pull_request` and `push` to main, no dependency on the Rust jobs.

`ingest.html` loads `whip.js` with a plain `<script src>`, so `whip.js` cannot take ESM exports, and the delay computation is unreachable from node while it sits inline in the HTML. Move the constants and the lookup into `whip.js` and give that file a `typeof module !== 'undefined'` export guard: inert in the browser, enough for node's CJS loader to `require()` the same source the page runs. No `package.json`, no bundler — `node:test` and `node:assert` are built in.

Eight tests, green locally and in CI:

| Test | Asserts |
| --- | --- |
| every attempt within the retry budget has a delay | attempts 1..`MAX_RECONNECT_ATTEMPTS` yield a finite positive number, never `undefined` |
| attempts past the end of the list clamp to the last delay | `len`, `len+1` and 100 all give 30 s |
| the delays are the schedule the page advertises | computed sequence equals `RECONNECT_DELAYS` |
| the backoff grows | monotonic, last delay strictly greater than first |
| the first retry beats the server freeing the slot | `ICE_DISCONNECT_GRACE_MS + delay(1)` < the server's 10 s `INACTIVITY_TIMEOUT` |
| the retry budget covers a long outage | total span >= 300 s |
| the browser path still works | `whip.js` through `node:vm` with no `module`: the guard stays inert, the globals still land in the page's scope |
| ingest.html does not redeclare the shared reconnect globals | a duplicate top-level `const` is a page-wide parse error, since classic scripts share one global lexical scope |

The assertions read the production constants rather than restating them, so a wider `MAX_RECONNECT_ATTEMPTS` or an edited `RECONNECT_DELAYS` stays covered without editing the test.

**Revert check.** With the flat 10 s put back (`RECONNECT_DELAYS = [10000]`, `ICE_DISCONNECT_GRACE_MS = 10000`), 3 of 8 fail:

```
the schedule is flat - it does not back off
first reconnect POST lands at 20000ms, at or past the server's 10000ms slot timeout
retries span only 150s
```

Injecting a duplicate `const RECONNECT_DELAYS` into `ingest.html` fires the redeclaration guard. Both reverts undone.

**Scope.** The unit tests cover `whip/whip.js` only. `webrtc/webrtc.js`, `webrtc/devices.js` and `whep/whep.js` get a `node --check` parse gate and nothing more — they are DOM-driven end to end, so loading them outside a browser means restructuring files this PR does not touch. `backend/static/tests/` sits outside every `#[folder]` in `assets.rs`, so nothing new is embedded in the binary.

**Not run:** `cargo test`, and the openapi snapshot — no Rust or API surface changed. `cargo clippy` and `cargo fmt` passed via the pre-commit hook. The Playwright rig was not re-run against v12; the constants changed file, not value, which the tests assert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
