### PR TITLE
fix(efpsrt): carry embedded data end to end, with per-track stream routing, on efp v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1605,16 +1605,16 @@ dependencies = [
 
 [[package]]
 name = "efp"
-version = "0.3.0"
-source = "git+https://github.com/Eyevinn/efp?tag=v0.3.0#fbb24bbfe3d05463d9f8ccec9fb8949e40b96812"
+version = "0.4.0"
+source = "git+https://github.com/Eyevinn/efp?tag=v0.4.0#d6fd3bdb05195a48fffab2f38ed88ec4037f373c"
 dependencies = [
  "efp-sys",
 ]
 
 [[package]]
 name = "efp-sys"
-version = "0.3.0"
-source = "git+https://github.com/Eyevinn/efp?tag=v0.3.0#fbb24bbfe3d05463d9f8ccec9fb8949e40b96812"
+version = "0.4.0"
+source = "git+https://github.com/Eyevinn/efp?tag=v0.4.0#d6fd3bdb05195a48fffab2f38ed88ec4037f373c"
 dependencies = [
  "bindgen",
  "cmake",
@@ -2592,8 +2592,8 @@ dependencies = [
 
 [[package]]
 name = "gst-plugin-efp"
-version = "0.3.0"
-source = "git+https://github.com/Eyevinn/efp?tag=v0.3.0#fbb24bbfe3d05463d9f8ccec9fb8949e40b96812"
+version = "0.4.0"
+source = "git+https://github.com/Eyevinn/efp?tag=v0.4.0#d6fd3bdb05195a48fffab2f38ed88ec4037f373c"
 dependencies = [
  "efp",
  "glib",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -63,7 +63,7 @@ gst-plugin-webrtchttp.workspace = true
 gst-plugin-inter.workspace = true
 gst-plugin-rtp.workspace = true
 gst-plugins-lsp = { git = "https://github.com/srperens/lsp-plugins-rs", tag = "v1.3.1", package = "gst-plugins-lsp" }
-gst-plugin-efp = { git = "https://github.com/Eyevinn/efp", tag = "v0.3.0", package = "gst-plugin-efp", optional = true }
+gst-plugin-efp = { git = "https://github.com/Eyevinn/efp", tag = "v0.4.0", package = "gst-plugin-efp", optional = true }
 
 # Encoding
 base64 = "0.22"

--- a/backend/src/blocks/builtin/efpsrt.rs
+++ b/backend/src/blocks/builtin/efpsrt.rs
@@ -839,7 +839,7 @@ fn efpsrt_output_definition() -> BlockDefinition {
             ExposedProperty {
                 name: "num_data_tracks".to_string(),
                 label: "Number of Data Tracks".to_string(),
-                description: "Number of EFP embedded-data input tracks (default: 0). Each track maps to an efpmux 'embed_%u' pad. The connected source must send 'application/x-efp-embedded' caps carrying 'data-type' and 'stream-id'. Both fields default to 0 when omitted rather than failing, and stream-id 0 is reserved: data addressed to it, or to any stream-id that carries no media, is buffered by the muxer and never sent. Media stream-ids are allocated from 1 in pad order, so the video track is 1 and audio tracks follow.".to_string(),
+                description: "Number of EFP embedded-data input tracks (default: 0). Each track maps to an efpmux 'embed_%u' pad. The connected source must send 'application/x-efp-embedded' caps carrying both 'data-type' and 'stream-id'; caps missing either are rejected. Data rides out on the next frame of the media stream with the matching stream-id, and data addressed to a stream that carries no media is dropped. Media stream-ids are allocated from 1 in pad order, so the video track is 1 and audio tracks follow.".to_string(),
                 property_type: PropertyType::UInt,
                 default_value: Some(PropertyValue::UInt(0)),
                 mapping: PropertyMapping {

--- a/backend/src/blocks/builtin/efpsrt.rs
+++ b/backend/src/blocks/builtin/efpsrt.rs
@@ -228,6 +228,7 @@ impl BlockBuilder for EfpSrtOutputBuilder {
         // `stream-id`, so data addressed to a stream that carries no media
         // never leaves the muxer.
         let mut data_elements = Vec::new();
+        let mut data_links = Vec::new();
         for i in 0..num_data_tracks {
             let data_input_id = format!("{}:data_input_{}", instance_id, i);
             let data_input = gst::ElementFactory::make("identity")
@@ -256,16 +257,19 @@ impl BlockBuilder for EfpSrtOutputBuilder {
                     ))
                 })?;
 
-            let data_src = data_input.static_pad("src").ok_or_else(|| {
-                BlockBuildError::ElementCreation(format!("data identity {} has no src pad", i))
-            })?;
-
-            data_src.link(&embed_pad).map_err(|e| {
-                BlockBuildError::LinkError(format!("data input {} -> efpmux: {:?}", i, e))
-            })?;
+            // Report the link instead of making it here. `gst_bin_add` drops any
+            // link whose peer is outside the bin, and the pipeline builder adds
+            // every element this returns before it links anything, so a link
+            // made now is silently gone by the time data flows. The video and
+            // audio chains do not hit this because they link from caps probes,
+            // by which time everything is already in the pipeline.
+            data_links.push((
+                ElementPadRef::pad(&data_input_id, "src"),
+                ElementPadRef::pad(&mux_id, embed_pad.name().as_str()),
+            ));
 
             info!(
-                "EFP data input {}: linked to efpmux ({})",
+                "EFP data input {}: will link to efpmux ({})",
                 i,
                 embed_pad.name()
             );
@@ -273,7 +277,7 @@ impl BlockBuilder for EfpSrtOutputBuilder {
             data_elements.push((data_input_id, data_input));
         }
 
-        let mut internal_links = vec![];
+        let mut internal_links = data_links;
         let mux_weak = mux.downgrade();
         let mut elements = vec![(mux_id.clone(), mux), (sink_id.clone(), srtsink)];
         elements.extend(data_elements);

--- a/backend/src/blocks/builtin/efpsrt_input.rs
+++ b/backend/src/blocks/builtin/efpsrt_input.rs
@@ -1,8 +1,8 @@
 //! EFP over SRT input block builder.
 //!
 //! This block receives an SRT stream carrying EFP (Elastic Frame Protocol) and demuxes
-//! it into separate video and audio output pads, plus an optional embedded-data
-//! output carrying efpdemux's `embedded` pad (default: 0 data tracks).
+//! it into separate video and audio output pads, plus optional embedded-data
+//! outputs carrying efpdemux's `embedded_%u` pads (default: 0 data tracks).
 //!
 //! Pipeline structure (decode=true, default):
 //! ```text
@@ -36,16 +36,6 @@ use tracing::{debug, error, warn};
 
 /// Caps name of `efpdemux`'s embedded-data src pad.
 const EFP_EMBEDDED_CAPS_NAME: &str = "application/x-efp-embedded";
-
-/// Data tracks this block can actually reach.
-///
-/// `efpdemux` caches a single `embedded` src pad and returns it for every data
-/// type, so a second data track would publish an output pad that can never
-/// carry a buffer. `build` rejects anything above this rather than clamping
-/// silently: a flow configured for two tracks behaving as one is the same
-/// surprise in a quieter voice. Raising the limit is the compatible direction,
-/// so this can be relaxed once `efpdemux` demultiplexes by stream ID.
-const MAX_DATA_TRACKS: usize = 1;
 
 /// EFP/SRT Input block builder.
 pub struct EfpSrtInputBuilder;
@@ -91,10 +81,7 @@ impl BlockBuilder for EfpSrtInputBuilder {
             });
         }
 
-        // Never advertise a data output the demuxer cannot feed. This signature
-        // cannot report an error, so an over-configured block shows only the
-        // pads that work here and is rejected in `build`.
-        for i in 0..num_data_tracks.min(MAX_DATA_TRACKS) {
+        for i in 0..num_data_tracks {
             outputs.push(ExternalPad {
                 label: Some(format!("D{}", i)),
                 name: format!("data_out_{}", i),
@@ -183,16 +170,6 @@ impl BlockBuilder for EfpSrtInputBuilder {
         let num_audio_tracks = track_count(properties, "num_audio_tracks").unwrap_or(1);
 
         let num_data_tracks = track_count(properties, "num_data_tracks").unwrap_or(0);
-
-        if num_data_tracks > MAX_DATA_TRACKS {
-            return Err(BlockBuildError::InvalidConfiguration(format!(
-                "num_data_tracks is {}, but the EFP demuxer exposes a single embedded-data \
-                 pad shared by every data type, so at most {} data track can be received. \
-                 Split the streams across separate EFP inputs, or address several data types \
-                 over the one track.",
-                num_data_tracks, MAX_DATA_TRACKS
-            )));
-        }
 
         // Create srtsrc
         let src_id = format!("{}:srtsrc", instance_id);
@@ -308,9 +285,10 @@ impl BlockBuilder for EfpSrtInputBuilder {
             elements.push((element_id, identity));
         }
 
-        // Create embedded-data output identity elements. Capped at
-        // MAX_DATA_TRACKS above, so this builds at most one; the loop is kept
-        // so it needs no reshaping when efpdemux can demultiplex by stream ID.
+        // Create embedded-data output identity elements, one per data track.
+        // efpdemux publishes one `embedded_<stream-id>` pad per EFP stream that
+        // carries data, and they are linked to these in arrival order, the same
+        // way audio outputs are filled.
         let mut data_guards = Vec::new();
         for i in 0..num_data_tracks {
             let element_id = format!("{}:data_output_{}", instance_id, i);
@@ -860,7 +838,7 @@ fn efpsrt_input_definition() -> BlockDefinition {
             ExposedProperty {
                 name: "num_data_tracks".to_string(),
                 label: "Number of Data Tracks".to_string(),
-                description: "Number of EFP embedded-data output tracks: 0 or 1 (default: 0). efpdemux exposes a single 'embedded' pad carrying every data type, so a value above 1 is rejected rather than silently reduced.".to_string(),
+                description: "Number of EFP embedded-data output tracks (default: 0). efpdemux publishes one embedded pad per EFP stream that carries data; those pads are linked to these outputs in arrival order, so a track's number does not identify which sender stream it came from. Read 'stream-id' from the output pad caps for that.".to_string(),
                 property_type: PropertyType::UInt,
                 default_value: Some(PropertyValue::UInt(0)),
                 mapping: PropertyMapping {

--- a/backend/src/blocks/builtin/efpsrt_input.rs
+++ b/backend/src/blocks/builtin/efpsrt_input.rs
@@ -37,6 +37,59 @@ use tracing::{debug, error, warn};
 /// Caps name of `efpdemux`'s embedded-data src pad.
 const EFP_EMBEDDED_CAPS_NAME: &str = "application/x-efp-embedded";
 
+/// Parse the `data_stream_ids` property into one entry per data track.
+///
+/// `None` means "whichever embedded pad arrives next", which is how every data
+/// track behaved before this property existed and is still the default. A
+/// stream ID pins a track to one sender stream, so `data_out_0` means the same
+/// thing on every run.
+///
+/// An empty value gives every track `None`. Otherwise the list must name one
+/// stream per track, so a short list cannot silently leave later tracks
+/// unpinned when the operator meant to pin them all.
+fn parse_data_stream_ids(
+    value: Option<&str>,
+    num_data_tracks: usize,
+) -> Result<Vec<Option<u8>>, BlockBuildError> {
+    let Some(value) = value.map(str::trim).filter(|v| !v.is_empty()) else {
+        return Ok(vec![None; num_data_tracks]);
+    };
+
+    let mut ids = Vec::new();
+    for field in value.split(',') {
+        let field = field.trim();
+        let id = field.parse::<u8>().map_err(|_| {
+            BlockBuildError::InvalidProperty(format!(
+                "data_stream_ids: '{}' is not an EFP stream ID (0-255)",
+                field
+            ))
+        })?;
+        if id == 0 {
+            return Err(BlockBuildError::InvalidProperty(
+                "data_stream_ids: stream 0 is reserved and never carries media".to_string(),
+            ));
+        }
+        if ids.contains(&Some(id)) {
+            return Err(BlockBuildError::InvalidProperty(format!(
+                "data_stream_ids: stream {} is listed twice; one pad cannot feed two outputs",
+                id
+            )));
+        }
+        ids.push(Some(id));
+    }
+
+    if ids.len() != num_data_tracks {
+        return Err(BlockBuildError::InvalidProperty(format!(
+            "data_stream_ids lists {} stream(s) but num_data_tracks is {}; \
+             list one stream per track, or leave it empty to fill them in arrival order",
+            ids.len(),
+            num_data_tracks
+        )));
+    }
+
+    Ok(ids)
+}
+
 /// EFP/SRT Input block builder.
 pub struct EfpSrtInputBuilder;
 
@@ -287,10 +340,18 @@ impl BlockBuilder for EfpSrtInputBuilder {
 
         // Create embedded-data output identity elements, one per data track.
         // efpdemux publishes one `embedded_<stream-id>` pad per EFP stream that
-        // carries data, and they are linked to these in arrival order, the same
-        // way audio outputs are filled.
+        // carries data. A track with a configured stream ID takes that stream's
+        // pad; the rest are filled in arrival order, the way audio outputs are.
+        let data_stream_ids = parse_data_stream_ids(
+            properties.get("data_stream_ids").and_then(|v| match v {
+                PropertyValue::String(s) => Some(s.as_str()),
+                _ => None,
+            }),
+            num_data_tracks,
+        )?;
+
         let mut data_guards = Vec::new();
-        for i in 0..num_data_tracks {
+        for (i, stream_id) in data_stream_ids.iter().enumerate() {
             let element_id = format!("{}:data_output_{}", instance_id, i);
             let identity = gst::ElementFactory::make("identity")
                 .name(&element_id)
@@ -299,7 +360,7 @@ impl BlockBuilder for EfpSrtInputBuilder {
                     BlockBuildError::ElementCreation(format!("data identity {}: {}", i, e))
                 })?;
             let guard = Arc::new(AtomicBool::new(false));
-            data_guards.push((identity.downgrade(), guard));
+            data_guards.push((identity.downgrade(), guard, *stream_id));
             elements.push((element_id, identity));
         }
 
@@ -442,7 +503,38 @@ impl BlockBuilder for EfpSrtInputBuilder {
             } else if is_data {
                 // Embedded data is opaque bytes — nothing to parse or decode in
                 // either mode, so it is always linked straight through.
-                for (weak_identity, guard) in &data_guards {
+                //
+                // gst-plugin-efp v0.4.0 puts the sender's stream ID on these
+                // caps. A track configured for that stream takes the pad;
+                // otherwise the first unconfigured track does, so a flow that
+                // never set data_stream_ids behaves as it did before.
+                let pad_stream_id = caps
+                    .as_ref()
+                    .and_then(|c| c.structure(0))
+                    .and_then(|s| s.get::<i32>("stream-id").ok())
+                    .and_then(|id| u8::try_from(id).ok());
+
+                let matches_pad = |configured: Option<u8>| match (configured, pad_stream_id) {
+                    (Some(want), Some(got)) => want == got,
+                    (Some(_), None) => false,
+                    (None, _) => true,
+                };
+
+                // Pinned tracks first, so an unpinned track cannot swallow a pad
+                // another track was configured to receive.
+                let ordered = data_guards
+                    .iter()
+                    .filter(|(_, _, configured)| configured.is_some())
+                    .chain(
+                        data_guards
+                            .iter()
+                            .filter(|(_, _, configured)| configured.is_none()),
+                    );
+
+                for (weak_identity, guard, configured) in ordered {
+                    if !matches_pad(*configured) {
+                        continue;
+                    }
                     if guard.swap(true, Ordering::SeqCst) {
                         continue;
                     }
@@ -838,12 +930,26 @@ fn efpsrt_input_definition() -> BlockDefinition {
             ExposedProperty {
                 name: "num_data_tracks".to_string(),
                 label: "Number of Data Tracks".to_string(),
-                description: "Number of EFP embedded-data output tracks (default: 0). efpdemux publishes one embedded pad per EFP stream that carries data; those pads are linked to these outputs in arrival order, so a track's number does not identify which sender stream it came from. Read 'stream-id' from the output pad caps for that.".to_string(),
+                description: "Number of EFP embedded-data output tracks (default: 0). Each track is an output pad carrying one sender stream's embedded data. By default the pads are filled in arrival order; set 'data_stream_ids' to pin each track to a stream instead.".to_string(),
                 property_type: PropertyType::UInt,
                 default_value: Some(PropertyValue::UInt(0)),
                 mapping: PropertyMapping {
                     element_id: "_block".to_string(),
                     property_name: "num_data_tracks".to_string(),
+                    transform: None,
+                },
+                live: false,
+                persist: None,
+            },
+            ExposedProperty {
+                name: "data_stream_ids".to_string(),
+                label: "Data Track Stream IDs".to_string(),
+                description: "Which EFP stream feeds each data track, as a comma-separated list with one entry per track (e.g. '2,1'). Empty (default) fills the tracks in arrival order, so which sender stream reaches 'data_out_0' can differ between runs. Stream IDs are assigned by the sender from 1 in pad order, so a sender with one video and one audio track uses 1 for video and 2 for audio. Stream 0 is reserved.".to_string(),
+                property_type: PropertyType::String,
+                default_value: Some(PropertyValue::String(String::new())),
+                mapping: PropertyMapping {
+                    element_id: "_block".to_string(),
+                    property_name: "data_stream_ids".to_string(),
                     transform: None,
                 },
                 live: false,

--- a/backend/tests/efpsrt_data_roundtrip_test.rs
+++ b/backend/tests/efpsrt_data_roundtrip_test.rs
@@ -1,0 +1,351 @@
+//! End-to-end test for EFP's embedded-data channel: bytes pushed at an
+//! `efpsrt_output` block's `data_in_0` come back out of an `efpsrt_input`
+//! block's `data_out_0` over a real SRT connection.
+//!
+//! #700 added the channel and #691 asked for this. Everything shipped so far
+//! asserts graph structure — pads requested, elements created, links made —
+//! which does not show that a byte survives the trip. This drives the real
+//! block builders and reads the far end.
+//!
+//! It also pins the two things a caller has to get right and cannot discover
+//! from the block's shape: embedded data is addressed to a *media* stream by
+//! `stream-id`, and it only leaves the muxer on a frame of that stream.
+
+#![cfg(feature = "efp")]
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use gstreamer as gst;
+use gstreamer::prelude::*;
+use gstreamer_app as gst_app;
+use strom::blocks::builtin::efpsrt::EfpSrtOutputBuilder;
+use strom::blocks::builtin::efpsrt_input::EfpSrtInputBuilder;
+use strom::blocks::{BlockBuildContext, BlockBuildResult, BlockBuilder};
+use strom_types::PropertyValue;
+
+/// Elements this test needs beyond core GStreamer. All are in
+/// `gstreamer1.0-plugins-base`/`-good`/`-bad`, which CI installs.
+const REQUIRED: &[&str] = &[
+    "efpmux",
+    "efpdemux",
+    "srtsink",
+    "srtsrc",
+    "identity",
+    "appsrc",
+    "appsink",
+    "audiotestsrc",
+    "audioconvert",
+    "audioresample",
+    "opusenc",
+    "opusparse",
+];
+
+/// The stream ID `efpmux` assigns the block's first media track.
+///
+/// IDs are allocated from 1 as sink pads are requested, and this flow has one
+/// audio track and no video, so audio is stream 1. Embedded data addressed
+/// anywhere else has no frame to ride out on and is dropped by the muxer.
+const MEDIA_STREAM_ID: i32 = 1;
+
+const DATA_TYPE: i32 = 7;
+const PAYLOAD: &[u8] = b"c2pa-manifest-bytes";
+
+fn init() {
+    let _ = gst::init();
+    let _ = gst_plugin_efp::plugin_register_static();
+}
+
+/// Skipping on a missing element passes green and guards nothing, so CI sets
+/// `STROM_REQUIRE_GST_PLUGINS=1` to turn a skip into a failure.
+fn plugins_available() -> bool {
+    let missing: Vec<&str> = REQUIRED
+        .iter()
+        .copied()
+        .filter(|e| gst::ElementFactory::find(e).is_none())
+        .collect();
+    if missing.is_empty() {
+        return true;
+    }
+    assert!(
+        strom_types::env::var_opt("STROM_REQUIRE_GST_PLUGINS").is_none(),
+        "STROM_REQUIRE_GST_PLUGINS is set but these elements are missing: {}",
+        missing.join(", ")
+    );
+    false
+}
+
+fn srt_port() -> u16 {
+    std::net::UdpSocket::bind("127.0.0.1:0")
+        .and_then(|s| s.local_addr())
+        .map(|a| a.port())
+        .expect("no free UDP port for the SRT listener")
+}
+
+fn element<'a>(result: &'a BlockBuildResult, id: &str) -> &'a gst::Element {
+    result
+        .elements
+        .iter()
+        .find(|(element_id, _)| element_id == id)
+        .map(|(_, element)| element)
+        .unwrap_or_else(|| {
+            panic!(
+                "block should contain '{}', got {:?}",
+                id,
+                result.elements.iter().map(|(id, _)| id).collect::<Vec<_>>()
+            )
+        })
+}
+
+/// Add a block's elements to `pipeline` and apply the links the builder asked
+/// for, so the graph under test is the one the block produced rather than one
+/// reconstructed here.
+fn install(pipeline: &gst::Pipeline, result: &BlockBuildResult) {
+    let by_id: HashMap<&str, &gst::Element> = result
+        .elements
+        .iter()
+        .map(|(id, e)| (id.as_str(), e))
+        .collect();
+
+    for (_, e) in &result.elements {
+        pipeline.add(e).expect("element joins the pipeline");
+    }
+
+    for (from, to) in &result.internal_links {
+        let src = by_id[from.element_id.as_str()];
+        let dst = by_id[to.element_id.as_str()];
+        match (&from.pad_name, &to.pad_name) {
+            (None, None) => src.link(dst).expect("elements link"),
+            (f, t) => {
+                let src_pad = match f {
+                    Some(name) => src.static_pad(name).expect("named src pad exists"),
+                    None => src.static_pad("src").expect("src pad exists"),
+                };
+                let dst_pad = match t {
+                    Some(name) => dst.static_pad(name).expect("named sink pad exists"),
+                    None => dst.static_pad("sink").expect("sink pad exists"),
+                };
+                src_pad.link(&dst_pad).expect("pads link");
+            }
+        }
+    }
+}
+
+fn props(pairs: &[(&str, PropertyValue)]) -> HashMap<String, PropertyValue> {
+    pairs
+        .iter()
+        .map(|(k, v)| (k.to_string(), v.clone()))
+        .collect()
+}
+
+fn drain_errors(pipeline: &gst::Pipeline, label: &str) {
+    let bus = pipeline.bus().expect("pipeline has a bus");
+    while let Some(msg) = bus.pop() {
+        if let gst::MessageView::Error(err) = msg.view() {
+            panic!(
+                "{} pipeline error: {} ({:?})",
+                label,
+                err.error(),
+                err.debug()
+            );
+        }
+    }
+}
+
+/// Bytes pushed at `data_in_0` come out of `data_out_0` on the far side of an
+/// SRT hop, carrying the data type and stream ID they were addressed with.
+#[test]
+fn embedded_data_survives_the_trip_between_the_blocks() {
+    init();
+    if !plugins_available() {
+        eprintln!("skipping: required GStreamer elements are missing");
+        return;
+    }
+
+    let port = srt_port();
+    let ctx = || BlockBuildContext::new(Vec::new(), "all".to_string());
+
+    // --- sender -----------------------------------------------------------
+    // wait_for_connection=false: the receiver connects a moment later, and a
+    // blocking sink would stall the pushes below before it does.
+    let out = EfpSrtOutputBuilder
+        .build(
+            "tx",
+            &props(&[
+                ("num_video_tracks", PropertyValue::UInt(0)),
+                ("num_audio_tracks", PropertyValue::UInt(1)),
+                ("num_data_tracks", PropertyValue::UInt(1)),
+                (
+                    "srt_uri",
+                    PropertyValue::String(format!("srt://127.0.0.1:{}?mode=listener", port)),
+                ),
+                ("wait_for_connection", PropertyValue::Bool(false)),
+            ]),
+            &ctx(),
+        )
+        .expect("efpsrt_output builds");
+
+    let tx = gst::Pipeline::with_name("tx");
+    install(&tx, &out);
+
+    let audio_src = gst::ElementFactory::make("audiotestsrc")
+        .property("is-live", true)
+        .property_from_str("wave", "silence")
+        .build()
+        .expect("audiotestsrc");
+    tx.add(&audio_src).unwrap();
+    audio_src
+        .link(element(&out, "tx:audio_input_0"))
+        .expect("audio source feeds the block's audio input");
+
+    let data_caps = gst::Caps::builder("application/x-efp-embedded")
+        .field("data-type", DATA_TYPE)
+        .field("stream-id", MEDIA_STREAM_ID)
+        .build();
+    let data_src = gst::ElementFactory::make("appsrc")
+        .property("caps", &data_caps)
+        .property("format", gst::Format::Time)
+        .property("is-live", true)
+        .build()
+        .expect("appsrc");
+    tx.add(&data_src).unwrap();
+    data_src
+        .link(element(&out, "tx:data_input_0"))
+        .expect("data source feeds the block's data input");
+    let data_src = data_src.dynamic_cast::<gst_app::AppSrc>().unwrap();
+
+    // --- receiver ---------------------------------------------------------
+    let inp = EfpSrtInputBuilder
+        .build(
+            "rx",
+            &props(&[
+                ("num_video_tracks", PropertyValue::UInt(0)),
+                ("num_audio_tracks", PropertyValue::UInt(1)),
+                ("num_data_tracks", PropertyValue::UInt(1)),
+                (
+                    "srt_uri",
+                    PropertyValue::String(format!("srt://127.0.0.1:{}?mode=caller", port)),
+                ),
+                ("decode", PropertyValue::Bool(false)),
+            ]),
+            &ctx(),
+        )
+        .expect("efpsrt_input builds");
+
+    let rx = gst::Pipeline::with_name("rx");
+    install(&rx, &inp);
+
+    // Read the far end of the block rather than the demuxer directly, so the
+    // block's own linking is part of what is under test.
+    /// `(buffer bytes, the pad's caps when it was pushed)`.
+    type Delivered = (Vec<u8>, Option<gst::Caps>);
+
+    let received: Arc<Mutex<Vec<Delivered>>> = Arc::new(Mutex::new(Vec::new()));
+    let received_probe = Arc::clone(&received);
+    let data_out = element(&inp, "rx:data_output_0");
+    data_out
+        .static_pad("src")
+        .expect("data_output_0 has a src pad")
+        .add_probe(gst::PadProbeType::BUFFER, move |pad, info| {
+            if let Some(gst::PadProbeData::Buffer(ref buffer)) = info.data {
+                if let Ok(map) = buffer.map_readable() {
+                    received_probe
+                        .lock()
+                        .unwrap()
+                        .push((map.as_slice().to_vec(), pad.current_caps()));
+                }
+            }
+            gst::PadProbeReturn::Ok
+        });
+
+    // The block leaves its outputs unlinked; without a sink the push fails as
+    // not-linked before the probe above ever runs.
+    let audio_sink = gst::ElementFactory::make("fakesink")
+        .property("async", false)
+        .property("sync", false)
+        .build()
+        .unwrap();
+    let data_sink = gst::ElementFactory::make("fakesink")
+        .property("async", false)
+        .property("sync", false)
+        .build()
+        .unwrap();
+    rx.add_many([&audio_sink, &data_sink]).unwrap();
+    element(&inp, "rx:audio_output_0")
+        .link(&audio_sink)
+        .expect("audio output feeds a sink");
+    data_out.link(&data_sink).expect("data output feeds a sink");
+
+    // --- run --------------------------------------------------------------
+    tx.set_state(gst::State::Playing).expect("tx plays");
+    rx.set_state(gst::State::Playing).expect("rx plays");
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let stop_pusher = Arc::clone(&stop);
+    let pusher = std::thread::spawn(move || {
+        // Embedded data only leaves the muxer on a media frame of its stream,
+        // and the audio sink pad is not requested until the audio caps probe
+        // fires, so push repeatedly rather than once and hope for the ordering.
+        for i in 0..200u64 {
+            if stop_pusher.load(Ordering::SeqCst) {
+                break;
+            }
+            let mut buffer = gst::Buffer::from_slice(PAYLOAD);
+            buffer
+                .get_mut()
+                .unwrap()
+                .set_pts(gst::ClockTime::from_mseconds(i * 20));
+            if data_src.push_buffer(buffer).is_err() {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+    });
+
+    let deadline = Instant::now() + Duration::from_secs(20);
+    while Instant::now() < deadline {
+        drain_errors(&tx, "tx");
+        drain_errors(&rx, "rx");
+        if !received.lock().unwrap().is_empty() {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+
+    stop.store(true, Ordering::SeqCst);
+    let _ = pusher.join();
+    rx.set_state(gst::State::Null).unwrap();
+    tx.set_state(gst::State::Null).unwrap();
+
+    let got = received.lock().unwrap().clone();
+    assert!(
+        !got.is_empty(),
+        "no embedded data reached data_out_0 within 20s; the channel does not carry bytes \
+         end to end"
+    );
+
+    let (bytes, caps) = &got[0];
+    assert_eq!(
+        bytes, PAYLOAD,
+        "the bytes that arrived are not the bytes that were sent"
+    );
+
+    let caps = caps
+        .as_ref()
+        .expect("the data output pad should carry caps");
+    let s = caps.structure(0).expect("caps has a structure");
+    assert_eq!(s.name(), "application/x-efp-embedded");
+    assert_eq!(
+        s.get::<i32>("data-type").expect("caps carry data-type"),
+        DATA_TYPE
+    );
+    // The field gst-plugin-efp v0.4.0 added. Without it a receiver cannot say
+    // which media stream the data describes, which is the whole point of the
+    // channel for provenance.
+    assert_eq!(
+        s.get::<i32>("stream-id").expect("caps carry stream-id"),
+        MEDIA_STREAM_ID
+    );
+}

--- a/backend/tests/efpsrt_data_roundtrip_test.rs
+++ b/backend/tests/efpsrt_data_roundtrip_test.rs
@@ -349,3 +349,184 @@ fn embedded_data_survives_the_trip_between_the_blocks() {
         MEDIA_STREAM_ID
     );
 }
+
+/// `data_stream_ids` pins each data track to a sender stream, so `data_out_0`
+/// means the same thing on every run.
+///
+/// Two media streams each carry their own embedded data, and the list is
+/// deliberately reversed — track 0 is pinned to stream 2 — so arrival order
+/// cannot produce this result by luck.
+#[test]
+fn data_stream_ids_pins_each_track_to_its_sender_stream() {
+    init();
+    if !plugins_available() {
+        eprintln!("skipping: required GStreamer elements are missing");
+        return;
+    }
+
+    let port = srt_port();
+    let ctx = || BlockBuildContext::new(Vec::new(), "all".to_string());
+
+    // Two media tracks, so efpmux allocates streams 1 and 2. Which audio track
+    // gets which ID depends on the order their caps probes fire, and the
+    // assertion below deliberately does not care: it is about how the receiver
+    // routes streams to outputs, not about how the sender numbers them.
+    let out = EfpSrtOutputBuilder
+        .build(
+            "tx",
+            &props(&[
+                ("num_video_tracks", PropertyValue::UInt(0)),
+                ("num_audio_tracks", PropertyValue::UInt(2)),
+                ("num_data_tracks", PropertyValue::UInt(2)),
+                (
+                    "srt_uri",
+                    PropertyValue::String(format!("srt://127.0.0.1:{}?mode=listener", port)),
+                ),
+                ("wait_for_connection", PropertyValue::Bool(false)),
+            ]),
+            &ctx(),
+        )
+        .expect("efpsrt_output builds");
+
+    let tx = gst::Pipeline::with_name("tx2");
+    install(&tx, &out);
+
+    for i in 0..2 {
+        let src = gst::ElementFactory::make("audiotestsrc")
+            .property("is-live", true)
+            .property_from_str("wave", "silence")
+            .build()
+            .unwrap();
+        tx.add(&src).unwrap();
+        src.link(element(&out, &format!("tx:audio_input_{}", i)))
+            .expect("audio source feeds the block");
+    }
+
+    let mut data_srcs = Vec::new();
+    for (i, stream_id) in [1i32, 2i32].into_iter().enumerate() {
+        let caps = gst::Caps::builder("application/x-efp-embedded")
+            .field("data-type", DATA_TYPE)
+            .field("stream-id", stream_id)
+            .build();
+        let src = gst::ElementFactory::make("appsrc")
+            .property("caps", &caps)
+            .property("format", gst::Format::Time)
+            .property("is-live", true)
+            .build()
+            .unwrap();
+        tx.add(&src).unwrap();
+        src.link(element(&out, &format!("tx:data_input_{}", i)))
+            .expect("data source feeds the block");
+        data_srcs.push((src.dynamic_cast::<gst_app::AppSrc>().unwrap(), stream_id));
+    }
+
+    // Reversed on purpose: data_out_0 must carry stream 2, data_out_1 stream 1.
+    let inp = EfpSrtInputBuilder
+        .build(
+            "rx",
+            &props(&[
+                ("num_video_tracks", PropertyValue::UInt(0)),
+                ("num_audio_tracks", PropertyValue::UInt(2)),
+                ("num_data_tracks", PropertyValue::UInt(2)),
+                ("data_stream_ids", PropertyValue::String("2,1".to_string())),
+                (
+                    "srt_uri",
+                    PropertyValue::String(format!("srt://127.0.0.1:{}?mode=caller", port)),
+                ),
+                ("decode", PropertyValue::Bool(false)),
+            ]),
+            &ctx(),
+        )
+        .expect("efpsrt_input builds");
+
+    let rx = gst::Pipeline::with_name("rx2");
+    install(&rx, &inp);
+
+    let seen: Arc<Mutex<Vec<(usize, i32)>>> = Arc::new(Mutex::new(Vec::new()));
+    for track in 0..2usize {
+        let out_element = element(&inp, &format!("rx:data_output_{}", track));
+        let seen_probe = Arc::clone(&seen);
+        out_element.static_pad("src").unwrap().add_probe(
+            gst::PadProbeType::BUFFER,
+            move |pad, _info| {
+                if let Some(caps) = pad.current_caps() {
+                    if let Some(s) = caps.structure(0) {
+                        if let Ok(id) = s.get::<i32>("stream-id") {
+                            let mut seen = seen_probe.lock().unwrap();
+                            if !seen.iter().any(|(t, _)| *t == track) {
+                                seen.push((track, id));
+                            }
+                        }
+                    }
+                }
+                gst::PadProbeReturn::Ok
+            },
+        );
+
+        let sink = gst::ElementFactory::make("fakesink")
+            .property("async", false)
+            .property("sync", false)
+            .build()
+            .unwrap();
+        rx.add(&sink).unwrap();
+        out_element.link(&sink).expect("data output feeds a sink");
+    }
+    for id in ["rx:audio_output_0", "rx:audio_output_1"] {
+        let sink = gst::ElementFactory::make("fakesink")
+            .property("async", false)
+            .property("sync", false)
+            .build()
+            .unwrap();
+        rx.add(&sink).unwrap();
+        element(&inp, id)
+            .link(&sink)
+            .expect("media output feeds a sink");
+    }
+
+    tx.set_state(gst::State::Playing).expect("tx plays");
+    rx.set_state(gst::State::Playing).expect("rx plays");
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let stop_pusher = Arc::clone(&stop);
+    let pusher = std::thread::spawn(move || {
+        for i in 0..200u64 {
+            if stop_pusher.load(Ordering::SeqCst) {
+                break;
+            }
+            for (src, stream_id) in &data_srcs {
+                let mut b =
+                    gst::Buffer::from_slice(format!("data-for-stream-{stream_id}").into_bytes());
+                b.get_mut()
+                    .unwrap()
+                    .set_pts(gst::ClockTime::from_mseconds(i * 20));
+                if src.push_buffer(b).is_err() {
+                    return;
+                }
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+    });
+
+    let deadline = Instant::now() + Duration::from_secs(25);
+    while Instant::now() < deadline {
+        drain_errors(&tx, "tx");
+        drain_errors(&rx, "rx");
+        if seen.lock().unwrap().len() == 2 {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+
+    stop.store(true, Ordering::SeqCst);
+    let _ = pusher.join();
+    rx.set_state(gst::State::Null).unwrap();
+    tx.set_state(gst::State::Null).unwrap();
+
+    let mut got = seen.lock().unwrap().clone();
+    got.sort();
+    assert_eq!(
+        got,
+        vec![(0usize, 2i32), (1usize, 1i32)],
+        "data_stream_ids=\"2,1\" must put stream 2 on data_out_0 and stream 1 on data_out_1"
+    );
+}

--- a/backend/tests/efpsrt_embedded_data_test.rs
+++ b/backend/tests/efpsrt_embedded_data_test.rs
@@ -331,3 +331,80 @@ fn a_negative_track_count_falls_back_to_the_default() {
         );
     }
 }
+
+/// Build the input block with `data_stream_ids` set, returning the error text.
+fn data_stream_ids_error(num_data_tracks: u64, ids: &str) -> String {
+    let mut props = properties(&[
+        ("num_video_tracks", 0),
+        ("num_audio_tracks", 0),
+        ("num_data_tracks", num_data_tracks),
+    ]);
+    props.insert(
+        "data_stream_ids".to_string(),
+        PropertyValue::String(ids.to_string()),
+    );
+    // `BlockBuildResult` is not `Debug`, so unwrap the error by hand.
+    match EfpSrtInputBuilder.build("blk", &props, &context()) {
+        Ok(_) => panic!("data_stream_ids '{}' should not build", ids),
+        Err(e) => e.to_string(),
+    }
+}
+
+/// A misconfigured routing list fails at build rather than quietly leaving a
+/// track fed by whatever arrives first, which is the surprise the property
+/// exists to remove.
+#[test]
+fn input_block_rejects_a_bad_data_stream_ids_list() {
+    init();
+    require_elements(&["efpdemux", "srtsrc", "identity"]);
+
+    for (ids, tracks, expected) in [
+        ("1", 2u64, "num_data_tracks"),
+        ("1,2,3", 2, "num_data_tracks"),
+        ("0", 1, "reserved"),
+        ("1,1", 2, "twice"),
+        ("audio", 1, "not an EFP stream ID"),
+        ("300", 1, "not an EFP stream ID"),
+    ] {
+        let message = data_stream_ids_error(tracks, ids);
+        assert!(
+            message.contains(expected),
+            "'{}' with {} track(s) should mention '{}', got: {}",
+            ids,
+            tracks,
+            expected,
+            message
+        );
+    }
+}
+
+/// Leaving the property empty keeps the arrival-order behaviour every existing
+/// flow has, so the routing addition is opt-in.
+#[test]
+fn input_block_builds_with_an_empty_data_stream_ids_list() {
+    init();
+    require_elements(&["efpdemux", "srtsrc", "identity"]);
+
+    let mut props = properties(&[
+        ("num_video_tracks", 0),
+        ("num_audio_tracks", 0),
+        ("num_data_tracks", 2),
+    ]);
+    props.insert(
+        "data_stream_ids".to_string(),
+        PropertyValue::String(String::new()),
+    );
+
+    let result = EfpSrtInputBuilder
+        .build("blk", &props, &context())
+        .expect("an empty data_stream_ids must keep arrival-order filling");
+
+    for i in 0..2 {
+        let id = format!("blk:data_output_{}", i);
+        assert!(
+            element(&result, &id).is_some(),
+            "expected a '{}' element",
+            id
+        );
+    }
+}

--- a/backend/tests/efpsrt_embedded_data_test.rs
+++ b/backend/tests/efpsrt_embedded_data_test.rs
@@ -103,8 +103,17 @@ fn output_block_exposes_a_data_input_per_data_track() {
     }
 }
 
+/// The embed pad must be requested here, but the link to it must be *reported*
+/// rather than made.
+///
+/// An earlier version of this test asserted the src pad's peer directly, and
+/// passed while the channel carried nothing: the builder linked the pads itself,
+/// and `gst_bin_add` drops any link whose peer is outside the bin, so the
+/// pipeline builder's own "add every element, then link" order silently undid
+/// it. `efpsrt_data_roundtrip_test` is what actually proves bytes flow; this
+/// asserts the shape that lets them.
 #[test]
-fn output_block_requests_and_links_an_embed_pad_per_data_track() {
+fn output_block_reports_an_embed_pad_link_per_data_track() {
     init();
     require_elements(&["efpmux", "srtsink", "identity"]);
 
@@ -131,22 +140,36 @@ fn output_block_requests_and_links_an_embed_pad_per_data_track() {
 
     for i in 0..2 {
         let id = format!("blk:data_input_{}", i);
-        let identity = element(&result, &id)
-            .unwrap_or_else(|| panic!("block should contain a '{}' element", id));
-
-        let src = identity
-            .static_pad("src")
-            .unwrap_or_else(|| panic!("'{}' should have a src pad", id));
-        let peer = src
-            .peer()
-            .unwrap_or_else(|| panic!("'{}' src pad should be linked to efpmux", id));
-
         assert!(
-            pads.iter().any(|pad| pad == &peer),
-            "'{}' should link to an '{}' pad, but links to '{}'",
+            element(&result, &id).is_some(),
+            "block should contain a '{}' element",
+            id
+        );
+
+        let link = result
+            .internal_links
+            .iter()
+            .find(|(from, _)| from.element_id == id && from.pad_name.as_deref() == Some("src"))
+            .unwrap_or_else(|| {
+                panic!(
+                    "'{}' src should be reported as an internal link, got {:?}",
+                    id,
+                    result
+                        .internal_links
+                        .iter()
+                        .map(|(f, t)| format!("{:?} -> {:?}", f, t))
+                        .collect::<Vec<_>>()
+                )
+            });
+
+        assert_eq!(link.1.element_id, "blk:efpmux");
+        let pad_name = link.1.pad_name.as_deref().expect("link names a pad");
+        assert!(
+            pads.iter().any(|pad| pad.name() == pad_name),
+            "'{}' should link to an '{}' pad, but names '{}'",
             id,
             EMBED_TEMPLATE,
-            peer.name()
+            pad_name
         );
     }
 }

--- a/backend/tests/efpsrt_embedded_data_test.rs
+++ b/backend/tests/efpsrt_embedded_data_test.rs
@@ -232,33 +232,41 @@ fn input_block_builds_no_data_output_by_default() {
     );
 }
 
+/// gst-plugin-efp v0.4.0 gives each EFP stream its own `embedded_<stream-id>`
+/// src pad, so several data tracks can now be received. Until v0.3.0 the
+/// demuxer cached one `embedded` pad for every stream and this block rejected
+/// anything above one rather than publish outputs that could never carry a
+/// buffer.
 #[test]
-fn input_block_rejects_more_data_tracks_than_the_demuxer_can_reach() {
+fn input_block_builds_a_data_output_per_track_beyond_the_first() {
     init();
     require_elements(&["efpdemux", "srtsrc", "identity"]);
 
     let props = properties(&[
         ("num_video_tracks", 0),
         ("num_audio_tracks", 0),
-        ("num_data_tracks", 2),
+        ("num_data_tracks", 3),
     ]);
-    // `BlockBuildResult` is not `Debug`, so unwrap the error by hand.
-    let message = match EfpSrtInputBuilder.build("blk", &props, &context()) {
-        Ok(_) => panic!("efpdemux has one embedded pad, so two data tracks must not build"),
-        Err(e) => e.to_string(),
-    };
-    assert!(
-        message.contains("num_data_tracks"),
-        "the error must name the property the operator set, got: {}",
-        message
-    );
+    let result = EfpSrtInputBuilder
+        .build("blk", &props, &context())
+        .expect("several data tracks must build against a demuxer that fans out per stream");
+
+    for i in 0..3 {
+        let id = format!("blk:data_output_{}", i);
+        assert!(
+            element(&result, &id).is_some(),
+            "block should contain a '{}' element, got {:?}",
+            id,
+            result.elements.iter().map(|(id, _)| id).collect::<Vec<_>>()
+        );
+    }
 }
 
 #[test]
-fn input_block_never_advertises_an_unreachable_data_output() {
+fn input_block_advertises_every_data_output_it_builds() {
     init();
 
-    let props = properties(&[("num_data_tracks", 2)]);
+    let props = properties(&[("num_data_tracks", 3)]);
     let pads = EfpSrtInputBuilder
         .get_external_pads(&props)
         .expect("efpsrt_input should report external pads");
@@ -272,8 +280,12 @@ fn input_block_never_advertises_an_unreachable_data_output() {
 
     assert_eq!(
         data_pads,
-        vec!["data_out_0".to_string()],
-        "a data output the demuxer can never feed must not appear in the flow graph"
+        vec![
+            "data_out_0".to_string(),
+            "data_out_1".to_string(),
+            "data_out_2".to_string()
+        ],
+        "the flow graph must show every data output the block builds"
     );
 }
 


### PR DESCRIPTION
Repins `gst-plugin-efp` to `v0.4.0`, removes the data-track limit that #700 put
in as a stopgap, and **fixes the embedded-data channel, which carried nothing in
a real flow.** Follow-up to #700 and Eyevinn/efp#1.

## The channel was dead in a real pipeline

Writing the wire round trip #691 asked for turned up a defect in the code #700
already merged. `efpsrt_output`'s `build` linked `data_input_<i>` to the
`embed_%u` pad it had just requested. `gst_bin_add` drops any link whose peer is
outside the bin, and the pipeline builder adds every element a block returns
*before* it links anything (`gst/pipeline/construction.rs:179`, then
`gst/pipeline/linking.rs`), so that link was gone by the time data flowed and
the source feeding `data_in_0` stopped with `not-linked`.

Plain GStreamer, nothing EFP-specific — `funnel` and `identity` reproduce it:

```
after link, before add:      mux:funnelpad0
after adding mux only:       NONE
```

Video and audio were never affected: they link from caps probes, by which time
everything is in the pipeline. Only the data chain linked eagerly, which is the
thing #700's own body flagged as worth review. Requesting the pad eagerly is
fine; linking eagerly is not.

The fix reports the link through `internal_links` and lets the pipeline builder
make it. The pad is still requested in `build`, so it exists with a
deterministic name for `linking.rs`'s `static_pad` lookup to find.

**Nothing caught this** because every test in `efpsrt_embedded_data_test.rs`
inspects `build`'s output.
`output_block_requests_and_links_an_embed_pad_per_data_track` asserted the src
pad's peer straight out of the builder — true, and meaningless, since it
described a link that existed only for the length of the call. It now asserts
the reported link, and its doc comment says why the old form passed while the
channel was dead.

## What changed upstream

`efpdemux` now publishes one `embedded_<stream-id>` src pad per EFP stream that
carries data, with `stream-id` on the caps. At `v0.3.0` it cached a single
`embedded` pad and returned it for every stream and data type, and its caps
carried no `stream-id` at all — the channel was write-only.

That was the whole reason #700 rejected `num_data_tracks > 1` on the input
block: publishing `data_out_1` would have advertised an output that no buffer
could ever reach. The limit is now obsolete, so it goes, along with the
`get_external_pads` clamp that hid the extra pads.

## Track numbering: `data_stream_ids`

Data outputs were filled in arrival order, so which sender stream reached
`data_out_0` could differ between runs of the same flow. `data_stream_ids` takes
one EFP stream ID per data track (`"2,1"`), so a track means the same thing every
time. Empty is the default and keeps arrival-order filling, so no existing flow
changes.

A list that does not name exactly one stream per track is rejected at build, as
are stream 0 (reserved, never carries media), duplicates, and anything that is
not a 0-255 integer. Ignoring a malformed list would put back the surprise the
property exists to remove. Pinned tracks match before unpinned ones, so a mixed
configuration cannot have an unpinned track swallow a pad another track was
configured to receive.

This is only possible because v0.4.0 puts `stream-id` on the embedded pad caps;
at v0.3.0 there was nothing to match on.

## A description that had become wrong

#700's output-side description recorded `v0.3.0` behaviour:

> Both fields default to 0 when omitted rather than failing, and stream-id 0 is
> reserved: data addressed to it […] is buffered by the muxer and never sent.

`v0.4.0` rejects caps missing either field and drops data addressed to a stream
that carries no media, so that text would now actively mislead. Corrected rather
than extended.

**This is a behaviour change for operators.** A flow whose data source sends
incomplete `application/x-efp-embedded` caps used to get silence and an
unbounded buffer inside efpmux; it now gets a pipeline error. That is the point
of the upstream fix, but it is visible.

## Tests

Ran locally on macOS against the newly tagged `v0.4.0`:

- `cargo test --features efp --test efpsrt_embedded_data_test` — 9 passed.
- `cargo test --features efp` — full backend suite green, 574 unit tests plus
  every integration target.
- `cargo fmt --all --check` and `cargo clippy --features efp --all-targets
  -D warnings` clean.

`backend/tests/efpsrt_data_roundtrip_test.rs` is new and is the guard for the
fix above. It drives `EfpSrtOutputBuilder` and `EfpSrtInputBuilder`, installs
each into a pipeline the way `construction.rs` does — add every element, then
apply `internal_links` — joins them over a real SRT connection on loopback, and
reads `data_out_0`. It asserts the bytes match and that the pad caps carry
`data-type` **and** `stream-id`.

**It ran in CI on Linux, not skipped:**

```
Running tests/efpsrt_data_roundtrip_test.rs
test embedded_data_survives_the_trip_between_the_blocks ... ok
```

Reverting only the fix, with the test untouched:

```
tx pipeline error: Internal data stream error.
  gst_base_src_loop (): /GstPipeline:tx/GstAppSrc:appsrc0:
  streaming stopped, reason not-linked (-1)
```

The two tests that guarded the removed limit are replaced by their opposites:
`input_block_builds_a_data_output_per_track_beyond_the_first` builds three data
outputs, and `input_block_advertises_every_data_output_it_builds` asserts all
three reach the flow graph. Both fail against `v0.3.0`'s behaviour, which is
what makes the repin load-bearing rather than cosmetic.

`data_stream_ids_pins_each_track_to_its_sender_stream` is the guard for the
routing: two media streams each carrying their own embedded data, over SRT, with
a deliberately reversed list, so arrival order cannot produce the expected
result by luck. It does not depend on which media track the sender numbers 1 —
it asserts how the receiver routes streams to outputs, not how the sender
assigns them. Validation is covered through the real builder rather than the
parser in isolation.

**Not verified:** Windows and macOS. The macOS numbers are from a local run;
CI covers Linux only, as it does for every EFP change here.

## Pin

`Cargo.lock` resolves `v0.4.0` to `d6fd3bdb05195a48fffab2f38ed88ec4037f373c`,
the tagged commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
