### PR TITLE
fix(whip): null a session bin whipserversrc removes mid-teardown

### DIFF
--- a/backend/src/blocks/builtin/whip.rs
+++ b/backend/src/blocks/builtin/whip.rs
@@ -16,6 +16,7 @@ use crate::blocks::{
 };
 use crate::gst::ice_preflight;
 use crate::gst::keyframe_request;
+use crate::gst::orphan_guard;
 use crate::whip_session_manager::{SessionCleanupRequest, WhipEndpointConfig};
 use gstreamer as gst;
 use gstreamer::prelude::*;
@@ -620,6 +621,11 @@ pub fn create_whipserversrc_for_session(
     let cleanup_tx_for_ice = cleanup_tx.clone();
 
     if let Ok(bin) = whipserversrc.clone().downcast::<gst::Bin>() {
+        // whipserversrc removes each session's internal bin from a thread of its
+        // own, which can land while this pipeline is on its way down and leave
+        // the bin orphaned above NULL with its WebRTC sockets still open.
+        orphan_guard::install(&bin);
+
         bin.connect("deep-element-added", false, move |values| {
             let element = values[2].get::<gst::Element>().unwrap();
             let element_name = element.name();

--- a/backend/src/gst/mod.rs
+++ b/backend/src/gst/mod.rs
@@ -8,6 +8,7 @@ pub mod discovery;
 pub mod gl_bridge;
 pub mod ice_preflight;
 pub mod keyframe_request;
+pub mod orphan_guard;
 pub mod pipeline;
 pub mod pipeline_monitor;
 pub mod shaders;

--- a/backend/src/gst/orphan_guard.rs
+++ b/backend/src/gst/orphan_guard.rs
@@ -1,0 +1,95 @@
+//! Drive to NULL any element a bin removes from itself while it is still running.
+//!
+//! An element disposed above NULL never ran its READY→NULL transition, so the
+//! UDP sockets, streaming threads and file descriptors it opened on the way up
+//! are still open when the last reference goes:
+//!
+//! ```text
+//! GStreamer-CRITICAL: Trying to dispose element bin31, but it is in PAUSED
+//! instead of the NULL state.
+//! ```
+//!
+//! A bin drives its children to whatever state it is driven to and only lets go
+//! of one at NULL, so the only way in is a child removed from a different
+//! thread than the one running the parent's state change.
+//!
+//! `whipserversrc` does exactly that. Each WHIP session lives in a plain
+//! `GstBin` holding the session's `webrtcbin`, and `webrtcsrc` ends a session by
+//! taking that bin to NULL and removing it — on its own thread
+//! (`State::finalize_session` in gst-plugins-rs `net/webrtc`, via
+//! `RUNTIME.spawn_blocking`). Nothing waits for it: the guard `unprepare()`
+//! blocks on is cleared at the top of that task, before it touches the bin.
+//!
+//! Strom's abrupt-drop teardown runs into it because both are woken by the same
+//! `notify::ice-connection-state` emission, and `webrtcsrc`'s handler is
+//! connected first. From a GST_DEBUG trace of the collision — A is
+//! `webrtcsrc`'s finalizer, B is `teardown_session_pipeline`:
+//!
+//! ```text
+//! A  <bin0> completed state change to NULL       session bin down, sockets closed
+//! B  <bin0> current NULL, desired next PAUSED    7 us later: the pipeline's
+//! B  <bin0> completed state change to PAUSED     PLAYING->PAUSED step raises it
+//!                                                back up, reopening everything
+//! A  gst_bin_remove(whipserversrc, bin0)         removed, in PAUSED
+//! B  <whipserversrc> children READY->NULL: iterator done, no children
+//! ```
+//!
+//! A plain child at NULL is left alone by a downward transition, but
+//! `gst_bin_element_set_state` recurses into a `GstBin` unconditionally ("always
+//! recurse into bins so that we can set the base time"), which is why it is the
+//! session bin, and not the elements inside it, that gets raised.
+//!
+//! The bin leaves the pipeline before the descent can reach it again, so nothing
+//! takes it back to NULL. Waiting for `set_state(NULL)` to settle does not help:
+//! PAUSED is a step on the way down, so the raise has already happened by the
+//! time it returns.
+//!
+//! Strom cannot make the removal wait, so it catches the element on the way out.
+//! `element-removed` fires with no bin lock held and the child already
+//! unparented — the one point where the state can still be fixed.
+
+use gstreamer as gst;
+use gstreamer::prelude::*;
+use tracing::{debug, warn};
+
+/// Guard every element `bin` removes from itself.
+///
+/// Locking the state before setting it is what makes this safe against a
+/// removal that lands *during* the parent's transition. `gst_bin_element_set_state`
+/// reads the locked flag under the child's state lock, so whichever thread gets
+/// there second sees the effect of the first: either the parent skips the child
+/// outright, or this call queues behind the raise and takes it back down.
+pub fn install(bin: &gst::Bin) {
+    // Captures nothing. Both the bin and the removed element arrive as
+    // arguments, so this handler cannot form the reference cycle that a
+    // captured `gst::Element`/`gst::Bin` clone would.
+    bin.connect_element_removed(|bin, element| {
+        // Read for the log only. It can still say NULL while the parent's
+        // cascade holds the state lock mid-raise, so it is never a reason to
+        // skip the work below.
+        let state = element.current_state();
+        if state == gst::State::Null {
+            debug!(
+                "Orphan guard: '{}' was removed from '{}' at NULL",
+                element.name(),
+                bin.name()
+            );
+        } else {
+            warn!(
+                "Orphan guard: '{}' was removed from '{}' in {:?}, forcing it to NULL",
+                element.name(),
+                bin.name(),
+                state
+            );
+        }
+
+        element.set_locked_state(true);
+        if let Err(e) = element.set_state(gst::State::Null) {
+            warn!(
+                "Orphan guard: failed to set '{}' to NULL after removal: {:?}",
+                element.name(),
+                e
+            );
+        }
+    });
+}

--- a/backend/src/gst/orphan_guard.rs
+++ b/backend/src/gst/orphan_guard.rs
@@ -22,17 +22,7 @@
 //!
 //! Strom's abrupt-drop teardown runs into it because both are woken by the same
 //! `notify::ice-connection-state` emission, and `webrtcsrc`'s handler is
-//! connected first. From a GST_DEBUG trace of the collision — A is
-//! `webrtcsrc`'s finalizer, B is `teardown_session_pipeline`:
-//!
-//! ```text
-//! A  <bin0> completed state change to NULL       session bin down, sockets closed
-//! B  <bin0> current NULL, desired next PAUSED    7 us later: the pipeline's
-//! B  <bin0> completed state change to PAUSED     PLAYING->PAUSED step raises it
-//!                                                back up, reopening everything
-//! A  gst_bin_remove(whipserversrc, bin0)         removed, in PAUSED
-//! B  <whipserversrc> children READY->NULL: iterator done, no children
-//! ```
+//! connected first, so the removal lands in the middle of the pipeline's descent.
 //!
 //! A plain child at NULL is left alone by a downward transition, but
 //! `gst_bin_element_set_state` recurses into a `GstBin` unconditionally ("always

--- a/backend/src/whip_session_manager.rs
+++ b/backend/src/whip_session_manager.rs
@@ -170,6 +170,10 @@ pub struct WhipSessionManager {
 /// sub-second in practice.
 const PENDING_CLEANUP_TTL: Duration = Duration::from_secs(30);
 
+/// How long to wait for a session pipeline that returns ASYNC from its
+/// transition to NULL. Bounded because the wait runs on a blocking thread.
+const TEARDOWN_TIMEOUT: gst::ClockTime = gst::ClockTime::from_seconds(5);
+
 impl WhipSessionManager {
     pub fn new() -> Self {
         let (cleanup_tx, cleanup_rx) = mpsc::unbounded_channel();
@@ -472,11 +476,25 @@ impl WhipSessionManager {
             name
         );
 
-        if let Err(e) = session_pipeline.set_state(gst::State::Null) {
-            warn!(
+        match session_pipeline.set_state(gst::State::Null) {
+            // Nothing in a session pipeline goes async on the way down today,
+            // but an element that did would have the pipeline dropped out from
+            // under a transition still in flight, leaving its children to be
+            // disposed above NULL.
+            Ok(gst::StateChangeSuccess::Async) => {
+                let (result, current, _) = session_pipeline.state(TEARDOWN_TIMEOUT);
+                if result.is_err() || current != gst::State::Null {
+                    warn!(
+                        "WhipSessionManager: Session pipeline {} did not reach Null within {:?} (current: {:?})",
+                        name, TEARDOWN_TIMEOUT, current
+                    );
+                }
+            }
+            Ok(_) => {}
+            Err(e) => warn!(
                 "WhipSessionManager: Failed to set session pipeline {} to Null: {:?}",
                 name, e
-            );
+            ),
         }
     }
 }

--- a/backend/tests/pipeline_lifecycle_test.rs
+++ b/backend/tests/pipeline_lifecycle_test.rs
@@ -244,3 +244,87 @@ async fn test_delete_running_flow_releases_pipeline() {
         leaked
     );
 }
+
+/// Regression test for the WHIP session-teardown P0: an element removed from
+/// its parent bin while it is still above NULL is disposed without ever running
+/// its READY→NULL transition, leaking every socket, thread and fd it holds.
+///
+/// `whipserversrc` removes each session's internal bin from a thread of its own,
+/// so the removal races the session pipeline's descent — see
+/// `strom::gst::orphan_guard`. This stands the same shape up with core elements
+/// and replays the two halves of that race in a fixed order.
+#[test]
+fn test_removed_child_is_driven_to_null() {
+    use gstreamer::prelude::*;
+
+    gstreamer::init().unwrap();
+
+    let pipeline = gstreamer::Pipeline::new();
+    // Stand-ins for whipserversrc and the session bin it removes.
+    let parent = gstreamer::Bin::builder().name("parent").build();
+    let session = gstreamer::Bin::builder().name("session").build();
+
+    let src = gstreamer::ElementFactory::make("fakesrc")
+        .property("is-live", true)
+        .build()
+        .expect("fakesrc is part of gstreamer core");
+    let sink = gstreamer::ElementFactory::make("fakesink")
+        .build()
+        .expect("fakesink is part of gstreamer core");
+    session.add_many([&src, &sink]).unwrap();
+    src.link(&sink).unwrap();
+    parent.add(&session).unwrap();
+    pipeline.add(&parent).unwrap();
+
+    strom::gst::orphan_guard::install(&parent);
+
+    pipeline
+        .set_state(gstreamer::State::Playing)
+        .expect("pipeline should reach Playing");
+    let (result, current, _) = pipeline.state(gstreamer::ClockTime::from_seconds(5));
+    assert!(result.is_ok(), "pipeline state change failed");
+    assert_eq!(current, gstreamer::State::Playing);
+    assert_eq!(session.current_state(), gstreamer::State::Playing);
+
+    // A removal that lands before the parent's descent has reached the child.
+    parent.remove(&session).unwrap();
+    assert_eq!(
+        session.current_state(),
+        gstreamer::State::Null,
+        "removed bin left above NULL — its OS resources are leaked and GStreamer \
+         will fire 'Trying to dispose element ... instead of the NULL state'"
+    );
+
+    // The other half of the race: the parent's own descent reaches the child
+    // after it has gone to NULL. A bin is never skipped for being below the
+    // target state, so without the state lock this raises it back to PAUSED and
+    // reopens everything it holds. Re-adding makes that deterministic; in
+    // production the two threads simply overlap.
+    parent.add(&session).unwrap();
+    parent.set_state(gstreamer::State::Ready).unwrap();
+    assert_eq!(
+        session.current_state(),
+        gstreamer::State::Null,
+        "parent raised a removed bin back out of NULL"
+    );
+
+    let session_weak = session.downgrade();
+    let src_weak = src.downgrade();
+    drop(src);
+    drop(sink);
+
+    parent.remove(&session).unwrap();
+    pipeline.set_state(gstreamer::State::Null).unwrap();
+    drop(session);
+    drop(parent);
+    drop(pipeline);
+
+    assert!(
+        session_weak.upgrade().is_none(),
+        "removed bin still alive after drop"
+    );
+    assert!(
+        src_weak.upgrade().is_none(),
+        "element inside the removed bin still alive after drop"
+    );
+}


### PR DESCRIPTION
## The bug

A WHIP publisher dropping without a DELETE leaves a GStreamer CRITICAL behind:

```
GStreamer-CRITICAL: Trying to dispose element bin31, but it is in PAUSED instead of the NULL state.
```

`bin31` is not a Strom element. `webrtcsrc` wraps each WHIP session in a plain `GstBin` holding
that session's `webrtcbin`, and ends the session by taking the bin to NULL and removing it from
`whipserversrc` — on its own thread (`State::finalize_session` in gst-plugins-rs `net/webrtc`
0.15.3, dispatched through `RUNTIME.spawn_blocking`). Nothing waits for it: the guard
`unprepare()` blocks on is cleared at the top of that task, before it touches the bin.

Both sides are woken by the same `notify::ice-connection-state` emission, and `webrtcsrc`'s
handler is connected first, so it always gets a head start. From a `GST_DEBUG` trace of the
collision — A is `webrtcsrc`'s finalizer, B is `teardown_session_pipeline`:

```
A  <bin0> completed state change to NULL       session bin down, sockets closed
B  <bin0> current NULL, desired next PAUSED    7 us later
B  <bin0> completed state change to PAUSED     raised back up, everything reopened
A  gst_bin_remove(whipserversrc, bin0)         removed, in PAUSED
B  <whipserversrc> children READY->NULL: iterator done, no children
```

The raise is not incidental. `gst_bin_element_set_state` skips a plain child that is already below
the target state, but recurses into a `GstBin` unconditionally ("always recurse into bins so that
we can set the base time"), so the session bin — and only the session bin — gets pulled back up on
the way down. It then leaves the pipeline before the descent can reach it again, and `bin0`,
`webrtcbin0`, `rtpbin` and `rtpfunnel0` are all dropped without ever running READY→NULL, taking
their UDP sockets and streaming threads with them.

Waiting for `set_state(Null)` to settle does not help: PAUSED is a step on the way down, so the
damage is done before it returns.

## The fix

`element-removed` fires with no bin lock held and the child already unparented, which makes it the
one point where the state can still be corrected. `gst::orphan_guard` locks the removed element's
state and then sets it to NULL. Locking first is what makes it safe under the race:
`gst_bin_element_set_state` reads the locked flag under the child's state lock, so whichever thread
gets there second sees the other's effect — either the parent skips the child outright, or this
call queues behind the raise and takes it back down.

`teardown_session_pipeline` also waits out an ASYNC return now. This is defensive, not a second
fix: no session-pipeline element returns ASYNC on the way down today, so the arm is currently dead.
One that did would have the pipeline dropped mid-transition, leaving the same kind of orphan.

## Verification

Repro: a `whipclientsink` publisher into a headless Strom, then the session ended from both sides
at once — a DELETE to `whipserversrc`'s own signaller racing Strom's. Same collision as the
ICE-failure path, on demand: on loopback, webrtcbin will not report `failed` without consent
freshness, so the ICE trigger itself was not reproduced.

- Before: 3 of 3 runs produced `Trying to dispose element binN, but it is in PAUSED`, plus knock-on
  CRITICALs for `webrtcbin0`, `rtpbin` and `rtpfunnel0`.
- After: 0 of 6 runs.
- Abrupt drop (SIGKILL the publisher, watchdog reaps the session) is clean, and the guard's debug
  line confirms it is wired to the real `whipserversrc`:
  `Orphan guard: 'bin0' was removed from 'whip1:whipserversrc_65d8...' at NULL`.

## Test

`test_removed_child_is_driven_to_null` in `backend/tests/pipeline_lifecycle_test.rs` stands the same
shape up with core elements and replays both halves of the race in a fixed order: a removal that
lands while the child is still running, then a parent-driven descent over a child that has already
gone to NULL. Reverting the guard fails the first assertion; reverting only `set_locked_state` fails
the second. Both verified.

It does not guard the call site. The test calls `orphan_guard::install` itself, so deleting the
`install(&bin)` line from `whip.rs` leaves it green. A `whipserversrc`-based test cannot close that
gap here — CI installs base/good/bad/ugly/libav and no gst-plugins-rs (see the `packages:` list in
`.github/workflows/ci.yml`), so it would skip green and guard nothing. The wiring is covered only
by the manual run above.

No CI package changes: the test uses `fakesrc`/`fakesink` from coreelements, which the file's
existing tests already rely on.

Ran locally: `cargo test --package strom` (all green, 4/4 in `pipeline_lifecycle_test`),
`cargo clippy --all-targets`, `cargo fmt --check`.

## WHEP output does not need the same guard

`whepserversink` is a `BaseWebRTCSink` subclass and does remove children from itself, but neither
half of the race is present. Each viewer's `webrtcbin` lives in a `gst::Pipeline` the sink owns
privately, not as a child of Strom's pipeline, so a disconnect removes nothing from the hierarchy
being torn down. The children it does remove from itself — `clocksync` and `appsink`, in
`InputStream::unprepare` — come out inside `change_state` on `PausedToReady`, on the thread already
driving the descent, so the cross-thread window this bug needs never opens. Its tokio branch defers
to `call_async` but blocks on the result, so that path closes before `change_state` returns. Read
in gst-plugin-webrtc 0.15.2, the version in `Cargo.lock`.

## Upstream

A workaround, not a fix: Strom cannot make the removal wait.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

