### PR TITLE
docs(agent): make SUMMARY.md's onward format authoritative over the task prompts

### DIFF
--- a/scripts/agent/README.md
+++ b/scripts/agent/README.md
@@ -79,11 +79,20 @@ useful if the runtime changes and safe to read in public.
   rule that made bare refs the only option — it now bans the URLs that actually matter
   (credentials, endpoints, anything outside this repository) and requires the ones that do
   not.
+- **A task prompt must not restate a rule one of these files owns.** The prompt is the outer
+  instruction, so a restated rule does not drift — it overrides, silently, and the file looks
+  correct while every run ignores it. Both prompts capped the onward message at five lines and
+  banned it from carrying a remote URL long after `SUMMARY.md` required linked, one-line-per-item
+  output; runs went on posting the old shape, and it read as a protocol failure rather than a
+  stale prompt. A prompt carries the role, the constraints, the budget and the wiring. The
+  shape of anything posted lives here.
 
 ## Changing the protocol
 
 Edit these files in a PR. The task definitions only need updating if the *dispatch* changes —
-which file to read when — not when a rule inside a file changes.
+which file to read when — not when a rule inside a file changes. That holds only while the
+prompts state no rule these files own; if one does, changing the file here is not enough, and
+the fix is to delete the rule from the prompt rather than to keep the two in step.
 
 Keep the instruction count per file low. Instruction-following degrades with the number of
 simultaneous constraints, and the earlier a rule sits the more reliably it is obeyed; that is

--- a/scripts/agent/README.md
+++ b/scripts/agent/README.md
@@ -82,9 +82,9 @@ useful if the runtime changes and safe to read in public.
 - **A task prompt must not restate a rule one of these files owns.** The prompt is the outer
   instruction, so a restated rule does not drift — it overrides, silently, and the file looks
   correct while every run ignores it. Both prompts capped the onward message at five lines and
-  banned it from carrying a remote URL long after `SUMMARY.md` required linked, one-line-per-item
-  output; runs went on posting the old shape, and it read as a protocol failure rather than a
-  stale prompt. A prompt carries the role, the constraints, the budget and the wiring. The
+  banned it from carrying a remote URL after `SUMMARY.md` required linked, one-line-per-item
+  output; the next two runs posted the old shape, and it read as a protocol failure rather than
+  a stale prompt. A prompt carries the role, the constraints, the budget and the wiring. The
   shape of anything posted lives here.
 
 ## Changing the protocol

--- a/scripts/agent/SUMMARY.md
+++ b/scripts/agent/SUMMARY.md
@@ -128,6 +128,12 @@ If the task definition gives you somewhere else to report, render that message f
 `needs_human` and the item lists — never from a second pass over the run. If the run did
 nothing, say that in one line rather than staying silent.
 
+**This section owns that message's format.** If the task definition also states a line
+ceiling, or a rule about what a reference may look like, it is out of date: follow this
+section and record the conflict in the summary. One stated both — five lines, and never a
+remote URL — which left a single line of bare `#721` refs as the only legal output, and runs
+kept shipping exactly that after this file had already required otherwise.
+
 **Every reference is a full URL, and every item is its own line.** A bare `#721` autolinks
 only inside this repository's own issues and pull requests. Everywhere else it is four
 characters a reader has to go look up by hand, so a message that names six items costs six


### PR DESCRIPTION
## The Slack message still has no links

The 10:33 notification from the review task, at `main@ccb8593`:

```
Agent review — main@ccb8593, 4 items
Needs you: #722 (dispatch macOS CI), #690 (release sign-off), #700 (clamp/reject/rename), #737 (keep-or-close), #749 (non-blocking nit)
Reviewed: #724 Approve, #749 Comment, #722 Comment, #752 Approve
Skipped 16 (drafts/dep bumps); left by cap: #753 #754
Queue: 0 candidates, 16 awaiting reply, 0 untriaged
```

Nine references, none of them clickable. `#722` autolinks only inside this repository; in
Slack it is four characters you have to go search for.

## #751 was not wrong, and it did land

`ccb8593` has `2b1013b` as its parent, so that run read the `SUMMARY.md` that already
required `<https://github.com/Eyevinn/strom/issues/721|#721>` and one numbered line per item,
and posted the old shape anyway.

The cause is outside this repo. Both task prompts end with:

> Then post one message to the notification channel, rendered from the summary's
> `needs_human` and item lists — **five lines at most** […] Never put a token, **a remote
> URL** or a raw log excerpt in the message.

A prompt is the outer instruction. Those two sentences did not drift against the protocol
file — they overrode it, and between them they leave one crammed line of bare refs as the
only legal output. That is exactly what shipped, while the file looked correct the whole time.
`README.md`'s own promise that "the task definitions only need updating […] not when a rule
inside a file changes" is what made it invisible.

## What this changes

Nothing about the required format — #751 already specified it. This records where the boundary
is, in the two places a later change reads:

- **`SUMMARY.md`** — "Reporting onward" now states that it owns the format, and that a task
  definition stating a line ceiling or a reference rule is by definition out of date: follow
  the file, and record the conflict in the summary. A run that meets a stale prompt again now
  has an instruction for that case rather than two contradictory ones.
- **`README.md`** — a design note that a prompt must never restate a rule these files own,
  with this as the worked example, and "Changing the protocol" no longer promises that editing
  a file here suffices unconditionally.

## The prompts themselves

Deployment configuration, outside this repo. Both have had the five-line cap and the remote-URL
ban removed and now defer to `SUMMARY.md` for the format; both tasks are updated. Their
reporting sections also gained the payload encoding, which the old five-line shape hid: a
message with one line per item cannot go through a hand-escaped `-d '{"text":"…"}'` — the first
newline or backtick makes it invalid JSON and Slack answers `"ok":false` with no other symptom.
They now pipe the rendered message through `jq -Rs` (with a `python3 -c json.dumps` fallback)
and post `-d @payload.json`.

## Tests

`scripts/agent/test-agent-scripts.sh` — 40 passed, 0 failed. Unchanged: this commit touches no
script. Nothing else here is executable; the check that matters is the next 14:00 UTC run's
message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
