### PR TITLE
docs(agent): hold draft PRs instead of skipping them silently

### DIFF
--- a/scripts/agent/PROTOCOL.md
+++ b/scripts/agent/PROTOCOL.md
@@ -89,12 +89,13 @@ Any risk you have not traced in the code gets the literal prefix `SPECULATIVE (n
 
 ## Markers
 
-Every posted review, triage comment and fix PR body ends with a marker. The keys are read by
-tooling, so spell them exactly and put them on one line.
+Every posted review, triage comment, draft-hold note and fix PR body ends with a marker. The
+keys are read by tooling, so spell them exactly and put them on one line.
 
     <!-- strom-agent protocol=v3 kind=review pr=721 head=<full-sha> verdict=Comment radius=GLOBAL confidence=HIGH -->
     <!-- strom-agent protocol=v3 kind=triage issue=719 base=<sha> verdict=CONFIRMED work=bug radius=LOCAL excluded=none ask=open confidence=HIGH -->
     <!-- strom-agent protocol=v3 kind=fix issue=719 pr=730 class=B -->
+    <!-- strom-agent protocol=v3 kind=draft-hold pr=726 -->
 
 `protocol=v3` is the generation gate and must not change — anything without it counts as an
 older generation and gets redone. The other keys are additive; a reader that finds one
@@ -120,6 +121,10 @@ as excluded would demand an override for the one placement the repo mandates. Ad
 a variant or a block is `none`; renaming or changing an existing `StromEvent` variant, an
 endpoint's shape or a config key is `contract`. `ask=open` means a design question is waiting for a
 human; `ask=none` means no decision is needed.
+
+`kind=draft-hold` is the one marker that carries no verdict, because holding is not a
+judgement on the diff. It records that a draft was seen and deliberately left alone, so that
+a later run says it once rather than every run (`REVIEW.md`).
 
 ## Write once, then cite
 

--- a/scripts/agent/README.md
+++ b/scripts/agent/README.md
@@ -66,6 +66,16 @@ useful if the runtime changes and safe to read in public.
   rubber stamp.
 - **`excluded=` means "would break", not "touches".** That distinction is what keeps gate 4 a
   real check.
+- **A draft is held, not skipped, and the hold is said exactly once.** Those are two separate
+  corrections to the same rule. Silently skipping a draft told its author nothing, so a
+  contributor who had opened one had no way to know whether it was queued, ignored or waiting
+  on them; and the shape that fixes that — a comment — is also the shape that turns into a
+  nag, because these tasks run twice a weekday and would otherwise re-post it on every new
+  commit. Hence a `kind=draft-hold` marker and "one per pull request, ever": the standing
+  comment is the memory. Do not "improve" the hold into a review that opens with a caveat,
+  and do not make it repeat when the head SHA moves — a moving head SHA is what a draft *is*.
+  Being asked is the only trigger for a real review, and then it is a full one, because a
+  half review of a draft is the outcome both halves of this rule exist to avoid.
 - **The worked examples are the format spec.** They exist because rules describing a shape
   drift and an example does not. If you change the required shape, change the example in the
   same commit.

--- a/scripts/agent/REVIEW.md
+++ b/scripts/agent/REVIEW.md
@@ -20,7 +20,7 @@ Reading `main` while reviewing a branch is a common and invisible error.
 - Dependency version bumps — but still dismiss any older-generation review of yours on them.
 - A PR whose current head SHA already carries your v3 review. Only a new head SHA or a new
   check conclusion is a re-review trigger.
-- Drafts, unless the body asks for review.
+- Drafts are neither reviewed nor silently skipped — see "Drafts" below.
 
 A review is a verdict on a diff, not a turn in a conversation. The maintainer and the author
 will keep talking under your review; that discussion is not addressed to you. If a comment
@@ -28,6 +28,43 @@ directly contradicts something your standing review concluded, post a short repl
 1000 characters, naming only what changed and what it does to the verdict — and do not
 re-review. Re-reviewing an unchanged diff because the thread moved buries the discussion the
 maintainer is actually having.
+
+## Drafts — hold, and say so once
+
+A draft is the author telling you they are not finished, so do not review it: no verdict, no
+claim table, no numbered requested changes. The diff is still moving, and a verdict on it
+costs the author a round trip and buys nobody anything.
+
+Holding is not ignoring. The first time you see someone else's draft, post one short comment
+on it (`gh pr comment`) so the author knows where they stand:
+
+    Noted as a draft, so I am holding off on a full review until it is marked ready for
+    review. If you want one before then, say so here or request me as a reviewer.
+
+    <!-- strom-agent protocol=v3 kind=draft-hold pr=726 -->
+
+**One per pull request, ever.** Not again on a new head SHA and not again next run — the
+standing `kind=draft-hold` comment is how you know it is already said, and a draft that
+collects the same note twice a day is a nag. It is one API call and no verification, so it
+does not consume item budget; do at most three per run, and check it with
+`verify-citations.sh --allow-no-citations`.
+
+You may add **one** observation to that comment, and only if it saves the author real work: a
+blocker that invalidates the approach, or a CLAUDE.md rule the diff is built on. Two
+sentences, cited as `PROTOCOL.md` requires, phrased as an observation — no verdict token, no
+list. Anything smaller than "this approach cannot work as written" waits for the real review.
+
+**Review a draft when you are asked, and then review it in full.** Asked means the body asks,
+a comment on the pull request asks you, or you are a requested reviewer. Nothing else counts:
+a new commit, a red check or a busy thread does not make a draft yours to review. Once it is
+asked for it is an ordinary review under this file, with a `kind=review` marker.
+
+**Never post a draft-hold on a draft you opened.** Every pull request the implementation
+stage authors is a draft; `FIX.md` Phase 1 owns those, and you recognise them by the
+`kind=fix` marker in the body — by the marker, never by the author (`PROTOCOL.md`).
+
+A draft-hold is not a review, so it never needs dismissal, and it does not stand in for the
+review the pull request gets once it is marked ready.
 
 ## Work these six, in order
 

--- a/scripts/agent/SUMMARY.md
+++ b/scripts/agent/SUMMARY.md
@@ -55,7 +55,8 @@ is rendered from it, so the two can never disagree.
       "triage": [],
       "fix": [],
       "skipped": [
-        {"ref": "#726", "reason": "draft, body does not ask for review"},
+        {"ref": "#726", "reason": "draft, holding — draft-hold note posted"},
+        {"ref": "#723", "reason": "draft, holding — draft-hold already standing"},
         {"ref": "#698", "reason": "dependency bump, no stale review of mine"}
       ],
       "unfinished": [
@@ -71,6 +72,10 @@ is rendered from it, so the two can never disagree.
 1. **An item gets an entry only if you posted something about it this run.** Everything else
    goes in `skipped` as one `{ref, reason}` line. Never a row per untouched item — a summary
    that enumerates sixteen issues to say nothing changed is why nobody reads it.
+   A draft you held is the one exception, and it stays in `skipped` on the run that posts its
+   draft-hold note: the note is not a verdict, so there is nothing for the table to show. It
+   never belongs in `needs_human` either — a draft is the author's next move, not the
+   maintainer's, and the whole point of holding is to stop it competing for attention.
 2. **Every value is copied from what you actually posted this run.** Never restate a standing
    verdict's attributes from memory. If you did not determine a field, it is `null` — a field
    invented to fill a column has already put three different radii in this log for one PR.


### PR DESCRIPTION
The whole rule for draft PRs was one line in `REVIEW.md`'s *Skip these* list:

    - Drafts, unless the body asks for review.

That gets two separate things wrong.

**Skipping tells the author nothing.** A contributor who opens a draft has no way to know
whether it is queued, ignored, or waiting on them. The reviewer is the only thing on that PR
that could have said so, and it said nothing.

**"unless the body asks" is too narrow a trigger.** A comment asking for review, or the
reviewer being requested on the PR, did not count.

## Change

A draft is now **held**, not skipped, and the hold is said **exactly once**.

- No review: no verdict, no claim table, no numbered requested changes. The diff is still
  moving, and a verdict on it costs the author a round trip and buys nobody anything.
- One short comment carrying a `kind=draft-hold` marker, saying a full review waits until the
  PR is marked ready and how to ask for one sooner.
- **One per pull request, ever.** Not on a new head SHA, not next run. These tasks run twice
  a weekday, so without that the signal becomes a nag on every commit; the standing marker is
  the memory. No verification and one API call, so it does not consume item budget — at most
  three per run.
- Substance is allowed in that comment only where it saves the author real work: a blocker
  that invalidates the approach, or a CLAUDE.md rule the diff is built on. Two cited
  sentences, no verdict token, no list.
- **Being asked is the only trigger for a real review, and then it is a full one.** The body
  asks, a comment asks, or you are a requested reviewer. A new commit, a red check or a busy
  thread is not being asked. A half review of a draft is the outcome both halves of this rule
  exist to avoid.
- **Never on a draft this stage opened itself.** Every fix PR is a draft; `FIX.md` Phase 1
  owns those, and they are recognised by their `kind=fix` marker rather than by author — these
  tasks may run under the same account a human uses.

`PROTOCOL.md` registers `kind=draft-hold` as the one marker that carries no verdict, because
holding is not a judgement on the diff.

`SUMMARY.md` keeps a held draft in `skipped` even on the run that posts its note, and out of
`needs_human` entirely: a draft is the author's next move, not the maintainer's, which is the
whole point of holding it.

`README.md` carries the design note, so a later change does not undo one half of the rule
while keeping the other.

## Deployment

One matching change to the review/triage task prompt, which lives outside this repo: its
*Allowed* list said "post issue comments", now "post comments on issues and on pull
requests", so the permission explicitly covers a comment on a PR. Nothing else in the prompt
— per `README.md`, a prompt that restates a rule these files own silently overrides the file.

## Tests

`scripts/agent/test-agent-scripts.sh` — 40 passed, 0 failed. That only shows the scripts still
work; **the tests cover `board.sh` and `verify-citations.sh`, not these markdown rules**, so
nothing here is exercised by a test and no run has yet applied the new rule to a live draft.

`board.sh` needed no change: it reads issues only, and `claiming_pr` matches PR bodies rather
than comments, so a `draft-hold` comment cannot be read as claiming an issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
