### PR TITLE
fix(recorder): retry an EOS the stalled track refused, and end it sooner

### DIFF
--- a/backend/src/blocks/builtin/recorder.rs
+++ b/backend/src/blocks/builtin/recorder.rs
@@ -25,6 +25,10 @@
 //! never carries data cannot hold the pipeline out of PLAYING (see
 //! `prepare_idle_recording_sink`).
 //!
+//! A track that carried data and then stopped is a different matter: splitmuxsink goes on
+//! waiting for it and the whole recording freezes. `spawn_track_stall_watchdog` ends such
+//! a track so the others keep recording.
+//!
 //! Output files are written to: {media_path}/{output_dir}/{filename_prefix}_%05d.{ext}
 
 use crate::blocks::{BlockBuildContext, BlockBuildError, BlockBuildResult, BlockBuilder};
@@ -33,8 +37,9 @@ use gst::glib::prelude::ToValue;
 use gstreamer as gst;
 use gstreamer::prelude::*;
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering};
 use std::sync::{Arc, OnceLock};
+use std::time::{Duration, Instant};
 use strom_types::{
     block::{EnumValue, *},
     PropertyValue, *,
@@ -76,6 +81,272 @@ fn activate_recording_sink(splitmuxsink: &gst::Element, instance_id: &str) {
             "Recorder {}: failed to sync splitmuxsink with pipeline state: {}",
             instance_id, e
         );
+    }
+}
+
+/// How long the muxer may accept nothing at all before the recorder ends the
+/// track it is waiting for.
+///
+/// The trigger is the whole recording being frozen, not one quiet input, so this
+/// is already well past anything a live source does normally — a WHIP seat's
+/// jitter buffer runs at 400 ms. Ending a track is not reversible: the recording
+/// keeps the tracks that are still running, but the one that ended does not come
+/// back.
+const TRACK_STALL_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// How often the stall watchdog looks. Also how quickly it notices the pipeline
+/// is gone and stops.
+const TRACK_STALL_POLL: Duration = Duration::from_millis(500);
+
+/// What the stall watchdog knows about one track, written by that track's probes.
+struct TrackActivity {
+    /// Milliseconds since the recorder's epoch when the muxer last took a buffer
+    /// from this track. 0 = it never has.
+    last_muxed_ms: AtomicU64,
+    /// Running time of that buffer, in milliseconds: how far this track has carried
+    /// the recording, in the form splitmuxsink compares between its pads.
+    last_muxed_running_ms: AtomicU64,
+    /// `base - start` of this track's segment, added to a PTS to reach running time.
+    running_time_offset_ns: AtomicI64,
+    /// Set once this track has left the recording — the watchdog ended it, or the
+    /// caps probe handed its sink pad back. The input probe then drops buffers, so
+    /// upstream never sees the flow error a dead branch would return: a WHIP seat's
+    /// encoder feeds the vision mixer through the same tee, and must not be stopped
+    /// along with the recording.
+    retired: AtomicBool,
+}
+
+/// A track the stall watchdog is responsible for.
+struct WatchedTrack {
+    /// "video 0" / "audio 1" — for the log line, built once at setup.
+    label: String,
+    input: gst::glib::WeakRef<gst::Element>,
+    activity: Arc<TrackActivity>,
+}
+
+/// Drop this track's buffers at the block boundary once it has left the recording.
+///
+/// Without it the branch answers upstream with a flow error, and a WHIP seat's
+/// encoder — which feeds the vision mixer through the same tee — stops with it.
+///
+/// A BUFFER probe is the hottest path in the pipeline, so this is one relaxed
+/// atomic load and nothing else.
+fn add_retired_input_probe(pad: &gst::Pad, activity: &Arc<TrackActivity>) {
+    let activity = Arc::clone(activity);
+    pad.add_probe(gst::PadProbeType::BUFFER, move |_pad, _info| {
+        if activity.retired.load(Ordering::Relaxed) {
+            gst::PadProbeReturn::Drop
+        } else {
+            gst::PadProbeReturn::Ok
+        }
+    });
+}
+
+/// Record what the muxer takes from this track: when, and how far it carried the
+/// recording. Measured at the splitmuxsink sink pad rather than at the block's
+/// input, because the input goes quiet whatever the cause — once the muxer stops,
+/// backpressure reaches every input within a second and they all look equally
+/// dead.
+///
+/// Position is kept as running time, not as the raw PTS. The two are far apart
+/// here — a WHIP seat's video arrives with a timestamp offset its audio does not
+/// have — and running time is what splitmuxsink itself compares between pads, so
+/// it is the only form in which two tracks can be ranked against each other.
+///
+/// A buffer with no PTS is dropped: `mp4mux` answers one with "Buffer has no PTS"
+/// and errors the whole pipeline, which takes the seat's video with it. `aacparse`
+/// emits one when it drains a partial frame at EOS, so ending a track produces
+/// exactly this buffer.
+///
+/// The segment arrives as an event, and events on a muxer sink pad are rare, so
+/// the conversion is folded into an offset there and the buffer path stays at two
+/// relaxed atomic stores plus `Instant::elapsed` on the vDSO fast path.
+fn add_muxer_intake_probe(pad: &gst::Pad, activity: &Arc<TrackActivity>, epoch: Instant) {
+    let segment_activity = Arc::clone(activity);
+    pad.add_probe(gst::PadProbeType::EVENT_DOWNSTREAM, move |_pad, info| {
+        let Some(gst::PadProbeData::Event(event)) = info.data.as_ref() else {
+            return gst::PadProbeReturn::Ok;
+        };
+        let gst::EventView::Segment(segment) = event.view() else {
+            return gst::PadProbeReturn::Ok;
+        };
+        if let Some(segment) = segment.segment().downcast_ref::<gst::ClockTime>() {
+            let base = segment.base().unwrap_or(gst::ClockTime::ZERO).nseconds() as i64;
+            let start = segment.start().unwrap_or(gst::ClockTime::ZERO).nseconds() as i64;
+            segment_activity
+                .running_time_offset_ns
+                .store(base - start, Ordering::Relaxed);
+        }
+        gst::PadProbeReturn::Ok
+    });
+
+    let activity = Arc::clone(activity);
+    pad.add_probe(gst::PadProbeType::BUFFER, move |_pad, info| {
+        let Some(gst::PadProbeData::Buffer(buffer)) = info.data.as_ref() else {
+            return gst::PadProbeReturn::Ok;
+        };
+        let Some(pts) = buffer.pts() else {
+            return gst::PadProbeReturn::Drop;
+        };
+        let offset_ns = activity.running_time_offset_ns.load(Ordering::Relaxed);
+        let running_ns = (pts.nseconds() as i64).saturating_add(offset_ns).max(0);
+        activity
+            .last_muxed_running_ms
+            .store(running_ns as u64 / 1_000_000, Ordering::Relaxed);
+        activity
+            .last_muxed_ms
+            .store(epoch.elapsed().as_millis() as u64, Ordering::Relaxed);
+        gst::PadProbeReturn::Ok
+    });
+}
+
+/// End a track, so the muxer stops waiting for it.
+///
+/// splitmuxsink holds a GOP until every one of its sink pads has advanced past it,
+/// so a single track that stops freezes the whole recording — and, through the tee
+/// that feeds the recorder, every other branch of that source with it. EOS is what
+/// takes a pad out of that wait. A GAP event does not: splitmuxsink ignores it on a
+/// non-reference stream, so the track has to end rather than idle.
+///
+/// The EOS is pushed from the watchdog thread rather than from an IDLE probe. By
+/// the time a track has stalled, the thread that fed it is usually parked inside
+/// `gst_pad_push` on this very pad, so the pad never goes idle and an IDLE probe
+/// would never run. An identity src pad has no task of its own, so its stream lock
+/// is free and the push goes straight through.
+fn end_stalled_track(input: &gst::Element, activity: &TrackActivity) {
+    if activity.retired.swap(true, Ordering::SeqCst) {
+        return;
+    }
+    let Some(pad) = input.static_pad("src") else {
+        return;
+    };
+    if !pad.push_event(gst::event::Eos::new()) {
+        warn!(
+            "Recorder: {} refused the EOS that would end its track — the recording stays stalled",
+            pad.parent()
+                .map(|p| p.name().to_string())
+                .unwrap_or_default()
+        );
+    }
+}
+
+/// Watch the recording and end a track that has stopped the muxer.
+///
+/// Only tracks that hold a splitmuxsink pad are watched, and only from the muxer's
+/// first buffer on that pad. A connected track that never carries one is not
+/// covered: the muxer does wait for it just the same, but the timeout would then be
+/// counting against a publisher that has not connected yet, whose track is meant to
+/// start late.
+///
+/// The thread holds weak references only and stops within a poll interval of the
+/// pipeline being torn down, so it cannot outlive its flow.
+fn spawn_track_stall_watchdog(
+    instance_id: &str,
+    splitmuxsink: &gst::Element,
+    tracks: Vec<WatchedTrack>,
+    epoch: Instant,
+) {
+    if tracks.len() < 2 {
+        // One track cannot be held up by another, and ending it would end the
+        // recording rather than rescue it.
+        return;
+    }
+    let splitmuxsink_weak = splitmuxsink.downgrade();
+    let block_id = instance_id.to_string();
+
+    let spawned = std::thread::Builder::new()
+        .name(format!("rec-stall-{}", instance_id))
+        .spawn(move || watch_tracks(&block_id, splitmuxsink_weak, &tracks, epoch));
+
+    if let Err(e) = spawned {
+        error!(
+            "Recorder {}: failed to start the track stall watchdog: {} — a track that stops will freeze this recording",
+            instance_id, e
+        );
+    }
+}
+
+/// The watchdog loop. Returns once the pipeline is gone or every track has ended.
+fn watch_tracks(
+    block_id: &str,
+    splitmuxsink: gst::glib::WeakRef<gst::Element>,
+    tracks: &[WatchedTrack],
+    epoch: Instant,
+) {
+    let timeout_ms = TRACK_STALL_TIMEOUT.as_millis() as u64;
+
+    // When the last track was ended. Ending one frees the others, but not within a
+    // poll interval: without a pause here the whole recording is ended track by
+    // track before the first one has taken effect.
+    let mut last_end_ms: Option<u64> = None;
+
+    loop {
+        std::thread::sleep(TRACK_STALL_POLL);
+
+        // The pipeline is gone: nothing left to watch.
+        if splitmuxsink.upgrade().is_none() {
+            return;
+        }
+
+        let now_ms = epoch.elapsed().as_millis() as u64;
+        let mut live = Vec::with_capacity(tracks.len());
+        let mut still_watching = 0usize;
+
+        for track in tracks {
+            if track.activity.retired.load(Ordering::Relaxed) {
+                continue;
+            }
+            let Some(input) = track.input.upgrade() else {
+                continue;
+            };
+            still_watching += 1;
+
+            let last_ms = track.activity.last_muxed_ms.load(Ordering::Relaxed);
+            if last_ms == 0 {
+                continue;
+            }
+            live.push((
+                track,
+                input,
+                now_ms.saturating_sub(last_ms),
+                track.activity.last_muxed_running_ms.load(Ordering::Relaxed),
+            ));
+        }
+
+        if still_watching == 0 {
+            return;
+        }
+
+        // The whole recording has to be frozen before anything is ended. One quiet
+        // input proves nothing: whichever track stopped, the muxer blocks and every
+        // other input backs up behind it within a second, so a machine that is
+        // merely overloaded looks exactly the same from any single input.
+        let frozen = live.len() > 1
+            && !last_end_ms.is_some_and(|t| now_ms.saturating_sub(t) < timeout_ms)
+            && live
+                .iter()
+                .all(|(_, _, quiet_ms, _)| *quiet_ms >= timeout_ms);
+        if !frozen {
+            continue;
+        }
+
+        // splitmuxsink waits on whichever track has carried the recording least far,
+        // so that is the one to end — the same choice it is making internally.
+        let Some((track, input, quiet_ms, running_ms)) = live
+            .into_iter()
+            .min_by_key(|(_, _, _, running_ms)| *running_ms)
+        else {
+            continue;
+        };
+        warn!(
+            "Recorder {}: nothing muxed for {}s and {} is furthest behind at {}ms — ending that track so the rest of the recording continues",
+            block_id,
+            quiet_ms / 1000,
+            track.label,
+            running_ms
+        );
+        end_stalled_track(&input, &track.activity);
+        last_end_ms = Some(now_ms);
     }
 }
 
@@ -398,6 +669,11 @@ impl BlockBuilder for RecorderBuilder {
         let mut video_input_weaks: Vec<gst::glib::WeakRef<gst::Element>> = Vec::new();
         let mut audio_input_weaks: Vec<gst::glib::WeakRef<gst::Element>> = Vec::new();
 
+        // Track liveness, for the stall watchdog the setup hook starts.
+        let stall_epoch = Instant::now();
+        let mut video_activities: Vec<Arc<TrackActivity>> = Vec::new();
+        let mut audio_activities: Vec<Arc<TrackActivity>> = Vec::new();
+
         // --- Create video input chains ---
         for vi in 0..num_video_tracks {
             let video_input_id = format!("{}:video_input_{}", instance_id, vi);
@@ -420,6 +696,16 @@ impl BlockBuilder for RecorderBuilder {
             let src_pad = video_input.static_pad("src").ok_or_else(|| {
                 BlockBuildError::ElementCreation("video identity has no src pad".to_string())
             })?;
+
+            let activity = Arc::new(TrackActivity {
+                last_muxed_ms: AtomicU64::new(0),
+                last_muxed_running_ms: AtomicU64::new(0),
+                running_time_offset_ns: AtomicI64::new(0),
+                retired: AtomicBool::new(false),
+            });
+            add_retired_input_probe(&src_pad, &activity);
+            let probe_activity = Arc::clone(&activity);
+            video_activities.push(activity);
 
             src_pad.add_probe(
                 gst::PadProbeType::EVENT_DOWNSTREAM,
@@ -474,8 +760,13 @@ impl BlockBuilder for RecorderBuilder {
                     };
 
                     // Every path that gives up below must hand the pad back, or splitmuxsink
-                    // waits on it forever and the recording stalls.
-                    let give_pad_back = || splitmuxsink.release_request_pad(&sink_pad);
+                    // waits on it forever and the recording stalls. Retiring the track with
+                    // it takes it off the stall watchdog, which has nothing left to end, and
+                    // drops the buffers that would otherwise be pushed into the dead branch.
+                    let give_pad_back = || {
+                        probe_activity.retired.store(true, Ordering::SeqCst);
+                        splitmuxsink.release_request_pad(&sink_pad)
+                    };
 
                     let (parser_factory, config_interval) = if caps_name == "video/x-h264" {
                         ("h264parse", -1i32)
@@ -644,6 +935,16 @@ impl BlockBuilder for RecorderBuilder {
                 BlockBuildError::ElementCreation(format!("audio_{} identity has no src pad", i))
             })?;
 
+            let activity = Arc::new(TrackActivity {
+                last_muxed_ms: AtomicU64::new(0),
+                last_muxed_running_ms: AtomicU64::new(0),
+                running_time_offset_ns: AtomicI64::new(0),
+                retired: AtomicBool::new(false),
+            });
+            add_retired_input_probe(&src_pad, &activity);
+            let probe_activity = Arc::clone(&activity);
+            audio_activities.push(activity);
+
             src_pad.add_probe(
                 gst::PadProbeType::EVENT_DOWNSTREAM,
                 move |pad, probe_info| {
@@ -698,8 +999,13 @@ impl BlockBuilder for RecorderBuilder {
                     };
 
                     // Every path that gives up below must hand the pad back, or splitmuxsink
-                    // waits on it forever and the recording stalls.
-                    let give_pad_back = || splitmuxsink.release_request_pad(&sink_pad);
+                    // waits on it forever and the recording stalls. Retiring the track with
+                    // it takes it off the stall watchdog, which has nothing left to end, and
+                    // drops the buffers that would otherwise be pushed into the dead branch.
+                    let give_pad_back = || {
+                        probe_activity.retired.store(true, Ordering::SeqCst);
+                        splitmuxsink.release_request_pad(&sink_pad)
+                    };
 
                     // Only accept pre-encoded audio. Raw audio requires an encoder before the recorder.
                     if caps_name == "audio/x-raw" {
@@ -864,9 +1170,11 @@ impl BlockBuilder for RecorderBuilder {
                 // on its keyframes; the rest take video_aux. splitmuxsink names video pads
                 // itself, so record what it handed back, not what we asked for.
                 let mut have_primary_video = false;
-                for (vi, (input, cell)) in video_input_weaks
+                let mut watched: Vec<WatchedTrack> = Vec::new();
+                for (vi, ((input, cell), activity)) in video_input_weaks
                     .iter()
                     .zip(video_pad_cells.iter())
+                    .zip(video_activities.iter())
                     .enumerate()
                 {
                     if !input_is_connected(input) {
@@ -893,6 +1201,12 @@ impl BlockBuilder for RecorderBuilder {
                                 vi
                             );
                             let _ = cell.set(pad.name().to_string());
+                            add_muxer_intake_probe(&pad, activity, stall_epoch);
+                            watched.push(WatchedTrack {
+                                label: format!("video {}", vi),
+                                input: input.clone(),
+                                activity: Arc::clone(activity),
+                            });
                         }
                         None => error!(
                             "Recorder {}: splitmuxsink refused a sink pad for video track {} — that track will not be recorded",
@@ -901,9 +1215,10 @@ impl BlockBuilder for RecorderBuilder {
                     }
                 }
 
-                for (i, (input, cell)) in audio_input_weaks
+                for (i, ((input, cell), activity)) in audio_input_weaks
                     .iter()
                     .zip(audio_pad_cells.iter())
+                    .zip(audio_activities.iter())
                     .enumerate()
                 {
                     if !input_is_connected(input) {
@@ -928,6 +1243,12 @@ impl BlockBuilder for RecorderBuilder {
                                 i
                             );
                             let _ = cell.set(pad.name().to_string());
+                            add_muxer_intake_probe(&pad, activity, stall_epoch);
+                            watched.push(WatchedTrack {
+                                label: format!("audio {}", i),
+                                input: input.clone(),
+                                activity: Arc::clone(activity),
+                            });
                         }
                         None => error!(
                             "Recorder {}: splitmuxsink refused a sink pad for audio track {} — that track will not be recorded",
@@ -935,6 +1256,10 @@ impl BlockBuilder for RecorderBuilder {
                         ),
                     }
                 }
+
+                // Every pad requested above is one the muxer will wait for. Watch
+                // exactly those.
+                spawn_track_stall_watchdog(&block_id, &splitmuxsink, watched, stall_epoch);
             }));
         }
 

--- a/backend/src/blocks/builtin/recorder.rs
+++ b/backend/src/blocks/builtin/recorder.rs
@@ -129,17 +129,37 @@ struct WatchedTrack {
 /// Without it the branch answers upstream with a flow error, and a WHIP seat's
 /// encoder — which feeds the vision mixer through the same tee — stops with it.
 ///
-/// A BUFFER probe is the hottest path in the pipeline, so this is one relaxed
-/// atomic load and nothing else.
+/// It has to be the identity's **sink** pad. `end_stalled_track` retires a track by
+/// pushing EOS out of the src pad, and `gst_pad_push` answers `GST_FLOW_EOS` from
+/// that sticky flag before it dispatches any probe — so a drop probe on the src pad
+/// stops running at the one moment it is needed.
+///
+/// Events have to be dropped as well as buffers, and that is what makes this a
+/// correctness matter rather than a tidiness one. An encoder upstream of the block
+/// emits a sticky TAG event every so often. Forwarding one into a pad that already
+/// carries EOS fails, `push_sticky` turns that refusal into `GST_FLOW_ERROR`, and
+/// the error travels back to the seat's source, which pauses its streaming task and
+/// never restarts. A buffer probe alone lets those events straight through.
+///
+/// Flush events are deliberately not covered: they carry pad state that has to
+/// reach the branch even after it has left the recording.
+///
+/// These are the hottest paths in the pipeline, so this is one relaxed atomic load
+/// and nothing else.
 fn add_retired_input_probe(pad: &gst::Pad, activity: &Arc<TrackActivity>) {
     let activity = Arc::clone(activity);
-    pad.add_probe(gst::PadProbeType::BUFFER, move |_pad, _info| {
-        if activity.retired.load(Ordering::Relaxed) {
-            gst::PadProbeReturn::Drop
-        } else {
-            gst::PadProbeReturn::Ok
-        }
-    });
+    pad.add_probe(
+        gst::PadProbeType::BUFFER
+            | gst::PadProbeType::BUFFER_LIST
+            | gst::PadProbeType::EVENT_DOWNSTREAM,
+        move |_pad, _info| {
+            if activity.retired.load(Ordering::Relaxed) {
+                gst::PadProbeReturn::Drop
+            } else {
+                gst::PadProbeReturn::Ok
+            }
+        },
+    );
 }
 
 /// Record what the muxer takes from this track: when, and how far it carried the
@@ -696,6 +716,9 @@ impl BlockBuilder for RecorderBuilder {
             let src_pad = video_input.static_pad("src").ok_or_else(|| {
                 BlockBuildError::ElementCreation("video identity has no src pad".to_string())
             })?;
+            let sink_pad_for_drops = video_input.static_pad("sink").ok_or_else(|| {
+                BlockBuildError::ElementCreation("video identity has no sink pad".to_string())
+            })?;
 
             let activity = Arc::new(TrackActivity {
                 last_muxed_ms: AtomicU64::new(0),
@@ -703,7 +726,7 @@ impl BlockBuilder for RecorderBuilder {
                 running_time_offset_ns: AtomicI64::new(0),
                 retired: AtomicBool::new(false),
             });
-            add_retired_input_probe(&src_pad, &activity);
+            add_retired_input_probe(&sink_pad_for_drops, &activity);
             let probe_activity = Arc::clone(&activity);
             video_activities.push(activity);
 
@@ -934,6 +957,9 @@ impl BlockBuilder for RecorderBuilder {
             let src_pad = audio_input.static_pad("src").ok_or_else(|| {
                 BlockBuildError::ElementCreation(format!("audio_{} identity has no src pad", i))
             })?;
+            let sink_pad_for_drops = audio_input.static_pad("sink").ok_or_else(|| {
+                BlockBuildError::ElementCreation(format!("audio_{} identity has no sink pad", i))
+            })?;
 
             let activity = Arc::new(TrackActivity {
                 last_muxed_ms: AtomicU64::new(0),
@@ -941,7 +967,7 @@ impl BlockBuilder for RecorderBuilder {
                 running_time_offset_ns: AtomicI64::new(0),
                 retired: AtomicBool::new(false),
             });
-            add_retired_input_probe(&src_pad, &activity);
+            add_retired_input_probe(&sink_pad_for_drops, &activity);
             let probe_activity = Arc::clone(&activity);
             audio_activities.push(activity);
 
@@ -1561,5 +1587,90 @@ fn recorder_definition() -> BlockDefinition {
             height: Some(2.5),
             ..Default::default()
         }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn idle_activity() -> TrackActivity {
+        TrackActivity {
+            last_muxed_ms: AtomicU64::new(0),
+            last_muxed_running_ms: AtomicU64::new(0),
+            running_time_offset_ns: AtomicI64::new(0),
+            retired: AtomicBool::new(false),
+        }
+    }
+
+    /// Ending a track must not take the rest of the seat with it.
+    ///
+    /// A WHIP seat's media leaves one tee for the recorder, the vision mixer, the
+    /// audio mixer and the return router. A retired branch that answers upstream
+    /// with a flow error stops the encoder feeding it, and the seat then goes
+    /// silent for the whole flow until it is restarted. It has to swallow what
+    /// arrives and answer OK instead.
+    ///
+    /// Both halves matter. Move the drop probe back to the identity's src pad and
+    /// the buffer case fails, because `gst_pad_push` reads the EOS flag before it
+    /// dispatches probes. Narrow the probe to buffers alone and the event case
+    /// fails, which is the half that bites in a real flow: an encoder upstream
+    /// emits a sticky TAG event every so often, and `push_sticky` reports a
+    /// refused one to the caller as `GST_FLOW_ERROR`.
+    #[test]
+    fn a_retired_track_still_answers_ok_upstream() {
+        gst::init().expect("gstreamer init");
+        let pipeline = gst::Pipeline::new();
+        let input = gst::ElementFactory::make("identity")
+            .build()
+            .expect("identity is part of gstreamer core");
+        let sink = gst::ElementFactory::make("fakesink")
+            .property("async", false)
+            .property("sync", false)
+            .build()
+            .expect("fakesink is part of gstreamer core");
+        pipeline.add_many([&input, &sink]).expect("add elements");
+        input.link(&sink).expect("link identity to fakesink");
+
+        let sink_pad = input.static_pad("sink").expect("identity has a sink pad");
+        let activity = Arc::new(idle_activity());
+        add_retired_input_probe(&sink_pad, &activity);
+
+        pipeline
+            .set_state(gst::State::Playing)
+            .expect("pipeline accepts PLAYING");
+        let _ = pipeline.state(gst::ClockTime::from_seconds(5));
+
+        let push = || sink_pad.chain(gst::Buffer::with_size(16).expect("allocate buffer"));
+        assert_eq!(
+            push(),
+            Ok(gst::FlowSuccess::Ok),
+            "the branch takes buffers while the track is live"
+        );
+
+        end_stalled_track(&input, &activity);
+        assert!(
+            activity.retired.load(Ordering::SeqCst),
+            "the watchdog ended the track"
+        );
+
+        assert_eq!(
+            push(),
+            Ok(gst::FlowSuccess::Ok),
+            "a retired branch has to keep answering OK, or it stops whatever feeds the tee it hangs off"
+        );
+
+        let tags = gst::TagList::new();
+        assert!(
+            sink_pad.send_event(gst::event::Tag::new(tags)),
+            "a retired branch has to take events too, not just buffers"
+        );
+        assert_eq!(
+            push(),
+            Ok(gst::FlowSuccess::Ok),
+            "a sticky event refused by the retired branch turns the next push into a flow error"
+        );
+
+        let _ = pipeline.set_state(gst::State::Null);
     }
 }

--- a/backend/tests/recorder_stalled_track_test.rs
+++ b/backend/tests/recorder_stalled_track_test.rs
@@ -1,0 +1,327 @@
+//! `splitmuxsink` releases a GOP only once every one of its sink pads has
+//! advanced past it, so one track that stops delivering freezes the whole
+//! recording — and, through the tee that feeds the recorder, every other branch
+//! of that source with it. A participant whose microphone dies mid-session takes
+//! their video and their recording down with it, and the program output too if
+//! they were the only live source.
+//!
+//! EOS is what takes a pad out of that wait; a GAP event does not, splitmuxsink
+//! ignores it on a non-reference stream. So the recorder ends the track rather
+//! than trying to keep it idling.
+//!
+//! The two tests are a pair: one asserts that a stopped track does not freeze the
+//! rest, the other that tracks which are still running are left alone. Ending
+//! every track on a timer would satisfy the first and destroy every recording.
+//! The first also pins down *which* track is ended: if the recorder ended the
+//! video track — the one still delivering — no video would reach the muxer either.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use strom::blocks::builtin::recorder::RecorderBuilder;
+use strom::blocks::{BlockBuildContext, BlockBuilder};
+use strom::events::EventBroadcaster;
+use strom_types::PropertyValue;
+
+use gstreamer as gst;
+use gstreamer::prelude::*;
+
+/// Elements these tests need beyond core GStreamer. Missing on a bare CI image.
+const REQUIRED: &[&str] = &[
+    "splitmuxsink",
+    "mp4mux",
+    "x264enc",
+    "h264parse",
+    "videotestsrc",
+    "audiotestsrc",
+    "audioconvert",
+    "audioresample",
+    "avenc_aac",
+    "aacparse",
+    "identity",
+    "queue",
+];
+
+/// Skipping on a missing element passes green and guards nothing, so CI sets
+/// `STROM_REQUIRE_GST_PLUGINS=1` to turn a skip into a failure.
+fn plugins_available() -> bool {
+    let missing: Vec<&str> = REQUIRED
+        .iter()
+        .copied()
+        .filter(|e| gst::ElementFactory::find(e).is_none())
+        .collect();
+    if missing.is_empty() {
+        return true;
+    }
+    assert!(
+        strom_types::env::var_opt("STROM_REQUIRE_GST_PLUGINS").is_none(),
+        "STROM_REQUIRE_GST_PLUGINS is set but these elements are missing: {}",
+        missing.join(", ")
+    );
+    false
+}
+
+/// Build a one-video, one-audio recorder through the real builder and add it to
+/// `pipeline`, returning both input elements and the build context. The
+/// context's setup hooks must run after the inputs are linked — that is what
+/// decides which tracks are connected, get a splitmuxsink pad, and are watched.
+fn add_recorder(
+    pipeline: &gst::Pipeline,
+    instance_id: &str,
+    media_root: &Path,
+) -> (gst::Element, gst::Element, BlockBuildContext) {
+    let mut props: HashMap<String, PropertyValue> = HashMap::new();
+    props.insert("container".to_string(), PropertyValue::String("mp4".into()));
+    props.insert("num_video_tracks".to_string(), PropertyValue::UInt(1));
+    props.insert("num_audio_tracks".to_string(), PropertyValue::UInt(1));
+    props.insert(
+        "output_dir".to_string(),
+        PropertyValue::String("recordings".into()),
+    );
+    props.insert(
+        "filename_prefix".to_string(),
+        PropertyValue::String(instance_id.to_string()),
+    );
+    props.insert(
+        "_media_path".to_string(),
+        PropertyValue::String(media_root.to_string_lossy().to_string()),
+    );
+
+    let ctx = BlockBuildContext::new(vec![], "all".to_string());
+    let built = RecorderBuilder
+        .build(instance_id, &props, &ctx)
+        .expect("recorder block builds");
+
+    let mut video = None;
+    let mut audio = None;
+    for (id, element) in &built.elements {
+        pipeline.add(element).expect("add block element");
+        if id == &format!("{}:video_input_0", instance_id) {
+            video = Some(element.clone());
+        }
+        if id == &format!("{}:audio_input_0", instance_id) {
+            audio = Some(element.clone());
+        }
+    }
+    (
+        video.expect("recorder exposes video_input_0"),
+        audio.expect("recorder exposes audio_input_0"),
+        ctx,
+    )
+}
+
+/// Run a recorder's element-setup hooks, as the pipeline manager does after
+/// linking and before PLAYING.
+fn run_setups(ctx: &BlockBuildContext) {
+    for setup in ctx.take_element_setups() {
+        setup(uuid::Uuid::new_v4(), EventBroadcaster::new(16));
+    }
+}
+
+/// Swallow EOS on `element`'s src pad, so a source that runs out of buffers
+/// looks like a track that simply stopped arriving. This is what the recorder
+/// actually sees: EOS does not cross a WebRTC hop, so a publisher whose
+/// microphone dies just stops sending RTP.
+fn drop_eos(element: &gst::Element) {
+    element.static_pad("src").expect("src pad").add_probe(
+        gst::PadProbeType::EVENT_DOWNSTREAM,
+        |_pad, info| match info.data.as_ref() {
+            Some(gst::PadProbeData::Event(e)) if e.type_() == gst::EventType::Eos => {
+                gst::PadProbeReturn::Drop
+            }
+            _ => gst::PadProbeReturn::Ok,
+        },
+    );
+}
+
+/// Live H.264 into `target`. `num_buffers` of -1 runs until the pipeline stops.
+fn feed_video(pipeline: &gst::Pipeline, target: &gst::Element, num_buffers: i32) {
+    let src = gst::ElementFactory::make("videotestsrc")
+        .property("is-live", true)
+        .property("num-buffers", num_buffers)
+        .build()
+        .expect("videotestsrc");
+    let caps = gst::ElementFactory::make("capsfilter")
+        .property(
+            "caps",
+            gst::Caps::builder("video/x-raw")
+                .field("width", 320i32)
+                .field("height", 240i32)
+                .field("framerate", gst::Fraction::new(30, 1))
+                .build(),
+        )
+        .build()
+        .expect("capsfilter");
+    let enc = gst::ElementFactory::make("x264enc")
+        .property("key-int-max", 10u32)
+        .property_from_str("tune", "zerolatency")
+        .build()
+        .expect("x264enc");
+    let gate = gst::ElementFactory::make("identity")
+        .build()
+        .expect("identity");
+    drop_eos(&gate);
+
+    pipeline.add_many([&src, &caps, &enc, &gate]).unwrap();
+    gst::Element::link_many([&src, &caps, &enc, &gate]).unwrap();
+    gate.link(target).expect("link video into recorder");
+}
+
+/// Live AAC into `target`. `num_buffers` of -1 runs until the pipeline stops.
+fn feed_audio(pipeline: &gst::Pipeline, target: &gst::Element, num_buffers: i32) {
+    let src = gst::ElementFactory::make("audiotestsrc")
+        .property("is-live", true)
+        .property("num-buffers", num_buffers)
+        .build()
+        .expect("audiotestsrc");
+    let conv = gst::ElementFactory::make("audioconvert").build().unwrap();
+    let resample = gst::ElementFactory::make("audioresample").build().unwrap();
+    let enc = gst::ElementFactory::make("avenc_aac").build().unwrap();
+    let gate = gst::ElementFactory::make("identity").build().unwrap();
+    drop_eos(&gate);
+
+    pipeline
+        .add_many([&src, &conv, &resample, &enc, &gate])
+        .unwrap();
+    gst::Element::link_many([&src, &conv, &resample, &enc, &gate]).unwrap();
+    gate.link(target).expect("link audio into recorder");
+}
+
+/// Buffers reaching splitmuxsink's primary video pad: what the muxer is
+/// actually consuming, which is what stops when it is waiting on another pad.
+fn count_into_muxer(pipeline: &gst::Pipeline, instance_id: &str, pad: &str) -> Arc<AtomicU64> {
+    let counter = Arc::new(AtomicU64::new(0));
+    let sink = pipeline
+        .by_name(&format!("{}:splitmuxsink", instance_id))
+        .expect("splitmuxsink in pipeline");
+    let sink_pad = sink
+        .static_pad(pad)
+        .unwrap_or_else(|| panic!("splitmuxsink has a {} pad", pad));
+    let c = Arc::clone(&counter);
+    sink_pad.add_probe(gst::PadProbeType::BUFFER, move |_pad, _info| {
+        c.fetch_add(1, Ordering::Relaxed);
+        gst::PadProbeReturn::Ok
+    });
+    counter
+}
+
+fn recorded_bytes(media_root: &Path) -> u64 {
+    std::fs::read_dir(media_root.join("recordings"))
+        .map(|rd| {
+            rd.filter_map(|e| e.ok())
+                .filter_map(|e| e.metadata().ok())
+                .filter(|m| m.is_file())
+                .map(|m| m.len())
+                .sum()
+        })
+        .unwrap_or(0)
+}
+
+/// Video keeps arriving, audio stops after two seconds. The recording must go
+/// on without the audio rather than freeze on it.
+///
+/// Reverting the fix pins the counted video at zero: with no watchdog to end the
+/// audio track, splitmuxsink never releases another GOP.
+#[test]
+fn a_track_that_stops_does_not_freeze_the_recording() {
+    gst::init().expect("gstreamer init");
+    if !plugins_available() {
+        eprintln!("skipping: required GStreamer elements missing");
+        return;
+    }
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let media_root = tmp.path();
+    let pipeline = gst::Pipeline::new();
+    let (video_in, audio_in, ctx) = add_recorder(&pipeline, "rec_stall", media_root);
+    feed_video(&pipeline, &video_in, -1);
+    feed_audio(&pipeline, &audio_in, 86); // ~2 s at 1024 samples / 44.1 kHz
+    run_setups(&ctx);
+
+    pipeline
+        .set_state(gst::State::Playing)
+        .expect("pipeline accepts PLAYING");
+    let _ = pipeline.state(gst::ClockTime::from_seconds(15));
+    let video_into_muxer = count_into_muxer(&pipeline, "rec_stall", "video");
+
+    // Audio stops at ~2 s and the watchdog ends that track five seconds later.
+    // Measure the window after that, so this is about recovery, not the stall.
+    std::thread::sleep(std::time::Duration::from_secs(8));
+    let (buffers_before, bytes_before) = (
+        video_into_muxer.load(Ordering::Relaxed),
+        recorded_bytes(media_root),
+    );
+    std::thread::sleep(std::time::Duration::from_secs(5));
+    let (buffers_after, bytes_after) = (
+        video_into_muxer.load(Ordering::Relaxed),
+        recorded_bytes(media_root),
+    );
+    pipeline
+        .set_state(gst::State::Null)
+        .expect("pipeline to NULL");
+
+    // 30 fps over five seconds is 150 frames; anything above a couple of seconds
+    // worth means the muxer is running rather than waiting on the dead track.
+    assert!(
+        buffers_after - buffers_before >= 45,
+        "the recording froze on the track that stopped: {} video buffers reached the muxer in 5 s ({} bytes written)",
+        buffers_after - buffers_before,
+        bytes_after - bytes_before
+    );
+}
+
+/// Every track still delivering: none of them may be ended.
+///
+/// Counterpart to the test above — ending tracks on a timer regardless of
+/// whether they are live would satisfy that one and lose the audio of every
+/// recording.
+#[test]
+fn tracks_that_keep_running_are_left_alone() {
+    gst::init().expect("gstreamer init");
+    if !plugins_available() {
+        eprintln!("skipping: required GStreamer elements missing");
+        return;
+    }
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let media_root = tmp.path();
+    let pipeline = gst::Pipeline::new();
+    let (video_in, audio_in, ctx) = add_recorder(&pipeline, "rec_live", media_root);
+    feed_video(&pipeline, &video_in, -1);
+    feed_audio(&pipeline, &audio_in, -1);
+    run_setups(&ctx);
+
+    pipeline
+        .set_state(gst::State::Playing)
+        .expect("pipeline accepts PLAYING");
+    let _ = pipeline.state(gst::ClockTime::from_seconds(15));
+    let audio_into_muxer = count_into_muxer(&pipeline, "rec_live", "audio_0");
+    let video_into_muxer = count_into_muxer(&pipeline, "rec_live", "video");
+
+    // Well past the stall timeout, so a watchdog that ignored liveness has fired.
+    std::thread::sleep(std::time::Duration::from_secs(8));
+    let (audio_before, video_before) = (
+        audio_into_muxer.load(Ordering::Relaxed),
+        video_into_muxer.load(Ordering::Relaxed),
+    );
+    std::thread::sleep(std::time::Duration::from_secs(5));
+    let (audio_after, video_after) = (
+        audio_into_muxer.load(Ordering::Relaxed),
+        video_into_muxer.load(Ordering::Relaxed),
+    );
+    pipeline
+        .set_state(gst::State::Null)
+        .expect("pipeline to NULL");
+
+    assert!(
+        audio_after - audio_before >= 45,
+        "the audio track was ended while it was still delivering: {} buffers reached the muxer in 5 s",
+        audio_after - audio_before
+    );
+    assert!(
+        video_after - video_before >= 45,
+        "the video track was ended while it was still delivering: {} buffers reached the muxer in 5 s",
+        video_after - video_before
+    );
+}


### PR DESCRIPTION
Follows #757, now merged. This branch is rebased onto `main` and carries only its own two commits.

In the field the #757 watchdog fired correctly, its EOS was refused, and the recording stayed
frozen.

## Why `push_event` returned false

Traced through `gst_pad_push_event` in GStreamer 1.28.6. A sticky, serialized event on a src pad
is refused in exactly five states: the pad is flushing, the pad is no longer activated, the pad
already carries a sticky EOS, the pad is unlinked (`push_sticky` forgives `NOT_LINKED` for every
event *except* EOS), or the peer is in one of those states. A busy downstream is not among them —
`gst_pad_send_event_unchecked` takes the peer's stream lock, so a blocked branch blocks the
caller. A refusal is positive evidence the branch was coming apart, but says nothing about which
state it was, and the fix does not depend on knowing. I could not reproduce a refusal from the
WHIP teardown on a rig: a WHIP session lives in its own `gst::Pipeline`, and tearing it down
starves the slot's `appsrc` without flushing anything below it.

## The change

**A refused EOS no longer retires the track.** `end_stalled_track` reports whether the event was
delivered and reopens the track when nothing took it, so the watchdog retries on later polls
instead of losing the track for good on one refusal.

**The track is closed before the EOS goes in.** A `queue` sits between the block's input and the
muxer, so `push_event` returns once that queue holds the event, not once the muxer does. Anything
arriving before the track is closed is queued *behind* the EOS; the muxer answers post-EOS data
with a flow error, and on a WHIP seat that branch hangs off a tee shared with the vision mixer,
the audio mixer and the return router, so the error reaches the seat's source and pauses its
streaming task for good. Closing first and reopening on a refusal keeps both properties.

**A second route out of the wait.** A failed push still leaves the sticky EOS on the pad, so that
pad refuses every retry — retrying alone would not have helped. The EOS falls back to the
splitmuxsink sink pad: the pad the muxer is actually waiting on, which no upstream teardown can
invalidate, and whose stream lock is free because the stalled track is the one nothing is pushing
into. The block's input stays first choice, since it lets the parser drain its last frame on the
way past.

**The stall is detected on the spread between tracks.** The 5s timeout was never the reason it
took 32s: `frozen` required *all* live tracks to be quiet, and splitmuxsink kept taking the
surviving track into its internal queues for another 27s. Ending on the lag instead — the
furthest-behind track is quiet *and* the recording has moved at least the timeout past it —
fires while the others are still delivering. An overloaded box stalls every track at the same
running time, so the spread stays flat and this does not fire.

Both routes keep #757's queue check: the furthest-behind track is ended only if the queue in
front of its muxer pad has drained. A track the muxer is refusing fills its queue, so a muxer
that stalls on storage ends nothing even if a spread happened to open before it stopped. The
all-quiet route additionally needs another track's queue backed up; all queues empty is every
source stopping together, and that ends nothing either. This replaces the earlier
`tracks_that_stopped_together_still_end_the_furthest_behind` unit test, whose case #757 now
deliberately leaves alone.

## Tests

Run on this branch head (ff8b240, after the rebase), macOS, GStreamer 1.28.6. No new elements, so no CI package change.

| Command | Result |
| --- | --- |
| `cargo fmt --check`, `cargo clippy --all-targets --features efp -- -D warnings` | clean |
| `STROM_REQUIRE_GST_PLUGINS=1 cargo test --features efp` | 848 passed, 0 failed, 2 ignored (both pre-existing), 39 binaries |

That includes 9 `track_holding_the_recording` unit tests and all 4 tests in `recorder_stalled_track_test`.

Revert checks. None were repeated after the rebase onto `main`; the rebase changed no line of this PR's patch. The first two were run on an earlier revision, the third on the commit before this rebase:

| Revert | Result |
| --- | --- |
| `end_stalled_track` back to retire-on-entry with no muxer-pad fallback | `a_stalled_track_whose_branch_is_coming_apart_still_ends` fails: `0 video buffers reached the muxer in 5 s` |
| retire after delivery instead of before it | `a_track_is_closed_before_its_eos_is_pushed` fails: the track was still taking data when its EOS went past |
| the selection rule back to `quiet && (lagging \|\| all_quiet)`, without the queue check | `a_muxer_that_stalls_for_every_track_ends_none` fails: `the video track was ended during a stall that was not its fault: 0 buffers reached the muxer in 5 s after it cleared` |

The integration test unlinks the stopped track's branch to make the input refuse, and asserts the
refusal before relying on it, so it cannot silently stop testing anything.

**Not run on this head**: the five-seat rig end to end. On the pre-rebase revision a SIGKILLed
WHIP seat had its track ended 7s after the kill with the live track untouched and the file still
growing. The queue check adds a condition that rig case should meet (the killed seat's queue
drains), but that has not been confirmed on the rig.

I could not build a rig that reproduces the 32s delay — in mine even an AAC track backs up at the
muxer within 5s, so old and new rules both recovered in 7s. The 27s is from the field log's own
numbers, so the rule change is guarded by unit tests, not by a timing test.

## Out of scope

`GStreamer-CRITICAL: Trying to dispose element bin31, but it is in PAUSED instead of the NULL
state` comes from the WHIP session cleanup path. Per CLAUDE.md that is a P0 and the usual cause
is a strong `gst::Element`/`gst::Bin` reference captured in a signal-handler closure. I did not
look for it — worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


