### PR TITLE
fix(whip): judge a session by the media it produces, not what arrives

### DIFF
--- a/backend/src/api/whip_ingest.rs
+++ b/backend/src/api/whip_ingest.rs
@@ -7,7 +7,7 @@
 use crate::api::sdp_transform::{
     add_goog_remb, fix_video_bitrate_hints, strip_cvo_extension, strip_redundancy_codecs,
 };
-use crate::blocks::builtin::whip::create_whipserversrc_for_session;
+use crate::blocks::builtin::whip::{create_whipserversrc_for_session, CreatedSession};
 use crate::json_rejection::JsonBody;
 use crate::state::AppState;
 use crate::whip_session_manager::{NewWhipSession, WhipSessionManager};
@@ -132,11 +132,15 @@ pub async fn whip_post(
     // Allocate a slot for this session (pre-allocate with a temporary resource_id,
     // will be updated when we learn the real resource_id from the Location header)
     let temp_resource_id = uuid::Uuid::new_v4().to_string();
-    let slot = match config.allocate_slot(&temp_resource_id) {
+    let slot = match state
+        .whip_session_manager()
+        .allocate_slot_or_take_over(&config, &temp_resource_id)
+        .await
+    {
         Some(s) => s,
         None => {
             warn!(
-                "WHIP endpoint '{}': all {} slots occupied, rejecting client",
+                "WHIP endpoint '{}': all {} slots occupied by live sessions, rejecting client",
                 endpoint_id, config.max_sessions
             );
             return (
@@ -155,7 +159,12 @@ pub async fn whip_post(
     let cleanup_tx = state.whip_session_manager().cleanup_sender();
     let cleanup_sent = Arc::new(AtomicBool::new(false));
     let cleanup_sent_for_session = cleanup_sent.clone();
-    let (element, session_pipeline, port) = match tokio::task::spawn_blocking(move || {
+    let CreatedSession {
+        element,
+        session_pipeline,
+        port,
+        activity,
+    } = match tokio::task::spawn_blocking(move || {
         create_whipserversrc_for_session(
             &config_for_session,
             slot,
@@ -369,6 +378,7 @@ pub async fn whip_post(
                         endpoint_id: endpoint_id.clone(),
                         slot,
                         cleanup_sent,
+                        activity,
                     });
                 if !registered {
                     warn!(

--- a/backend/src/blocks/builtin/whip.rs
+++ b/backend/src/blocks/builtin/whip.rs
@@ -1030,13 +1030,15 @@ pub fn create_whipserversrc_for_session(
                 let main_pipeline_for_ts = main_pipeline_weak.clone();
                 let media_for_log = media_type.to_string();
                 let activity_cb = activity_for_pads.clone();
+                // Resolved here, not per buffer: the pad's media type is fixed.
+                let pad_is_audio = media_type == "audio";
 
                 appsink.set_callbacks(
                     gst_app::AppSinkCallbacks::builder()
                         .new_sample(move |sink| {
                             // Mark the session live: read by its inactivity
                             // watchdog and by slot takeover
-                            activity_cb.touch();
+                            activity_cb.touch(pad_is_audio);
 
                             let sample = sink.pull_sample().map_err(|_| gst::FlowError::Eos)?;
                             let buffer = sample.buffer().ok_or(gst::FlowError::Error)?;

--- a/backend/src/blocks/builtin/whip.rs
+++ b/backend/src/blocks/builtin/whip.rs
@@ -16,7 +16,7 @@ use crate::blocks::{
 };
 use crate::gst::ice_preflight;
 use crate::gst::keyframe_request;
-use crate::whip_session_manager::{SessionCleanupRequest, WhipEndpointConfig};
+use crate::whip_session_manager::{SessionActivity, SessionCleanupRequest, WhipEndpointConfig};
 use gstreamer as gst;
 use gstreamer::prelude::*;
 use gstreamer_app as gst_app;
@@ -599,6 +599,17 @@ fn wait_for_inactivity(
     }
 }
 
+/// A whipserversrc session that has been created and is playing, handed back to
+/// the HTTP handler so it can register the session with the manager.
+pub struct CreatedSession {
+    pub element: gst::Element,
+    pub session_pipeline: gst::Pipeline,
+    /// Internal port the session's whipserversrc is listening on.
+    pub port: u16,
+    /// Liveness handle, shared with the appsink callbacks that feed the slot.
+    pub activity: Arc<SessionActivity>,
+}
+
 /// Create a new whipserversrc element for a single WHIP client session.
 ///
 /// Each session runs in its own isolated GStreamer pipeline to avoid
@@ -608,7 +619,6 @@ fn wait_for_inactivity(
 /// Media is bridged to the main pipeline via appsink→appsrc, where the
 /// appsrc targets are the pre-built slot elements.
 ///
-/// Returns (element, session_pipeline, port) on success.
 /// `cleanup_sent` is owned by the caller so it can be handed to the session
 /// manager alongside the session: every teardown path sets it, which both
 /// suppresses duplicate cleanup requests and stops this session's inactivity
@@ -618,7 +628,7 @@ pub fn create_whipserversrc_for_session(
     slot: usize,
     cleanup_tx: tokio::sync::mpsc::UnboundedSender<SessionCleanupRequest>,
     cleanup_sent: Arc<AtomicBool>,
-) -> Result<(gst::Element, gst::Pipeline, u16), String> {
+) -> Result<CreatedSession, String> {
     // Allocate a free port
     let listener =
         TcpListener::bind("127.0.0.1:0").map_err(|e| format!("Failed to find free port: {}", e))?;
@@ -828,6 +838,13 @@ pub fn create_whipserversrc_for_session(
     // that (recycled) port pending cleanup for nothing.
     let last_buffer_epoch = Instant::now();
     let last_buffer_ms = Arc::new(AtomicU64::new(0));
+    // Same two values, in the shape the session manager reads them: it has to be
+    // able to tell a slot with a live publisher behind it from one whose
+    // publisher went away without a WHIP DELETE.
+    let activity = Arc::new(SessionActivity::new(
+        last_buffer_epoch,
+        last_buffer_ms.clone(),
+    ));
     {
         let last_buffer_ms_watchdog = last_buffer_ms.clone();
         let cleanup_sent_watchdog = cleanup_sent.clone();
@@ -867,6 +884,7 @@ pub fn create_whipserversrc_for_session(
         let stream_counter = Arc::new(AtomicUsize::new(0));
         let audio_connected = Arc::new(AtomicBool::new(false));
         let video_connected = Arc::new(AtomicBool::new(false));
+        let activity_for_pads = activity.clone();
 
         whipserversrc.connect_pad_added(move |_src, pad| {
             let pad_name = pad.name();
@@ -1011,17 +1029,14 @@ pub fn create_whipserversrc_for_session(
                 let ts_offset = shared_ts_offset.clone();
                 let main_pipeline_for_ts = main_pipeline_weak.clone();
                 let media_for_log = media_type.to_string();
-                let last_buffer_ms_cb = last_buffer_ms.clone();
-                let last_buffer_epoch_cb = last_buffer_epoch;
+                let activity_cb = activity_for_pads.clone();
 
                 appsink.set_callbacks(
                     gst_app::AppSinkCallbacks::builder()
                         .new_sample(move |sink| {
-                            // Update inactivity watchdog
-                            last_buffer_ms_cb.store(
-                                last_buffer_epoch_cb.elapsed().as_millis() as u64,
-                                Ordering::Relaxed,
-                            );
+                            // Mark the session live: read by its inactivity
+                            // watchdog and by slot takeover
+                            activity_cb.touch();
 
                             let sample = sink.pull_sample().map_err(|_| gst::FlowError::Eos)?;
                             let buffer = sample.buffer().ok_or(gst::FlowError::Error)?;
@@ -1116,7 +1131,12 @@ pub fn create_whipserversrc_for_session(
         slot
     );
 
-    Ok((whipserversrc, session_pipeline, port))
+    Ok(CreatedSession {
+        element: whipserversrc,
+        session_pipeline,
+        port,
+        activity,
+    })
 }
 
 // ============================================================================

--- a/backend/src/blocks/builtin/whip.rs
+++ b/backend/src/blocks/builtin/whip.rs
@@ -16,14 +16,16 @@ use crate::blocks::{
 };
 use crate::gst::ice_preflight;
 use crate::gst::keyframe_request;
-use crate::whip_session_manager::{SessionActivity, SessionCleanupRequest, WhipEndpointConfig};
+use crate::whip_session_manager::{
+    ActivityStamp, SessionActivity, SessionCleanupRequest, WhipEndpointConfig,
+};
 use gstreamer as gst;
 use gstreamer::prelude::*;
 use gstreamer_app as gst_app;
 use gstreamer_video as gst_video;
 use std::collections::HashMap;
 use std::net::TcpListener;
-use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI64, AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::Instant;
 use strom_types::block::StreamMode;
@@ -183,6 +185,44 @@ fn prepare_idle_decodebin(decodebin: &gst::Element) {
     decodebin.set_locked_state(true);
 }
 
+/// Stamp a slot's output activity for every buffer that reaches its tee.
+///
+/// The tee's sink pad is the far end of the slot's chain: with `decode=true`
+/// everything upstream of it — `decodebin`, the converter — has already run, and
+/// everything downstream is a flow consumer. A buffer here is media the flow can
+/// actually use, which is the thing the session's appsink cannot see. The appsink
+/// sits in the isolated session pipeline, upstream of all of this, so it stamps
+/// bytes arriving over the network and nothing more.
+///
+/// It is also where a stall shows up: a blocked consumer backs pressure up
+/// through the tee, and the probe simply stops firing while RTP keeps arriving.
+///
+/// BUFFER probes fire per buffer, so the callback is one clock read (`Instant`
+/// takes the vDSO fast path) and a couple of relaxed atomic ops — no lock, no
+/// allocation, no formatting. See `ActivityStamp::touch`.
+fn stamp_slot_output(tee: &gst::Element, stamp: Arc<ActivityStamp>, slot: usize, media: &str) {
+    let Some(sink_pad) = tee.static_pad("sink") else {
+        // Unreachable: a tee has a static sink pad. If it ever were not, nothing
+        // would stamp this slot and every session on it would be reaped once its
+        // decode grace ran out — recoverable, unlike a panic in a block build,
+        // and this line is what makes it diagnosable.
+        warn!(
+            "WHIP Input: slot {} {} output tee has no sink pad, cannot track its liveness",
+            slot, media
+        );
+        return;
+    };
+    sink_pad.add_probe(
+        // BUFFER_LIST as well: nothing on this chain batches today, but an
+        // element that started to would silently stop the stamp otherwise.
+        gst::PadProbeType::BUFFER | gst::PadProbeType::BUFFER_LIST,
+        move |_pad, _info| {
+            stamp.touch();
+            gst::PadProbeReturn::Ok
+        },
+    );
+}
+
 /// Build WHIP Input per-slot output chains.
 ///
 /// At build time, per-slot chains are created in the main pipeline:
@@ -281,7 +321,16 @@ fn build_whipserversrc(
     let video_decoding: Arc<Vec<AtomicBool>> =
         Arc::new((0..max_sessions).map(|_| AtomicBool::new(false)).collect());
 
-    for slot in 0..max_sessions {
+    // One stamp per slot, written by a probe on that slot's output tees below.
+    // This is where a session's media becomes usable to the flow, so this is
+    // where its liveness is measured; see `SessionActivity`. All slots share an
+    // epoch — the stamps are only ever compared against their own readings.
+    let output_epoch = Instant::now();
+    let slot_output: Vec<Arc<ActivityStamp>> = (0..max_sessions)
+        .map(|_| Arc::new(ActivityStamp::new(output_epoch)))
+        .collect();
+
+    for (slot, output_stamp) in slot_output.iter().enumerate() {
         let mut decodebins_for_slot: Vec<gst::glib::WeakRef<gst::Element>> = Vec::new();
 
         // Audio chain for this slot
@@ -385,6 +434,8 @@ fn build_whipserversrc(
                 ));
             }
 
+            stamp_slot_output(&audio_out_tee, output_stamp.clone(), slot, "audio");
+
             slot_audio_appsrcs.push(appsrc.clone());
             elements.push((appsrc_id, appsrc.upcast()));
             elements.push((audio_out_tee_id, audio_out_tee));
@@ -484,6 +535,8 @@ fn build_whipserversrc(
                 ));
             }
 
+            stamp_slot_output(&video_out_tee, output_stamp.clone(), slot, "video");
+
             slot_video_appsrcs.push(appsrc.clone());
             elements.push((appsrc_id, appsrc.upcast()));
             elements.push((video_out_tee_id, video_out_tee));
@@ -526,6 +579,7 @@ fn build_whipserversrc(
             slot_audio_appsrcs,
             slot_video_appsrcs,
             slot_decodebins,
+            slot_output,
             slot_assignments,
         },
     );
@@ -538,7 +592,8 @@ fn build_whipserversrc(
     })
 }
 
-/// How long a session may go without a buffer before the watchdog tears it down.
+/// How long a session may go without producing usable media before the watchdog
+/// tears it down; see `SessionActivity::idle`.
 const INACTIVITY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
 /// How often the watchdog re-checks its stop flag while waiting.
@@ -564,14 +619,17 @@ fn wait_until_deadline_or_stop(stop: &AtomicBool, deadline: Instant) -> bool {
     }
 }
 
-/// Block until the session has been idle for `timeout`, or until `stop` is set.
+/// Block until the session has gone `timeout` without producing usable media, or
+/// until `stop` is set.
 ///
 /// Returns `Some(idle_ms)` once the idle time crosses `timeout`, or `None` if a
 /// teardown path set `stop` first.
 ///
-/// `last_buffer_ms` is the arrival time of the most recent buffer on any stream,
-/// as milliseconds since `epoch`; 0 means no buffer has arrived yet, in which case
-/// the session is still negotiating and the clock has not started.
+/// Idle comes from `SessionActivity::idle`, so this reaps both a publisher that
+/// went away and a seat that keeps receiving RTP while nothing comes out of its
+/// slot's chain. `None` from it means the session must not be judged yet — still
+/// negotiating, or inside the grace a decoder gets before its first frame — and
+/// the clock has not started.
 ///
 /// Idle is re-evaluated on every `WATCHDOG_POLL` tick. The poll must stay finer than
 /// `timeout`: evaluating once per `timeout` puts detection anywhere between one and
@@ -579,22 +637,18 @@ fn wait_until_deadline_or_stop(stop: &AtomicBool, deadline: Instant) -> bool {
 /// the next one.
 fn wait_for_inactivity(
     stop: &AtomicBool,
-    last_buffer_ms: &AtomicU64,
-    epoch: Instant,
+    activity: &SessionActivity,
     timeout: std::time::Duration,
 ) -> Option<u64> {
-    let timeout_ms = timeout.as_millis() as u64;
     loop {
         if wait_until_deadline_or_stop(stop, Instant::now() + WATCHDOG_POLL) {
             return None;
         }
-        let last = last_buffer_ms.load(Ordering::Relaxed);
-        if last == 0 {
+        let Some(idle) = activity.idle() else {
             continue;
-        }
-        let idle_ms = (epoch.elapsed().as_millis() as u64).saturating_sub(last);
-        if idle_ms >= timeout_ms {
-            return Some(idle_ms);
+        };
+        if idle >= timeout {
+            return Some(idle.as_millis() as u64);
         }
     }
 }
@@ -826,27 +880,38 @@ pub fn create_whipserversrc_for_session(
     // i64::MIN means "not yet computed".
     let shared_ts_offset = Arc::new(AtomicI64::new(i64::MIN));
 
-    // Inactivity watchdog: tracks when the last buffer arrived on any stream.
-    // A background thread checks this and triggers cleanup if no data arrives
-    // for INACTIVITY_TIMEOUT (covers the case where ICE disconnect
-    // notification doesn't fire from the isolated session pipeline).
+    // Liveness for this session, in the shape the session manager reads it: it
+    // has to tell a slot that still has a publisher producing media behind it
+    // from one whose publisher went away without a WHIP DELETE, or whose media
+    // arrives but never comes out of the slot's chain.
+    let slot_output = match config.slot_output.get(slot) {
+        Some(stamp) => stamp.clone(),
+        None => {
+            // Unreachable: one stamp is built per slot. The orphan below is
+            // never written, so this session would be reaped once its decode
+            // grace ran out; this line is what makes that diagnosable.
+            warn!(
+                "WHIP Input: no output stamp for slot {}, its liveness cannot be tracked",
+                slot
+            );
+            Arc::new(ActivityStamp::new(Instant::now()))
+        }
+    };
+    let activity = Arc::new(SessionActivity::new(Instant::now(), slot_output));
+
+    // Inactivity watchdog. A background thread triggers cleanup once the session
+    // has gone INACTIVITY_TIMEOUT without producing usable media — which covers
+    // both a transport that went away without the ICE disconnect notification
+    // reaching this isolated session pipeline, and a seat that keeps receiving
+    // RTP while nothing decodes out the other end. Neither is worth a slot.
     //
     // The wait is sliced rather than one long sleep so that `cleanup_sent` — set by
     // the ICE callback and by every teardown path in the session manager — ends the
     // thread promptly. A watchdog that outlived its session would send a cleanup
     // request for a port the manager no longer knows, and the manager would then mark
     // that (recycled) port pending cleanup for nothing.
-    let last_buffer_epoch = Instant::now();
-    let last_buffer_ms = Arc::new(AtomicU64::new(0));
-    // Same two values, in the shape the session manager reads them: it has to be
-    // able to tell a slot with a live publisher behind it from one whose
-    // publisher went away without a WHIP DELETE.
-    let activity = Arc::new(SessionActivity::new(
-        last_buffer_epoch,
-        last_buffer_ms.clone(),
-    ));
     {
-        let last_buffer_ms_watchdog = last_buffer_ms.clone();
+        let activity_watchdog = activity.clone();
         let cleanup_sent_watchdog = cleanup_sent.clone();
         let cleanup_tx_watchdog = cleanup_tx.clone();
         std::thread::Builder::new()
@@ -856,20 +921,19 @@ pub fn create_whipserversrc_for_session(
                 // finished with this session first.
                 let Some(idle_ms) = wait_for_inactivity(
                     &cleanup_sent_watchdog,
-                    &last_buffer_ms_watchdog,
-                    last_buffer_epoch,
+                    &activity_watchdog,
                     INACTIVITY_TIMEOUT,
                 ) else {
                     return;
                 };
                 if !cleanup_sent_watchdog.swap(true, Ordering::SeqCst) {
                     info!(
-                        "WHIP Input: Inactivity timeout ({}ms idle) on port {}, triggering cleanup",
+                        "WHIP Input: Inactivity timeout ({}ms without usable media) on port {}, triggering cleanup",
                         idle_ms, port
                     );
                     let _ = cleanup_tx_watchdog.send(SessionCleanupRequest {
                         port,
-                        reason: format!("inactivity ({}ms idle)", idle_ms),
+                        reason: format!("inactivity ({}ms without usable media)", idle_ms),
                     });
                 }
             })
@@ -1036,9 +1100,10 @@ pub fn create_whipserversrc_for_session(
                 appsink.set_callbacks(
                     gst_app::AppSinkCallbacks::builder()
                         .new_sample(move |sink| {
-                            // Mark the session live: read by its inactivity
-                            // watchdog and by slot takeover
-                            activity_cb.touch(pad_is_audio);
+                            // Media arriving from the publisher. Half of this
+                            // session's liveness; the other half is stamped on
+                            // the slot's output tee in the main pipeline.
+                            activity_cb.touch_ingress(pad_is_audio);
 
                             let sample = sink.pull_sample().map_err(|_| gst::FlowError::Eos)?;
                             let buffer = sample.buffer().ok_or(gst::FlowError::Error)?;
@@ -1960,8 +2025,8 @@ mod tests {
     /// A dead session must be detected one poll interval after the inactivity
     /// threshold, not one whole extra timeout later.
     ///
-    /// The last buffer here lands 150 ms after the epoch, so the threshold is crossed
-    /// at ~1150 ms — just *after* a once-per-timeout check at 1000 ms would have run,
+    /// The session's only buffer lands 150 ms in, so the threshold is crossed at
+    /// ~1150 ms — just *after* a once-per-timeout check at 1000 ms would have run,
     /// and far enough past it that scheduler slop cannot blur the two. Evaluating once
     /// per `timeout` instead of once per poll fails this test: it detects at ~2000 ms,
     /// where polling detects at ~1250 ms.
@@ -1969,11 +2034,19 @@ mod tests {
     fn watchdog_detects_inactivity_within_one_poll_of_the_timeout() {
         let timeout = std::time::Duration::from_millis(1000);
         let stop = Arc::new(AtomicBool::new(false));
-        let epoch = Instant::now();
-        let last_buffer_ms = Arc::new(AtomicU64::new(150));
+        let output = Arc::new(ActivityStamp::new(Instant::now()));
+        let activity = Arc::new(SessionActivity::new(Instant::now(), output.clone()));
+
+        // One buffer that both arrives and comes out of the slot, then nothing.
+        let publisher = activity.clone();
+        std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(150));
+            publisher.touch_ingress(true);
+            output.touch();
+        });
 
         let started = Instant::now();
-        let idle_ms = wait_for_inactivity(&stop, &last_buffer_ms, epoch, timeout)
+        let idle_ms = wait_for_inactivity(&stop, &activity, timeout)
             .expect("watchdog must report inactivity, not a stop");
         let detection = started.elapsed();
 
@@ -1999,10 +2072,12 @@ mod tests {
     #[test]
     fn watchdog_inactivity_wait_gives_up_when_stopped() {
         let stop = Arc::new(AtomicBool::new(false));
-        let epoch = Instant::now();
-        // Still negotiating: no buffer has arrived, so the idle clock never starts
+        // Still negotiating: nothing has arrived, so the idle clock never starts
         // and only the stop flag can end the wait.
-        let last_buffer_ms = Arc::new(AtomicU64::new(0));
+        let activity = Arc::new(SessionActivity::new(
+            Instant::now(),
+            Arc::new(ActivityStamp::new(Instant::now())),
+        ));
 
         let setter = stop.clone();
         std::thread::spawn(move || {
@@ -2011,12 +2086,7 @@ mod tests {
         });
 
         let started = Instant::now();
-        let result = wait_for_inactivity(
-            &stop,
-            &last_buffer_ms,
-            epoch,
-            std::time::Duration::from_secs(30),
-        );
+        let result = wait_for_inactivity(&stop, &activity, std::time::Duration::from_secs(30));
 
         assert!(
             result.is_none(),
@@ -2027,6 +2097,228 @@ mod tests {
             "wait took {:?} — it is not polling the stop flag",
             started.elapsed()
         );
+    }
+
+    /// The watchdog reads the same signal slot takeover does, so it reaps a seat
+    /// that keeps receiving RTP while nothing comes out of its slot's chain.
+    /// Measured on arriving bytes alone such a seat never goes idle, and holds
+    /// its slot for as long as its publisher keeps sending.
+    #[test]
+    fn watchdog_reaps_a_session_that_receives_media_it_never_decodes() {
+        let stop = Arc::new(AtomicBool::new(false));
+        // Receiving for a minute already, so the decoder's grace is long spent.
+        let activity = Arc::new(SessionActivity::from_stamps(
+            ActivityStamp::backdated(
+                std::time::Duration::from_secs(60),
+                std::time::Duration::ZERO,
+            ),
+            Arc::new(ActivityStamp::new(Instant::now())),
+        ));
+
+        let publisher_stop = Arc::new(AtomicBool::new(false));
+        let receiving = activity.clone();
+        let stop_receiving = publisher_stop.clone();
+        std::thread::spawn(move || {
+            while !stop_receiving.load(Ordering::SeqCst) {
+                receiving.touch_ingress(true);
+                std::thread::sleep(std::time::Duration::from_millis(20));
+            }
+        });
+
+        // The wait never returns while the seat counts as live, so it runs on its
+        // own thread: a regression has to fail this test, not hang it.
+        let (tx, rx) = std::sync::mpsc::channel();
+        let watched = activity.clone();
+        std::thread::spawn(move || {
+            let _ = tx.send(wait_for_inactivity(&stop, &watched, INACTIVITY_TIMEOUT));
+        });
+        let reaped = rx.recv_timeout(std::time::Duration::from_secs(5));
+        publisher_stop.store(true, Ordering::SeqCst);
+
+        assert!(
+            matches!(reaped, Ok(Some(ms)) if ms >= INACTIVITY_TIMEOUT.as_millis() as u64),
+            "a seat receiving RTP it never decodes must be reaped, not held \
+             alive by its arriving-bytes counter: {:?}",
+            reaped
+        );
+    }
+
+    /// Assemble a built block's elements into a pipeline the way the flow
+    /// builder does: add them all, then make the links the block asked for.
+    /// `decodebin`'s src pad is dynamic and is linked by the block's own
+    /// `pad-added` handler, so it is deliberately absent from `internal_links`.
+    fn assemble(result: &BlockBuildResult) -> gst::Pipeline {
+        let pipeline = gst::Pipeline::new();
+        for (_, element) in &result.elements {
+            pipeline.add(element).expect("add element");
+        }
+        let by_id: HashMap<&str, &gst::Element> = result
+            .elements
+            .iter()
+            .map(|(id, element)| (id.as_str(), element))
+            .collect();
+        for (from, to) in &result.internal_links {
+            let src = by_id[from.element_id.as_str()]
+                .static_pad(from.pad_name.as_deref().unwrap_or("src"))
+                .expect("source pad");
+            let sink = by_id[to.element_id.as_str()]
+                .static_pad(to.pad_name.as_deref().unwrap_or("sink"))
+                .expect("sink pad");
+            src.link(&sink).expect("internal link");
+        }
+        pipeline
+    }
+
+    fn i420_frame(index: u64) -> gst::Buffer {
+        let mut buffer = gst::Buffer::with_size(64 * 64 * 3 / 2).expect("allocate frame");
+        {
+            let buffer = buffer.get_mut().unwrap();
+            buffer.set_pts(gst::ClockTime::from_mseconds(index * 33));
+            buffer.set_duration(gst::ClockTime::from_mseconds(33));
+        }
+        buffer
+    }
+
+    /// Poll until `check` holds, up to five seconds. Buffers cross a pipeline on
+    /// its own streaming threads, so a test cannot read the result straight after
+    /// pushing.
+    fn wait_for(what: &str, check: impl Fn() -> bool) {
+        let deadline = Instant::now() + std::time::Duration::from_secs(5);
+        while Instant::now() < deadline {
+            if check() {
+                return;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        }
+        panic!("timed out waiting for {}", what);
+    }
+
+    /// The signal a WHIP slot is judged by has to mean "this session is producing
+    /// media the flow can use", so it is stamped at the end of the slot's chain,
+    /// past `decodebin` and the converter. The session's own appsink is upstream
+    /// of all of that, in a separate pipeline, and only ever sees bytes arrive.
+    ///
+    /// Both halves matter, so this checks both: media that gets through stamps
+    /// the slot, and media that arrives but cannot get through does not. The
+    /// second half is the seat that holds a slot for 45 minutes while receiving
+    /// RTP the whole time — here its tee is blocked by a stuck consumer, which is
+    /// what a stalled recorder branch does to it in a real flow.
+    #[test]
+    fn the_slot_stamp_follows_media_out_of_the_decode_chain_not_into_it() {
+        let _ = gst::init();
+
+        let ctx = BlockBuildContext::new(Vec::new(), "all".to_string());
+        let result = build_whipserversrc(
+            "whip-liveness-test",
+            &props(&[
+                ("mode", PropertyValue::String("video".to_string())),
+                ("decode", PropertyValue::Bool(true)),
+                ("max_sessions", PropertyValue::Int(1)),
+            ]),
+            &ctx,
+        )
+        .expect("build_whipserversrc failed");
+
+        let configs = ctx.take_whip_endpoint_configs();
+        let config = &configs[0].1;
+        let stamp = config.slot_output[0].clone();
+        let appsrc = config.slot_video_appsrcs[0].clone();
+        assert_eq!(
+            stamp.last(),
+            0,
+            "nothing has gone through the slot's chain yet"
+        );
+
+        let pipeline = assemble(&result);
+
+        // The slot's `decodebin` is built with its state locked so an unclaimed
+        // slot cannot hold the pipeline short of PLAYING. Claiming the slot is
+        // what unlocks it, exactly as a WHIP POST does.
+        assert_eq!(
+            config.allocate_slot("test-session"),
+            Some(0),
+            "the endpoint starts with its only slot free"
+        );
+
+        // Somewhere for the slot's tee to push, and a pad this test can block to
+        // stall the chain.
+        let sink = gst::ElementFactory::make("fakesink")
+            .property("async", false)
+            .property("sync", false)
+            .build()
+            .expect("fakesink is part of gstreamer core");
+        pipeline.add(&sink).expect("add fakesink");
+        let tee = result
+            .elements
+            .iter()
+            .find(|(id, _)| id.ends_with(":video_out_tee_0"))
+            .map(|(_, element)| element.clone())
+            .expect("the block builds an output tee per slot");
+        let tee_src = tee.request_pad_simple("src_%u").expect("tee src pad");
+        tee_src
+            .link(&sink.static_pad("sink").unwrap())
+            .expect("link tee to fakesink");
+
+        appsrc.set_caps(Some(
+            &gst::Caps::builder("video/x-raw")
+                .field("format", "I420")
+                .field("width", 64i32)
+                .field("height", 64i32)
+                .field("framerate", gst::Fraction::new(30, 1))
+                .build(),
+        ));
+        pipeline
+            .set_state(gst::State::Playing)
+            .expect("pipeline to PLAYING");
+
+        for index in 0..30 {
+            appsrc.push_buffer(i420_frame(index)).expect("push frame");
+        }
+        wait_for("the slot's stamp to follow the first frames", || {
+            stamp.last() != 0
+        });
+
+        // Now stall the slot's consumer, the way a stuck recorder branch does:
+        // hold the streaming thread inside a probe until the test releases it.
+        // Returning from the callback would let the buffer straight through.
+        let release = Arc::new(AtomicBool::new(false));
+        let gate = release.clone();
+        let block = tee_src
+            .add_probe(gst::PadProbeType::BLOCK_DOWNSTREAM, move |_, _| {
+                while !gate.load(Ordering::Relaxed) {
+                    std::thread::sleep(std::time::Duration::from_millis(5));
+                }
+                gst::PadProbeReturn::Ok
+            })
+            .expect("block probe");
+        // One buffer still reaches the tee's sink pad — it is the one that runs
+        // into the block — and stamps the slot on its way. Let it, and read the
+        // stamp afterwards: everything behind it is stuck upstream.
+        for index in 30..60 {
+            appsrc.push_buffer(i420_frame(index)).expect("push frame");
+        }
+        std::thread::sleep(std::time::Duration::from_millis(300));
+        let stalled_at = stamp.last();
+
+        for index in 60..150 {
+            appsrc.push_buffer(i420_frame(index)).expect("push frame");
+        }
+        std::thread::sleep(std::time::Duration::from_millis(500));
+
+        assert_eq!(
+            stamp.last(),
+            stalled_at,
+            "media kept arriving at the slot's appsrc while its chain was blocked; \
+             the stamp must not move for media that never gets through"
+        );
+
+        // Let the held streaming thread go before removing the probe: removing it
+        // waits for the callback to return.
+        release.store(true, Ordering::Relaxed);
+        tee_src.remove_probe(block);
+        pipeline
+            .set_state(gst::State::Null)
+            .expect("pipeline to NULL");
     }
 
     /// The block property must reach the `WhipEndpointConfig` handed to the

--- a/backend/src/whip_session_manager.rs
+++ b/backend/src/whip_session_manager.rs
@@ -62,6 +62,10 @@ pub struct WhipEndpointConfig {
     /// cannot hold the pipeline short of PLAYING; `allocate_slot` unlocks them.
     /// Empty when the endpoint runs with `decode=false`.
     pub slot_decodebins: Vec<Vec<gst::glib::WeakRef<gst::Element>>>,
+    /// Per-slot stamp of the media coming out of that slot's chain, written by
+    /// a pad probe on its output tee. The session sitting in a slot borrows its
+    /// stamp; see `SessionActivity`.
+    pub slot_output: Vec<Arc<ActivityStamp>>,
     /// Slot assignments: slot index → Option<resource_id>
     /// Protected by RwLock for concurrent access from HTTP handlers.
     pub slot_assignments: Arc<RwLock<Vec<Option<String>>>>,
@@ -154,64 +158,188 @@ pub struct SessionCleanupRequest {
     pub reason: String,
 }
 
-/// Liveness of one WHIP session: when its last media buffer crossed the
-/// appsink→appsrc bridge into the main pipeline.
+/// One stream of buffers, reduced to when its first and most recent buffer went
+/// past, as milliseconds from a fixed epoch.
 ///
-/// The counters are written from the appsink's `new_sample` callback, i.e. once
-/// per buffer, so a stamp is a single relaxed store against an epoch taken at
-/// session start. They are read by the session's own inactivity watchdog and by
-/// `allocate_slot_or_take_over`, which needs to know whether an occupied slot
-/// still has a publisher behind it. `last_buffer_ms` is an `Arc` of its own
-/// because the session's watchdog thread reads it directly.
-pub struct SessionActivity {
-    /// Session start. All timestamps are milliseconds from here.
+/// Written from GStreamer's data path — an appsink callback, a pad probe — so
+/// `touch` is one clock read (`Instant` takes the vDSO fast path) plus relaxed
+/// atomics: no lock, no allocation, no formatting. 0 means "nothing yet", so a
+/// buffer landing inside the first millisecond counts as 1.
+pub struct ActivityStamp {
     epoch: Instant,
-    /// Milliseconds from `epoch` at which the last buffer arrived on any
-    /// stream; 0 = none yet.
-    last_buffer_ms: Arc<AtomicU64>,
-    /// The same, counting audio buffers only. Non-zero means this session
-    /// negotiated an audio stream and it produced something, which is what
-    /// makes `TAKEOVER_IDLE_THRESHOLD` a sound bound; see `has_delivered_audio`.
-    last_audio_ms: AtomicU64,
+    first_ms: AtomicU64,
+    last_ms: AtomicU64,
+}
+
+impl ActivityStamp {
+    pub fn new(epoch: Instant) -> Self {
+        Self {
+            epoch,
+            first_ms: AtomicU64::new(0),
+            last_ms: AtomicU64::new(0),
+        }
+    }
+
+    /// Stamp a buffer. Per-buffer hot path; see the type comment.
+    pub fn touch(&self) {
+        let ms = (self.epoch.elapsed().as_millis() as u64).max(1);
+        self.last_ms.store(ms, Ordering::Relaxed);
+        // Only the very first buffer writes `first_ms`; every later one pays a
+        // relaxed load and a branch that predicts perfectly.
+        if self.first_ms.load(Ordering::Relaxed) == 0 {
+            let _ = self
+                .first_ms
+                .compare_exchange(0, ms, Ordering::Relaxed, Ordering::Relaxed);
+        }
+    }
+
+    /// Forget everything seen so far. Used when a new session claims a slot
+    /// whose output chain outlives individual sessions.
+    pub fn reset(&self) {
+        self.first_ms.store(0, Ordering::Relaxed);
+        self.last_ms.store(0, Ordering::Relaxed);
+    }
+
+    /// Milliseconds from `epoch` at which the most recent buffer went past,
+    /// 0 if none has. Only meaningful compared against another reading of the
+    /// same stamp — a value that changed between two of them is a stream that
+    /// is still moving.
+    pub fn last(&self) -> u64 {
+        self.last_ms.load(Ordering::Relaxed)
+    }
+
+    /// Time since the most recent buffer, `None` if none has gone past.
+    pub fn since_last(&self) -> Option<Duration> {
+        self.since(self.last_ms.load(Ordering::Relaxed))
+    }
+
+    /// Time since the first buffer, `None` if none has gone past.
+    pub fn since_first(&self) -> Option<Duration> {
+        self.since(self.first_ms.load(Ordering::Relaxed))
+    }
+
+    /// A stamp that already looks as if its first buffer went past
+    /// `since_first` ago and its most recent one `since_last` ago, so a test can
+    /// stand a session up mid-life without waiting out real seconds.
+    #[cfg(test)]
+    pub fn backdated(since_first: Duration, since_last: Duration) -> Self {
+        assert!(
+            since_last <= since_first,
+            "the first buffer cannot be newer than the last"
+        );
+        // 1 ms of headroom keeps `first_ms` clear of the 0 that means "nothing
+        // yet", exactly as `touch` does.
+        let stamp = Self::new(Instant::now() - since_first - Duration::from_millis(1));
+        stamp.first_ms.store(1, Ordering::Relaxed);
+        stamp.last_ms.store(
+            (since_first - since_last).as_millis() as u64 + 1,
+            Ordering::Relaxed,
+        );
+        stamp
+    }
+
+    fn since(&self, ms: u64) -> Option<Duration> {
+        if ms == 0 {
+            return None;
+        }
+        Some(
+            self.epoch
+                .elapsed()
+                .saturating_sub(Duration::from_millis(ms)),
+        )
+    }
+}
+
+/// Liveness of one WHIP session, in the only terms that matter to the slot it
+/// occupies: is it still producing media the flow can use?
+///
+/// Two stamps decide it, because arriving bytes are not the same thing as usable
+/// media:
+///
+/// - `ingress` is stamped by the session pipeline's appsink, once per buffer
+///   that crosses the appsink→appsrc bridge. It says the publisher is still
+///   sending, and nothing more.
+/// - `output` is stamped by a pad probe on the slot's output tee, in the *main*
+///   pipeline, downstream of the slot's `decodebin`. It says frames are coming
+///   out the far end and reaching the flow's consumers.
+///
+/// A third, `ingress_audio`, does not measure liveness at all — it only records
+/// whether this session ever carried audio, which is what decides how short a
+/// silence may be held against it; see `has_delivered_audio`.
+///
+/// A seat can sit at the first without the second indefinitely — a decoder that
+/// never gets the keyframe it needs, or a downstream consumer that blocks and
+/// backs pressure up through the slot's tee — and by `ingress` alone it looks
+/// perfectly healthy while producing nothing.
+///
+/// Read by the session's inactivity watchdog and by
+/// `allocate_slot_or_take_over`.
+pub struct SessionActivity {
+    ingress: ActivityStamp,
+    /// The same arrivals, counting audio buffers only. Shares `ingress`'s epoch.
+    /// Non-zero means this session negotiated an audio stream and it produced
+    /// something, which is what makes `TAKEOVER_IDLE_THRESHOLD` a sound bound;
+    /// see `has_delivered_audio`.
+    ingress_audio: ActivityStamp,
+    /// Shared with the slot, not owned by the session: the slot's output chain
+    /// is built once, at flow build time, and outlives the sessions that pass
+    /// through it. `SessionActivity::new` resets it so one session never
+    /// inherits its predecessor's liveness.
+    output: Arc<ActivityStamp>,
 }
 
 impl SessionActivity {
-    pub fn new(epoch: Instant, last_buffer_ms: Arc<AtomicU64>) -> Self {
+    /// `epoch` is session start; `output` is the stamp belonging to the slot
+    /// this session was assigned.
+    pub fn new(epoch: Instant, output: Arc<ActivityStamp>) -> Self {
+        // This session has to prove for itself that its media comes out of the
+        // slot's chain. Buffers left in flight from the previous occupant can
+        // still stamp it for a moment afterwards, which only ever makes the new
+        // session look healthier than it is — the safe direction, and it
+        // corrects itself as soon as the chain drains.
+        output.reset();
         Self {
-            epoch,
-            last_buffer_ms,
-            last_audio_ms: AtomicU64::new(0),
+            ingress: ActivityStamp::new(epoch),
+            ingress_audio: ActivityStamp::new(epoch),
+            output,
         }
     }
 
-    /// Stamp the arrival of a buffer. Called from the appsink callback, so this
-    /// is the per-buffer hot path: one `Instant::now()` and one or two relaxed
-    /// stores, no lock and no allocation.
-    pub fn touch(&self, is_audio: bool) {
-        // 0 is reserved for "no buffer yet", so a buffer that lands inside the
-        // first millisecond of the session counts as 1.
-        let now_ms = (self.epoch.elapsed().as_millis() as u64).max(1);
-        self.last_buffer_ms.store(now_ms, Ordering::Relaxed);
-        if is_audio {
-            self.last_audio_ms.store(now_ms, Ordering::Relaxed);
-        }
-    }
-
-    /// Assemble a session whose counters a test has already positioned in time.
+    /// Assemble a session from stamps a test has already positioned in time.
+    /// Skips the reset `new` does, which would wipe them.
     #[cfg(test)]
-    pub fn from_counters(
-        epoch: Instant,
-        last_buffer_ms: Arc<AtomicU64>,
-        last_audio_ms: u64,
-    ) -> Self {
+    pub fn from_stamps(ingress: ActivityStamp, output: Arc<ActivityStamp>) -> Self {
+        // Carries audio, so it is in displacement range at all.
+        let ingress_audio = ActivityStamp::new(Instant::now());
+        ingress_audio.touch();
         Self {
-            epoch,
-            last_buffer_ms,
-            last_audio_ms: AtomicU64::new(last_audio_ms),
+            ingress,
+            ingress_audio,
+            output,
         }
     }
 
-    /// Whether this session has ever delivered an audio buffer.
+    /// Assemble a session that has never carried audio, so nothing about it can
+    /// be judged on a short silence; see `has_delivered_audio`.
+    #[cfg(test)]
+    pub fn video_only_from_stamps(ingress: ActivityStamp, output: Arc<ActivityStamp>) -> Self {
+        Self {
+            ingress,
+            ingress_audio: ActivityStamp::new(Instant::now()),
+            output,
+        }
+    }
+
+    /// Stamp the arrival of a buffer from the publisher. Called from the
+    /// appsink callback, so this is the per-buffer hot path.
+    pub fn touch_ingress(&self, is_audio: bool) {
+        self.ingress.touch();
+        if is_audio {
+            self.ingress_audio.touch();
+        }
+    }
+
+    /// Whether this session has ever carried an audio buffer.
     ///
     /// Only an audio-bearing session can be judged dead on a couple of seconds
     /// of silence, because only audio has a cadence tight enough for a gap that
@@ -222,29 +350,46 @@ impl SessionActivity {
     /// perfectly healthy transport, and is indistinguishable from a dead one by
     /// any media-based signal. Such a session is left to the inactivity
     /// watchdog; see `allocate_slot_or_take_over`.
+    ///
+    /// Read on the arriving side, not the slot's output: the output stamp is
+    /// shared by the slot's audio and video tees and cannot tell them apart,
+    /// and the question is what the publisher negotiated.
     pub fn has_delivered_audio(&self) -> bool {
-        self.last_audio_ms.load(Ordering::Relaxed) != 0
+        self.ingress_audio.last() != 0
     }
 
-    /// The raw counter: milliseconds from `epoch` at which the last buffer
-    /// arrived, 0 if none has. Only useful for comparing two readings — a value
-    /// that changes between them is a publisher that is still sending.
-    pub fn last_buffer(&self) -> u64 {
-        self.last_buffer_ms.load(Ordering::Relaxed)
+    /// The slot's output counter, for comparing two readings a poll apart. A
+    /// value that changed is a session that is genuinely still producing.
+    pub fn last_usable(&self) -> u64 {
+        self.output.last()
     }
 
-    /// Time since the last media buffer, or `None` if no buffer has arrived at
-    /// all — the session is still negotiating, or never produced media.
+    /// Time since this session last produced usable media, or `None` if it must
+    /// not be judged yet.
+    ///
+    /// `None` means one of two states that must both be left alone: nothing has
+    /// arrived at all (still negotiating — ICE through a TURN relay is slow, and
+    /// evicting it lets two clients take turns throwing each other off before
+    /// either sends media), or the first buffers arrived less than
+    /// `DECODE_GRACE` ago and the decoder may still be waiting for the keyframe
+    /// that carries H.264's parameter sets.
+    ///
+    /// Otherwise it is the staler of the two stamps: a session is usable only
+    /// while both move, and a publisher going away freezes `ingress` first while
+    /// a stall below the decoder freezes `output` first.
     pub fn idle(&self) -> Option<Duration> {
-        let last = self.last_buffer_ms.load(Ordering::Relaxed);
-        if last == 0 {
-            return None;
-        }
-        Some(
-            self.epoch
-                .elapsed()
-                .saturating_sub(Duration::from_millis(last)),
-        )
+        let ingress_idle = self.ingress.since_last()?;
+
+        let output_idle = match self.output.since_last() {
+            Some(idle) => idle,
+            // Media is arriving but nothing has come out of the decode chain.
+            // Inside the grace that is just preroll; past it, this is the
+            // failure the output stamp exists to catch, and the session has
+            // been useless since the grace ran out.
+            None => self.ingress.since_first()?.checked_sub(DECODE_GRACE)?,
+        };
+
+        Some(ingress_idle.max(output_idle))
     }
 }
 
@@ -317,6 +462,17 @@ pub struct WhipSessionManager {
 /// sub-second in practice.
 const PENDING_CLEANUP_TTL: Duration = Duration::from_secs(30);
 
+/// How long a session may receive media without any of it coming out of its
+/// slot's chain before it counts as producing nothing.
+///
+/// Some delay is normal: H.264 cannot be decoded until a keyframe brings its
+/// parameter sets, and `decodebin` has to autoplug a decoder first. Measured
+/// from the session's *first* buffer, so a session that spent a minute
+/// negotiating still gets the full grace once media starts. It has to stay under
+/// the watchdog's `INACTIVITY_TIMEOUT` for the watchdog to reap a session that
+/// never decodes at all.
+const DECODE_GRACE: Duration = Duration::from_secs(5);
+
 /// How long a session must have gone without media before a new client is
 /// allowed to take its slot.
 ///
@@ -342,10 +498,11 @@ const TAKEOVER_POLL: Duration = Duration::from_millis(100);
 struct IdlestSession {
     resource_id: String,
     port: u16,
-    /// Time since its last media buffer, `None` if it has never delivered one.
+    /// Time since it last produced usable media, `None` if it must not be
+    /// judged yet; see `SessionActivity::idle`.
     idle: Option<Duration>,
-    /// Its raw buffer counter, for comparison against the previous poll.
-    last_buffer: u64,
+    /// Its slot's output counter, for comparison against the previous poll.
+    last_usable: u64,
     /// Another path is already tearing it down, so its slot is about to free.
     dying: bool,
     /// Whether it has ever delivered audio; see `SessionActivity::has_delivered_audio`.
@@ -529,22 +686,24 @@ impl WhipSessionManager {
         true
     }
 
-    /// Allocate a slot for a new client, displacing a demonstrably dead session
-    /// if the endpoint is full.
+    /// Allocate a slot for a new client, displacing a session that is no longer
+    /// producing usable media if the endpoint is full.
     ///
-    /// A publisher that dies without sending a WHIP DELETE — network loss, the
-    /// common case for a real participant — leaves its slot occupied until the
-    /// session's inactivity watchdog notices, and every reconnect in between is
-    /// refused with 503.
+    /// Two ways a seat stops being worth its slot: the publisher dies without
+    /// sending a WHIP DELETE (network loss, the common case for a real
+    /// participant), or its media keeps arriving while nothing usable comes out
+    /// the far end — a decoder that never gets its keyframe, or a consumer
+    /// downstream of the slot's tee that blocks and backs pressure up the chain.
+    /// `SessionActivity` covers both.
     ///
     /// When all slots are taken, this watches the sitting session for up to
-    /// `TAKEOVER_WAIT` instead of refusing outright. A session whose buffer
-    /// counter is still moving has a publisher behind it and is never touched:
-    /// the new client gets its 503 as soon as the counter is seen to move, which
-    /// is a poll interval, not a wait. A counter that stays frozen past
-    /// `TAKEOVER_IDLE_THRESHOLD` is a dead transport, and the session is handed
-    /// to the ordinary cleanup path so the new client can take the slot it
-    /// releases.
+    /// `TAKEOVER_WAIT` instead of refusing outright. A session whose output
+    /// counter is still moving is producing for real and is never touched: the
+    /// new client gets its 503 as soon as the counter is seen to move, which is
+    /// a poll interval, not a wait. A counter frozen past
+    /// `TAKEOVER_IDLE_THRESHOLD` means the seat is dead, and the session is
+    /// handed to the ordinary cleanup path so the new client can take the slot
+    /// it releases.
     ///
     /// Both cases start out looking identical — a reconnect that lands 300 ms
     /// after the drop sees the same near-zero idle time as a healthy stream —
@@ -564,7 +723,7 @@ impl WhipSessionManager {
         resource_id: &str,
     ) -> Option<usize> {
         let deadline = Instant::now() + TAKEOVER_WAIT;
-        // The candidate's buffer counter as of the previous poll, so this poll
+        // The candidate's output counter as of the previous poll, so this poll
         // can tell whether it moved.
         let mut previous: Option<(String, u64)> = None;
 
@@ -591,41 +750,39 @@ impl WhipSessionManager {
                 if !candidate.cleanup_sent.swap(true, Ordering::SeqCst) {
                     let idle_ms = candidate.idle.unwrap_or_default().as_millis();
                     warn!(
-                        "WhipSessionManager: Displacing session '{}' on port {} ({} ms without media) so a new client can take its slot on endpoint '{}'",
+                        "WhipSessionManager: Displacing session '{}' on port {} ({} ms without usable media) so a new client can take its slot on endpoint '{}'",
                         candidate.resource_id, candidate.port, idle_ms, config.endpoint_id
                     );
                     let _ = self.cleanup_tx.send(SessionCleanupRequest {
                         port: candidate.port,
                         reason: format!(
-                            "displaced by a new client after {} ms without media",
+                            "displaced by a new client after {} ms without usable media",
                             idle_ms
                         ),
                     });
                 }
             } else if previous.as_ref().is_some_and(|(id, last)| {
-                *id == candidate.resource_id && *last != candidate.last_buffer
+                *id == candidate.resource_id && *last != candidate.last_usable
             }) {
-                // Its counter moved while we watched: the publisher is still
-                // sending and the endpoint is genuinely full.
+                // Its counter moved while we watched: media is still coming out
+                // of that slot and the endpoint is genuinely full.
                 return None;
             }
 
             if Instant::now() + TAKEOVER_POLL >= deadline {
                 return None;
             }
-            previous = Some((candidate.resource_id, candidate.last_buffer));
+            previous = Some((candidate.resource_id, candidate.last_usable));
             tokio::time::sleep(TAKEOVER_POLL).await;
         }
     }
 
-    /// The session on an endpoint that has gone longest without media — the one
-    /// a new client would displace. `None` if the endpoint has no registered
-    /// session at all.
+    /// The session on an endpoint that has gone longest without producing usable
+    /// media — the one a new client would displace. `None` if the endpoint has
+    /// no registered session at all.
     ///
-    /// A session that has never delivered a buffer sorts last and is never
-    /// displaced: it may simply be slow to negotiate (ICE through a TURN relay),
-    /// and evicting it would let two clients take turns throwing each other off
-    /// before either ever sends media.
+    /// A session `SessionActivity::idle` refuses to judge sorts last and is
+    /// never displaced: it is still negotiating, or still inside `DECODE_GRACE`.
     fn idlest_session(&self, endpoint_id: &str) -> Option<IdlestSession> {
         let sessions = self.sessions.read().unwrap();
         sessions
@@ -635,7 +792,7 @@ impl WhipSessionManager {
                 resource_id: resource_id.clone(),
                 port: s.port,
                 idle: s.activity.idle(),
-                last_buffer: s.activity.last_buffer(),
+                last_usable: s.activity.last_usable(),
                 dying: s.cleanup_sent.load(Ordering::SeqCst),
                 has_audio: s.activity.has_delivered_audio(),
                 cleanup_sent: s.cleanup_sent.clone(),
@@ -799,54 +956,104 @@ mod tests {
         (element, pipeline, Arc::new(AtomicBool::new(false)))
     }
 
-    /// A publisher whose transport is gone: its last buffer arrived `idle` ago
-    /// and the counter has not moved since. `idle` of zero is the case that
-    /// matters — a client reconnecting the instant its publisher died looks, at
-    /// that moment, exactly like a healthy one.
-    ///
-    /// It carries audio, so it is in displacement range at all.
-    fn dead_publisher(idle: Duration) -> Arc<SessionActivity> {
-        // The buffer landed 1 ms into the session, so the counter is non-zero
-        // (0 is reserved for "no buffer yet") and nothing has stamped it since.
-        let epoch = Instant::now() - idle - Duration::from_millis(1);
-        Arc::new(SessionActivity::from_counters(
-            epoch,
-            Arc::new(AtomicU64::new(1)),
-            1,
-        ))
-    }
+    /// How long a fixture session has been running before the test looks at it.
+    /// Comfortably past `DECODE_GRACE`, so a session that has produced nothing
+    /// usable in that time is genuinely broken rather than still starting up.
+    const RUNNING_FOR: Duration = Duration::from_secs(60);
 
-    /// A healthy video-only publisher of static content, mid-gap: its last frame
-    /// arrived `gap` ago and the next one is not due yet. Never delivered audio,
-    /// so nothing about it can be judged on a two-second silence.
-    fn sparse_video_publisher(gap: Duration) -> Arc<SessionActivity> {
-        let epoch = Instant::now() - gap - Duration::from_millis(1);
-        Arc::new(SessionActivity::new(epoch, Arc::new(AtomicU64::new(1))))
-    }
-
-    /// A publisher that is still sending: a thread stamps the counter every
-    /// 20 ms, the way the appsink callback does for every buffer that crosses
-    /// the bridge. The caller sets `stop` to end it.
-    fn live_publisher(stop: Arc<AtomicBool>) -> Arc<SessionActivity> {
-        let activity = Arc::new(SessionActivity::new(
-            Instant::now(),
-            Arc::new(AtomicU64::new(0)),
-        ));
-        let ticking = activity.clone();
+    /// Tick `stamp` every 20 ms until `stop` is set — the rate the session
+    /// appsink and the slot's output probe stamp a running publisher at.
+    fn tick_until_stopped(stop: Arc<AtomicBool>, stamp: impl Fn() + Send + 'static) {
         std::thread::spawn(move || {
             while !stop.load(Ordering::SeqCst) {
-                ticking.touch(true);
+                stamp();
                 std::thread::sleep(Duration::from_millis(20));
             }
         });
+    }
+
+    /// A publisher whose transport is gone: nothing has arrived and nothing has
+    /// come out of its slot for `idle`. `idle` of zero is the case that matters
+    /// — a client reconnecting the instant its publisher died looks, at that
+    /// moment, exactly like a healthy one.
+    fn dead_publisher(idle: Duration) -> Arc<SessionActivity> {
+        let ran_for = RUNNING_FOR + idle;
+        Arc::new(SessionActivity::from_stamps(
+            ActivityStamp::backdated(ran_for, idle),
+            Arc::new(ActivityStamp::backdated(ran_for, idle)),
+        ))
+    }
+
+    /// A publisher that is still sending and whose media still comes out of its
+    /// slot: both stamps tick, the way the appsink callback and the tee probe do
+    /// for a running session. The caller sets `stop` to end it.
+    fn live_publisher(stop: Arc<AtomicBool>) -> Arc<SessionActivity> {
+        let output = Arc::new(ActivityStamp::backdated(RUNNING_FOR, Duration::ZERO));
+        let activity = Arc::new(SessionActivity::from_stamps(
+            ActivityStamp::backdated(RUNNING_FOR, Duration::ZERO),
+            output.clone(),
+        ));
+        let ingress = activity.clone();
+        tick_until_stopped(stop.clone(), move || ingress.touch_ingress(true));
+        tick_until_stopped(stop, move || output.touch());
         activity
     }
 
-    /// A session that is still negotiating: connected, but no media yet.
+    /// A healthy video-only publisher of static content, mid-gap: its last frame
+    /// arrived `gap` ago, came out of its slot, and the next one is not due yet.
+    /// Never carried audio, so nothing about it can be judged on a two-second
+    /// silence.
+    fn sparse_video_publisher(gap: Duration) -> Arc<SessionActivity> {
+        let ran_for = RUNNING_FOR + gap;
+        Arc::new(SessionActivity::video_only_from_stamps(
+            ActivityStamp::backdated(ran_for, gap),
+            Arc::new(ActivityStamp::backdated(ran_for, gap)),
+        ))
+    }
+
+    /// The bug: RTP keeps arriving and has done for a minute, but nothing has
+    /// ever come out of the slot's chain — the decoder never got a usable
+    /// keyframe, or a consumer below the slot's tee is blocking it. Judged on
+    /// arriving bytes alone this seat looks perfectly healthy.
+    fn receiving_but_never_usable(stop: Arc<AtomicBool>) -> Arc<SessionActivity> {
+        let activity = Arc::new(SessionActivity::from_stamps(
+            ActivityStamp::backdated(RUNNING_FOR, Duration::ZERO),
+            Arc::new(ActivityStamp::new(Instant::now())),
+        ));
+        let ingress = activity.clone();
+        tick_until_stopped(stop, move || ingress.touch_ingress(true));
+        activity
+    }
+
+    /// The other half of the bug: the seat decoded fine and then froze
+    /// `stalled_for` ago, while RTP keeps arriving.
+    fn receiving_but_stalled(stop: Arc<AtomicBool>, stalled_for: Duration) -> Arc<SessionActivity> {
+        let activity = Arc::new(SessionActivity::from_stamps(
+            ActivityStamp::backdated(RUNNING_FOR, Duration::ZERO),
+            Arc::new(ActivityStamp::backdated(RUNNING_FOR, stalled_for)),
+        ));
+        let ingress = activity.clone();
+        tick_until_stopped(stop, move || ingress.touch_ingress(true));
+        activity
+    }
+
+    /// Media has only just started arriving and nothing has decoded yet. Normal:
+    /// H.264 cannot be decoded until a keyframe brings its parameter sets.
+    fn still_prerolling(stop: Arc<AtomicBool>) -> Arc<SessionActivity> {
+        let activity = Arc::new(SessionActivity::from_stamps(
+            ActivityStamp::backdated(Duration::from_millis(200), Duration::ZERO),
+            Arc::new(ActivityStamp::new(Instant::now())),
+        ));
+        let ingress = activity.clone();
+        tick_until_stopped(stop, move || ingress.touch_ingress(true));
+        activity
+    }
+
+    /// A session that is still negotiating: connected, but nothing has arrived.
     fn no_media_yet() -> Arc<SessionActivity> {
         Arc::new(SessionActivity::new(
             Instant::now(),
-            Arc::new(AtomicU64::new(0)),
+            Arc::new(ActivityStamp::new(Instant::now())),
         ))
     }
 
@@ -869,6 +1076,9 @@ mod tests {
             slot_audio_appsrcs: Vec::new(),
             slot_video_appsrcs: Vec::new(),
             slot_decodebins: vec![Vec::new(); max_sessions],
+            slot_output: (0..max_sessions)
+                .map(|_| Arc::new(ActivityStamp::new(Instant::now())))
+                .collect(),
             slot_assignments: Arc::new(RwLock::new(vec![None; max_sessions])),
         }
     }
@@ -1127,6 +1337,110 @@ mod tests {
             "a live publisher must be recognised from its moving counter, not \
              waited out: took {:?}",
             started.elapsed()
+        );
+    }
+
+    /// THE BUG. A seat keeps receiving RTP while nothing usable ever comes out
+    /// of its slot — the decoder never got a keyframe it could use, or a
+    /// consumer below the slot's tee is blocking the chain. Its arriving-bytes
+    /// counter moves the whole time, so liveness measured there says "healthy"
+    /// and every rejoining client is refused for as long as the seat sits there.
+    #[tokio::test]
+    async fn a_session_receiving_media_it_never_decodes_is_displaced() {
+        let stop = Arc::new(AtomicBool::new(false));
+        let (manager, config, cleanup_sent) = full_endpoint(
+            "receiving-nothing-usable",
+            40014,
+            receiving_but_never_usable(stop.clone()),
+        );
+
+        let slot = manager
+            .allocate_slot_or_take_over(&config, "rejoining-client")
+            .await;
+        stop.store(true, Ordering::SeqCst);
+
+        assert_eq!(
+            slot,
+            Some(0),
+            "a seat producing nothing usable must give its slot up, however much RTP it receives"
+        );
+        assert!(cleanup_sent.load(Ordering::SeqCst));
+        assert!(
+            manager
+                .get_session_port("receiving-nothing-usable")
+                .is_none(),
+            "the displaced session must be torn down by the ordinary cleanup path"
+        );
+    }
+
+    /// The same seat by the other route: it decoded fine and then froze, which is
+    /// what tee backpressure from a stuck consumer does to it. RTP keeps
+    /// arriving either way.
+    #[tokio::test]
+    async fn a_session_whose_output_has_stalled_is_displaced() {
+        let stop = Arc::new(AtomicBool::new(false));
+        let (manager, config, cleanup_sent) = full_endpoint(
+            "stalled-output",
+            40015,
+            receiving_but_stalled(stop.clone(), TAKEOVER_IDLE_THRESHOLD * 2),
+        );
+
+        let slot = manager
+            .allocate_slot_or_take_over(&config, "rejoining-client")
+            .await;
+        stop.store(true, Ordering::SeqCst);
+
+        assert_eq!(slot, Some(0), "a stalled seat must give its slot up");
+        assert!(cleanup_sent.load(Ordering::SeqCst));
+    }
+
+    /// The risk in judging a seat by its decoded output: media arrives before it
+    /// can be decoded, because H.264 carries its parameter sets with a keyframe
+    /// and `decodebin` has a decoder to autoplug first. A session inside that
+    /// window has produced nothing usable yet and must still be left alone.
+    #[tokio::test]
+    async fn a_session_still_waiting_for_its_first_decoded_frame_is_not_displaced() {
+        let stop = Arc::new(AtomicBool::new(false));
+        let (manager, config, cleanup_sent) =
+            full_endpoint("prerolling", 40016, still_prerolling(stop.clone()));
+
+        let slot = manager
+            .allocate_slot_or_take_over(&config, "second-client")
+            .await;
+        stop.store(true, Ordering::SeqCst);
+
+        assert_eq!(slot, None, "a prerolling session must keep its slot");
+        assert!(!cleanup_sent.load(Ordering::SeqCst));
+        assert!(
+            manager.get_session_port("prerolling").is_some(),
+            "the prerolling session must still be registered"
+        );
+    }
+
+    /// The output stamp belongs to the slot, which outlives the sessions passing
+    /// through it. A new session must not be judged on frames its predecessor
+    /// produced: inheriting a stale one makes the newcomer look stalled the
+    /// moment its own media starts arriving, and the next client evicts it.
+    #[test]
+    fn a_new_session_does_not_inherit_the_slots_previous_liveness() {
+        let slot_output = Arc::new(ActivityStamp::backdated(RUNNING_FOR, Duration::ZERO));
+        assert!(
+            slot_output.last() != 0,
+            "the previous occupant left the slot's stamp set"
+        );
+
+        let session = SessionActivity::new(Instant::now(), slot_output.clone());
+        session.touch_ingress(true);
+
+        assert_eq!(
+            slot_output.last(),
+            0,
+            "claiming a slot must clear what the previous session left on it"
+        );
+        assert_eq!(
+            session.idle(),
+            None,
+            "a session whose own media has only just started must not be judged yet"
         );
     }
 

--- a/backend/src/whip_session_manager.rs
+++ b/backend/src/whip_session_manager.rs
@@ -12,7 +12,7 @@ use gstreamer as gst;
 use gstreamer::prelude::*;
 use gstreamer_app as gst_app;
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, Instant};
 use strom_types::block::StreamMode;
@@ -154,6 +154,64 @@ pub struct SessionCleanupRequest {
     pub reason: String,
 }
 
+/// Liveness of one WHIP session: when its last media buffer crossed the
+/// appsink→appsrc bridge into the main pipeline.
+///
+/// The counter is written from the appsink's `new_sample` callback, i.e. once
+/// per buffer, so it is a single relaxed store against an epoch taken at session
+/// start. It is read by the session's own inactivity watchdog and by
+/// `allocate_slot_or_take_over`, which needs to know whether an occupied slot
+/// still has a publisher behind it. The counter is an `Arc` of its own because
+/// the session's watchdog thread reads it directly.
+pub struct SessionActivity {
+    /// Session start. All timestamps are milliseconds from here.
+    epoch: Instant,
+    /// Milliseconds from `epoch` at which the last buffer arrived; 0 = none yet.
+    last_buffer_ms: Arc<AtomicU64>,
+}
+
+impl SessionActivity {
+    pub fn new(epoch: Instant, last_buffer_ms: Arc<AtomicU64>) -> Self {
+        Self {
+            epoch,
+            last_buffer_ms,
+        }
+    }
+
+    /// Stamp the arrival of a buffer. Called from the appsink callback, so this
+    /// is the per-buffer hot path: one `Instant::now()` and one relaxed store,
+    /// no lock and no allocation.
+    pub fn touch(&self) {
+        // 0 is reserved for "no buffer yet", so a buffer that lands inside the
+        // first millisecond of the session counts as 1.
+        self.last_buffer_ms.store(
+            (self.epoch.elapsed().as_millis() as u64).max(1),
+            Ordering::Relaxed,
+        );
+    }
+
+    /// The raw counter: milliseconds from `epoch` at which the last buffer
+    /// arrived, 0 if none has. Only useful for comparing two readings — a value
+    /// that changes between them is a publisher that is still sending.
+    pub fn last_buffer(&self) -> u64 {
+        self.last_buffer_ms.load(Ordering::Relaxed)
+    }
+
+    /// Time since the last media buffer, or `None` if no buffer has arrived at
+    /// all — the session is still negotiating, or never produced media.
+    pub fn idle(&self) -> Option<Duration> {
+        let last = self.last_buffer_ms.load(Ordering::Relaxed);
+        if last == 0 {
+            return None;
+        }
+        Some(
+            self.epoch
+                .elapsed()
+                .saturating_sub(Duration::from_millis(last)),
+        )
+    }
+}
+
 /// An active WHIP session (one whipserversrc element per client).
 /// Each session runs in its own GStreamer pipeline to isolate NiceAgent instances.
 struct WhipSession {
@@ -171,6 +229,9 @@ struct WhipSession {
     /// Stops the session's inactivity watchdog thread and suppresses duplicate
     /// cleanup requests. Shared with the callbacks in `whip.rs`.
     cleanup_sent: Arc<AtomicBool>,
+    /// When this session last delivered media. Shared with the session's appsink
+    /// callbacks; see `SessionActivity`.
+    activity: Arc<SessionActivity>,
 }
 
 /// A freshly created WHIP session, handed to `register_session`.
@@ -189,6 +250,8 @@ pub struct NewWhipSession {
     pub slot: usize,
     /// Shared with the session's own callbacks; see `WhipSession::cleanup_sent`.
     pub cleanup_sent: Arc<AtomicBool>,
+    /// Shared with the session's appsink callbacks; see `SessionActivity`.
+    pub activity: Arc<SessionActivity>,
 }
 
 /// Manages WHIP sessions across all endpoints.
@@ -217,6 +280,40 @@ pub struct WhipSessionManager {
 /// gap between a session dying and `register_session` running for it, which is
 /// sub-second in practice.
 const PENDING_CLEANUP_TTL: Duration = Duration::from_secs(30);
+
+/// How long a session must have gone without media before a new client is
+/// allowed to take its slot.
+///
+/// A connected WebRTC publisher delivers audio every ~20 ms and video every
+/// ~33 ms, so two seconds of nothing means the transport is gone, not that the
+/// network had a bad moment. The threshold has to stay well under the session
+/// watchdog's own inactivity timeout, otherwise the watchdog frees the slot
+/// first and takeover buys nothing.
+const TAKEOVER_IDLE_THRESHOLD: Duration = Duration::from_secs(2);
+
+/// How long a POST may be held while the sitting session is judged. Long enough
+/// for a dead session to cross `TAKEOVER_IDLE_THRESHOLD` with polls to spare; the
+/// reasoning is on `allocate_slot_or_take_over`.
+const TAKEOVER_WAIT: Duration = Duration::from_secs(3);
+
+/// How often the takeover wait re-reads the slots and the sitting session's
+/// buffer counter. A live publisher stamps that counter every audio packet
+/// (~20 ms) and every video frame (~33 ms), so one poll is plenty to catch it
+/// moving.
+const TAKEOVER_POLL: Duration = Duration::from_millis(100);
+
+/// The least-live session on an endpoint: the one a new client would displace.
+struct IdlestSession {
+    resource_id: String,
+    port: u16,
+    /// Time since its last media buffer, `None` if it has never delivered one.
+    idle: Option<Duration>,
+    /// Its raw buffer counter, for comparison against the previous poll.
+    last_buffer: u64,
+    /// Another path is already tearing it down, so its slot is about to free.
+    dying: bool,
+    cleanup_sent: Arc<AtomicBool>,
+}
 
 impl WhipSessionManager {
     pub fn new() -> Self {
@@ -347,6 +444,7 @@ impl WhipSessionManager {
             endpoint_id,
             slot,
             cleanup_sent,
+            activity,
         } = session;
 
         // Check if this port was marked for cleanup before we could register it
@@ -387,9 +485,114 @@ impl WhipSessionManager {
                 endpoint_id,
                 slot,
                 cleanup_sent,
+                activity,
             },
         );
         true
+    }
+
+    /// Allocate a slot for a new client, displacing a demonstrably dead session
+    /// if the endpoint is full.
+    ///
+    /// A publisher that dies without sending a WHIP DELETE — network loss, the
+    /// common case for a real participant — leaves its slot occupied until the
+    /// session's inactivity watchdog notices, and every reconnect in between is
+    /// refused with 503.
+    ///
+    /// When all slots are taken, this watches the sitting session for up to
+    /// `TAKEOVER_WAIT` instead of refusing outright. A session whose buffer
+    /// counter is still moving has a publisher behind it and is never touched:
+    /// the new client gets its 503 as soon as the counter is seen to move, which
+    /// is a poll interval, not a wait. A counter that stays frozen past
+    /// `TAKEOVER_IDLE_THRESHOLD` is a dead transport, and the session is handed
+    /// to the ordinary cleanup path so the new client can take the slot it
+    /// releases.
+    ///
+    /// Both cases start out looking identical — a reconnect that lands 300 ms
+    /// after the drop sees the same near-zero idle time as a healthy stream —
+    /// which is why the decision is made on the counter moving rather than on a
+    /// single reading of it.
+    pub async fn allocate_slot_or_take_over(
+        &self,
+        config: &WhipEndpointConfig,
+        resource_id: &str,
+    ) -> Option<usize> {
+        let deadline = Instant::now() + TAKEOVER_WAIT;
+        // The candidate's buffer counter as of the previous poll, so this poll
+        // can tell whether it moved.
+        let mut previous: Option<(String, u64)> = None;
+
+        loop {
+            if let Some(slot) = config.allocate_slot(resource_id) {
+                return Some(slot);
+            }
+
+            // Full. Nothing registered on this endpoint means the slots are held
+            // by sessions still being set up: there is nothing to displace.
+            let candidate = self.idlest_session(&config.endpoint_id)?;
+
+            if candidate.dying {
+                // Another path is already tearing it down. Wait for the slot it
+                // is about to release rather than asking for cleanup twice.
+            } else if candidate
+                .idle
+                .is_some_and(|idle| idle >= TAKEOVER_IDLE_THRESHOLD)
+            {
+                // Win the flag every other teardown path uses, so the session is
+                // cleaned up exactly once and its watchdog thread stops. The
+                // cleanup task is what releases the slot; the next poll takes it.
+                if !candidate.cleanup_sent.swap(true, Ordering::SeqCst) {
+                    let idle_ms = candidate.idle.unwrap_or_default().as_millis();
+                    warn!(
+                        "WhipSessionManager: Displacing session '{}' on port {} ({} ms without media) so a new client can take its slot on endpoint '{}'",
+                        candidate.resource_id, candidate.port, idle_ms, config.endpoint_id
+                    );
+                    let _ = self.cleanup_tx.send(SessionCleanupRequest {
+                        port: candidate.port,
+                        reason: format!(
+                            "displaced by a new client after {} ms without media",
+                            idle_ms
+                        ),
+                    });
+                }
+            } else if previous.as_ref().is_some_and(|(id, last)| {
+                *id == candidate.resource_id && *last != candidate.last_buffer
+            }) {
+                // Its counter moved while we watched: the publisher is still
+                // sending and the endpoint is genuinely full.
+                return None;
+            }
+
+            if Instant::now() + TAKEOVER_POLL >= deadline {
+                return None;
+            }
+            previous = Some((candidate.resource_id, candidate.last_buffer));
+            tokio::time::sleep(TAKEOVER_POLL).await;
+        }
+    }
+
+    /// The session on an endpoint that has gone longest without media — the one
+    /// a new client would displace. `None` if the endpoint has no registered
+    /// session at all.
+    ///
+    /// A session that has never delivered a buffer sorts last and is never
+    /// displaced: it may simply be slow to negotiate (ICE through a TURN relay),
+    /// and evicting it would let two clients take turns throwing each other off
+    /// before either ever sends media.
+    fn idlest_session(&self, endpoint_id: &str) -> Option<IdlestSession> {
+        let sessions = self.sessions.read().unwrap();
+        sessions
+            .iter()
+            .filter(|(_, s)| s.endpoint_id == endpoint_id)
+            .map(|(resource_id, s)| IdlestSession {
+                resource_id: resource_id.clone(),
+                port: s.port,
+                idle: s.activity.idle(),
+                last_buffer: s.activity.last_buffer(),
+                dying: s.cleanup_sent.load(Ordering::SeqCst),
+                cleanup_sent: s.cleanup_sent.clone(),
+            })
+            .max_by_key(|c| (c.dying, c.idle))
     }
 
     /// Look up the port for a session by resource_id.
@@ -548,10 +751,111 @@ mod tests {
         (element, pipeline, Arc::new(AtomicBool::new(false)))
     }
 
+    /// A publisher whose transport is gone: its last buffer arrived `idle` ago
+    /// and the counter has not moved since. `idle` of zero is the case that
+    /// matters — a client reconnecting the instant its publisher died looks, at
+    /// that moment, exactly like a healthy one.
+    fn dead_publisher(idle: Duration) -> Arc<SessionActivity> {
+        // The buffer landed 1 ms into the session, so the counter is non-zero
+        // (0 is reserved for "no buffer yet") and nothing has stamped it since.
+        let epoch = Instant::now() - idle - Duration::from_millis(1);
+        Arc::new(SessionActivity::new(epoch, Arc::new(AtomicU64::new(1))))
+    }
+
+    /// A publisher that is still sending: a thread stamps the counter every
+    /// 20 ms, the way the appsink callback does for every buffer that crosses
+    /// the bridge. The caller sets `stop` to end it.
+    fn live_publisher(stop: Arc<AtomicBool>) -> Arc<SessionActivity> {
+        let activity = Arc::new(SessionActivity::new(
+            Instant::now(),
+            Arc::new(AtomicU64::new(0)),
+        ));
+        let ticking = activity.clone();
+        std::thread::spawn(move || {
+            while !stop.load(Ordering::SeqCst) {
+                ticking.touch();
+                std::thread::sleep(Duration::from_millis(20));
+            }
+        });
+        activity
+    }
+
+    /// A session that is still negotiating: connected, but no media yet.
+    fn no_media_yet() -> Arc<SessionActivity> {
+        Arc::new(SessionActivity::new(
+            Instant::now(),
+            Arc::new(AtomicU64::new(0)),
+        ))
+    }
+
+    fn endpoint_config(max_sessions: usize) -> WhipEndpointConfig {
+        WhipEndpointConfig {
+            instance_id: "whip-input".to_string(),
+            endpoint_id: "endpoint".to_string(),
+            mode: StreamMode::AudioVideo,
+            stun_server: None,
+            turn_server: None,
+            ice_transport_policy: "all".to_string(),
+            pipeline_weak: Default::default(),
+            decode: true,
+            video_decoding: Arc::new((0..max_sessions).map(|_| AtomicBool::new(false)).collect()),
+            jitterbuffer_latency_ms: 200,
+            do_retransmission: true,
+            dynamic_webrtcbin_store: Arc::new(Mutex::new(HashMap::new())),
+            max_video_bitrate_kbps: 4000,
+            max_sessions,
+            slot_audio_appsrcs: Vec::new(),
+            slot_video_appsrcs: Vec::new(),
+            slot_decodebins: vec![Vec::new(); max_sessions],
+            slot_assignments: Arc::new(RwLock::new(vec![None; max_sessions])),
+        }
+    }
+
+    /// A manager with one single-slot endpoint whose only slot is held by a
+    /// registered session with the given liveness — i.e. a full endpoint.
+    fn full_endpoint(
+        resource_id: &str,
+        port: u16,
+        activity: Arc<SessionActivity>,
+    ) -> (
+        Arc<WhipSessionManager>,
+        Arc<WhipEndpointConfig>,
+        Arc<AtomicBool>,
+    ) {
+        let manager = Arc::new(WhipSessionManager::new());
+        manager.start_cleanup_task();
+        manager.register_endpoint("endpoint".to_string(), endpoint_config(1));
+        let config = manager
+            .get_endpoint_config("endpoint")
+            .expect("endpoint was just registered");
+
+        assert_eq!(
+            config.allocate_slot(resource_id),
+            Some(0),
+            "the endpoint starts with its only slot free"
+        );
+        let cleanup_sent = register_with_activity(&manager, resource_id, port, activity);
+        assert_eq!(
+            config.allocate_slot("someone-else"),
+            None,
+            "the endpoint is now full"
+        );
+        (manager, config, cleanup_sent)
+    }
+
     /// A session's `cleanup_sent` flag is the only way to stop its inactivity
     /// watchdog thread. Every path that removes a session must set it, or the
     /// watchdog outlives the session and asks for cleanup of a port that is gone.
     fn register(manager: &WhipSessionManager, resource_id: &str, port: u16) -> Arc<AtomicBool> {
+        register_with_activity(manager, resource_id, port, dead_publisher(Duration::ZERO))
+    }
+
+    fn register_with_activity(
+        manager: &WhipSessionManager,
+        resource_id: &str,
+        port: u16,
+        activity: Arc<SessionActivity>,
+    ) -> Arc<AtomicBool> {
         let (element, pipeline, cleanup_sent) = dummy_session();
         let registered = manager.register_session(NewWhipSession {
             resource_id: resource_id.to_string(),
@@ -561,6 +865,7 @@ mod tests {
             endpoint_id: "endpoint".to_string(),
             slot: 0,
             cleanup_sent: cleanup_sent.clone(),
+            activity,
         });
         assert!(registered, "session should register");
         assert!(
@@ -629,6 +934,7 @@ mod tests {
             endpoint_id: "endpoint".to_string(),
             slot: 0,
             cleanup_sent: cleanup_sent.clone(),
+            activity: dead_publisher(Duration::ZERO),
         });
 
         assert!(
@@ -657,12 +963,127 @@ mod tests {
             endpoint_id: "endpoint".to_string(),
             slot: 0,
             cleanup_sent: cleanup_sent.clone(),
+            activity: dead_publisher(Duration::ZERO),
         });
 
         assert!(!registered, "a fresh mark must still reject the session");
         assert!(
             cleanup_sent.load(Ordering::SeqCst),
             "a rejected session's watchdog must be stopped too"
+        );
+    }
+
+    /// The bug this guards: a publisher that dies without sending a WHIP DELETE
+    /// (network loss) leaves its slot occupied, and the rejoining client is
+    /// refused with 503 until the inactivity watchdog reclaims the slot seconds
+    /// later. A session whose media has stopped must give its slot up instead.
+    #[tokio::test]
+    async fn a_dead_session_gives_its_slot_to_a_new_client() {
+        let (manager, config, cleanup_sent) = full_endpoint(
+            "dead-session",
+            40010,
+            dead_publisher(TAKEOVER_IDLE_THRESHOLD * 2),
+        );
+
+        let slot = manager
+            .allocate_slot_or_take_over(&config, "rejoining-client")
+            .await;
+
+        assert_eq!(
+            slot,
+            Some(0),
+            "the rejoining client must get the dead session's slot"
+        );
+        assert!(
+            cleanup_sent.load(Ordering::SeqCst),
+            "the displaced session's watchdog must be stopped"
+        );
+        assert!(
+            manager.get_session_port("dead-session").is_none(),
+            "the displaced session must be torn down by the ordinary cleanup path"
+        );
+        assert_eq!(
+            config.slot_assignments.read().unwrap()[0].as_deref(),
+            Some("rejoining-client"),
+            "the slot must be assigned to the new client, not left free"
+        );
+    }
+
+    /// The measured case, and the one a single reading of the idle time gets
+    /// wrong: the publisher is SIGKILLed and its client reconnects a few hundred
+    /// milliseconds later, while the dead session still looks freshly fed. It is
+    /// the counter staying frozen, not its value, that gives the session away.
+    #[tokio::test]
+    async fn a_session_that_died_moments_before_the_post_is_still_displaced() {
+        let (manager, config, cleanup_sent) =
+            full_endpoint("just-died", 40013, dead_publisher(Duration::ZERO));
+
+        let started = Instant::now();
+        let slot = manager
+            .allocate_slot_or_take_over(&config, "rejoining-client")
+            .await;
+
+        assert_eq!(
+            slot,
+            Some(0),
+            "a client reconnecting straight after the drop must still get the slot"
+        );
+        assert!(cleanup_sent.load(Ordering::SeqCst));
+        assert!(
+            started.elapsed() >= TAKEOVER_IDLE_THRESHOLD,
+            "the session must not be displaced before it has been quiet long enough"
+        );
+    }
+
+    /// The risk in takeover: a second participant must not be able to evict a
+    /// publisher that is streaming fine. Its buffer counter is moving, so that
+    /// client still gets 503, and gets it in a poll interval rather than after
+    /// the full takeover wait.
+    #[tokio::test]
+    async fn a_live_session_is_never_displaced() {
+        let stop = Arc::new(AtomicBool::new(false));
+        let (manager, config, cleanup_sent) =
+            full_endpoint("live-session", 40011, live_publisher(stop.clone()));
+
+        let started = Instant::now();
+        let slot = manager
+            .allocate_slot_or_take_over(&config, "second-client")
+            .await;
+        stop.store(true, Ordering::SeqCst);
+
+        assert_eq!(slot, None, "a second client must still be refused");
+        assert!(
+            !cleanup_sent.load(Ordering::SeqCst),
+            "a session that is delivering media must not be torn down"
+        );
+        assert!(
+            manager.get_session_port("live-session").is_some(),
+            "the live session must still be registered"
+        );
+        assert!(
+            started.elapsed() < TAKEOVER_IDLE_THRESHOLD,
+            "a live publisher must be recognised from its moving counter, not \
+             waited out: took {:?}",
+            started.elapsed()
+        );
+    }
+
+    /// A session that has not produced a buffer yet may just be slow to
+    /// negotiate (ICE through a TURN relay). Displacing it would let two clients
+    /// take turns evicting each other before either ever sends media.
+    #[tokio::test]
+    async fn a_session_that_has_not_delivered_media_yet_is_not_displaced() {
+        let (manager, config, cleanup_sent) = full_endpoint("negotiating", 40012, no_media_yet());
+
+        let slot = manager
+            .allocate_slot_or_take_over(&config, "second-client")
+            .await;
+
+        assert_eq!(slot, None, "a negotiating session must keep its slot");
+        assert!(!cleanup_sent.load(Ordering::SeqCst));
+        assert!(
+            manager.get_session_port("negotiating").is_some(),
+            "the negotiating session must still be registered"
         );
     }
 }

--- a/backend/src/whip_session_manager.rs
+++ b/backend/src/whip_session_manager.rs
@@ -157,17 +157,22 @@ pub struct SessionCleanupRequest {
 /// Liveness of one WHIP session: when its last media buffer crossed the
 /// appsink→appsrc bridge into the main pipeline.
 ///
-/// The counter is written from the appsink's `new_sample` callback, i.e. once
-/// per buffer, so it is a single relaxed store against an epoch taken at session
-/// start. It is read by the session's own inactivity watchdog and by
+/// The counters are written from the appsink's `new_sample` callback, i.e. once
+/// per buffer, so a stamp is a single relaxed store against an epoch taken at
+/// session start. They are read by the session's own inactivity watchdog and by
 /// `allocate_slot_or_take_over`, which needs to know whether an occupied slot
-/// still has a publisher behind it. The counter is an `Arc` of its own because
-/// the session's watchdog thread reads it directly.
+/// still has a publisher behind it. `last_buffer_ms` is an `Arc` of its own
+/// because the session's watchdog thread reads it directly.
 pub struct SessionActivity {
     /// Session start. All timestamps are milliseconds from here.
     epoch: Instant,
-    /// Milliseconds from `epoch` at which the last buffer arrived; 0 = none yet.
+    /// Milliseconds from `epoch` at which the last buffer arrived on any
+    /// stream; 0 = none yet.
     last_buffer_ms: Arc<AtomicU64>,
+    /// The same, counting audio buffers only. Non-zero means this session
+    /// negotiated an audio stream and it produced something, which is what
+    /// makes `TAKEOVER_IDLE_THRESHOLD` a sound bound; see `has_delivered_audio`.
+    last_audio_ms: AtomicU64,
 }
 
 impl SessionActivity {
@@ -175,19 +180,50 @@ impl SessionActivity {
         Self {
             epoch,
             last_buffer_ms,
+            last_audio_ms: AtomicU64::new(0),
         }
     }
 
     /// Stamp the arrival of a buffer. Called from the appsink callback, so this
-    /// is the per-buffer hot path: one `Instant::now()` and one relaxed store,
-    /// no lock and no allocation.
-    pub fn touch(&self) {
+    /// is the per-buffer hot path: one `Instant::now()` and one or two relaxed
+    /// stores, no lock and no allocation.
+    pub fn touch(&self, is_audio: bool) {
         // 0 is reserved for "no buffer yet", so a buffer that lands inside the
         // first millisecond of the session counts as 1.
-        self.last_buffer_ms.store(
-            (self.epoch.elapsed().as_millis() as u64).max(1),
-            Ordering::Relaxed,
-        );
+        let now_ms = (self.epoch.elapsed().as_millis() as u64).max(1);
+        self.last_buffer_ms.store(now_ms, Ordering::Relaxed);
+        if is_audio {
+            self.last_audio_ms.store(now_ms, Ordering::Relaxed);
+        }
+    }
+
+    /// Assemble a session whose counters a test has already positioned in time.
+    #[cfg(test)]
+    pub fn from_counters(
+        epoch: Instant,
+        last_buffer_ms: Arc<AtomicU64>,
+        last_audio_ms: u64,
+    ) -> Self {
+        Self {
+            epoch,
+            last_buffer_ms,
+            last_audio_ms: AtomicU64::new(last_audio_ms),
+        }
+    }
+
+    /// Whether this session has ever delivered an audio buffer.
+    ///
+    /// Only an audio-bearing session can be judged dead on a couple of seconds
+    /// of silence, because only audio has a cadence tight enough for a gap that
+    /// short to mean anything: ~20 ms per packet, against a video stream whose
+    /// interval is whatever the publisher's encoder decided to emit. A
+    /// video-only publisher of static content — a screen share of a window
+    /// nobody is touching — legitimately goes seconds between frames on a
+    /// perfectly healthy transport, and is indistinguishable from a dead one by
+    /// any media-based signal. Such a session is left to the inactivity
+    /// watchdog; see `allocate_slot_or_take_over`.
+    pub fn has_delivered_audio(&self) -> bool {
+        self.last_audio_ms.load(Ordering::Relaxed) != 0
     }
 
     /// The raw counter: milliseconds from `epoch` at which the last buffer
@@ -312,6 +348,8 @@ struct IdlestSession {
     last_buffer: u64,
     /// Another path is already tearing it down, so its slot is about to free.
     dying: bool,
+    /// Whether it has ever delivered audio; see `SessionActivity::has_delivered_audio`.
+    has_audio: bool,
     cleanup_sent: Arc<AtomicBool>,
 }
 
@@ -512,6 +550,14 @@ impl WhipSessionManager {
     /// after the drop sees the same near-zero idle time as a healthy stream —
     /// which is why the decision is made on the counter moving rather than on a
     /// single reading of it.
+    ///
+    /// Only a session that has delivered audio is ever displaced. Audio is what
+    /// makes `TAKEOVER_IDLE_THRESHOLD` mean anything; a video-only session can
+    /// sit that long between frames while its publisher is healthy, so it is
+    /// left to the inactivity watchdog and the new client gets a 503. The
+    /// residual case is a session whose audio stopped for good — a muted or
+    /// failed microphone — while its video continues at gaps wider than the
+    /// threshold: that one can still be displaced.
     pub async fn allocate_slot_or_take_over(
         &self,
         config: &WhipEndpointConfig,
@@ -534,9 +580,10 @@ impl WhipSessionManager {
             if candidate.dying {
                 // Another path is already tearing it down. Wait for the slot it
                 // is about to release rather than asking for cleanup twice.
-            } else if candidate
-                .idle
-                .is_some_and(|idle| idle >= TAKEOVER_IDLE_THRESHOLD)
+            } else if candidate.has_audio
+                && candidate
+                    .idle
+                    .is_some_and(|idle| idle >= TAKEOVER_IDLE_THRESHOLD)
             {
                 // Win the flag every other teardown path uses, so the session is
                 // cleaned up exactly once and its watchdog thread stops. The
@@ -590,6 +637,7 @@ impl WhipSessionManager {
                 idle: s.activity.idle(),
                 last_buffer: s.activity.last_buffer(),
                 dying: s.cleanup_sent.load(Ordering::SeqCst),
+                has_audio: s.activity.has_delivered_audio(),
                 cleanup_sent: s.cleanup_sent.clone(),
             })
             .max_by_key(|c| (c.dying, c.idle))
@@ -755,10 +803,24 @@ mod tests {
     /// and the counter has not moved since. `idle` of zero is the case that
     /// matters — a client reconnecting the instant its publisher died looks, at
     /// that moment, exactly like a healthy one.
+    ///
+    /// It carries audio, so it is in displacement range at all.
     fn dead_publisher(idle: Duration) -> Arc<SessionActivity> {
         // The buffer landed 1 ms into the session, so the counter is non-zero
         // (0 is reserved for "no buffer yet") and nothing has stamped it since.
         let epoch = Instant::now() - idle - Duration::from_millis(1);
+        Arc::new(SessionActivity::from_counters(
+            epoch,
+            Arc::new(AtomicU64::new(1)),
+            1,
+        ))
+    }
+
+    /// A healthy video-only publisher of static content, mid-gap: its last frame
+    /// arrived `gap` ago and the next one is not due yet. Never delivered audio,
+    /// so nothing about it can be judged on a two-second silence.
+    fn sparse_video_publisher(gap: Duration) -> Arc<SessionActivity> {
+        let epoch = Instant::now() - gap - Duration::from_millis(1);
         Arc::new(SessionActivity::new(epoch, Arc::new(AtomicU64::new(1))))
     }
 
@@ -773,7 +835,7 @@ mod tests {
         let ticking = activity.clone();
         std::thread::spawn(move || {
             while !stop.load(Ordering::SeqCst) {
-                ticking.touch();
+                ticking.touch(true);
                 std::thread::sleep(Duration::from_millis(20));
             }
         });
@@ -1084,6 +1146,36 @@ mod tests {
         assert!(
             manager.get_session_port("negotiating").is_some(),
             "the negotiating session must still be registered"
+        );
+    }
+
+    /// A video-only publisher of static content goes seconds between frames on a
+    /// healthy transport, so its frozen counter says nothing about whether it is
+    /// still there. Measured on the rig: a 0.2 fps video-only seat was displaced
+    /// at 3100 ms without media while its publisher was still sending.
+    #[tokio::test]
+    async fn a_sparse_video_only_session_is_not_displaced() {
+        let (manager, config, cleanup_sent) = full_endpoint(
+            "screenshare",
+            40013,
+            sparse_video_publisher(TAKEOVER_IDLE_THRESHOLD * 2),
+        );
+
+        let slot = manager
+            .allocate_slot_or_take_over(&config, "second-client")
+            .await;
+
+        assert_eq!(
+            slot, None,
+            "a video-only session must keep its slot however wide its frame gap"
+        );
+        assert!(
+            !cleanup_sent.load(Ordering::SeqCst),
+            "a healthy publisher must not be torn down"
+        );
+        assert!(
+            manager.get_session_port("screenshare").is_some(),
+            "the video-only session must still be registered"
         );
     }
 }


### PR DESCRIPTION
## The bug

A browser seat on the live rig kept receiving RTP but stopped producing usable video, and held its slot for 45 minutes. Every rejoining client got a 503, and #753's takeover never fired. Liveness was stamped by the session pipeline's appsink, which sits upstream of `decodebin`. It recorded bytes arriving, not frames decoding or reaching a consumer.

## What changed

`SessionActivity` now tracks two `ActivityStamp`s:

- **ingress**: the session appsink. Shows the publisher is sending.
- **output**: a BUFFER probe on the slot's output tee, past `decodebin` and the converter. Shows frames are reaching the flow's consumers.

`idle()` returns the staler of the two. The watchdog (`wait_for_inactivity`) and slot takeover both read `idle()`, so both now catch a seat that receives without producing.

- The output stamp belongs to the slot, which outlives the sessions that use it, so claiming a slot resets it.
- `idle()` does not judge a session until `DECODE_GRACE` (5 s) after its first arriving buffer. H.264 cannot decode before a keyframe arrives with its parameter sets. The measured delay is 0.9-1.0 s.
- #753's audio gate stays on the arriving side, because one output stamp serves both a slot's audio and video tees and cannot tell them apart.

**Takeover.** Both sessions share the slot's appsrc, and the displaced session is still tearing down when the newcomer resets the stamp. #753's `session_finished` gate stops it pushing new samples, but frames already inside the chain still cross the tee and move the newcomer's output stamp. `idle()` therefore holds the grace regardless of output, so that tail cannot let the next POST evict a newcomer that has not decoded anything yet. The cost: a session that dies within 5 s of its first buffer cannot be displaced until those 5 s are up, where before it could be after 2 s. I have not measured the tail's width. The fix only needs it to be shorter than the grace.

## Tests

Each new test fails with its fix reverted: ingress-only `idle()`, the tee probe deleted, or the conditional grace restored.

- `whip_session_manager.rs`:
  - `a_session_receiving_media_it_never_decodes_is_displaced`
  - `a_session_whose_output_has_stalled_is_displaced`
  - `a_session_still_waiting_for_its_first_decoded_frame_is_not_displaced`
  - `a_new_session_does_not_inherit_the_slots_previous_liveness`
  - `a_predecessors_trailing_frames_do_not_cut_the_decode_grace_short`
- `whip.rs`:
  - `the_slot_stamp_follows_media_out_of_the_decode_chain_not_into_it` pushes real buffers through the block's own `appsrc -> decodebin -> videoconvert -> tee` chain. It then blocks the consumer and asserts the stamp stops moving. It uses only `plugins-base` elements, which CI installs.
  - `watchdog_reaps_a_session_that_receives_media_it_never_decodes` runs under a 5 s bound, so a regression fails the test instead of hanging it.
- `watchdog_detects_inactivity_within_one_poll_of_the_timeout` (#752) now backdates its session. Its 1 s timeout is shorter than the grace.
- #753's guards pass unchanged, including `a_finished_session_stops_feeding_its_slot` and `a_dead_session_is_displaced_past_a_quieter_video_only_one`.

**Ran locally on macOS, on this head:** `cargo test --features efp` (821 passed, 0 failed, 2 pre-existing ignores), plus clippy with `-D warnings` and `fmt --check`, all clean. **Not run:** the `nvidia` feature and the WASM clippy.

## Rig verification (pre-rebase)

These six trials ran on the old #753 base and have not been repeated on `main`. The second commit only lengthens protection for sessions younger than 5 s, and every trial was judged well past that point.

Setup: headless, `max_sessions: 1`, and a `whipclientsink` H.264 publisher feeding a flow that ends in an MP4 recorder. Stopping the publisher's audio makes the muxer back-pressure video through the slot's tee while RTP keeps arriving.

- **Stalled seat (3 trials):** displaced 2027-2049 ms after its output froze, with the publisher still sending. The watchdog reaped nothing.
- **Healthy seat (3 trials):** 75 rejoin attempts over 32 s, all refused within 101-107 ms (one poll), and none displaced.

## Trade-offs

- **Flow-wide stalls.** If the whole flow stalls, a new POST can displace a seat that was not at fault. That costs a reconnect, not media.
- **Grace margin.** The 5 s `DECODE_GRACE` has no hard bound behind it beyond the ~1 s measurement. It must stay below `INACTIVITY_TIMEOUT` (10 s).
- **Per-slot stamp.** Output is stamped per slot, not per medium, so frozen video with live audio still reads as live. #792 addresses that on top of this PR.
- **File size.** `whip_session_manager.rs` (1605 lines) and `whip.rs` (2629) are past the split threshold. I'd split them in a separate PR before #792.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
