### PR TITLE
ci: build macOS and Windows on main, and on labelled pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,15 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    # `labeled` is what lets a maintainer ask for a macOS or Windows build on a
+    # pull request (see build-macos). Naming `types` at all replaces the default
+    # set, so the three defaults have to be listed again or pushes to a PR stop
+    # triggering CI.
+    types: [opened, synchronize, reopened, labeled]
   workflow_dispatch:
     inputs:
       platforms:
-        description: "Which extra platform builds to run (they are off for push/PR because of cost)"
+        description: "Which extra platform builds to run on a branch (they run on main and on ci:macos / ci:windows PRs anyway)"
         type: choice
         default: both
         options: [both, macos, windows, none]
@@ -42,6 +47,14 @@ jobs:
   # build instead of failing CI. Exposes cache_ok consumed by every build job.
   preflight:
     name: sccache preflight
+    # A `labeled` event is only interesting when the label is one of the two
+    # that ask for a platform build. Skipping here takes every job that needs
+    # this one with it, and api-contract excludes `labeled` itself, so adding an
+    # unrelated label to a pull request costs nothing.
+    if: >-
+      github.event.action != 'labeled'
+      || contains(github.event.pull_request.labels.*.name, 'ci:macos')
+      || contains(github.event.pull_request.labels.*.name, 'ci:windows')
     runs-on: ubuntu-latest
     outputs:
       cache_ok: ${{ steps.probe.outputs.cache_ok }}
@@ -68,6 +81,10 @@ jobs:
   # Fast checks on Linux: fmt + clippy + test
   check-linux:
     name: Check (Linux)
+    # Labelling a PR must not re-run everything that already passed. Only the
+    # platform builds care about the label; `github.event.action` is unset for
+    # push and workflow_dispatch, so this is a no-op there.
+    if: github.event.action != 'labeled'
     needs: preflight
     runs-on: ubuntu-24.04
     timeout-minutes: 25
@@ -196,7 +213,8 @@ jobs:
   api-contract:
     name: API Contract Check
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    # See check-linux for the `labeled` exclusion.
+    if: github.event_name == 'pull_request' && github.event.action != 'labeled'
     steps:
       - uses: actions/checkout@v6
         with:
@@ -224,6 +242,8 @@ jobs:
   # Linux x86_64 build
   build-linux-x86_64:
     name: Build (Linux x86_64)
+    # See check-linux for the `labeled` exclusion.
+    if: github.event.action != 'labeled'
     needs: [check-wasm, preflight]
     runs-on: ubuntu-24.04
     timeout-minutes: 30
@@ -341,6 +361,8 @@ jobs:
   # Linux ARM64 build (build only - no native clippy/test)
   build-linux-arm64:
     name: Build (Linux ARM64)
+    # See check-linux for the `labeled` exclusion.
+    if: github.event.action != 'labeled'
     needs: [check-wasm, preflight]
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 30
@@ -449,10 +471,17 @@ jobs:
           if-no-files-found: error
 
   # Windows: clippy + test + build
-  # Only runs manually (workflow_dispatch) to save CI cost (2× multiplier).
+  # Runs on every merge to main, on a pull request carrying the `ci:windows`
+  # label, and on demand. Not on every pull request: it is the slowest job in
+  # the workflow and most diffs contain no `target_os = "windows"` code.
   build-windows:
     name: Build (Windows)
-    if: github.event_name == 'workflow_dispatch' && contains(fromJSON('["both","windows"]'), inputs.platforms)
+    if: >-
+      github.event_name == 'push'
+      || (github.event_name == 'pull_request'
+          && contains(github.event.pull_request.labels.*.name, 'ci:windows'))
+      || (github.event_name == 'workflow_dispatch'
+          && contains(fromJSON('["both","windows"]'), inputs.platforms))
     needs: [check-wasm, preflight]
     runs-on: windows-latest
     timeout-minutes: 45
@@ -500,10 +529,10 @@ jobs:
           name: frontend-dist
           path: backend/dist
 
-      # No rust-cache here: this job is workflow_dispatch-only, so a saved
-      # target/ (~1-2 GB against the 10 GB repo ceiling) is almost always
-      # stale or evicted by the next manual run. sccache via MinIO covers
-      # recompiles instead.
+      # No rust-cache here: this job runs seldom enough that a saved target/
+      # (~1-2 GB against the 10 GB repo ceiling) is almost always stale or
+      # evicted before the next run. sccache via MinIO covers recompiles
+      # instead, on the runs that have credentials for it.
       - name: Setup sccache
         if: needs.preflight.outputs.cache_ok == 'true'
         uses: mozilla-actions/sccache-action@v0.0.10
@@ -541,17 +570,33 @@ jobs:
           if-no-files-found: error
 
   # macOS: clippy + test + build
-  # Only runs manually (workflow_dispatch) to save CI cost (10× multiplier).
+  #
+  # Runs on every merge to main, on a pull request carrying the `ci:macos`
+  # label, and on demand.
+  #
+  # Dispatch alone could not verify a fork's pull request, which is where most
+  # macOS code arrives: `workflow_dispatch` resolves `--ref` against a branch or
+  # tag in this repository, and a fork PR's head is reachable here only as
+  # `refs/pull/<N>/head`, which it does not accept. That left `#[cfg(target_os =
+  # "macos")]` code merged without any toolchain ever compiling it. The label is
+  # a maintainer's way to ask for the run before merge; `push` is the backstop
+  # that makes sure it happens at all.
   build-macos:
     name: Build (macOS)
-    if: github.event_name == 'workflow_dispatch' && contains(fromJSON('["both","macos"]'), inputs.platforms)
+    if: >-
+      github.event_name == 'push'
+      || (github.event_name == 'pull_request'
+          && contains(github.event.pull_request.labels.*.name, 'ci:macos'))
+      || (github.event_name == 'workflow_dispatch'
+          && contains(fromJSON('["both","macos"]'), inputs.platforms))
     needs: [check-wasm, preflight]
     runs-on: macos-latest
-    # 30 was not enough: the job is workflow_dispatch-only, so it runs rarely
-    # and sccache's Rust cache is cold almost every time (measured 0.00% Rust
-    # hit rate on a fresh branch), which means clippy, the test build and the
-    # release build each compile the tree from scratch. Matches the Windows
-    # job, which is dispatch-only for the same reason and already sits at 45.
+    # 30 was not enough: sccache's Rust cache is cold on a fresh branch
+    # (measured 0.00% Rust hit rate), which means clippy, the test build and the
+    # release build each compile the tree from scratch — 27 minutes observed.
+    # A fork's pull request has no sccache credentials at all, so it is always
+    # that number. Matches the Windows job, which sits at 45 for the same
+    # reason.
     timeout-minutes: 45
     env:
       RUSTC_WRAPPER: ${{ needs.preflight.outputs.cache_ok == 'true' && 'sccache' || '' }}
@@ -581,7 +626,7 @@ jobs:
           name: frontend-dist
           path: backend/dist
 
-      # No rust-cache here: workflow_dispatch-only, see the Windows job.
+      # No rust-cache here: see the Windows job.
       - name: Setup sccache
         if: needs.preflight.outputs.cache_ok == 'true'
         uses: mozilla-actions/sccache-action@v0.0.10

--- a/scripts/agent/REVIEW.md
+++ b/scripts/agent/REVIEW.md
@@ -75,9 +75,15 @@ maintainer is actually having.
    `pipeline_lifecycle_test.rs` for new GStreamer elements or closures, the openapi snapshot
    for API types.
 
-   macOS and Windows do not build on push or pull_request. Platform-specific code is
-   therefore `UNVERIFIED`, with the command for the maintainer:
-   `gh workflow run ci.yml --ref <branch> -f platforms=macos` (or `windows`, or `both`).
+   macOS and Windows build on every merge to main, but on a pull request only when it carries
+   the `ci:macos` or `ci:windows` label. Platform-specific code is `UNVERIFIED` until such a
+   run exists, and the remedy to ask the maintainer for is the label — not
+   `gh workflow run ci.yml --ref <branch>`, which cannot reach a fork's pull request at all
+   (dispatch takes a branch or tag in this repository; a fork PR's head is only
+   `refs/pull/<N>/head`). A green run on the author's own fork does not count either: it
+   builds their base, not this one. Where the platform-specific part is small, merging on
+   Linux-green and letting the main run cover it is a legitimate call — say so, rather than
+   leaving the row silently unverified.
 
 5. **Repo rules.** Check CLAUDE.md and quote any rule violated: BUFFER probe constraints,
    `WeakRef` instead of strong refs to pipeline/element/bin in closures, queue properties


### PR DESCRIPTION
## Description

`Build (macOS)` and `Build (Windows)` were `workflow_dispatch`-only, and the remedy `REVIEW.md`
handed out for a pull request cannot work for the pull requests that need it:

`.github/workflows/ci.yml:589` — `          && contains(github.event.pull_request.labels.*.name, 'ci:macos'))`

Dispatch resolves `--ref` against a branch or tag in this repository. A fork PR's head exists
here only as `refs/pull/<N>/head`, which `workflow_dispatch` does not accept, and none of the
affected branches exist here (16 branches on `Eyevinn/strom`, none of them a `wagenet/*` head).
Since most macOS code arrives from a fork, `#[cfg(target_os = "macos")]` code was reviewable
but never compilable — which is what left #721, #722, #726 and #735 unapprovable on a ground
neither the author nor a maintainer could clear alone. Raised by @wagenet on #735.

#735 has since merged, carrying a new `macos_app_nap.rs` whose only macOS compile was on the
author's fork. That is the case this change is meant to stop repeating.

## What changes

Both platform jobs now run in three situations instead of one:

| | before | after |
|---|---|---|
| merge to main | — | runs |
| PR with `ci:macos` / `ci:windows` | — | runs |
| `workflow_dispatch` | runs | runs, unchanged |
| PR without the label | — | — |

The `push` trigger is the backstop: platform code is now always compiled by something, within
half an hour of merging. The label is the pre-merge path, and it is the only one that works
for a fork — it also builds **the PR merged with main**, which pushing a branch copy into this
repository would not.

## Why the label needs care, and what it costs

`labeled` is not in the default `pull_request` types, so it had to be named — and naming
`types` replaces the defaults, so the three defaults are re-listed or pushes to a PR stop
triggering CI:

`.github/workflows/ci.yml:12` — `    types: [opened, synchronize, reopened, labeled]`

That alone would make every unrelated label re-run the whole workflow. So `preflight` skips a
`labeled` event unless one of the two labels is present, which takes every job that needs it
along, and the Linux jobs plus `api-contract` exclude `labeled` outright:

`.github/workflows/ci.yml:55` — `      github.event.action != 'labeled'`

Resulting job sets, traced through every trigger:

| event | jobs that run |
|---|---|
| PR opened / synchronize | exactly as today (plus the platform job if the PR carries its label) |
| PR labelled `ci:macos` | `preflight`, `check-wasm`, `Build (macOS)` — nothing else |
| PR labelled anything else | none |
| push to main | as today, plus `Build (macOS)` and `Build (Windows)` |
| `workflow_dispatch` | unchanged, `platforms=none` still runs neither |

`check-wasm` has to stay in the label set: it produces the `frontend-dist` artifact the
platform jobs download, and it uploads it unconditionally, so a PR run satisfies the
dependency.

## Cost and security

The repository is public, so standard runners — `macos-latest` and `windows-latest` included —
are not billed. The cost is wall-clock and a concurrency slot, and nothing waits on either job
after a merge.

A fork's pull request gets no `SCCACHE_S3_*` secrets, so `preflight` reports the cache off and
the job compiles cold. That is already the case for the 27m14s @wagenet measured on their own
fork, so it is the realistic figure rather than an optimistic one, and it sits inside the
existing 45-minute timeout. This is `pull_request`, not `pull_request_target`: no fork code
gains access to secrets.

## REVIEW.md

The protocol file was wrong for fork PRs, independently of this workflow change, so it is
corrected in the same commit: the label is now the remedy to ask for, the dispatch command is
explicitly not for a fork's pull request, a green run on the author's own fork does not count,
and merging on Linux-green while the main run covers a small platform-specific part is named
as a legitimate call rather than left as a silent `UNVERIFIED`.

Comments in `ci.yml` that claimed the jobs were dispatch-only are updated with them.

## Testing

- `ci.yml` parses, and every job's resolved `needs`/`if` was printed and checked against the
  five trigger cases in the table above.
- `scripts/agent/test-agent-scripts.sh` — 40 passed, 0 failed. Unchanged: this commit touches
  no script.
- The `ci:macos` and `ci:windows` labels are created in the repository, so the gate is usable
  the moment this merges.

**Not verified:** that `workflow_dispatch` rejects `refs/pull/<N>/head`. Testing it means
either a 422 or a real 27-minute macOS run, so it rests on the documented API contract (a
branch or tag) rather than on an attempt. It is also not load-bearing for this change: the
label path does not depend on it.

**Not verified:** the first real `Build (macOS)` run under the new gate. The CI run on this PR
exercises the unlabelled path only — by design, since this PR touches no platform code. The
label can be applied to this PR to prove the path end to end before merging, which is probably
worth doing once.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
