### PR TITLE
test(config): serialize test_from_figment_cli_args_override

### DIFF
--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -429,7 +429,12 @@ mod tests {
         assert!(config.database_url.is_none());
     }
 
+    // Serialized with its neighbours: from_figment reads `.strom.toml` from the
+    // process working directory, which those tests move into a TempDir and then
+    // delete. Without the lock this test can pick up their config file and try to
+    // create a data directory that is being torn down.
     #[test]
+    #[serial]
     fn test_from_figment_cli_args_override() {
         let temp_dir = TempDir::new().unwrap();
         let flows = temp_dir.path().join("flows.json");


### PR DESCRIPTION
`config::tests::test_from_figment_cli_args_override` was the only test in the
config module without `#[serial]`. It fails intermittently in a full parallel
`cargo test` run with:

```
called `Result::unwrap()` on an `Err` value: Invalid argument (os error 22)
```

## Cause

Every neighbouring `test_from_figment_*` test moves the process working
directory into a `TempDir` with `std::env::set_current_dir`, then lets the
`TempDir` drop. `#[serial]` serializes those against each other but not against
this one, so it can run inside that window.

`Config::from_figment` looks for `.strom.toml` in the process working directory.
When it runs while `test_config_file_with_data_dir` is chdir'd into its
`TempDir`, it reads *that* test's config file, picks up its
`storage.data_dir` — which points inside the same `TempDir` — and
`DataPaths::resolve` calls `create_dir_all` on a directory the other test is
deleting. On macOS that `mkdir` mostly fails with `EINVAL`, which is the
reported `os error 22`; occasionally `ENOENT`.

Note this is *not* the working directory read failing. `from_figment` calls
`std::env::current_dir().ok()`, so an unlinked working directory is swallowed
(and would give `ENOENT`, not `EINVAL`). The failure comes from the config file
the borrowed working directory exposes.

## Confirmation

Forced the race with a throwaway probe (not committed): a background thread
looping chdir-into-TempDir / write `.strom.toml` / delete, while the main thread
ran this test's `from_figment` call 4000 times. Three runs:

| run | failures / 4000 | `EINVAL` | `ENOENT` |
| --- | --- | --- | --- |
| 1 | 214 | 204 | 10 |
| 2 | 219 | 210 | 9 |
| 3 | 210 | 201 | 9 |

That reproduces the exact reported message.

## Fix

Add `#[serial]`, matching every other test in the module.

The two remaining unserialized tests in the module are not exposed:
`test_ice_servers_normalization` is a pure string test, and
`test_legacy_config_new` calls `Config::new` with `data_dir: None` and no
config-file or environment read, so its base directory is always the platform
data directory.

## Testing

- `cargo test --features efp --lib`, 12 runs before the change and 12 after — all
  544 tests green in every run. **A green run is weak evidence**: the flake is
  reported at roughly 1 in 8 full runs, so 12 clean runs before the change is a
  ~20% likely outcome on its own, and I did not observe the flake in the baseline.
  The argument for this fix is the serialization reasoning plus the forced-race
  reproduction above, not the run count.
- No deterministic regression guard is included. A committed version of the probe
  would prove `from_figment` is working-directory-sensitive, but it would not fail
  if the `#[serial]` were reverted, so per the repo's test rules it would be a
  demonstration rather than a guard. Forcing the real race would require a thread
  mutating the process working directory outside the serial lock, which is the
  disease, not a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
