### PR TITLE
docs(agent): give the fix PR body a size allocation, not just a ceiling

### DIFF
--- a/scripts/agent/FIX.md
+++ b/scripts/agent/FIX.md
@@ -194,10 +194,23 @@ Required sections, in this order, omitting any with nothing to say:
 6. **Blast radius.** What else calls the changed symbol (grep and read at least one call
    site), and which configurations other than the reporter's change behaviour.
 
-**The PR body is at most 3500 characters**, checked with
-`scripts/agent/verify-citations.sh --max-chars 3500 <file>`. The Problem, Change and Evidence
-sections are the design record and are worth their length; what to cut is anything the diff
-already says.
+### Size the body before you write it
+
+**At most 3500 characters**, checked with
+`scripts/agent/verify-citations.sh --max-chars 3500 <file>`. Aim at 3000, and write to this
+allocation so the first draft is already the right size:
+
+| | Verdict | Problem | Change | Evidence | Not verified | Blast radius |
+|---|---|---|---|---|---|---|
+| Characters | 150 | 700 | 800 | 800 | 350 | 500 |
+
+Per-section ceilings; a section with nothing to say is still omitted. Problem, Change and
+Evidence are the design record and are worth their length — cut anything the diff already says.
+
+Over the ceiling means **one section is over its allocation.** Rewrite that section against
+its number; do not reword across the whole body to recover a few dozen characters. Two checks
+is the budget. Still over after the second: cut Not verified to one sentence naming the
+categories, and Blast radius to the one call site you read.
 
 Then comment once on the issue linking the PR and naming its class. **Do not restate the
 body** — link it. That comment is read alongside the PR, not instead of it.

--- a/scripts/agent/README.md
+++ b/scripts/agent/README.md
@@ -96,6 +96,15 @@ permission is a finding rather than an instruction.
   and do not make it repeat when the head SHA moves — a moving head SHA is what a draft *is*.
   Being asked is the only trigger for a real review, and then it is a full one, because a
   half review of a draft is the outcome both halves of this rule exist to avoid.
+- **`FIX.md` gives the PR body a per-section allocation, not just a ceiling.** A ceiling alone
+  tells a writer nothing until the text already exists, so the body got written at full length
+  and then shaved. One run descended 4970 -> 4329 -> 4105 -> 3772 -> 3633 -> 3488 characters
+  across six checks, the last of them a script substituting phrases to land twelve characters
+  under the limit — turns that should have gone into the change. The allocation exists so the
+  first draft is the right size; `REVIEW.md` achieves the same thing by saying its worked
+  example is 1500 characters and most reviews should land near it. Do not delete the numbers
+  and leave the ceiling.
+
 - **The worked examples are the format spec.** They exist because rules describing a shape
   drift and an example does not. If you change the required shape, change the example in the
   same commit.


### PR DESCRIPTION
## The observation

`FIX.md` set a 3500-character ceiling on the PR body and said nothing about how to hit it. A
ceiling tells a writer nothing until the text already exists, so the body got written at full
length and then shaved. Today's 10:00 run, visible in its own logs:

    4970 -> 4329 -> 4105 -> 3772 -> 3633 -> 3488

Six checks. The last was a Python script substituting individual phrases to land twelve
characters under the limit. Those turns should have gone into the change.

`REVIEW.md` does not have this problem, and the reason is instructive: its worked example
states its own length — *"It is 1500 characters; most reviews should land near it"* — so a
review has a target, not only a limit. `FIX.md` had no such anchor.

## The change

A per-section allocation summing to 3300, with a stated target of 3000:

| | Verdict | Problem | Change | Evidence | Not verified | Blast radius |
|---|---|---|---|---|---|---|
| Characters | 150 | 700 | 800 | 800 | 350 | 500 |

Plus the rule that makes it act on the failure mode: a draft over the ceiling means **one
section is over its number**, not the whole body being uniformly too wordy — so rewrite that
section rather than rewording everywhere. Two checks is the budget, with a named fallback for
what to cut if the second is still over.

## Where the reasoning went

`README.md`, which is not in any agent's read path — the role files dispatch to `PROTOCOL.md`,
`REVIEW.md`, `TRIAGE.md`, `FIX.md` and `SUMMARY.md`, never to `README.md`. So the narrative of
the descent sits there, where a human editor will find it, and `FIX.md` carries only the table
and the rules.

That split is worth stating because the first draft of this change did the opposite: it put
the whole story in `FIX.md` and added 1100 characters of prose to a file an agent loads on
every run — while arguing for concision. A review run already loads about 36 700 characters of
instructions before it looks at a diff, and `README.md` itself says instruction-following
degrades with the number of simultaneous constraints. Rationale in an agent-read file is not
free.

## Tests

None. `scripts/agent/test-agent-scripts.sh` passes (40 passed, 0 failed), which only shows the
shell scripts still work; **it does not execute anything in this diff.** The allocation is
instructions to a model, and the first evidence either way will be the next fix run's body
length and check count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
