### PR TITLE
fix(whip): stop an unstamped buffer at the session bridge before qtmux sees it

### DIFF
--- a/backend/src/blocks/builtin/mediaplayer/bridge.rs
+++ b/backend/src/blocks/builtin/mediaplayer/bridge.rs
@@ -571,3 +571,85 @@ pub fn watch_internal_bus(
         bus.remove_signal_watch();
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::blocks::builtin::mediaplayer::state::Playlist;
+    use crate::gst::pipeline_bridge::test_support::{at, Harness, SessionPipeline};
+    use std::sync::atomic::AtomicBool;
+    use std::sync::RwLock;
+    use uuid::Uuid;
+
+    fn test_state(main_pipeline: &Harness) -> Arc<MediaPlayerState> {
+        Arc::new(MediaPlayerState {
+            instance_id: Uuid::new_v4(),
+            source_element: gst::glib::WeakRef::new(),
+            internal_pipeline: RwLock::new(None),
+            video_appsrc: None,
+            audio_appsrc: None,
+            playlist: RwLock::new(Playlist {
+                files: Vec::new(),
+                current_index: 0,
+            }),
+            is_paused: AtomicBool::new(false),
+            loop_playlist: AtomicBool::new(false),
+            block_id: "test".to_string(),
+            flow_id: Uuid::new_v4(),
+            switching_file: AtomicBool::new(false),
+            video_linked: AtomicBool::new(false),
+            audio_linked: AtomicBool::new(false),
+            decode: false,
+            sync: false,
+            media_path: std::path::PathBuf::from("/media"),
+            bridge: Arc::new(pipeline_bridge::SessionBridge::new()),
+            main_pipeline: main_pipeline.pipeline_weak(),
+            bus_watch: std::sync::Mutex::new(None),
+        })
+    }
+
+    /// The wiring guard for this block. [`pipeline_bridge`] can only promise
+    /// that `SessionBridge::forward` drops an unstamped buffer; it cannot
+    /// promise this bridge still calls it. So drive the real appsink callback
+    /// that [`link_pad_through_clocksync`] installs: three buffers in, the
+    /// middle one with no PTS, and only the two stamped ones may reach the
+    /// appsrc in the main pipeline.
+    ///
+    /// In passthrough mode this block's output reaches the same `qtmux` as a
+    /// WHIP seat's, where an unstamped buffer answers `GST_FLOW_ERROR` and
+    /// takes the whole flow down.
+    #[test]
+    fn an_unstamped_buffer_never_reaches_the_main_pipeline() {
+        let main = Harness::new();
+        let session = SessionPipeline::new();
+        let state = test_state(&main);
+
+        session.start();
+        link_pad_through_clocksync(
+            &session.pipeline,
+            &session.src_pad(),
+            &main.src,
+            &state,
+            "test_clocksync",
+            "test_appsink",
+            false,
+            "video",
+        )
+        .expect("bridge chain");
+
+        session.push(at(1));
+        session.push(None);
+        session.push(at(3));
+
+        let first = main.next_pts().expect("first buffer crossed");
+        assert!(first.is_some(), "a stamped buffer must keep its stamp");
+        let second = main.next_pts().expect("the third buffer crossed too");
+        assert!(
+            second.is_some(),
+            "the unstamped buffer must not be here — the third one is next"
+        );
+        assert!(second > first, "and it must follow the first");
+        assert_eq!(main.next_pts(), None, "nothing else should have crossed");
+        assert_eq!(state.bridge.dropped_unstamped(), 1);
+    }
+}

--- a/backend/src/blocks/builtin/mediaplayer/bridge.rs
+++ b/backend/src/blocks/builtin/mediaplayer/bridge.rs
@@ -7,6 +7,7 @@
 use super::state::MediaPlayerState;
 use crate::blocks::BlockBuildError;
 use crate::events::EventBroadcaster;
+use crate::gst::pipeline_bridge;
 use gstreamer as gst;
 use gstreamer::prelude::*;
 use gstreamer_app as gst_app;
@@ -321,10 +322,9 @@ pub fn create_passthrough_pipeline(
 
 /// Link a dynamic pad through clocksync → appsink, with appsink bridging to the given appsrc.
 ///
-/// The bridge computes a timestamp offset from the first buffer:
-///   `offset = main_running_time - buffer_pts`
-/// and applies it to all subsequent buffers so PTS aligns with the main pipeline clock.
-/// The offset is shared (via `ts_offset`) between audio and video streams for A/V sync.
+/// Rebasing and the unstamped-buffer drop live in [`crate::gst::pipeline_bridge`],
+/// shared with the WHIP block's session bridge; this function is the plumbing
+/// around it.
 #[allow(clippy::too_many_arguments)]
 fn link_pad_through_clocksync(
     pipeline: &gst::Pipeline,
@@ -376,7 +376,7 @@ fn link_pad_through_clocksync(
     // Set up bridge callback: appsink → appsrc with timestamp offset
     let appsrc_weak = appsrc.downgrade();
     let media_type_owned = media_type.to_string();
-    let ts_offset = Arc::clone(&state.ts_offset);
+    let bridge = Arc::clone(&state.bridge);
     let main_pipeline_weak = state.main_pipeline.clone();
     let pushed_count = Arc::new(std::sync::atomic::AtomicU64::new(0));
 
@@ -395,81 +395,50 @@ fn link_pad_through_clocksync(
                     }
                 };
 
-                let buffer = sample.buffer().ok_or(gst::FlowError::Error)?;
-                let pts = buffer.pts();
+                let outcome = bridge
+                    .forward(&sample, &appsrc, || {
+                        let main_pipe = main_pipeline_weak.upgrade()?;
+                        let clock = main_pipe.clock()?;
+                        let base_time = main_pipe.base_time()?;
+                        Some(clock.time().saturating_sub(base_time))
+                    })
+                    .ok_or(gst::FlowError::Error)?;
 
-                // Compute or reuse timestamp offset
-                let offset_ns = {
-                    let current = ts_offset.load(Ordering::Relaxed);
-                    if current != i64::MIN {
-                        current
-                    } else if let (Some(pts_val), Some(main_pipe)) =
-                        (pts, main_pipeline_weak.upgrade())
-                    {
-                        let clock = main_pipe.clock();
-                        let base_time = main_pipe.base_time();
-                        if let (Some(clock), Some(base_time)) = (clock, base_time) {
-                            let running = clock.time().saturating_sub(base_time);
-                            let offset = running.nseconds() as i64 - pts_val.nseconds() as i64;
-                            ts_offset.store(offset, Ordering::Relaxed);
-                            offset
-                        } else {
-                            0
-                        }
-                    } else {
-                        0
+                // A refused push (typically FLUSHING while the main pipeline is
+                // still starting) must not kill the appsink: drop the sample and
+                // let the next one retry once the appsrc is ready.
+                match outcome {
+                    pipeline_bridge::Forwarded::OffsetComputed(offset) => {
+                        pushed_count.fetch_add(1, Ordering::Relaxed);
+                        info!(
+                            "Media Player bridge: {} delivered its first sample, computed shared ts-offset={}ms",
+                            media_type_owned,
+                            offset / 1_000_000
+                        );
                     }
-                };
-
-                // Build the sample to push, applying timestamp offset if needed
-                let push_result = if offset_ns != 0 {
-                    if let Some(pts_val) = pts {
-                        let adjusted = (pts_val.nseconds() as i64 + offset_ns).max(0) as u64;
-                        let mut new_buf = buffer.copy();
-                        {
-                            let buf_ref = new_buf.get_mut().unwrap();
-                            buf_ref.set_pts(gst::ClockTime::from_nseconds(adjusted));
-                            if let Some(dts) = buffer.dts() {
-                                let adj_dts = (dts.nseconds() as i64 + offset_ns).max(0) as u64;
-                                buf_ref.set_dts(gst::ClockTime::from_nseconds(adj_dts));
-                            }
-                        }
-                        let owned_caps = sample.caps().map(|c| c.to_owned());
-                        let mut builder = gst::Sample::builder().buffer(&new_buf);
-                        if let Some(ref caps) = owned_caps {
-                            builder = builder.caps(caps);
-                        }
-                        appsrc.push_sample(&builder.build())
-                    } else {
-                        appsrc.push_sample(&sample)
-                    }
-                } else {
-                    appsrc.push_sample(&sample)
-                };
-
-                // Don't kill the appsink on transient errors (e.g. FLUSHING while
-                // the main pipeline is still starting). Drop the sample and retry
-                // on the next one — the appsrc will accept data once it's ready.
-                match push_result {
-                    Ok(_) => {
-                        if pushed_count.fetch_add(1, Ordering::Relaxed) == 0 {
-                            info!(
-                                "Media Player bridge: {} first sample delivered, pts={:?}",
-                                media_type_owned, pts
+                    pipeline_bridge::Forwarded::DroppedUnstamped { dropped } => {
+                        if pipeline_bridge::should_log_drop(dropped) {
+                            warn!(
+                                "Media Player bridge: dropped {} buffer(s) with no PTS on the {} stream; forwarding one fails the downstream muxer and takes the whole flow with it",
+                                dropped, media_type_owned
                             );
                         }
-                        Ok(gst::FlowSuccess::Ok)
                     }
-                    Err(e) => {
+                    pipeline_bridge::Forwarded::PushFailed(e) => {
                         if pushed_count.load(Ordering::Relaxed) == 0 {
                             debug!(
                                 "Media Player bridge: {} push_sample failed ({:?}), waiting for appsrc",
                                 media_type_owned, e
                             );
                         }
-                        Ok(gst::FlowSuccess::Ok)
+                    }
+                    pipeline_bridge::Forwarded::Restamped
+                    | pipeline_bridge::Forwarded::Unadjusted => {
+                        pushed_count.fetch_add(1, Ordering::Relaxed);
                     }
                 }
+
+                Ok(gst::FlowSuccess::Ok)
             })
             .build(),
     );

--- a/backend/src/blocks/builtin/mediaplayer/builder.rs
+++ b/backend/src/blocks/builtin/mediaplayer/builder.rs
@@ -12,7 +12,7 @@ use gstreamer as gst;
 use gstreamer::prelude::*;
 use gstreamer_app as gst_app;
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, AtomicI64};
+use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, RwLock};
 use strom_types::element::ElementPadRef;
 use strom_types::{FlowId, PropertyValue, StromEvent};
@@ -178,7 +178,7 @@ fn build_media_player(
     // --- Create shared state ---
     let player_instance_id = Uuid::new_v4();
     let source_element_weak = gst::glib::WeakRef::new();
-    let ts_offset = Arc::new(AtomicI64::new(i64::MIN));
+    let bridge = Arc::new(crate::gst::pipeline_bridge::SessionBridge::new());
     let state = Arc::new(MediaPlayerState {
         instance_id: player_instance_id,
         source_element: source_element_weak,
@@ -199,7 +199,7 @@ fn build_media_player(
         decode,
         sync,
         media_path: media_path.clone(),
-        ts_offset,
+        bridge,
         main_pipeline: gst::glib::WeakRef::new(),
         bus_watch: std::sync::Mutex::new(None),
     });

--- a/backend/src/blocks/builtin/mediaplayer/mod.rs
+++ b/backend/src/blocks/builtin/mediaplayer/mod.rs
@@ -68,7 +68,7 @@ mod tests {
         MediaPlayerKey, MediaPlayerRegistry, MediaPlayerState, Playlist,
     };
     use gstreamer as gst;
-    use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
+    use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::{Arc, RwLock};
     use strom_types::block::PropertyType;
     use strom_types::PropertyValue;
@@ -96,7 +96,7 @@ mod tests {
             decode: false,
             sync: true,
             media_path: std::path::PathBuf::from("/media"),
-            ts_offset: Arc::new(AtomicI64::new(i64::MIN)),
+            bridge: Arc::new(crate::gst::pipeline_bridge::SessionBridge::new()),
             main_pipeline: gst::glib::WeakRef::new(),
             bus_watch: std::sync::Mutex::new(None),
         }

--- a/backend/src/blocks/builtin/mediaplayer/state.rs
+++ b/backend/src/blocks/builtin/mediaplayer/state.rs
@@ -1,11 +1,12 @@
 //! Media player runtime state, global registry, and lifecycle methods.
 
 use super::normalize_uri;
+use crate::gst::pipeline_bridge;
 use gstreamer as gst;
 use gstreamer::prelude::*;
 use gstreamer_app as gst_app;
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, LazyLock, Mutex, RwLock};
 use strom_types::FlowId;
 use tracing::{debug, error, info};
@@ -62,10 +63,11 @@ pub struct MediaPlayerState {
     pub sync: bool,
     /// Configured media files directory (for resolving relative playlist paths)
     pub media_path: std::path::PathBuf,
-    /// Shared timestamp offset (ns) for the appsink→appsrc bridge.
-    /// Computed once from the first buffer: `main_running_time - buffer_pts`.
-    /// Set to `i64::MIN` to signal "needs recomputation" (on startup, file switch, resume).
-    pub ts_offset: Arc<AtomicI64>,
+    /// Timestamp rebasing for the appsink→appsrc bridge, shared by the audio
+    /// and video streams so they keep their relative timing, and shared as code
+    /// with the WHIP block. Also what stops an unstamped buffer reaching the
+    /// main pipeline; see [`crate::gst::pipeline_bridge`].
+    pub bridge: Arc<pipeline_bridge::SessionBridge>,
     /// Weak reference to the main pipeline (for computing running time in the bridge).
     pub main_pipeline: gst::glib::WeakRef<gst::Pipeline>,
     /// Handler id of the signal watch on the internal pipeline's bus.
@@ -236,7 +238,7 @@ impl MediaPlayerState {
         // and the bridge recomputes the offset from the first buffer
         self.video_linked.store(false, Ordering::SeqCst);
         self.audio_linked.store(false, Ordering::SeqCst);
-        self.ts_offset.store(i64::MIN, Ordering::SeqCst);
+        self.bridge.reset_offset();
 
         // Set the new URI on source element
         source_element.set_property("uri", &uri);
@@ -263,7 +265,7 @@ impl MediaPlayerState {
             .ok_or("Internal pipeline not created")?;
         // Reset timestamp offset so the bridge recomputes from the first buffer
         // after resume — prevents accumulated drift from pause duration.
-        self.ts_offset.store(i64::MIN, Ordering::SeqCst);
+        self.bridge.reset_offset();
         pipeline.set_state(gst::State::Playing).map_err(|e| {
             error!("Failed to resume playback: {:?}", e);
             "Failed to resume playback".to_string()
@@ -317,7 +319,7 @@ impl MediaPlayerState {
 
         // Reset timestamp offset so the bridge recomputes from the first buffer
         // after the seek — the file PTS jumps but main pipeline running time doesn't.
-        self.ts_offset.store(i64::MIN, Ordering::SeqCst);
+        self.bridge.reset_offset();
 
         let seek_result = source.seek_simple(
             gst::SeekFlags::FLUSH | gst::SeekFlags::KEY_UNIT,

--- a/backend/src/blocks/builtin/whip.rs
+++ b/backend/src/blocks/builtin/whip.rs
@@ -16,6 +16,7 @@ use crate::blocks::{
 };
 use crate::gst::ice_preflight;
 use crate::gst::keyframe_request;
+use crate::gst::whip_bridge::{self, SessionBridge};
 use crate::whip_session_manager::{SessionCleanupRequest, WhipEndpointConfig};
 use gstreamer as gst;
 use gstreamer::prelude::*;
@@ -23,7 +24,7 @@ use gstreamer_app as gst_app;
 use gstreamer_video as gst_video;
 use std::collections::HashMap;
 use std::net::TcpListener;
-use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::Instant;
 use strom_types::block::StreamMode;
@@ -810,11 +811,9 @@ pub fn create_whipserversrc_for_session(
         flag.store(false, Ordering::Relaxed);
     }
 
-    // Shared timestamp offset for A/V sync across audio and video appsrcs.
-    // Computed from the first buffer on either stream:
-    //   offset = main_pipeline_running_time - buffer_pts
-    // i64::MIN means "not yet computed".
-    let shared_ts_offset = Arc::new(AtomicI64::new(i64::MIN));
+    // Shared appsink -> appsrc bridge state for this session: the A/V timestamp
+    // offset both streams rebase onto, and the unstamped-buffer drop count.
+    let session_bridge = Arc::new(SessionBridge::new());
 
     // Inactivity watchdog: tracks when the last buffer arrived on any stream.
     // A background thread checks this and triggers cleanup if no data arrives
@@ -1008,7 +1007,7 @@ pub fn create_whipserversrc_for_session(
                     }
                 }
 
-                let ts_offset = shared_ts_offset.clone();
+                let bridge = session_bridge.clone();
                 let main_pipeline_for_ts = main_pipeline_weak.clone();
                 let media_for_log = media_type.to_string();
                 let last_buffer_ms_cb = last_buffer_ms.clone();
@@ -1024,58 +1023,35 @@ pub fn create_whipserversrc_for_session(
                             );
 
                             let sample = sink.pull_sample().map_err(|_| gst::FlowError::Eos)?;
-                            let buffer = sample.buffer().ok_or(gst::FlowError::Error)?;
-                            let pts = buffer.pts();
 
-                            // Compute offset on the first buffer from either stream
-                            let offset_ns = {
-                                let current = ts_offset.load(Ordering::Relaxed);
-                                if current != i64::MIN {
-                                    current
-                                } else if let (Some(pts_val), Some(main_pipeline)) =
-                                    (pts, main_pipeline_for_ts.upgrade())
-                                {
-                                    let clock = main_pipeline.clock();
-                                    let base_time = main_pipeline.base_time();
-                                    if let (Some(clock), Some(base_time)) = (clock, base_time) {
-                                        let now = clock.time();
-                                        let running = now.saturating_sub(base_time);
-                                        let offset = running.nseconds() as i64 - pts_val.nseconds() as i64;
-                                        ts_offset.store(offset, Ordering::Relaxed);
-                                        info!(
-                                            "WHIP Input: Computed shared ts-offset={}ms from {} stream (slot {})",
-                                            offset / 1_000_000,
-                                            media_for_log,
-                                            slot
+                            let outcome = bridge
+                                .forward(&sample, &appsrc, || {
+                                    let main_pipeline = main_pipeline_for_ts.upgrade()?;
+                                    let clock = main_pipeline.clock()?;
+                                    let base_time = main_pipeline.base_time()?;
+                                    Some(clock.time().saturating_sub(base_time))
+                                })
+                                .ok_or(gst::FlowError::Error)?;
+
+                            match outcome {
+                                whip_bridge::Forwarded::OffsetComputed(offset) => {
+                                    info!(
+                                        "WHIP Input: Computed shared ts-offset={}ms from {} stream (slot {})",
+                                        offset / 1_000_000,
+                                        media_for_log,
+                                        slot
+                                    );
+                                }
+                                whip_bridge::Forwarded::DroppedUnstamped { dropped } => {
+                                    if whip_bridge::should_log_drop(dropped) {
+                                        warn!(
+                                            "WHIP Input: dropped {} buffer(s) with no PTS on the {} stream (slot {}); forwarding one fails the downstream muxer and takes the whole flow with it",
+                                            dropped, media_for_log, slot
                                         );
-                                        offset
-                                    } else {
-                                        0
                                     }
-                                } else {
-                                    0
                                 }
-                            };
-
-                            // Apply offset to buffer PTS
-                            if offset_ns != 0 {
-                                if let Some(pts_val) = pts {
-                                    let adjusted = (pts_val.nseconds() as i64 + offset_ns).max(0) as u64;
-                                    let mut new_buffer = buffer.copy();
-                                    {
-                                        let buf_ref = new_buffer.get_mut().unwrap();
-                                        buf_ref.set_pts(gst::ClockTime::from_nseconds(adjusted));
-                                    }
-                                    let new_sample = gst::Sample::builder()
-                                        .buffer(&new_buffer)
-                                        .caps(&sample.caps().unwrap().to_owned())
-                                        .build();
-                                    let _ = appsrc.push_sample(&new_sample);
-                                } else {
-                                    let _ = appsrc.push_sample(&sample);
-                                }
-                            } else {
-                                let _ = appsrc.push_sample(&sample);
+                                whip_bridge::Forwarded::Restamped
+                                | whip_bridge::Forwarded::Unadjusted => {}
                             }
 
                             Ok(gst::FlowSuccess::Ok)

--- a/backend/src/blocks/builtin/whip.rs
+++ b/backend/src/blocks/builtin/whip.rs
@@ -600,6 +600,74 @@ fn wait_for_inactivity(
     }
 }
 
+/// Wire one session stream's appsink into its slot's appsrc in the main
+/// pipeline.
+///
+/// A function rather than an inline closure so a test can drive the callback:
+/// the guard that matters is here, not in [`pipeline_bridge`]. A bare
+/// `appsrc.push_sample(&sample)` in this body re-opens the cascade an unstamped
+/// buffer starts and fails nothing in that module's tests.
+#[allow(clippy::too_many_arguments)]
+fn install_slot_bridge(
+    appsink: &gst_app::AppSink,
+    appsrc: gst_app::AppSrc,
+    bridge: Arc<SessionBridge>,
+    main_pipeline_weak: gst::glib::WeakRef<gst::Pipeline>,
+    media_type: &str,
+    slot: usize,
+    last_buffer_ms: Arc<AtomicU64>,
+    last_buffer_epoch: Instant,
+) {
+    let media_for_log = media_type.to_string();
+
+    appsink.set_callbacks(
+        gst_app::AppSinkCallbacks::builder()
+            .new_sample(move |sink| {
+                // Update inactivity watchdog
+                last_buffer_ms.store(
+                    last_buffer_epoch.elapsed().as_millis() as u64,
+                    Ordering::Relaxed,
+                );
+
+                let sample = sink.pull_sample().map_err(|_| gst::FlowError::Eos)?;
+
+                let outcome = bridge
+                    .forward(&sample, &appsrc, || {
+                        let main_pipeline = main_pipeline_weak.upgrade()?;
+                        let clock = main_pipeline.clock()?;
+                        let base_time = main_pipeline.base_time()?;
+                        Some(clock.time().saturating_sub(base_time))
+                    })
+                    .ok_or(gst::FlowError::Error)?;
+
+                match outcome {
+                    pipeline_bridge::Forwarded::OffsetComputed(offset) => {
+                        info!(
+                            "WHIP Input: Computed shared ts-offset={}ms from {} stream (slot {})",
+                            offset / 1_000_000,
+                            media_for_log,
+                            slot
+                        );
+                    }
+                    pipeline_bridge::Forwarded::DroppedUnstamped { dropped } => {
+                        if pipeline_bridge::should_log_drop(dropped) {
+                            warn!(
+                                "WHIP Input: dropped {} buffer(s) with no PTS on the {} stream (slot {}); forwarding one fails the downstream muxer and takes the whole flow with it",
+                                dropped, media_for_log, slot
+                            );
+                        }
+                    }
+                    pipeline_bridge::Forwarded::Restamped
+                    | pipeline_bridge::Forwarded::Unadjusted
+                    | pipeline_bridge::Forwarded::PushFailed(_) => {}
+                }
+
+                Ok(gst::FlowSuccess::Ok)
+            })
+            .build(),
+    );
+}
+
 /// Create a new whipserversrc element for a single WHIP client session.
 ///
 /// Each session runs in its own isolated GStreamer pipeline to avoid
@@ -1007,57 +1075,15 @@ pub fn create_whipserversrc_for_session(
                     }
                 }
 
-                let bridge = session_bridge.clone();
-                let main_pipeline_for_ts = main_pipeline_weak.clone();
-                let media_for_log = media_type.to_string();
-                let last_buffer_ms_cb = last_buffer_ms.clone();
-                let last_buffer_epoch_cb = last_buffer_epoch;
-
-                appsink.set_callbacks(
-                    gst_app::AppSinkCallbacks::builder()
-                        .new_sample(move |sink| {
-                            // Update inactivity watchdog
-                            last_buffer_ms_cb.store(
-                                last_buffer_epoch_cb.elapsed().as_millis() as u64,
-                                Ordering::Relaxed,
-                            );
-
-                            let sample = sink.pull_sample().map_err(|_| gst::FlowError::Eos)?;
-
-                            let outcome = bridge
-                                .forward(&sample, &appsrc, || {
-                                    let main_pipeline = main_pipeline_for_ts.upgrade()?;
-                                    let clock = main_pipeline.clock()?;
-                                    let base_time = main_pipeline.base_time()?;
-                                    Some(clock.time().saturating_sub(base_time))
-                                })
-                                .ok_or(gst::FlowError::Error)?;
-
-                            match outcome {
-                                pipeline_bridge::Forwarded::OffsetComputed(offset) => {
-                                    info!(
-                                        "WHIP Input: Computed shared ts-offset={}ms from {} stream (slot {})",
-                                        offset / 1_000_000,
-                                        media_for_log,
-                                        slot
-                                    );
-                                }
-                                pipeline_bridge::Forwarded::DroppedUnstamped { dropped } => {
-                                    if pipeline_bridge::should_log_drop(dropped) {
-                                        warn!(
-                                            "WHIP Input: dropped {} buffer(s) with no PTS on the {} stream (slot {}); forwarding one fails the downstream muxer and takes the whole flow with it",
-                                            dropped, media_for_log, slot
-                                        );
-                                    }
-                                }
-                                pipeline_bridge::Forwarded::Restamped
-                                | pipeline_bridge::Forwarded::Unadjusted
-                                | pipeline_bridge::Forwarded::PushFailed(_) => {}
-                            }
-
-                            Ok(gst::FlowSuccess::Ok)
-                        })
-                        .build(),
+                install_slot_bridge(
+                    &appsink,
+                    appsrc,
+                    session_bridge.clone(),
+                    main_pipeline_weak.clone(),
+                    media_type,
+                    slot,
+                    last_buffer_ms.clone(),
+                    last_buffer_epoch,
                 );
             } else {
                 info!(
@@ -1811,6 +1837,64 @@ fn setup_incoming_rtp_handler(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::gst::pipeline_bridge::test_support::{at, Harness, SessionPipeline};
+
+    /// The wiring guard for this block. [`pipeline_bridge`] can only promise
+    /// that [`SessionBridge::forward`] drops an unstamped buffer; it cannot
+    /// promise this block still calls it. So drive the real appsink callback:
+    /// three buffers into a session pipeline, the middle one with no PTS, and
+    /// only the two stamped ones may reach the slot's appsrc.
+    ///
+    /// Forwarding that buffer is what makes `qtmux` answer `Buffer has no PTS`
+    /// with `GST_FLOW_ERROR`, which tears down the whole flow — every seat, not
+    /// just this one.
+    #[test]
+    fn an_unstamped_buffer_never_reaches_the_slot_appsrc() {
+        let slot_pipeline = Harness::new();
+        let session = SessionPipeline::new();
+
+        let appsink = gst_app::AppSink::builder().sync(false).build();
+        session
+            .pipeline
+            .add(appsink.upcast_ref::<gst::Element>())
+            .expect("add appsink");
+        session
+            .src
+            .link(&appsink)
+            .expect("link session appsrc to appsink");
+
+        install_slot_bridge(
+            &appsink,
+            slot_pipeline.src.clone(),
+            Arc::new(SessionBridge::new()),
+            slot_pipeline.pipeline_weak(),
+            "video",
+            0,
+            Arc::new(AtomicU64::new(0)),
+            Instant::now(),
+        );
+
+        session.start();
+        session.push(at(1));
+        session.push(None);
+        session.push(at(3));
+
+        let first = slot_pipeline.next_pts().expect("first buffer crossed");
+        assert!(first.is_some(), "a stamped buffer must keep its stamp");
+        let second = slot_pipeline
+            .next_pts()
+            .expect("the third buffer crossed too");
+        assert!(
+            second.is_some(),
+            "the unstamped buffer must not be here — the third one is next"
+        );
+        assert!(second > first, "and it must follow the first");
+        assert_eq!(
+            slot_pipeline.next_pts(),
+            None,
+            "nothing else should have crossed"
+        );
+    }
 
     fn props(entries: &[(&str, PropertyValue)]) -> HashMap<String, PropertyValue> {
         entries

--- a/backend/src/blocks/builtin/whip.rs
+++ b/backend/src/blocks/builtin/whip.rs
@@ -16,7 +16,7 @@ use crate::blocks::{
 };
 use crate::gst::ice_preflight;
 use crate::gst::keyframe_request;
-use crate::gst::whip_bridge::{self, SessionBridge};
+use crate::gst::pipeline_bridge::{self, SessionBridge};
 use crate::whip_session_manager::{SessionCleanupRequest, WhipEndpointConfig};
 use gstreamer as gst;
 use gstreamer::prelude::*;
@@ -1034,7 +1034,7 @@ pub fn create_whipserversrc_for_session(
                                 .ok_or(gst::FlowError::Error)?;
 
                             match outcome {
-                                whip_bridge::Forwarded::OffsetComputed(offset) => {
+                                pipeline_bridge::Forwarded::OffsetComputed(offset) => {
                                     info!(
                                         "WHIP Input: Computed shared ts-offset={}ms from {} stream (slot {})",
                                         offset / 1_000_000,
@@ -1042,16 +1042,17 @@ pub fn create_whipserversrc_for_session(
                                         slot
                                     );
                                 }
-                                whip_bridge::Forwarded::DroppedUnstamped { dropped } => {
-                                    if whip_bridge::should_log_drop(dropped) {
+                                pipeline_bridge::Forwarded::DroppedUnstamped { dropped } => {
+                                    if pipeline_bridge::should_log_drop(dropped) {
                                         warn!(
                                             "WHIP Input: dropped {} buffer(s) with no PTS on the {} stream (slot {}); forwarding one fails the downstream muxer and takes the whole flow with it",
                                             dropped, media_for_log, slot
                                         );
                                     }
                                 }
-                                whip_bridge::Forwarded::Restamped
-                                | whip_bridge::Forwarded::Unadjusted => {}
+                                pipeline_bridge::Forwarded::Restamped
+                                | pipeline_bridge::Forwarded::Unadjusted
+                                | pipeline_bridge::Forwarded::PushFailed(_) => {}
                             }
 
                             Ok(gst::FlowSuccess::Ok)

--- a/backend/src/gst/mod.rs
+++ b/backend/src/gst/mod.rs
@@ -19,6 +19,7 @@ pub(crate) mod underlay;
 pub mod video_frame;
 pub mod volume_ramp;
 pub mod whep_probe;
+pub mod whip_bridge;
 
 pub use discovery::ElementDiscovery;
 pub use pipeline::{PipelineError, PipelineManager};

--- a/backend/src/gst/mod.rs
+++ b/backend/src/gst/mod.rs
@@ -9,6 +9,7 @@ pub mod gl_bridge;
 pub mod ice_preflight;
 pub mod keyframe_request;
 pub mod pipeline;
+pub mod pipeline_bridge;
 pub mod pipeline_monitor;
 pub mod shaders;
 pub mod thread_priority;
@@ -19,7 +20,6 @@ pub(crate) mod underlay;
 pub mod video_frame;
 pub mod volume_ramp;
 pub mod whep_probe;
-pub mod whip_bridge;
 
 pub use discovery::ElementDiscovery;
 pub use pipeline::{PipelineError, PipelineManager};

--- a/backend/src/gst/pipeline_bridge.rs
+++ b/backend/src/gst/pipeline_bridge.rs
@@ -219,36 +219,71 @@ pub fn should_log_drop(dropped: u64) -> bool {
     dropped == 1 || dropped.is_multiple_of(100)
 }
 
+/// Rig shared by this module's own tests and by the call-site tests in
+/// `whip.rs` and `mediaplayer/bridge.rs`. Those two have to keep calling
+/// [`SessionBridge::forward`], and nothing in this module can enforce that, so
+/// each caller needs a test of its own driving a real appsink callback.
 #[cfg(test)]
-mod tests {
+pub(crate) mod test_support {
     use super::*;
     use gstreamer::prelude::*;
 
-    const CAPS: &str = "application/x-strom-bridge-test";
-    const SEC: u64 = gst::ClockTime::SECOND.nseconds();
+    pub(crate) const CAPS: &str = "application/x-strom-bridge-test";
+    pub(crate) const SEC: u64 = gst::ClockTime::SECOND.nseconds();
+
+    pub(crate) fn caps() -> gst::Caps {
+        gst::Caps::builder(CAPS).build()
+    }
+
+    /// One buffer wrapped as a sample, stamped however the test wants.
+    pub(crate) fn sample(pts: Option<gst::ClockTime>, dts: Option<gst::ClockTime>) -> gst::Sample {
+        let mut buffer = gst::Buffer::with_size(4).expect("buffer");
+        {
+            let b = buffer.get_mut().unwrap();
+            b.set_pts(pts);
+            b.set_dts(dts);
+        }
+        gst::Sample::builder().buffer(&buffer).caps(&caps()).build()
+    }
+
+    pub(crate) fn at(secs: u64) -> Option<gst::ClockTime> {
+        Some(gst::ClockTime::from_seconds(secs))
+    }
 
     /// A real `appsrc ! appsink` pair standing in for the main pipeline's slot:
     /// what comes out of `sink` is exactly what the bridge let across.
-    struct Harness {
+    pub(crate) struct Harness {
         pipeline: gst::Pipeline,
-        src: gst_app::AppSrc,
-        sink: gst_app::AppSink,
+        pub(crate) src: gst_app::AppSrc,
+        pub(crate) sink: gst_app::AppSink,
     }
 
     impl Harness {
-        fn new() -> Self {
+        pub(crate) fn new() -> Self {
             let _ = gst::init();
             let src = gst_app::AppSrc::builder()
                 .format(gst::Format::Time)
-                .caps(&gst::Caps::builder(CAPS).build())
+                .caps(&caps())
                 .build();
-            let sink = gst_app::AppSink::builder().sync(false).build();
+            // `async(false)`, so the pipeline reaches PLAYING without waiting
+            // for a first buffer to preroll on. A caller that reads this
+            // pipeline's running time to compute its offset gets `None` until
+            // PLAYING is reached and a base time is set, which would push the
+            // offset onto whichever buffer happened to arrive after that.
+            let sink = gst_app::AppSink::builder()
+                .sync(false)
+                .async_(false)
+                .build();
             let pipeline = gst::Pipeline::new();
             pipeline
                 .add_many([src.upcast_ref::<gst::Element>(), sink.upcast_ref()])
                 .expect("add");
             src.link(&sink).expect("link");
             pipeline.set_state(gst::State::Playing).expect("playing");
+            pipeline
+                .state(gst::ClockTime::from_seconds(2))
+                .0
+                .expect("reach PLAYING");
             Self {
                 pipeline,
                 src,
@@ -257,10 +292,16 @@ mod tests {
         }
 
         /// PTS of the next buffer to arrive, or `None` if none does.
-        fn next_pts(&self) -> Option<Option<gst::ClockTime>> {
+        pub(crate) fn next_pts(&self) -> Option<Option<gst::ClockTime>> {
             self.sink
                 .try_pull_sample(gst::ClockTime::from_mseconds(500))
                 .map(|s| s.buffer().expect("sample has a buffer").pts())
+        }
+
+        /// The pipeline behind `src`, for a caller that reads its running time
+        /// to compute the session offset.
+        pub(crate) fn pipeline_weak(&self) -> gst::glib::WeakRef<gst::Pipeline> {
+            self.pipeline.downgrade()
         }
     }
 
@@ -270,22 +311,55 @@ mod tests {
         }
     }
 
-    fn sample(pts: Option<gst::ClockTime>, dts: Option<gst::ClockTime>) -> gst::Sample {
-        let mut buffer = gst::Buffer::with_size(4).expect("buffer");
-        {
-            let b = buffer.get_mut().unwrap();
-            b.set_pts(pts);
-            b.set_dts(dts);
-        }
-        gst::Sample::builder()
-            .buffer(&buffer)
-            .caps(&gst::Caps::builder(CAPS).build())
-            .build()
+    /// Stands in for a session pipeline: an `appsrc` the test pushes into,
+    /// waiting for the caller to wire the appsink under test onto the other end
+    /// and then call [`SessionPipeline::start`].
+    pub(crate) struct SessionPipeline {
+        pub(crate) pipeline: gst::Pipeline,
+        pub(crate) src: gst_app::AppSrc,
     }
 
-    fn at(secs: u64) -> Option<gst::ClockTime> {
-        Some(gst::ClockTime::from_seconds(secs))
+    impl SessionPipeline {
+        pub(crate) fn new() -> Self {
+            let _ = gst::init();
+            let src = gst_app::AppSrc::builder()
+                .format(gst::Format::Time)
+                .caps(&caps())
+                .build();
+            let pipeline = gst::Pipeline::new();
+            pipeline
+                .add(src.upcast_ref::<gst::Element>())
+                .expect("add appsrc");
+            Self { pipeline, src }
+        }
+
+        pub(crate) fn start(&self) {
+            self.pipeline
+                .set_state(gst::State::Playing)
+                .expect("playing");
+        }
+
+        /// The pad the element under test links to.
+        pub(crate) fn src_pad(&self) -> gst::Pad {
+            self.src.static_pad("src").expect("appsrc has a src pad")
+        }
+
+        pub(crate) fn push(&self, pts: Option<gst::ClockTime>) {
+            self.src.push_sample(&sample(pts, None)).expect("push");
+        }
     }
+
+    impl Drop for SessionPipeline {
+        fn drop(&mut self) {
+            let _ = self.pipeline.set_state(gst::State::Null);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::test_support::*;
+    use super::*;
 
     /// The regression this module exists for. A buffer with no PTS must not
     /// reach the main pipeline: downstream of that appsrc sits a recorder whose

--- a/backend/src/gst/pipeline_bridge.rs
+++ b/backend/src/gst/pipeline_bridge.rs
@@ -1,10 +1,12 @@
-//! The WHIP session → flow pipeline bridge: what crosses it, and with what timestamps.
+//! The session → flow pipeline bridge: what crosses it, and with what timestamps.
 //!
-//! Each WHIP publisher gets its own *session* pipeline, isolated from the flow's
-//! main pipeline so that a publisher connecting or dropping cannot restart the
-//! flow. Media crosses the boundary through an `appsink`/`appsrc` pair: the
-//! session pipeline's appsink hands each sample to this module, which pushes it
-//! into the slot's appsrc in the main pipeline.
+//! Two blocks run media in a *session* pipeline of their own, isolated from the
+//! flow's main pipeline: a WHIP publisher, so that a publisher connecting or
+//! dropping cannot restart the flow, and the Media Player, so that a file
+//! switch or a seek stays local to the player. Both cross the boundary through
+//! an `appsink`/`appsrc` pair: the session pipeline's appsink hands each sample
+//! to this module, which pushes it into the block's appsrc in the main
+//! pipeline.
 //!
 //! Two things have to happen at that boundary.
 //!
@@ -13,7 +15,10 @@
 //! The bridge computes one offset per session — `main_running_time - pts`, from
 //! the first buffer that carries a PTS — and adds it to every buffer on both
 //! streams. One offset shared between audio and video, not one each, or the two
-//! would drift apart from each other after the shift.
+//! would drift apart from each other after the shift. Audio and video arrive on
+//! their own streaming threads, so "once per session" is a `compare_exchange`:
+//! whichever stream gets there first sets the offset and the other reads it
+//! back, rather than both computing against clocks read milliseconds apart.
 //!
 //! **A buffer with no PTS has to stop here.** `qtmux` cannot place an
 //! untimestamped buffer in a track and answers with `GST_FLOW_ERROR`:
@@ -37,6 +42,13 @@
 //! dropped frame on a live source is the ordinary recoverable failure — the
 //! receiver already tolerates loss, and [`crate::gst::keyframe_request`]
 //! recovers a decoder that lost part of its GOP.
+//!
+//! **What is not covered.** [`shift`] clamps a shifted timestamp at zero, so a
+//! stream whose PTS base sits far behind the offset-setting stream's pins its
+//! first buffers at 0 — equal timestamps, which is the muxer's third complaint
+//! after missing and backwards ones. Pre-existing, and it needs a policy for
+//! what a stream that starts *before* the session's time origin should be
+//! worth; not decided here.
 
 use gstreamer as gst;
 use gstreamer_app as gst_app;
@@ -59,6 +71,11 @@ pub enum Forwarded {
     /// Not pushed: the buffer had no PTS. `dropped` is the running total for
     /// this session.
     DroppedUnstamped { dropped: u64 },
+    /// The appsrc refused the sample — normally `Flushing`, while the main
+    /// pipeline is still coming up. The media is lost; the next buffer tries
+    /// again. If this buffer was also the one that established the session
+    /// offset, the offset is kept even though the buffer did not cross.
+    PushFailed(gst::FlowError),
 }
 
 /// Per-session bridge state, shared by the audio and video appsink callbacks.
@@ -87,6 +104,14 @@ impl SessionBridge {
         self.dropped_unstamped.load(Ordering::Relaxed)
     }
 
+    /// Forget the session offset, so the next buffer with a PTS computes a new
+    /// one. The Media Player calls this whenever the relationship between file
+    /// time and main-pipeline running time breaks: a file switch, a seek, or a
+    /// resume after a pause. The drop count is a lifetime total and survives.
+    pub fn reset_offset(&self) {
+        self.offset_ns.store(OFFSET_UNSET, Ordering::Relaxed);
+    }
+
     /// Push one sample from the session pipeline into the main pipeline.
     ///
     /// Runs once per buffer on the appsink's streaming thread: atomics only, no
@@ -94,7 +119,8 @@ impl SessionBridge {
     ///
     /// `main_running_time` is consulted only while the offset is still unset —
     /// the caller uses it to upgrade its weak pipeline reference and read the
-    /// clock, work not worth doing on every buffer.
+    /// clock, work not worth doing on every buffer. It may be called and its
+    /// answer discarded, if the other stream set the offset first.
     ///
     /// Returns `None` if the sample carried no buffer; the caller decides what
     /// that means for the appsink.
@@ -116,15 +142,31 @@ impl SessionBridge {
         let mut just_computed = false;
         if offset_ns == OFFSET_UNSET {
             if let Some(running) = main_running_time() {
-                offset_ns = running.nseconds() as i64 - pts.nseconds() as i64;
-                self.offset_ns.store(offset_ns, Ordering::Relaxed);
-                just_computed = true;
+                let candidate = running.nseconds() as i64 - pts.nseconds() as i64;
+                // Audio and video reach this on their own streaming threads and
+                // can both have read OFFSET_UNSET above. Exactly one may win:
+                // two offsets computed from clocks read milliseconds apart is
+                // the A/V drift this shared offset exists to prevent.
+                match self.offset_ns.compare_exchange(
+                    OFFSET_UNSET,
+                    candidate,
+                    Ordering::Relaxed,
+                    Ordering::Relaxed,
+                ) {
+                    Ok(_) => {
+                        offset_ns = candidate;
+                        just_computed = true;
+                    }
+                    Err(winner) => offset_ns = winner,
+                }
             }
         }
 
         if offset_ns == OFFSET_UNSET {
-            let _ = appsrc.push_sample(sample);
-            return Some(Forwarded::Unadjusted);
+            return Some(match appsrc.push_sample(sample) {
+                Ok(_) => Forwarded::Unadjusted,
+                Err(e) => Forwarded::PushFailed(e),
+            });
         }
 
         let mut adjusted = buffer.copy();
@@ -132,14 +174,17 @@ impl SessionBridge {
             let Some(buf_ref) = adjusted.get_mut() else {
                 // A fresh copy is always writable. If that ever stops being
                 // true, forward the original rather than lose media.
-                let _ = appsrc.push_sample(sample);
-                return Some(Forwarded::Unadjusted);
+                return Some(match appsrc.push_sample(sample) {
+                    Ok(_) => Forwarded::Unadjusted,
+                    Err(e) => Forwarded::PushFailed(e),
+                });
             };
             buf_ref.set_pts(shift(pts, offset_ns));
-            // DTS is in the session's time base too. It is normally unset here
-            // (WebRTC H.264 has no B-frames), so this is usually a no-op — but
-            // leaving a session-base DTS beside a main-base PTS would be the
-            // muxer's other way to reject the buffer.
+            // DTS is in the session's time base too. It is unset on WHIP
+            // traffic (WebRTC H.264 carries no B-frames) and set on a file the
+            // Media Player passes through encoded. Leaving a session-base DTS
+            // beside a main-base PTS is the muxer's other way to reject the
+            // buffer.
             if let Some(dts) = buffer.dts() {
                 buf_ref.set_dts(shift(dts, offset_ns));
             }
@@ -151,7 +196,9 @@ impl SessionBridge {
         if let Some(caps) = &caps {
             builder = builder.caps(caps);
         }
-        let _ = appsrc.push_sample(&builder.build());
+        if let Err(e) = appsrc.push_sample(&builder.build()) {
+            return Some(Forwarded::PushFailed(e));
+        }
 
         Some(if just_computed {
             Forwarded::OffsetComputed(offset_ns)
@@ -347,6 +394,10 @@ mod tests {
     /// The offset is shared so audio and video keep their relative timing. Both
     /// streams push through one `SessionBridge`; the second must reuse the
     /// offset the first computed rather than recomputing against a later clock.
+    ///
+    /// One thread, so this covers only the case where one stream's first buffer
+    /// clearly precedes the other's. The concurrent case is
+    /// [`two_streams_racing_for_the_offset_still_get_one`].
     #[test]
     fn both_streams_share_one_offset() {
         let h = Harness::new();
@@ -367,6 +418,76 @@ mod tests {
             h.next_pts(),
             Some(at(10)),
             "same input time, same output time"
+        );
+    }
+
+    /// Audio and video run on their own streaming threads, so both can find the
+    /// offset unset and read the clock before either has stored anything. The
+    /// barrier inside the clock closure forces that interleaving instead of
+    /// hoping for it: both threads are past the `OFFSET_UNSET` load and inside
+    /// `main_running_time` before either returns.
+    ///
+    /// With a plain store both callers report `OffsetComputed` and the two
+    /// buffers leave shifted by clocks read milliseconds apart — the A/V drift
+    /// the shared offset exists to prevent. With the `compare_exchange` exactly
+    /// one wins and both buffers get the winner's offset.
+    #[test]
+    fn two_streams_racing_for_the_offset_still_get_one() {
+        use std::sync::{Arc, Barrier};
+
+        let h = Harness::new();
+        let bridge = Arc::new(SessionBridge::new());
+        let gate = Arc::new(Barrier::new(2));
+
+        // Same input PTS on both streams, different clock readings: if the two
+        // computed their own offsets, the outputs would differ by a second.
+        let outcomes: Vec<_> = [10u64, 11u64]
+            .into_iter()
+            .map(|clock_secs| {
+                let bridge = Arc::clone(&bridge);
+                let gate = Arc::clone(&gate);
+                let src = h.src.clone();
+                std::thread::spawn(move || {
+                    bridge.forward(&sample(at(1), None), &src, || {
+                        gate.wait();
+                        Some(gst::ClockTime::from_seconds(clock_secs))
+                    })
+                })
+            })
+            .collect::<Vec<_>>()
+            .into_iter()
+            .map(|t| t.join().expect("thread"))
+            .collect();
+
+        let computed: Vec<_> = outcomes
+            .iter()
+            .filter_map(|o| match o {
+                Some(Forwarded::OffsetComputed(offset)) => Some(*offset),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            computed.len(),
+            1,
+            "exactly one stream may establish the offset, got {:?}",
+            outcomes
+        );
+        assert_eq!(
+            outcomes
+                .iter()
+                .filter(|o| matches!(o, Some(Forwarded::Restamped)))
+                .count(),
+            1,
+            "the loser reuses the winner's offset, got {:?}",
+            outcomes
+        );
+
+        let winner = gst::ClockTime::from_nseconds(computed[0] as u64 + SEC);
+        assert_eq!(h.next_pts(), Some(Some(winner)));
+        assert_eq!(
+            h.next_pts(),
+            Some(Some(winner)),
+            "both buffers shifted by the same offset"
         );
     }
 

--- a/backend/src/gst/whip_bridge.rs
+++ b/backend/src/gst/whip_bridge.rs
@@ -1,0 +1,400 @@
+//! The WHIP session → flow pipeline bridge: what crosses it, and with what timestamps.
+//!
+//! Each WHIP publisher gets its own *session* pipeline, isolated from the flow's
+//! main pipeline so that a publisher connecting or dropping cannot restart the
+//! flow. Media crosses the boundary through an `appsink`/`appsrc` pair: the
+//! session pipeline's appsink hands each sample to this module, which pushes it
+//! into the slot's appsrc in the main pipeline.
+//!
+//! Two things have to happen at that boundary.
+//!
+//! **Timestamps have to be rebased.** The two pipelines have independent base
+//! times, so a buffer's PTS only means anything in the pipeline it came from.
+//! The bridge computes one offset per session — `main_running_time - pts`, from
+//! the first buffer that carries a PTS — and adds it to every buffer on both
+//! streams. One offset shared between audio and video, not one each, or the two
+//! would drift apart from each other after the shift.
+//!
+//! **A buffer with no PTS has to stop here.** `qtmux` cannot place an
+//! untimestamped buffer in a track and answers with `GST_FLOW_ERROR`:
+//!
+//! ```text
+//! ERROR Could not multiplex stream.
+//!   gst_qt_mux_add_buffer (): .../GstMP4Mux:rec_p2:mux: Buffer has no PTS.
+//! ```
+//!
+//! That error propagates out of the recorder, up through the mixer, and takes
+//! the whole flow down — every seat, not just the one whose publisher produced
+//! the buffer. Observed on a live rig: a second participant joining killed the
+//! first. So an unstamped buffer is dropped here and counted, never forwarded.
+//!
+//! Dropping beats inventing a stamp. The main pipeline's running time *now* is
+//! a different time base from `pts + offset` and the two drift apart over a
+//! session, so a synthesised stamp can land before its own predecessor — and a
+//! muxer rejects backwards timestamps as hard as missing ones, the same cascade
+//! by another route. A stamp that is merely a little wrong is worse still: it
+//! desynchronises audio from video for the rest of the session, silently. A
+//! dropped frame on a live source is the ordinary recoverable failure — the
+//! receiver already tolerates loss, and [`crate::gst::keyframe_request`]
+//! recovers a decoder that lost part of its GOP.
+
+use gstreamer as gst;
+use gstreamer_app as gst_app;
+use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
+
+/// `offset_ns` value meaning "no buffer carrying a PTS has arrived yet".
+const OFFSET_UNSET: i64 = i64::MIN;
+
+/// What the bridge did with one sample.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Forwarded {
+    /// Pushed, with its PTS shifted into the main pipeline's time base.
+    Restamped,
+    /// As [`Forwarded::Restamped`], and this is the buffer the session's offset
+    /// was computed from. Worth one log line per session.
+    OffsetComputed(i64),
+    /// Pushed unchanged: the main pipeline is gone or has no clock yet, so
+    /// there is no running time to rebase onto. The next buffer tries again.
+    Unadjusted,
+    /// Not pushed: the buffer had no PTS. `dropped` is the running total for
+    /// this session.
+    DroppedUnstamped { dropped: u64 },
+}
+
+/// Per-session bridge state, shared by the audio and video appsink callbacks.
+#[derive(Debug)]
+pub struct SessionBridge {
+    offset_ns: AtomicI64,
+    dropped_unstamped: AtomicU64,
+}
+
+impl Default for SessionBridge {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SessionBridge {
+    pub fn new() -> Self {
+        Self {
+            offset_ns: AtomicI64::new(OFFSET_UNSET),
+            dropped_unstamped: AtomicU64::new(0),
+        }
+    }
+
+    /// Buffers dropped so far for want of a PTS, across both streams.
+    pub fn dropped_unstamped(&self) -> u64 {
+        self.dropped_unstamped.load(Ordering::Relaxed)
+    }
+
+    /// Push one sample from the session pipeline into the main pipeline.
+    ///
+    /// Runs once per buffer on the appsink's streaming thread: atomics only, no
+    /// locks, and no allocation beyond the buffer copy the restamp needs.
+    ///
+    /// `main_running_time` is consulted only while the offset is still unset —
+    /// the caller uses it to upgrade its weak pipeline reference and read the
+    /// clock, work not worth doing on every buffer.
+    ///
+    /// Returns `None` if the sample carried no buffer; the caller decides what
+    /// that means for the appsink.
+    pub fn forward(
+        &self,
+        sample: &gst::Sample,
+        appsrc: &gst_app::AppSrc,
+        main_running_time: impl FnOnce() -> Option<gst::ClockTime>,
+    ) -> Option<Forwarded> {
+        let buffer = sample.buffer()?;
+
+        // The whole point of this module: an unstamped buffer never crosses.
+        let Some(pts) = buffer.pts() else {
+            let dropped = self.dropped_unstamped.fetch_add(1, Ordering::Relaxed) + 1;
+            return Some(Forwarded::DroppedUnstamped { dropped });
+        };
+
+        let mut offset_ns = self.offset_ns.load(Ordering::Relaxed);
+        let mut just_computed = false;
+        if offset_ns == OFFSET_UNSET {
+            if let Some(running) = main_running_time() {
+                offset_ns = running.nseconds() as i64 - pts.nseconds() as i64;
+                self.offset_ns.store(offset_ns, Ordering::Relaxed);
+                just_computed = true;
+            }
+        }
+
+        if offset_ns == OFFSET_UNSET {
+            let _ = appsrc.push_sample(sample);
+            return Some(Forwarded::Unadjusted);
+        }
+
+        let mut adjusted = buffer.copy();
+        {
+            let Some(buf_ref) = adjusted.get_mut() else {
+                // A fresh copy is always writable. If that ever stops being
+                // true, forward the original rather than lose media.
+                let _ = appsrc.push_sample(sample);
+                return Some(Forwarded::Unadjusted);
+            };
+            buf_ref.set_pts(shift(pts, offset_ns));
+            // DTS is in the session's time base too. It is normally unset here
+            // (WebRTC H.264 has no B-frames), so this is usually a no-op — but
+            // leaving a session-base DTS beside a main-base PTS would be the
+            // muxer's other way to reject the buffer.
+            if let Some(dts) = buffer.dts() {
+                buf_ref.set_dts(shift(dts, offset_ns));
+            }
+        }
+
+        // `to_owned` on a caps ref is a refcount bump, not a deep copy.
+        let caps = sample.caps().map(|c| c.to_owned());
+        let mut builder = gst::Sample::builder().buffer(&adjusted);
+        if let Some(caps) = &caps {
+            builder = builder.caps(caps);
+        }
+        let _ = appsrc.push_sample(&builder.build());
+
+        Some(if just_computed {
+            Forwarded::OffsetComputed(offset_ns)
+        } else {
+            Forwarded::Restamped
+        })
+    }
+}
+
+fn shift(ts: gst::ClockTime, offset_ns: i64) -> gst::ClockTime {
+    let shifted = (ts.nseconds() as i64).saturating_add(offset_ns).max(0);
+    gst::ClockTime::from_nseconds(shifted as u64)
+}
+
+/// Rate limit for the drop warning. A publisher that sends nothing but
+/// unstamped buffers must stay visible without filling the log at frame rate.
+pub fn should_log_drop(dropped: u64) -> bool {
+    dropped == 1 || dropped.is_multiple_of(100)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gstreamer::prelude::*;
+
+    const CAPS: &str = "application/x-strom-bridge-test";
+    const SEC: u64 = gst::ClockTime::SECOND.nseconds();
+
+    /// A real `appsrc ! appsink` pair standing in for the main pipeline's slot:
+    /// what comes out of `sink` is exactly what the bridge let across.
+    struct Harness {
+        pipeline: gst::Pipeline,
+        src: gst_app::AppSrc,
+        sink: gst_app::AppSink,
+    }
+
+    impl Harness {
+        fn new() -> Self {
+            let _ = gst::init();
+            let src = gst_app::AppSrc::builder()
+                .format(gst::Format::Time)
+                .caps(&gst::Caps::builder(CAPS).build())
+                .build();
+            let sink = gst_app::AppSink::builder().sync(false).build();
+            let pipeline = gst::Pipeline::new();
+            pipeline
+                .add_many([src.upcast_ref::<gst::Element>(), sink.upcast_ref()])
+                .expect("add");
+            src.link(&sink).expect("link");
+            pipeline.set_state(gst::State::Playing).expect("playing");
+            Self {
+                pipeline,
+                src,
+                sink,
+            }
+        }
+
+        /// PTS of the next buffer to arrive, or `None` if none does.
+        fn next_pts(&self) -> Option<Option<gst::ClockTime>> {
+            self.sink
+                .try_pull_sample(gst::ClockTime::from_mseconds(500))
+                .map(|s| s.buffer().expect("sample has a buffer").pts())
+        }
+    }
+
+    impl Drop for Harness {
+        fn drop(&mut self) {
+            let _ = self.pipeline.set_state(gst::State::Null);
+        }
+    }
+
+    fn sample(pts: Option<gst::ClockTime>, dts: Option<gst::ClockTime>) -> gst::Sample {
+        let mut buffer = gst::Buffer::with_size(4).expect("buffer");
+        {
+            let b = buffer.get_mut().unwrap();
+            b.set_pts(pts);
+            b.set_dts(dts);
+        }
+        gst::Sample::builder()
+            .buffer(&buffer)
+            .caps(&gst::Caps::builder(CAPS).build())
+            .build()
+    }
+
+    fn at(secs: u64) -> Option<gst::ClockTime> {
+        Some(gst::ClockTime::from_seconds(secs))
+    }
+
+    /// The regression this module exists for. A buffer with no PTS must not
+    /// reach the main pipeline: downstream of that appsrc sits a recorder whose
+    /// muxer answers `Buffer has no PTS` with `GST_FLOW_ERROR`, which tears the
+    /// whole flow down — every seat, not just this one.
+    ///
+    /// Revert the drop and the unstamped buffer arrives at `sink` between the
+    /// other two, and this fails.
+    #[test]
+    fn an_unstamped_buffer_never_crosses_the_bridge() {
+        let h = Harness::new();
+        let bridge = SessionBridge::new();
+        let now = || Some(gst::ClockTime::from_seconds(10));
+
+        assert_eq!(
+            bridge.forward(&sample(at(1), None), &h.src, now),
+            Some(Forwarded::OffsetComputed(9 * SEC as i64))
+        );
+        assert_eq!(
+            bridge.forward(&sample(None, None), &h.src, now),
+            Some(Forwarded::DroppedUnstamped { dropped: 1 })
+        );
+        assert_eq!(
+            bridge.forward(&sample(at(3), None), &h.src, now),
+            Some(Forwarded::Restamped)
+        );
+
+        assert_eq!(h.next_pts(), Some(at(10)), "first buffer, rebased");
+        assert_eq!(
+            h.next_pts(),
+            Some(at(12)),
+            "the unstamped buffer must not be here — the third one is next"
+        );
+        assert_eq!(h.next_pts(), None, "nothing else should have crossed");
+        assert_eq!(bridge.dropped_unstamped(), 1);
+    }
+
+    /// The other way in: if the *first* buffer of a session has no PTS there is
+    /// no offset yet, so the restamping path is not even reached. It still must
+    /// not be forwarded, and it must not poison the offset for the buffer that
+    /// does carry one.
+    #[test]
+    fn an_unstamped_first_buffer_is_dropped_and_does_not_fix_the_offset() {
+        let h = Harness::new();
+        let bridge = SessionBridge::new();
+
+        assert_eq!(
+            bridge.forward(&sample(None, None), &h.src, || panic!(
+                "the clock must not be read for a buffer with no PTS"
+            )),
+            Some(Forwarded::DroppedUnstamped { dropped: 1 })
+        );
+        assert_eq!(
+            bridge.forward(&sample(at(2), None), &h.src, || Some(
+                gst::ClockTime::from_seconds(5)
+            )),
+            Some(Forwarded::OffsetComputed(3 * SEC as i64)),
+            "the first buffer with a PTS establishes the offset"
+        );
+
+        assert_eq!(h.next_pts(), Some(at(5)));
+        assert_eq!(h.next_pts(), None);
+    }
+
+    /// With no running time to rebase onto — the main pipeline is being torn
+    /// down, or has not been given a clock yet — a stamped buffer still goes
+    /// through unchanged, and the next one retries the offset.
+    #[test]
+    fn a_missing_running_time_forwards_unadjusted_and_retries() {
+        let h = Harness::new();
+        let bridge = SessionBridge::new();
+
+        assert_eq!(
+            bridge.forward(&sample(at(1), None), &h.src, || None),
+            Some(Forwarded::Unadjusted)
+        );
+        assert_eq!(
+            bridge.forward(&sample(at(2), None), &h.src, || Some(
+                gst::ClockTime::from_seconds(20)
+            )),
+            Some(Forwarded::OffsetComputed(18 * SEC as i64))
+        );
+
+        assert_eq!(h.next_pts(), Some(at(1)), "pushed as it came");
+        assert_eq!(h.next_pts(), Some(at(20)));
+    }
+
+    /// DTS is in the session's time base too. Leaving it unshifted beside a
+    /// rebased PTS is the muxer's other way to reject the buffer.
+    #[test]
+    fn dts_is_shifted_with_pts() {
+        let h = Harness::new();
+        let bridge = SessionBridge::new();
+        let now = || Some(gst::ClockTime::from_seconds(10));
+
+        bridge.forward(&sample(at(2), at(1)), &h.src, now);
+        let out = h
+            .sink
+            .try_pull_sample(gst::ClockTime::from_mseconds(500))
+            .expect("sample");
+        let buffer = out.buffer().unwrap();
+        assert_eq!(buffer.pts(), at(10));
+        assert_eq!(buffer.dts(), at(9));
+    }
+
+    /// The offset is shared so audio and video keep their relative timing. Both
+    /// streams push through one `SessionBridge`; the second must reuse the
+    /// offset the first computed rather than recomputing against a later clock.
+    #[test]
+    fn both_streams_share_one_offset() {
+        let h = Harness::new();
+        let bridge = SessionBridge::new();
+
+        bridge.forward(&sample(at(1), None), &h.src, || {
+            Some(gst::ClockTime::from_seconds(10))
+        });
+        assert_eq!(
+            bridge.forward(&sample(at(1), None), &h.src, || panic!(
+                "the offset is computed once per session, not once per stream"
+            )),
+            Some(Forwarded::Restamped)
+        );
+
+        assert_eq!(h.next_pts(), Some(at(10)));
+        assert_eq!(
+            h.next_pts(),
+            Some(at(10)),
+            "same input time, same output time"
+        );
+    }
+
+    /// A shifted PTS cannot go negative: `ClockTime` is unsigned and
+    /// `ClockTime::NONE` is what we are here to avoid producing.
+    #[test]
+    fn a_negative_shift_clamps_to_zero() {
+        let h = Harness::new();
+        let bridge = SessionBridge::new();
+
+        bridge.forward(&sample(at(100), None), &h.src, || {
+            Some(gst::ClockTime::from_seconds(1))
+        });
+        bridge.forward(&sample(at(1), None), &h.src, || unreachable!());
+
+        assert_eq!(h.next_pts(), Some(at(1)));
+        assert_eq!(h.next_pts(), Some(at(0)));
+    }
+
+    /// A publisher sending nothing but unstamped buffers must stay visible in
+    /// the log without writing a line per frame.
+    #[test]
+    fn drops_are_logged_first_then_sparsely() {
+        assert!(should_log_drop(1));
+        assert!(!should_log_drop(2));
+        assert!(!should_log_drop(99));
+        assert!(should_log_drop(100));
+        assert!(!should_log_drop(101));
+        assert!(should_log_drop(1_000));
+    }
+}


### PR DESCRIPTION
## The bug

A WHIP session runs in its own pipeline and is bridged into the flow's main pipeline through an `appsink`/`appsrc` pair. The bridge rebased the PTS of buffers that carried one and forwarded the rest untouched:

```rust
if offset_ns != 0 {
    if let Some(pts_val) = pts { /* restamp, push */ }
    else { let _ = appsrc.push_sample(&sample); }   // forwarded UNSTAMPED
} else {
    let _ = appsrc.push_sample(&sample);            // also unstamped
}
```

Downstream of that appsrc sits a recorder, and `qtmux` cannot place an untimestamped buffer in a track:

```
ERROR Could not multiplex stream.
  gstqtmux.c(5927): gst_qt_mux_add_buffer ():
  /GstSplitMuxSink:rec_p2:splitmuxsink/GstMP4Mux:rec_p2:mux:
  Buffer has no PTS.
```

The resulting `GST_FLOW_ERROR` propagates out of the recorder and up through the mixer, so one seat's stray buffer takes the **whole flow** down. The same incident logged errors from `whip_p2:appsrc_audio_0`, `rec_p2:audio_0_queue`, `vmix:queue_1`, `vmix:appsrc_overlay` and others. Observed on a live rig: a second participant joining killed the first.

The Media Player carried a second copy of that same code, down to the else-branch, in a bridge whose output reaches the same `qtmux`.

## The fix

Drop the buffer at the bridge. The `new_sample` closure moves into `gst::pipeline_bridge::SessionBridge`, which owns the per-session timestamp offset and the drop count, and both blocks call it.

**Why drop rather than stamp from the pipeline clock.** There is no correct value to invent. The main pipeline's running time *now* is a different time base from `pts + offset`, and the two drift apart over a session, so a synthesised stamp can land *before* its own predecessor — and a muxer rejects backwards timestamps exactly as hard as missing ones. That is the same cascade by another route. A stamp that is merely a little wrong is worse still: it desynchronises audio from video for the rest of the session, silently. A dropped frame on a live source is the ordinary recoverable failure — the receiver already tolerates loss, and the `keyframe_request` machinery already in this file recovers a decoder that lost part of its GOP.

**Not silent.** Drops are counted per session and warned on the first, then every hundredth, so a publisher sending nothing usable stays visible without writing a line per frame.

**One offset per session, enforced.** Audio and video reach the bridge on their own streaming threads and can both find the offset unset, read the clock milliseconds apart, and store different offsets — the A/V drift the shared offset exists to prevent. `compare_exchange` lets exactly one win; the loser reads back the winner's value.

Three smaller things in the same code, fixed by the move:

- The shared A/V offset is now taken from the first buffer that **carries a PTS**, not the first buffer of the session.
- DTS is shifted with PTS. It is unset on WHIP traffic (WebRTC H.264 has no B-frames) and set on a file the Media Player passes through encoded; leaving a session-base DTS beside a main-base PTS is the muxer's other way to reject the buffer.
- `sample.caps().unwrap()` no longer panics on a sample without caps.

## Bounds, deliberately not in this PR

**A recorder failing should degrade that seat, not kill the mixer, the program and every other participant.** That is a larger piece of work than a bridge fix: the recorder needs its own bin with a bus handler that fails the seat and leaves the rest of the flow running, plus a way to surface a failed seat through the API and UI. Bundling it here would mix a two-line behavioural fix with a pipeline-topology change. Filing separately.

**The clamp in `shift()`.** A stream whose PTS base sits far behind the offset-setting stream's has its first buffers pinned at 0 — equal timestamps, which is the muxer's third complaint after missing and backwards ones. Pre-existing, unchanged here, and it needs a policy for what a stream starting before the session's time origin should be worth. Stated in the module doc.

## Tests

`backend/src/gst/pipeline_bridge.rs` — 8 unit tests driving a **real `appsrc ! appsink` pair**, so the assertion is on what actually comes out of the sink, not on a returned enum:

- `an_unstamped_buffer_never_crosses_the_bridge` — three samples in, stamped/unstamped/stamped; only the two stamped ones arrive, rebased.
- `an_unstamped_first_buffer_is_dropped_and_does_not_fix_the_offset` — the other route in: no offset yet, so the restamping path is never reached; the buffer must still not cross, and must not poison the offset for the one that follows.
- `two_streams_racing_for_the_offset_still_get_one` — two threads, with a barrier inside the clock closure so both are past the unset check before either stores. Exactly one may report `OffsetComputed`, and both buffers must leave shifted by the same amount.
- `both_streams_share_one_offset` — the sequential case, one thread.
- `a_missing_running_time_forwards_unadjusted_and_retries`, `dts_is_shifted_with_pts`, `a_negative_shift_clamps_to_zero`, `drops_are_logged_first_then_sparsely`.

Two more guard the **wiring**, one per caller. The module tests above cannot see a caller that stops calling `forward`: reverting either call site to a bare `push_sample` left all eight green. Each of these drives its caller's real appsink callback — three buffers into a session pipeline, the middle one unstamped, and only the two stamped ones may reach the appsrc in the main pipeline:

- `blocks::builtin::whip` — `an_unstamped_buffer_never_reaches_the_slot_appsrc`. The callback moved out of the pad-added handler into `install_slot_bridge` so a test can install it without a `whipserversrc`.
- `blocks::builtin::mediaplayer::bridge` — `an_unstamped_buffer_never_reaches_the_main_pipeline`, through `link_pad_through_clocksync` and a real `clocksync`.

The `appsrc`/`appsink` rig is now `pipeline_bridge::test_support`, shared by all three modules. Its main-pipeline half sets `async=false` on the appsink and waits for PLAYING: with no base time the first buffer gets no offset, and the offset lands on whichever buffer arrives after the state change instead.

**All three guards bite.** Re-adding `push_sample` on the PTS-less path in the module fails 2 of the 8 with `left: Some(None)` — the unstamped buffer arriving at the sink. Reverting the `compare_exchange` to a plain store fails the race test with `got [Some(OffsetComputed(9000000000)), Some(OffsetComputed(10000000000))]` — two offsets a second apart, from the same input PTS. Reverting either call site to `appsrc.push_sample(&sample)` fails that caller's test on "the unstamped buffer must not be here". Real guards, not demonstrations.

Uses only `appsrc`/`appsink` from `gstreamer1.0-plugins-base`, already in `.github/workflows/ci.yml`. No element skip, nothing to add.

## What I ran

- `cargo test --features efp` with `STROM_REQUIRE_GST_PLUGINS=1` — 554 lib + 57 integration tests, all pass.
- `cargo clippy --all-targets --features efp,nvidia -- -D warnings` — clean. `cargo fmt --all --check` — clean.
- Live rig, headless on macOS, two `whipclientsink` publishers: both sessions' A/V pads bridged, exactly one shared ts-offset per session, zero unstamped drops on healthy traffic, zero mux errors, neither publisher killed the other.
- Live Media Player → Recorder flow, headless on macOS, passthrough mode on an H.264 + AAC file: one shared ts-offset logged per play, video and audio both muxed into every fragment, no `Buffer has no PTS` and no mux error. Looping the playlist recomputes the offset, which exercises `reset_offset`.

**What I could not run.** I could not drive the Meeting Rig to PLAYING on `upstream/main` — it needs #744 (`builtin.audioenc`), #749 (idle seats holding the pipeline out of PLAYING) and #750 (recorders with no data), all still open. So `qtmux` never ran in my live *WHIP* sessions and **I did not reproduce the WHIP cascade end to end**. The Media Player run above does put a real `qtmux` behind a real bridge; the WHIP guard is the unit test.

## Conflicts to expect

- #753 rewrites the first lines of this same `new_sample` closure (watchdog store to `activity.touch()`). Small mechanical conflict, whichever lands second.
- #752 touches the adjacent watchdog block. #721's `whip.rs` hunk is elsewhere.
- A concurrent branch owns slot reuse / caps negotiation in this file. This diff stays inside the callback and the new module and does not touch slot or decode-chain setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

