### PR TITLE
feat(gst): report blocks whose element chain has stopped

### DIFF
--- a/backend/src/gst/pipeline/construction.rs
+++ b/backend/src/gst/pipeline/construction.rs
@@ -90,6 +90,8 @@ impl PipelineManager {
             cached_state: std::sync::Arc::new(std::sync::RwLock::new(PipelineState::Null)),
             qos_aggregator: QoSAggregator::new(),
             qos_broadcast_task: None,
+            block_health: std::sync::Arc::new(std::sync::RwLock::new(Vec::new())),
+            block_health_task: None,
             ptp_clock: None,
             ptp_stats: std::sync::Arc::new(std::sync::RwLock::new(None)),
             ntp_clock: None,

--- a/backend/src/gst/pipeline/health.rs
+++ b/backend/src/gst/pipeline/health.rs
@@ -49,14 +49,21 @@ fn first_stalled_pad(element: &gst::Element) -> Option<StalledPad> {
 
 /// Find the first paused pad task on `element` itself.
 ///
-/// Two kinds of legitimately paused task are excluded. An element held below
-/// `PLAYING` - a webrtcbin added for a newly connected WHEP consumer, say -
-/// pauses its tasks as part of that transition. And a pad that has seen EOS is
-/// finished by definition:
-/// `gst_base_src_loop` pauses its task on the way out for *every* reason
-/// including end of stream, and the element stays `PLAYING` afterwards, so a
-/// finite source that has played out would otherwise be reported as failed
-/// forever. The stall this looks for pushes no EOS.
+/// Three kinds of legitimately paused task are excluded.
+///
+/// An element held below `PLAYING` - a webrtcbin added for a newly connected
+/// WHEP consumer, say - pauses its tasks as part of that transition.
+///
+/// A pad that has seen EOS is finished by definition: `gst_base_src_loop` pauses
+/// its task on the way out for *every* reason including end of stream, and the
+/// element stays `PLAYING` afterwards, so a finite source that has played out
+/// would otherwise be reported as failed forever. The stall this looks for
+/// pushes no EOS.
+///
+/// An unlinked pad has no branch to report on. A `queue` feeding a block output
+/// that the flow leaves unconnected gets `not-linked` from its loop and parks
+/// the task there permanently - the vision mixer's `multiview_out` does exactly
+/// this whenever a flow uses only the program output.
 fn stalled_pad_on(element: &gst::Element) -> Option<StalledPad> {
     if element.current_state() != gst::State::Playing {
         return None;
@@ -67,6 +74,7 @@ fn stalled_pad_on(element: &gst::Element) -> Option<StalledPad> {
         .find(|pad| {
             pad.task_state() == gst::TaskState::Paused
                 && !pad.pad_flags().contains(gst::PadFlags::EOS)
+                && pad.peer().is_some()
         })
         .map(|pad| StalledPad {
             element: element.name().to_string(),
@@ -309,6 +317,46 @@ mod tests {
         flow
     }
 
+    /// videotestsrc -> tee, with one tee branch queued and left unconnected.
+    ///
+    /// Mirrors a block output the flow does not wire up - the vision mixer's
+    /// `multiview_out` is exactly this - where the queue's loop takes
+    /// `not-linked` and parks its task for good.
+    fn unwired_output_flow() -> Flow {
+        let mut flow = Flow::new("unwired output health test");
+        flow.elements = vec![
+            element(
+                "src",
+                "videotestsrc",
+                &[("is-live", PropertyValue::Bool(true))],
+            ),
+            element("split", "tee", &[]),
+            element("q_used", "queue", &[]),
+            element("sink", "fakesink", &[("sync", PropertyValue::Bool(false))]),
+            // Fed by the tee, going nowhere.
+            element("q_dangling", "queue", &[]),
+        ];
+        flow.links = vec![
+            Link {
+                from: "src".to_string(),
+                to: "split".to_string(),
+            },
+            Link {
+                from: "split".to_string(),
+                to: "q_used".to_string(),
+            },
+            Link {
+                from: "q_used".to_string(),
+                to: "sink".to_string(),
+            },
+            Link {
+                from: "split".to_string(),
+                to: "q_dangling".to_string(),
+            },
+        ];
+        flow
+    }
+
     /// videotestsrc with a fixed buffer count -> fakesink. Runs to EOS.
     fn finite_source_flow() -> Flow {
         let mut flow = Flow::new("eos health test");
@@ -336,6 +384,53 @@ mod tests {
             std::thread::sleep(Duration::from_millis(100));
         }
         condition()
+    }
+
+    /// A `queue` whose source pad is left unconnected takes `not-linked` from its
+    /// loop and parks the task while the element stays `PLAYING`. Blocks expose
+    /// optional outputs built this way, so reporting it would mark most flows
+    /// using them permanently failed.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn an_unwired_output_branch_is_not_reported_as_failed() {
+        gst::init().unwrap();
+
+        let mut manager = PipelineManager::new(
+            &unwired_output_flow(),
+            EventBroadcaster::default(),
+            &BlockRegistry::new("test_blocks.json"),
+            vec!["stun:stun.l.google.com:19302".to_string()],
+            "all".to_string(),
+            None,
+            std::path::PathBuf::from("./media"),
+            std::sync::Arc::new(std::sync::Mutex::new(HashMap::new())),
+        )
+        .expect("pipeline should build");
+
+        manager.start().expect("pipeline should start");
+        assert!(
+            wait_for(
+                || manager.get_state() == strom_types::PipelineState::Playing,
+                Duration::from_secs(10)
+            ),
+            "pipeline never reached Playing"
+        );
+
+        let went_failed = wait_for(
+            || {
+                manager
+                    .get_block_health()
+                    .iter()
+                    .any(|h| h.status == BlockHealthStatus::Failed)
+            },
+            HEALTH_POLL_INTERVAL * (CONFIRMATIONS_BEFORE_FAILED + 3),
+        );
+        assert!(
+            !went_failed,
+            "an unwired output branch must not read as failed: {:?}",
+            manager.get_block_health()
+        );
+
+        manager.stop().expect("pipeline should stop");
     }
 
     /// `gst_base_src_loop` pauses its pad task on the way out for every reason,

--- a/backend/src/gst/pipeline/health.rs
+++ b/backend/src/gst/pipeline/health.rs
@@ -41,9 +41,13 @@ fn first_stalled_pad(element: &gst::Element) -> Option<StalledPad> {
 
 /// Find the first paused pad task on `element` itself.
 ///
-/// Only elements that are themselves playing are considered. A sub-bin held in
-/// `PAUSED` inside a playing pipeline - a WebRTC session bin mid-setup, say -
-/// has paused pad tasks legitimately.
+/// Two kinds of legitimately paused task are excluded. An element held below
+/// `PLAYING` - a WebRTC session bin mid-setup, say - pauses its tasks as part of
+/// that transition. And a pad that has seen EOS is finished by definition:
+/// `gst_base_src_loop` pauses its task on the way out for *every* reason
+/// including end of stream, and the element stays `PLAYING` afterwards, so a
+/// finite source that has played out would otherwise be reported as failed
+/// forever. The stall this looks for pushes no EOS.
 fn stalled_pad_on(element: &gst::Element) -> Option<StalledPad> {
     if element.current_state() != gst::State::Playing {
         return None;
@@ -51,7 +55,10 @@ fn stalled_pad_on(element: &gst::Element) -> Option<StalledPad> {
     element
         .pads()
         .into_iter()
-        .find(|pad| pad.task_state() == gst::TaskState::Paused)
+        .find(|pad| {
+            pad.task_state() == gst::TaskState::Paused
+                && !pad.pad_flags().contains(gst::PadFlags::EOS)
+        })
         .map(|pad| StalledPad {
             element: element.name().to_string(),
             pad: pad.name().to_string(),
@@ -90,7 +97,7 @@ pub(crate) fn scan_block_health(elements: &HashMap<String, gst::Element>) -> Vec
         if let Some(stalled) = first_stalled_pad(element) {
             entry.status = BlockHealthStatus::Failed;
             entry.detail = Some(format!(
-                "pad task stopped on {}:{} - this branch is not passing data",
+                "pad task paused on {}:{} - this branch is not passing data",
                 stalled.element, stalled.pad
             ));
         }
@@ -101,6 +108,13 @@ pub(crate) fn scan_block_health(elements: &HashMap<String, gst::Element>) -> Vec
 
 /// How often the running pipeline is scanned for stalled pad tasks.
 const HEALTH_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// Consecutive scans a block must look stalled before it is reported.
+///
+/// Pad tasks are briefly paused for legitimate reasons - a flushing seek, a
+/// dynamic bin being linked in - so a single sample is not enough to call a
+/// block failed. Costs one extra poll interval of detection latency.
+const CONFIRMATIONS_BEFORE_FAILED: u32 = 2;
 
 impl super::PipelineManager {
     /// Current per-block health. Empty until the health task has run once.
@@ -129,6 +143,7 @@ impl super::PipelineManager {
         let task = tokio::spawn(async move {
             let mut interval = tokio::time::interval(HEALTH_POLL_INTERVAL);
             let mut failed: std::collections::HashSet<String> = std::collections::HashSet::new();
+            let mut strikes: HashMap<String, u32> = HashMap::new();
 
             loop {
                 interval.tick().await;
@@ -136,9 +151,8 @@ impl super::PipelineManager {
                 // Only meaningful while playing - a paused task is expected in
                 // every other state, including during startup and shutdown.
                 if *cached_state.read().unwrap() != strom_types::PipelineState::Playing {
-                    if !failed.is_empty() {
-                        failed.clear();
-                    }
+                    failed.clear();
+                    strikes.clear();
                     block_health.write().unwrap().clear();
                     continue;
                 }
@@ -151,7 +165,29 @@ impl super::PipelineManager {
                     continue;
                 }
 
-                let snapshot = scan_block_health(&elements);
+                let mut snapshot = scan_block_health(&elements);
+
+                // A block is only reported once it has looked stalled on
+                // CONFIRMATIONS_BEFORE_FAILED scans in a row. Downgrade the
+                // unconfirmed ones before anything observes the snapshot.
+                for health in &mut snapshot {
+                    if health.status.is_failed() {
+                        let count = strikes.entry(health.block_id.clone()).or_insert(0);
+                        *count += 1;
+                        if *count < CONFIRMATIONS_BEFORE_FAILED {
+                            health.status = BlockHealthStatus::Ok;
+                            health.detail = None;
+                        }
+                    } else {
+                        strikes.remove(&health.block_id);
+                    }
+                }
+
+                // Blocks whose elements have gone away drop out of the scan
+                // entirely; forget them rather than leaving a stale entry that
+                // no later iteration can clear.
+                failed.retain(|block_id| snapshot.iter().any(|h| &h.block_id == block_id));
+                strikes.retain(|block_id, _| snapshot.iter().any(|h| &h.block_id == block_id));
 
                 for health in &snapshot {
                     let was_failed = failed.contains(&health.block_id);
@@ -264,6 +300,24 @@ mod tests {
         flow
     }
 
+    /// videotestsrc with a fixed buffer count -> fakesink. Runs to EOS.
+    fn finite_source_flow() -> Flow {
+        let mut flow = Flow::new("eos health test");
+        flow.elements = vec![
+            element(
+                "src",
+                "videotestsrc",
+                &[("num-buffers", PropertyValue::Int(5))],
+            ),
+            element("sink", "fakesink", &[("sync", PropertyValue::Bool(false))]),
+        ];
+        flow.links = vec![Link {
+            from: "src".to_string(),
+            to: "sink".to_string(),
+        }];
+        flow
+    }
+
     fn wait_for(condition: impl Fn() -> bool, timeout: Duration) -> bool {
         let start = Instant::now();
         while start.elapsed() < timeout {
@@ -273,6 +327,64 @@ mod tests {
             std::thread::sleep(Duration::from_millis(100));
         }
         condition()
+    }
+
+    /// `gst_base_src_loop` pauses its pad task on the way out for every reason,
+    /// end of stream included, and leaves the element in `PLAYING`. Playing a
+    /// finite source to completion must not read as a failure.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_source_that_reaches_eos_is_not_reported_as_failed() {
+        gst::init().unwrap();
+
+        let mut manager = PipelineManager::new(
+            &finite_source_flow(),
+            EventBroadcaster::default(),
+            &BlockRegistry::new("test_blocks.json"),
+            vec!["stun:stun.l.google.com:19302".to_string()],
+            "all".to_string(),
+            None,
+            std::path::PathBuf::from("./media"),
+            std::sync::Arc::new(std::sync::Mutex::new(HashMap::new())),
+        )
+        .expect("pipeline should build");
+
+        manager.start().expect("pipeline should start");
+
+        // Let the source play out and the scan run several times over the
+        // drained pipeline.
+        assert!(
+            wait_for(
+                || manager
+                    .elements
+                    .get("src")
+                    .map(|e| e.static_pad("src").unwrap().pad_flags())
+                    .is_some_and(|f| f.contains(gst::PadFlags::EOS)),
+                Duration::from_secs(15)
+            ),
+            "source never reached EOS"
+        );
+        // Watch across several scans - long enough that a block would clear the
+        // confirmation threshold - and assert it never flips to failed.
+        let went_failed = wait_for(
+            || {
+                manager
+                    .get_block_health()
+                    .iter()
+                    .any(|h| h.status == BlockHealthStatus::Failed)
+            },
+            HEALTH_POLL_INTERVAL * (CONFIRMATIONS_BEFORE_FAILED + 3),
+        );
+        assert!(
+            !went_failed,
+            "a drained finite source must not read as failed: {:?}",
+            manager.get_block_health()
+        );
+        assert!(
+            !manager.get_block_health().is_empty(),
+            "health scan never produced a snapshot"
+        );
+
+        manager.stop().expect("pipeline should stop");
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/backend/src/gst/pipeline/health.rs
+++ b/backend/src/gst/pipeline/health.rs
@@ -11,6 +11,14 @@
 //! `GstBaseSrc` is the exception: it posts a flow error before pausing, so
 //! source-side failures already reach the bus handler.
 //!
+//! Scope: the scan reaches the flow pipeline's own elements and the bins beneath
+//! them, and nothing else. Blocks that run an isolated `gst::Pipeline` of their
+//! own - WHIP ingest sessions, a Media Player's decode chain - are siblings of
+//! that pipeline rather than children of it, so `iterate_recurse` never enters
+//! them. An `Ok` here therefore means "no stalled pad task among this flow
+//! pipeline's elements", not "this flow is passing data". Sinks that live in the
+//! flow pipeline, `whepserversink` included, are covered.
+//!
 //! A paused task on an element that is itself `PLAYING` is always wrong, so
 //! that is the signal used here. `gst_pad_get_task_state()` returns `Stopped`
 //! both for a pad whose task was stopped and for a pad that never had one, so
@@ -42,8 +50,9 @@ fn first_stalled_pad(element: &gst::Element) -> Option<StalledPad> {
 /// Find the first paused pad task on `element` itself.
 ///
 /// Two kinds of legitimately paused task are excluded. An element held below
-/// `PLAYING` - a WebRTC session bin mid-setup, say - pauses its tasks as part of
-/// that transition. And a pad that has seen EOS is finished by definition:
+/// `PLAYING` - a webrtcbin added for a newly connected WHEP consumer, say -
+/// pauses its tasks as part of that transition. And a pad that has seen EOS is
+/// finished by definition:
 /// `gst_base_src_loop` pauses its task on the way out for *every* reason
 /// including end of stream, and the element stays `PLAYING` afterwards, so a
 /// finite source that has played out would otherwise be reported as failed

--- a/backend/src/gst/pipeline/health.rs
+++ b/backend/src/gst/pipeline/health.rs
@@ -1,0 +1,368 @@
+//! Detection of stalled pad tasks in a running pipeline.
+//!
+//! A pad task is the thread that drives data out of a pad. Elements pause their
+//! own task when a downstream push fails with a non-fatal flow return such as
+//! `not-negotiated` - video encoders do this, and so does `GstAggregator`,
+//! which additionally marks all its sink pads flushing, stalling everything
+//! upstream of it. Neither posts to the bus, and pausing a task is not a state
+//! change, so the pipeline and every element in it stay `PLAYING` while that
+//! branch carries nothing.
+//!
+//! `GstBaseSrc` is the exception: it posts a flow error before pausing, so
+//! source-side failures already reach the bus handler.
+//!
+//! A paused task on an element that is itself `PLAYING` is always wrong, so
+//! that is the signal used here. `gst_pad_get_task_state()` returns `Stopped`
+//! both for a pad whose task was stopped and for a pad that never had one, so
+//! `Stopped` cannot be told apart from the common case and is not reported.
+
+use gstreamer as gst;
+use gstreamer::prelude::*;
+use std::collections::{BTreeMap, HashMap};
+use strom_types::flow::{BlockHealth, BlockHealthStatus};
+
+/// A pad whose task has been paused while the pipeline is playing.
+struct StalledPad {
+    element: String,
+    pad: String,
+}
+
+/// Find the first paused pad task on `element`, and on its children if it is a bin.
+fn first_stalled_pad(element: &gst::Element) -> Option<StalledPad> {
+    if let Some(stalled) = stalled_pad_on(element) {
+        return Some(stalled);
+    }
+    let bin = element.downcast_ref::<gst::Bin>()?;
+    bin.iterate_recurse()
+        .into_iter()
+        .flatten()
+        .find_map(|child| stalled_pad_on(&child))
+}
+
+/// Find the first paused pad task on `element` itself.
+///
+/// Only elements that are themselves playing are considered. A sub-bin held in
+/// `PAUSED` inside a playing pipeline - a WebRTC session bin mid-setup, say -
+/// has paused pad tasks legitimately.
+fn stalled_pad_on(element: &gst::Element) -> Option<StalledPad> {
+    if element.current_state() != gst::State::Playing {
+        return None;
+    }
+    element
+        .pads()
+        .into_iter()
+        .find(|pad| pad.task_state() == gst::TaskState::Paused)
+        .map(|pad| StalledPad {
+            element: element.name().to_string(),
+            pad: pad.name().to_string(),
+        })
+}
+
+/// Block instance ID owning `element_id`.
+///
+/// Block elements are namespaced `block_id:internal_id` by `BlockBuildResult`.
+/// A standalone element has no prefix and is reported under its own ID so that
+/// a stall outside a block is not silently dropped.
+fn owning_block(element_id: &str) -> &str {
+    element_id.split(':').next().unwrap_or(element_id)
+}
+
+/// Report health for every block with at least one element in `elements`.
+///
+/// Call only while the pipeline is playing; a paused task is expected in any
+/// other pipeline state.
+pub(crate) fn scan_block_health(elements: &HashMap<String, gst::Element>) -> Vec<BlockHealth> {
+    let mut by_block: BTreeMap<&str, BlockHealth> = BTreeMap::new();
+
+    for (element_id, element) in elements {
+        let block_id = owning_block(element_id);
+        let entry = by_block.entry(block_id).or_insert_with(|| BlockHealth {
+            block_id: block_id.to_string(),
+            status: BlockHealthStatus::Ok,
+            detail: None,
+        });
+
+        // A block is failed if any of its elements has a stalled pad; the first
+        // one found names the failure.
+        if entry.status.is_failed() {
+            continue;
+        }
+        if let Some(stalled) = first_stalled_pad(element) {
+            entry.status = BlockHealthStatus::Failed;
+            entry.detail = Some(format!(
+                "pad task stopped on {}:{} - this branch is not passing data",
+                stalled.element, stalled.pad
+            ));
+        }
+    }
+
+    by_block.into_values().collect()
+}
+
+/// How often the running pipeline is scanned for stalled pad tasks.
+const HEALTH_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);
+
+impl super::PipelineManager {
+    /// Current per-block health. Empty until the health task has run once.
+    pub fn get_block_health(&self) -> Vec<BlockHealth> {
+        self.block_health.read().unwrap().clone()
+    }
+
+    /// Start the periodic scan for stalled pad tasks.
+    pub(super) fn start_block_health_task(&mut self) {
+        self.stop_block_health_task();
+
+        // WeakRef, not a clone: a task holding strong element references would
+        // keep the pipeline alive past drop.
+        let weak_elements: Vec<(String, gst::glib::WeakRef<gst::Element>)> = self
+            .elements
+            .iter()
+            .map(|(id, element)| (id.clone(), element.downgrade()))
+            .collect();
+
+        let cached_state = self.cached_state.clone();
+        let block_health = self.block_health.clone();
+        let events = self.events.clone();
+        let flow_id = self.flow_id;
+        let flow_name = self.flow_name.clone();
+
+        let task = tokio::spawn(async move {
+            let mut interval = tokio::time::interval(HEALTH_POLL_INTERVAL);
+            let mut failed: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+            loop {
+                interval.tick().await;
+
+                // Only meaningful while playing - a paused task is expected in
+                // every other state, including during startup and shutdown.
+                if *cached_state.read().unwrap() != strom_types::PipelineState::Playing {
+                    if !failed.is_empty() {
+                        failed.clear();
+                    }
+                    block_health.write().unwrap().clear();
+                    continue;
+                }
+
+                let elements: HashMap<String, gst::Element> = weak_elements
+                    .iter()
+                    .filter_map(|(id, weak)| weak.upgrade().map(|el| (id.clone(), el)))
+                    .collect();
+                if elements.is_empty() {
+                    continue;
+                }
+
+                let snapshot = scan_block_health(&elements);
+
+                for health in &snapshot {
+                    let was_failed = failed.contains(&health.block_id);
+                    match (health.status.is_failed(), was_failed) {
+                        (true, false) => {
+                            failed.insert(health.block_id.clone());
+                            tracing::error!(
+                                "Block '{}' in flow '{}' has stopped: {}. The pipeline still reports Playing",
+                                health.block_id,
+                                flow_name,
+                                health.detail.as_deref().unwrap_or("no detail")
+                            );
+                            events.broadcast(strom_types::StromEvent::BlockHealthChanged {
+                                flow_id,
+                                block_id: health.block_id.clone(),
+                                status: health.status,
+                                detail: health.detail.clone(),
+                            });
+                        }
+                        (false, true) => {
+                            failed.remove(&health.block_id);
+                            tracing::info!(
+                                "Block '{}' in flow '{}' resumed passing data",
+                                health.block_id,
+                                flow_name
+                            );
+                            events.broadcast(strom_types::StromEvent::BlockHealthChanged {
+                                flow_id,
+                                block_id: health.block_id.clone(),
+                                status: health.status,
+                                detail: None,
+                            });
+                        }
+                        _ => {}
+                    }
+                }
+
+                *block_health.write().unwrap() = snapshot;
+            }
+        });
+
+        self.block_health_task = Some(task);
+    }
+
+    /// Stop the periodic health scan and drop the last snapshot.
+    pub(super) fn stop_block_health_task(&mut self) {
+        if let Some(task) = self.block_health_task.take() {
+            task.abort();
+        }
+        self.block_health.write().unwrap().clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::blocks::BlockRegistry;
+    use crate::events::EventBroadcaster;
+    use crate::gst::pipeline::PipelineManager;
+    use std::time::{Duration, Instant};
+    use strom_types::{Element, Flow, Link, PropertyValue};
+
+    #[test]
+    fn block_elements_are_attributed_to_their_block() {
+        assert_eq!(owning_block("whep:videoenc"), "whep");
+        assert_eq!(owning_block("whep:sink:inner"), "whep");
+        assert_eq!(owning_block("standalone_element"), "standalone_element");
+    }
+
+    fn element(id: &str, element_type: &str, props: &[(&str, PropertyValue)]) -> Element {
+        Element {
+            id: id.to_string(),
+            element_type: element_type.to_string(),
+            properties: props
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.clone()))
+                .collect(),
+            pad_properties: HashMap::new(),
+            position: (0.0, 0.0),
+        }
+    }
+
+    /// videotestsrc -> compositor -> capsfilter -> fakesink, as a real flow.
+    fn stall_flow() -> Flow {
+        let mut flow = Flow::new("block health test");
+        flow.elements = vec![
+            element(
+                "src",
+                "videotestsrc",
+                &[("is-live", PropertyValue::Bool(true))],
+            ),
+            element("comp", "compositor", &[]),
+            element("filter", "capsfilter", &[]),
+            element("sink", "fakesink", &[("sync", PropertyValue::Bool(false))]),
+        ];
+        flow.links = vec![
+            Link {
+                from: "src".to_string(),
+                to: "comp".to_string(),
+            },
+            Link {
+                from: "comp".to_string(),
+                to: "filter".to_string(),
+            },
+            Link {
+                from: "filter".to_string(),
+                to: "sink".to_string(),
+            },
+        ];
+        flow
+    }
+
+    fn wait_for(condition: impl Fn() -> bool, timeout: Duration) -> bool {
+        let start = Instant::now();
+        while start.elapsed() < timeout {
+            if condition() {
+                return true;
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+        condition()
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stalled_branch_is_reported_while_the_pipeline_still_says_playing() {
+        gst::init().unwrap();
+
+        let mut manager = PipelineManager::new(
+            &stall_flow(),
+            EventBroadcaster::default(),
+            &BlockRegistry::new("test_blocks.json"),
+            vec!["stun:stun.l.google.com:19302".to_string()],
+            "all".to_string(),
+            None,
+            std::path::PathBuf::from("./media"),
+            std::sync::Arc::new(std::sync::Mutex::new(HashMap::new())),
+        )
+        .expect("pipeline should build");
+
+        manager.start().expect("pipeline should start");
+        assert!(
+            wait_for(
+                || manager.get_state() == strom_types::PipelineState::Playing,
+                Duration::from_secs(10)
+            ),
+            "pipeline never reached Playing"
+        );
+        assert!(
+            wait_for(
+                || !manager.get_block_health().is_empty(),
+                Duration::from_secs(10)
+            ),
+            "health scan never produced a snapshot"
+        );
+        assert!(
+            manager
+                .get_block_health()
+                .iter()
+                .all(|h| h.status == BlockHealthStatus::Ok),
+            "a healthy pipeline should report no failures: {:?}",
+            manager.get_block_health()
+        );
+
+        // Retighten the capsfilter to a format the compositor cannot produce.
+        // The next push fails negotiation and the compositor pauses its source
+        // pad task without posting anything to the bus.
+        manager
+            .elements
+            .get("filter")
+            .expect("capsfilter should exist")
+            .set_property(
+                "caps",
+                gst::Caps::builder("video/x-bayer")
+                    .field("format", "bggr")
+                    .build(),
+            );
+
+        assert!(
+            wait_for(
+                || manager
+                    .get_block_health()
+                    .iter()
+                    .any(|h| h.block_id == "comp" && h.status == BlockHealthStatus::Failed),
+                Duration::from_secs(15)
+            ),
+            "stalled compositor was not reported: {:?}",
+            manager.get_block_health()
+        );
+
+        // The failure has to be visible without the pipeline state changing,
+        // which is the case the scan exists for.
+        assert_eq!(manager.get_state(), strom_types::PipelineState::Playing);
+
+        // An element deliberately held below Playing has paused pad tasks for a
+        // legitimate reason and must not be reported. Upstream elements that
+        // are still Playing and now blocked behind it are a real stall and stay
+        // reported, so only the paused element itself is checked here.
+        let compositor = manager.elements.get("comp").unwrap().clone();
+        compositor.set_state(gst::State::Paused).unwrap();
+        assert!(
+            wait_for(
+                || manager
+                    .get_block_health()
+                    .iter()
+                    .any(|h| h.block_id == "comp" && h.status == BlockHealthStatus::Ok),
+                Duration::from_secs(15)
+            ),
+            "a paused element should not be reported as failed: {:?}",
+            manager.get_block_health()
+        );
+
+        manager.stop().expect("pipeline should stop");
+    }
+}

--- a/backend/src/gst/pipeline/lifecycle.rs
+++ b/backend/src/gst/pipeline/lifecycle.rs
@@ -47,6 +47,9 @@ impl PipelineManager {
         self.start_qos_broadcast_task();
         info!("QoS stats task started");
 
+        // Start the scan for stalled pad tasks
+        self.start_block_health_task();
+
         // Configure clock before starting
         info!(
             "Configuring clock (type: {:?})...",
@@ -202,6 +205,7 @@ impl PipelineManager {
 
         // Stop QoS broadcast task
         self.stop_qos_broadcast_task();
+        self.stop_block_health_task();
 
         // Stop thumbnail deactivation task
         if let Some(task) = self.thumbnail_deactivation_task.take() {

--- a/backend/src/gst/pipeline/mod.rs
+++ b/backend/src/gst/pipeline/mod.rs
@@ -3,6 +3,7 @@
 mod bus;
 mod construction;
 pub(crate) mod effects;
+mod health;
 mod lifecycle;
 mod linking;
 mod properties;
@@ -195,6 +196,10 @@ pub struct PipelineManager {
     qos_aggregator: QoSAggregator,
     /// Handle for the periodic QoS stats broadcast task
     qos_broadcast_task: Option<tokio::task::JoinHandle<()>>,
+    /// Latest per-block health snapshot from the stalled-pad-task scan
+    block_health: std::sync::Arc<std::sync::RwLock<Vec<strom_types::flow::BlockHealth>>>,
+    /// Handle for the periodic block health scan task
+    block_health_task: Option<tokio::task::JoinHandle<()>>,
     /// PTP clock reference (stored for querying grandmaster/master info)
     ptp_clock: Option<gst_net::PtpClock>,
     /// PTP statistics (updated by statistics callback)
@@ -244,6 +249,7 @@ impl Drop for PipelineManager {
         self.probe_manager.stop_broadcast_task();
         self.probe_manager.deactivate_all();
         self.stop_qos_broadcast_task();
+        self.stop_block_health_task();
 
         // Ensure pipeline is in Null state before releasing references.
         // If stop() was already called this is a no-op.

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -609,9 +609,11 @@ impl AppState {
                     }
                     flow.properties.ntp_info = pipeline.get_ntp_info();
                     flow.properties.thread_priority_status = pipeline.get_thread_priority_status();
+                    flow.block_health = pipeline.get_block_health();
                 } else {
                     // Clear runtime-only status when no pipeline is running
                     flow.set_gst_state(None);
+                    flow.block_health.clear();
                     flow.properties.thread_priority_status = None;
                     flow.properties.clock_sync_status = None;
                     flow.properties.ptp_info = None;
@@ -643,9 +645,11 @@ impl AppState {
                 }
                 flow.properties.ntp_info = pipeline.get_ntp_info();
                 flow.properties.thread_priority_status = pipeline.get_thread_priority_status();
+                flow.block_health = pipeline.get_block_health();
             } else {
                 // Clear runtime-only status when no pipeline is running
                 flow.set_gst_state(None);
+                flow.block_health.clear();
                 flow.properties.thread_priority_status = None;
                 flow.properties.clock_sync_status = None;
                 flow.properties.ptp_info = None;

--- a/backend/tests/block_health_test.rs
+++ b/backend/tests/block_health_test.rs
@@ -1,0 +1,146 @@
+//! A pipeline branch can stop dead while the pipeline still reports Playing.
+//!
+//! When a downstream push fails with `not-negotiated`, `GstAggregator` marks
+//! its sink pads flushing and pauses its source pad task. Nothing is posted to
+//! the bus and no element changes state, so the failure is invisible in
+//! `gst_state`. These tests pin both halves: that the stall is silent, and
+//! that the block health scan reports it.
+
+use gstreamer as gst;
+use gstreamer::prelude::*;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+fn init() {
+    gst::init().unwrap();
+}
+
+/// Poll `condition` until true or `timeout` elapses. Returns whether it held.
+fn wait_for(condition: impl Fn() -> bool, timeout: Duration) -> bool {
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        if condition() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    condition()
+}
+
+/// videotestsrc -> compositor -> capsfilter -> fakesink.
+///
+/// The capsfilter is the lever: retightening it to a caps the compositor
+/// cannot produce makes the next push fail negotiation.
+struct StallRig {
+    pipeline: gst::Pipeline,
+    compositor: gst::Element,
+    capsfilter: gst::Element,
+    bus_errors: Arc<Mutex<Vec<String>>>,
+}
+
+impl StallRig {
+    fn build() -> Self {
+        let pipeline = gst::Pipeline::new();
+        let src = gst::ElementFactory::make("videotestsrc")
+            .property("is-live", true)
+            .build()
+            .unwrap();
+        let compositor = gst::ElementFactory::make("compositor").build().unwrap();
+        let capsfilter = gst::ElementFactory::make("capsfilter")
+            .property(
+                "caps",
+                gst::Caps::builder("video/x-raw")
+                    .field("width", 320i32)
+                    .field("height", 240i32)
+                    .build(),
+            )
+            .build()
+            .unwrap();
+        let sink = gst::ElementFactory::make("fakesink")
+            .property("sync", false)
+            .build()
+            .unwrap();
+
+        pipeline
+            .add_many([&src, &compositor, &capsfilter, &sink])
+            .unwrap();
+        src.link(&compositor).unwrap();
+        gst::Element::link_many([&compositor, &capsfilter, &sink]).unwrap();
+
+        let bus_errors = Arc::new(Mutex::new(Vec::new()));
+        let collected = bus_errors.clone();
+        let bus = pipeline.bus().unwrap();
+        bus.add_signal_watch();
+        bus.connect_message(Some("error"), move |_, msg| {
+            if let gst::MessageView::Error(err) = msg.view() {
+                collected.lock().unwrap().push(err.error().to_string());
+            }
+        });
+
+        Self {
+            pipeline,
+            compositor,
+            capsfilter,
+            bus_errors,
+        }
+    }
+
+    fn compositor_task_state(&self) -> gst::TaskState {
+        self.compositor.static_pad("src").unwrap().task_state()
+    }
+
+    /// Force the next compositor push to fail negotiation.
+    fn break_negotiation(&self) {
+        self.capsfilter.set_property(
+            "caps",
+            gst::Caps::builder("video/x-bayer")
+                .field("format", "bggr")
+                .build(),
+        );
+    }
+}
+
+impl Drop for StallRig {
+    fn drop(&mut self) {
+        let _ = self.pipeline.set_state(gst::State::Null);
+    }
+}
+
+#[test]
+fn aggregator_stall_is_silent_and_leaves_pipeline_playing() {
+    init();
+    let rig = StallRig::build();
+    rig.pipeline.set_state(gst::State::Playing).unwrap();
+
+    // videotestsrc is live, so the transition is async. Block until it settles:
+    // the compositor task starts before the pipeline finishes reaching Playing,
+    // so waiting on the task state alone races the state change.
+    let (res, current, _) = rig.pipeline.state(gst::ClockTime::from_seconds(10));
+    assert_eq!(res, Ok(gst::StateChangeSuccess::Success));
+    assert_eq!(current, gst::State::Playing);
+    assert_eq!(rig.compositor_task_state(), gst::TaskState::Started);
+
+    rig.break_negotiation();
+
+    assert!(
+        wait_for(
+            || rig.compositor_task_state() == gst::TaskState::Paused,
+            Duration::from_secs(10)
+        ),
+        "compositor task never stalled after negotiation was broken"
+    );
+
+    // The whole point: the stall reports nothing where a caller would look.
+    let (_, current, _) = rig.pipeline.state(gst::ClockTime::from_seconds(1));
+    assert_eq!(
+        current,
+        gst::State::Playing,
+        "pipeline should still report Playing while the branch is dead"
+    );
+    let errors = rig.bus_errors.lock().unwrap();
+    assert!(
+        errors.is_empty(),
+        "expected no bus error, got: {:?}",
+        errors
+    );
+}

--- a/frontend/src/app/rendering.rs
+++ b/frontend/src/app/rendering.rs
@@ -8,6 +8,9 @@ use strom_types::Flow;
 
 use super::*;
 use super::{FocusTarget, ThemePreference};
+
+/// Colour for a block that has stopped passing data.
+const FAILED_BLOCK_COLOR: Color32 = Color32::from_rgb(220, 60, 60);
 impl StromApp {
     /// Render the top toolbar.
     pub(super) fn render_toolbar(&mut self, ui: &mut egui::Ui) {
@@ -762,14 +765,42 @@ impl StromApp {
                                 );
                                 child_ui.add_space(4.0);
 
-                                // Show running state icon
+                                // Show running state icon. A flow with a failed
+                                // block is not running even though GStreamer
+                                // still reports Playing, so it must not read as
+                                // healthy here.
+                                let failed_blocks: Vec<_> = flow.failed_blocks().collect();
                                 let state_icon = if flow.running { "▶" } else { "■" };
-                                let state_color = if flow.running {
+                                let state_color = if !failed_blocks.is_empty() {
+                                    FAILED_BLOCK_COLOR
+                                } else if flow.running {
                                     Color32::from_rgb(0, 200, 0)
                                 } else {
                                     Color32::GRAY
                                 };
                                 child_ui.colored_label(state_color, state_icon);
+
+                                if !failed_blocks.is_empty() {
+                                    child_ui
+                                        .colored_label(FAILED_BLOCK_COLOR, "⚠")
+                                        .on_hover_ui(|ui| {
+                                            ui.label(
+                                                egui::RichText::new("Stopped passing data")
+                                                    .strong(),
+                                            );
+                                            ui.separator();
+                                            for health in &failed_blocks {
+                                                ui.label(format!(
+                                                    "{}: {}",
+                                                    health.block_id,
+                                                    health
+                                                        .detail
+                                                        .as_deref()
+                                                        .unwrap_or("no detail")
+                                                ));
+                                            }
+                                        });
+                                }
 
                                 // Show QoS indicator if there are issues - make it clickable to open log
                                 if let Some(qos_health) = self.qos_stats.get_flow_health(&flow.id) {
@@ -898,12 +929,24 @@ impl StromApp {
                                     }
 
                                     ui.add_space(5.0);
-                                    let state_text = if flow.running {
+                                    let state_text = if flow.has_failed_block() {
+                                        "Failed"
+                                    } else if flow.running {
                                         "Running"
                                     } else {
                                         "Stopped"
                                     };
                                     ui.label(format!("State: {}", state_text));
+                                    for health in flow.failed_blocks() {
+                                        ui.colored_label(
+                                            FAILED_BLOCK_COLOR,
+                                            format!(
+                                                "{} stopped: {}",
+                                                health.block_id,
+                                                health.detail.as_deref().unwrap_or("no detail")
+                                            ),
+                                        );
+                                    }
 
                                     // Show timestamps
                                     if flow.properties.started_at.is_some()

--- a/frontend/src/app/update.rs
+++ b/frontend/src/app/update.rs
@@ -395,6 +395,46 @@ impl eframe::App for StromApp {
                                 }
                             });
                         }
+                        StromEvent::BlockHealthChanged {
+                            flow_id,
+                            block_id,
+                            status,
+                            detail,
+                        } => {
+                            // block_health rides on the Flow payload, so the
+                            // indicator only updates if the flow is refetched.
+                            match status {
+                                strom_types::BlockHealthStatus::Failed => tracing::error!(
+                                    "Block {} in flow {} stopped passing data: {}",
+                                    block_id,
+                                    flow_id,
+                                    detail.as_deref().unwrap_or("no detail")
+                                ),
+                                strom_types::BlockHealthStatus::Ok => {
+                                    tracing::info!("Block {} in flow {} resumed", block_id, flow_id)
+                                }
+                            }
+                            let api = self.api.clone();
+                            let tx = self.channels.sender();
+                            let ctx = ui.ctx().clone();
+
+                            spawn_task(async move {
+                                match api.get_flow(flow_id).await {
+                                    Ok(flow) => {
+                                        let _ = tx.send(AppMessage::FlowFetched(Box::new(flow)));
+                                        ctx.request_repaint();
+                                    }
+                                    Err(e) => {
+                                        tracing::error!(
+                                            "Failed to fetch flow after block health change: {}",
+                                            e
+                                        );
+                                        let _ = tx.send(AppMessage::RefreshNeeded);
+                                        ctx.request_repaint();
+                                    }
+                                }
+                            });
+                        }
                         StromEvent::FlowUpdated { flow_id } => {
                             // For updates, fetch the specific flow to update it in-place
                             tracing::info!("Flow {} updated, fetching updated flow", flow_id);

--- a/openapi.json
+++ b/openapi.json
@@ -4907,6 +4907,39 @@
           }
         }
       },
+      "BlockHealth": {
+        "type": "object",
+        "description": "Runtime health of one block in a running flow.",
+        "required": [
+          "block_id",
+          "status"
+        ],
+        "properties": {
+          "block_id": {
+            "type": "string",
+            "description": "Block instance ID this health report belongs to."
+          },
+          "detail": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Human-readable detail naming the element and pad whose task stopped.\n`None` when the block is healthy."
+          },
+          "status": {
+            "$ref": "#/components/schemas/BlockHealthStatus",
+            "description": "Whether the block's element chain is running or has stopped."
+          }
+        }
+      },
+      "BlockHealthStatus": {
+        "type": "string",
+        "description": "Health of a single block's element chain while the flow is running.\n\nPausing a pad task is not a state change: the pipeline and every element in\nit stay `PLAYING` while that branch stops passing data, so the failure does\nnot show up in the flow's `gst_state`.",
+        "enum": [
+          "ok",
+          "failed"
+        ]
+      },
       "BlockInstance": {
         "type": "object",
         "description": "Block instance in a flow",
@@ -5991,6 +6024,13 @@
           "name"
         ],
         "properties": {
+          "block_health": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BlockHealth"
+            },
+            "description": "Per-block runtime health. Populated only while a pipeline is running;\nempty otherwise. An entry with a failed status means that block has\nstopped passing data even though `gst_state` is still `Playing`."
+          },
           "blocks": {
             "type": "array",
             "items": {
@@ -9553,6 +9593,52 @@
                 "type": "string",
                 "enum": [
                   "SubscriptionStatusChanged"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "A block's element chain stopped passing data, or resumed.\n\nEmitted only on a change of status, not on every health poll.",
+            "required": [
+              "data",
+              "type"
+            ],
+            "properties": {
+              "data": {
+                "type": "object",
+                "description": "A block's element chain stopped passing data, or resumed.\n\nEmitted only on a change of status, not on every health poll.",
+                "required": [
+                  "flow_id",
+                  "block_id",
+                  "status"
+                ],
+                "properties": {
+                  "block_id": {
+                    "type": "string",
+                    "description": "Block instance ID, or element ID for a standalone element"
+                  },
+                  "detail": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Element and pad whose task stopped; None when the block recovered"
+                  },
+                  "flow_id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "status": {
+                    "$ref": "#/components/schemas/BlockHealthStatus",
+                    "description": "Whether the block is passing data or has stopped"
+                  }
+                }
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "BlockHealthChanged"
                 ]
               }
             }

--- a/types/src/events.rs
+++ b/types/src/events.rs
@@ -1,6 +1,7 @@
 //! Events for real-time updates across clients.
 
 use crate::element::PropertyValue;
+use crate::flow::BlockHealthStatus;
 use crate::system_monitor::SystemStats;
 use crate::thread_stats::ThreadStats;
 use crate::FlowId;
@@ -182,6 +183,19 @@ pub enum StromEvent {
         source_flow_id: FlowId,
         output_name: String,
         connected: bool,
+    },
+    /// A block's element chain stopped passing data, or resumed.
+    ///
+    /// Emitted only on a change of status, not on every health poll.
+    BlockHealthChanged {
+        #[cfg_attr(feature = "openapi", schema(value_type = String, format = Uuid))]
+        flow_id: FlowId,
+        /// Block instance ID, or element ID for a standalone element
+        block_id: String,
+        /// Whether the block is passing data or has stopped
+        status: BlockHealthStatus,
+        /// Element and pad whose task stopped; None when the block recovered
+        detail: Option<String>,
     },
     /// Quality of Service statistics (aggregated buffer drop info)
     QoSStats {
@@ -541,6 +555,22 @@ impl StromEvent {
             StromEvent::ThreadStats(stats) => {
                 format!("Thread stats: {} active threads", stats.threads.len())
             }
+            StromEvent::BlockHealthChanged {
+                flow_id,
+                block_id,
+                status,
+                detail,
+            } => match status {
+                BlockHealthStatus::Failed => format!(
+                    "Block {} in flow {} stopped passing data: {}",
+                    block_id,
+                    flow_id,
+                    detail.as_deref().unwrap_or("no detail")
+                ),
+                BlockHealthStatus::Ok => {
+                    format!("Block {} in flow {} resumed", block_id, flow_id)
+                }
+            },
             StromEvent::QoSStats {
                 flow_id,
                 block_id,

--- a/types/src/flow.rs
+++ b/types/src/flow.rs
@@ -419,6 +419,11 @@ pub struct Flow {
     /// Prefer [`running`](Self::running) for logic and display.
     #[serde(default)]
     pub gst_state: Option<PipelineState>,
+    /// Per-block runtime health. Populated only while a pipeline is running;
+    /// empty otherwise. An entry with a failed status means that block has
+    /// stopped passing data even though `gst_state` is still `Playing`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub block_health: Vec<BlockHealth>,
     /// Flow configuration properties
     #[serde(default)]
     pub properties: FlowProperties,
@@ -435,6 +440,7 @@ impl Flow {
             links: Vec::new(),
             running: false,
             gst_state: Some(PipelineState::Null),
+            block_health: Vec::new(),
             properties: FlowProperties::default(),
         }
     }
@@ -449,6 +455,7 @@ impl Flow {
             links: Vec::new(),
             running: false,
             gst_state: Some(PipelineState::Null),
+            block_health: Vec::new(),
             properties: FlowProperties::default(),
         }
     }
@@ -458,6 +465,57 @@ impl Flow {
         self.running = state.is_some_and(|s| s.is_active());
         self.gst_state = state;
     }
+
+    /// Blocks whose element chain has stopped passing data.
+    pub fn failed_blocks(&self) -> impl Iterator<Item = &BlockHealth> {
+        self.block_health.iter().filter(|h| h.status.is_failed())
+    }
+
+    /// Whether any block in this flow has failed.
+    ///
+    /// `running` only reports that the pipeline reached `Playing`; it stays
+    /// `true` when a block underneath has stopped. Callers deciding whether a
+    /// flow is actually working need both.
+    pub fn has_failed_block(&self) -> bool {
+        self.failed_blocks().next().is_some()
+    }
+}
+
+/// Health of a single block's element chain while the flow is running.
+///
+/// Pausing a pad task is not a state change: the pipeline and every element in
+/// it stay `PLAYING` while that branch stops passing data, so the failure does
+/// not show up in the flow's `gst_state`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[serde(rename_all = "lowercase")]
+pub enum BlockHealthStatus {
+    /// No stopped pad task was found in this block's element chain.
+    Ok,
+    /// A pad task in this block's element chain has stopped. The block is not
+    /// passing data, regardless of what the pipeline state says.
+    Failed,
+}
+
+impl BlockHealthStatus {
+    /// Whether this status means the block has failed.
+    pub fn is_failed(&self) -> bool {
+        matches!(self, BlockHealthStatus::Failed)
+    }
+}
+
+/// Runtime health of one block in a running flow.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct BlockHealth {
+    /// Block instance ID this health report belongs to.
+    pub block_id: String,
+    /// Whether the block's element chain is running or has stopped.
+    pub status: BlockHealthStatus,
+    /// Human-readable detail naming the element and pad whose task stopped.
+    /// `None` when the block is healthy.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
 }
 
 #[cfg(test)]

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -47,7 +47,9 @@ pub use block::{
 };
 pub use element::{Element, ElementId, Link, MediaType, PropertyValue};
 pub use events::StromEvent;
-pub use flow::{CpuAffinity, Flow, FlowId, ThreadPriority, ThreadPriorityStatus};
+pub use flow::{
+    BlockHealth, BlockHealthStatus, CpuAffinity, Flow, FlowId, ThreadPriority, ThreadPriorityStatus,
+};
 pub use network::{
     Ipv4AddressInfo, Ipv6AddressInfo, NetworkInterfaceInfo, NetworkInterfacesResponse,
 };


### PR DESCRIPTION
## Problem

A flow can report `gst_state: Playing` and `running: true` while a branch of its
pipeline has stopped dead, with nothing in the API, the UI, or the default log.

On a non-fatal flow return such as `not-negotiated`, `GstAggregator` sets **all**
its sink pads flushing and pauses its source pad task, posting nothing to the
bus; encoders pause their output loop the same way. Pausing a pad task is not a
state change, so every element stays `PLAYING` — and because the aggregator
flushes its inputs, the visible symptom appears far upstream of the real failure.
`GstBaseSrc` posts a flow error before pausing, so source-side failures already
reach the bus handler; the gap is the mixer-to-output path.

## What this adds

`Flow::block_health`: a `Vec<BlockHealth>` of `{ block_id, status, detail }`,
populated only while running, `status` binary `ok`/`failed` with no intermediate
tier a failed block could hide behind. It comes from a two-second scan for pads
whose task is `PAUSED` on an element that is itself `PLAYING`. Block elements are
already namespaced `block_id:internal_id`, so attribution is free; standalone
elements report under their own ID.

One `ERROR` per transition into failure and one `INFO` on recovery, plus
`StromEvent::BlockHealthChanged` on status change only — no `GST_DEBUG` needed.
The flow list shows an affected flow as **Failed** with detail on hover.

`running` is unchanged: it means "reached Playing", much logic depends on that,
and redefining it would blur "stopped" against "failed". Use
`Flow::has_failed_block()` for the distinction.

## Why it does not cry wolf

Only `Paused` counts — `gst_pad_get_task_state()` returns `Stopped` both for a
stopped task and for a pad that never had one, which is most pads. Three further
exclusions, each a real false positive rather than a hypothetical:

- **Elements below `PLAYING`** pause tasks as part of that transition.
- **Pads carrying EOS.** `gst_base_src_loop` pauses its task on the way out for
  *every* reason including end of stream, leaving the element `PLAYING`. Without
  this, any flow with a finite source reads as failed forever once it plays out.
- **Single samples.** Tasks pause briefly during flushing seeks and dynamic bin
  linking, so a block must look stalled on two consecutive scans.

## Scope

The scan reaches the flow pipeline's elements and the bins beneath them, and
nothing else. Blocks that build an isolated `gst::Pipeline` — WHIP ingest
sessions (`whip.rs`), a Media Player's decode chain (`mediaplayer/bridge.rs`) —
are siblings of that pipeline, not children, so `iterate_recurse` never enters
them. **An `ok` means "no stalled pad task among this flow pipeline's elements",
not "this flow is passing data."** Sinks in the flow pipeline are covered,
`whepserversink` included, so the path this targets is in scope. Reaching into
per-block sub-pipelines is follow-up work.

## Tests

Locally on macOS: 746 passed, 0 failed, clippy clean. All four new tests use only
`gstreamer1.0-plugins-base` elements and are visible in the `Check (Linux)` log,
so none skip. Not run on real hardware — no GPU path.

- `aggregator_stall_is_silent_and_leaves_pipeline_playing` breaks negotiation on
  a live `videotestsrc ! compositor ! capsfilter ! fakesink` and asserts the task
  reaches `Paused`, the pipeline still says `Playing`, and no bus error was
  posted. This pins the premise: if a future GStreamer posts an error here, it
  fails and says so.
- `stalled_branch_is_reported_while_the_pipeline_still_says_playing` is the
  guard, driving that stall through `PipelineManager::start()`. Verified to fail
  with the detector stubbed out.
- `a_source_that_reaches_eos_is_not_reported_as_failed` plays a finite source to
  completion and asserts it never flips. Verified to fail with the EOS check
  removed.

## Risks

- Up to 4s detection latency. The scan takes GST object locks only — no pad
  probes, nothing per-buffer.
- Auto-inserted tees are named `auto_tee_<src>` with colons replaced, so a stall
  on one reports a `block_id` absent from the flow graph. Left as-is: the mapping
  back is lossy and a `tee` runs no pad task in push mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
