### PR TITLE
fix(whip): stop a session's second stream stalling below PLAYING

### DIFF
--- a/backend/src/blocks/builtin/whip.rs
+++ b/backend/src/blocks/builtin/whip.rs
@@ -599,6 +599,83 @@ fn wait_for_inactivity(
     }
 }
 
+/// Drain one `whipserversrc` pad into the session pipeline: `pad → tee →
+/// fakesink + appsink`, with every element brought up to the pipeline's state.
+///
+/// Returns the appsink the caller installs its bridge callbacks on, or `None`
+/// if the branch could not be built — every failure is logged here.
+///
+/// Both sinks run with `async` off. The pipeline they join is already PLAYING,
+/// and a sink that still wants a preroll answers the state change with ASYNC.
+/// whipserversrc adds its audio and video pads one after the other within a
+/// millisecond, so the second branch lands while the first is still waiting,
+/// and the second is then left below PLAYING: it takes a single buffer and
+/// blocks its streaming thread for good. From the outside that is a publisher
+/// whose audio or video never starts, with nothing in the log to say so —
+/// `sync_state_with_parent` reports the state change as accepted either way.
+pub fn attach_session_branch(
+    session_pipeline: &gst::Pipeline,
+    pad: &gst::Pad,
+    appsink_name: &str,
+) -> Option<gst_app::AppSink> {
+    let tee = match gst::ElementFactory::make("tee")
+        .property("allow-not-linked", true)
+        .build()
+    {
+        Ok(t) => t,
+        Err(e) => {
+            error!("WHIP Input: Failed to create tee in pad-added: {}", e);
+            return None;
+        }
+    };
+    let fakesink = match gst::ElementFactory::make("fakesink")
+        .property("sync", false)
+        .property("async", false)
+        .build()
+    {
+        Ok(f) => f,
+        Err(e) => {
+            error!("WHIP Input: Failed to create fakesink in pad-added: {}", e);
+            return None;
+        }
+    };
+    let appsink = gst_app::AppSink::builder()
+        .name(appsink_name)
+        .sync(false)
+        .async_(false)
+        .build();
+
+    if let Err(e) = session_pipeline.add_many([&tee, &fakesink, appsink.upcast_ref()]) {
+        error!(
+            "WHIP Input: Failed to add elements to session pipeline: {}",
+            e
+        );
+        return None;
+    }
+    if let Err(e) = pad.link(&tee.static_pad("sink").expect("tee has no sink pad")) {
+        error!("WHIP Input: Failed to link pad to tee: {:?}", e);
+        return None;
+    }
+    if let (Some(tee_src1), Some(tee_src2)) = (
+        tee.request_pad_simple("src_%u"),
+        tee.request_pad_simple("src_%u"),
+    ) {
+        let _ = tee_src1.link(
+            &fakesink
+                .static_pad("sink")
+                .expect("fakesink has no sink pad"),
+        );
+        let _ = tee_src2.link(&appsink.static_pad("sink").expect("appsink has no sink pad"));
+    } else {
+        error!("WHIP Input: Failed to request tee src pads");
+        return None;
+    }
+    let _ = tee.sync_state_with_parent();
+    let _ = fakesink.sync_state_with_parent();
+    let _ = appsink.sync_state_with_parent();
+    Some(appsink)
+}
+
 /// Create a new whipserversrc element for a single WHIP client session.
 ///
 /// Each session runs in its own isolated GStreamer pipeline to avoid
@@ -878,54 +955,13 @@ pub fn create_whipserversrc_for_session(
                 return;
             };
 
-            // Session pipeline: pad → tee → fakesink (drain) + appsink (bridge)
-            let tee = match gst::ElementFactory::make("tee")
-                .property("allow-not-linked", true)
-                .build()
-            {
-                Ok(t) => t,
-                Err(e) => {
-                    error!("WHIP Input: Failed to create tee in pad-added: {}", e);
-                    return;
-                }
+            let Some(appsink) = attach_session_branch(
+                &session_pipeline,
+                pad,
+                &format!("{}:{}_appsink_{}", prefix, pad_name, stream_num),
+            ) else {
+                return;
             };
-            let fakesink = match gst::ElementFactory::make("fakesink")
-                .property("sync", false)
-                .property("async", false)
-                .build()
-            {
-                Ok(f) => f,
-                Err(e) => {
-                    error!("WHIP Input: Failed to create fakesink in pad-added: {}", e);
-                    return;
-                }
-            };
-            let appsink = gst_app::AppSink::builder()
-                .name(format!("{}:{}_appsink_{}", prefix, pad_name, stream_num))
-                .sync(false)
-                .build();
-
-            if let Err(e) = session_pipeline.add_many([&tee, &fakesink, appsink.upcast_ref()]) {
-                error!("WHIP Input: Failed to add elements to session pipeline: {}", e);
-                return;
-            }
-            if let Err(e) = pad.link(&tee.static_pad("sink").expect("tee has no sink pad")) {
-                error!("WHIP Input: Failed to link pad to tee: {:?}", e);
-                return;
-            }
-            if let (Some(tee_src1), Some(tee_src2)) = (
-                tee.request_pad_simple("src_%u"),
-                tee.request_pad_simple("src_%u"),
-            ) {
-                let _ = tee_src1.link(&fakesink.static_pad("sink").expect("fakesink has no sink pad"));
-                let _ = tee_src2.link(&appsink.static_pad("sink").expect("appsink has no sink pad"));
-            } else {
-                error!("WHIP Input: Failed to request tee src pads");
-                return;
-            }
-            let _ = tee.sync_state_with_parent();
-            let _ = fakesink.sync_state_with_parent();
-            let _ = appsink.sync_state_with_parent();
 
             // Determine which slot appsrc to feed based on pad type
             let target_appsrc: Option<gst_app::AppSrc> =

--- a/backend/src/gst/thumbnail_tap.rs
+++ b/backend/src/gst/thumbnail_tap.rs
@@ -285,11 +285,18 @@ impl ThumbnailTap {
             .build()
             .map_err(|e| ThumbnailError::FrameMapping(format!("capsfilter: {}", e)))?;
 
+        // `async` off: the branch joins a pipeline that is already running, and
+        // a sink still wanting a preroll answers that state change with ASYNC,
+        // taking the pipeline back to PAUSED until a frame arrives. Activation
+        // is allowed during that wait, and a branch attached inside one never
+        // completes its own state change: it takes a single buffer, then blocks
+        // its streaming thread.
         let appsink = gst_app::AppSink::builder()
             .name(format!("{}_thumb_sink", prefix))
             .max_buffers(1)
             .drop(true)
             .sync(false)
+            .async_(false)
             .build();
 
         // Set up appsink callback — pad probe on queue src limits fps,

--- a/backend/tests/whip_session_branch_test.rs
+++ b/backend/tests/whip_session_branch_test.rs
@@ -1,0 +1,183 @@
+//! A WHIP session's audio and video pads appear one after the other within a
+//! millisecond, each already carrying media, and each gets a
+//! `tee -> fakesink + appsink` branch added to a session pipeline that is
+//! already PLAYING.
+//!
+//! A sink that still wants a preroll answers that state change with ASYNC. Two
+//! of those in quick succession on one pipeline leave the second branch below
+//! PLAYING, where it takes a single buffer and then blocks its streaming thread
+//! for good. From the outside that is a publisher whose audio or video never
+//! starts, with nothing in the log to say so — and the seat is useless either
+//! way, because the flow's recorder and mixer are waiting on both streams.
+//!
+//! `attach_session_branch` builds both sinks with `async` off, so there is no
+//! ASYNC cycle for the second branch to land in.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use strom::blocks::builtin::whip::attach_session_branch;
+
+use gstreamer as gst;
+use gstreamer::prelude::*;
+use gstreamer_app as gst_app;
+
+/// Elements this test needs beyond core GStreamer. Missing on a bare CI image.
+const REQUIRED: &[&str] = &["tee", "fakesink", "appsink", "videotestsrc", "audiotestsrc"];
+
+/// One round is enough to strand a branch here — 20 runs of each arm, all 20
+/// failing with the fix reverted and all 20 passing with it. A few rounds are
+/// cheap insurance in case a faster or slower host makes it probabilistic
+/// again, which is what it is on the rig.
+const ROUNDS: usize = 3;
+
+/// Skipping on a missing element passes green and guards nothing, so CI sets
+/// `STROM_REQUIRE_GST_PLUGINS=1` to turn a skip into a failure.
+fn plugins_available() -> bool {
+    let missing: Vec<&str> = REQUIRED
+        .iter()
+        .copied()
+        .filter(|e| gst::ElementFactory::find(e).is_none())
+        .collect();
+    if missing.is_empty() {
+        return true;
+    }
+    assert!(
+        strom_types::env::var_opt("STROM_REQUIRE_GST_PLUGINS").is_none(),
+        "STROM_REQUIRE_GST_PLUGINS is set but these elements are missing: {}",
+        missing.join(", ")
+    );
+    false
+}
+
+/// A running source standing in for one of whipserversrc's pads, which carry
+/// media by the time they appear.
+///
+/// The pad handed out is a `tee`'s, not the source's own: `allow-not-linked`
+/// lets it drop data until the branch arrives, where a source pushing into its
+/// own unlinked pad would stop with a flow error first.
+struct LiveSource {
+    pad: gst::Pad,
+}
+
+impl LiveSource {
+    fn new(pipeline: &gst::Pipeline, factory: &str) -> Self {
+        let element = gst::ElementFactory::make(factory)
+            .property("is-live", true)
+            .build()
+            .unwrap_or_else(|_| panic!("{factory} available"));
+        let tee = gst::ElementFactory::make("tee")
+            .property("allow-not-linked", true)
+            .build()
+            .expect("tee");
+        pipeline.add_many([&element, &tee]).expect("add source");
+        element.link(&tee).expect("source -> tee");
+        let pad = tee.request_pad_simple("src_%u").expect("tee src pad");
+        Self { pad }
+    }
+}
+
+/// Count what an appsink actually receives. Pulling is what the real bridge
+/// callback does; without it the sink's queue would fill and hide a stall.
+fn count_samples(appsink: &gst_app::AppSink) -> Arc<AtomicUsize> {
+    let seen = Arc::new(AtomicUsize::new(0));
+    let seen_cb = Arc::clone(&seen);
+    appsink.set_callbacks(
+        gst_app::AppSinkCallbacks::builder()
+            .new_sample(move |sink| {
+                let _ = sink.pull_sample().map_err(|_| gst::FlowError::Eos)?;
+                seen_cb.fetch_add(1, Ordering::Relaxed);
+                Ok(gst::FlowSuccess::Ok)
+            })
+            .build(),
+    );
+    seen
+}
+
+/// One session: two pads carrying media, each given a branch on a pipeline that
+/// is already PLAYING. Reports each branch's sample count and the state its
+/// appsink ended in, so a failure can name both.
+fn run_round() -> ((usize, gst::State), (usize, gst::State)) {
+    let pipeline = gst::Pipeline::new();
+    let video = LiveSource::new(&pipeline, "videotestsrc");
+    let audio = LiveSource::new(&pipeline, "audiotestsrc");
+
+    pipeline
+        .set_state(gst::State::Playing)
+        .expect("pipeline accepts PLAYING");
+    let (_, current, _) = pipeline.state(gst::ClockTime::from_seconds(10));
+    assert_eq!(
+        current,
+        gst::State::Playing,
+        "the session pipeline must be PLAYING before its branches are attached"
+    );
+
+    // One after the other on one thread, as whipserversrc's pad-added fires.
+    let sinks: Vec<gst_app::AppSink> = [(&video.pad, "video_0"), (&audio.pad, "audio_0")]
+        .into_iter()
+        .map(|(pad, name)| {
+            attach_session_branch(&pipeline, pad, name)
+                .unwrap_or_else(|| panic!("{name} branch attaches"))
+        })
+        .collect();
+
+    let counts: Vec<Arc<AtomicUsize>> = sinks.iter().map(count_samples).collect();
+
+    // A stranded branch takes one buffer and stops, so wait long enough that
+    // "one" cannot be confused with "still starting".
+    let deadline = Instant::now() + Duration::from_secs(3);
+    while Instant::now() < deadline {
+        if counts.iter().all(|c| c.load(Ordering::Relaxed) > 5) {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+
+    let out = (
+        (
+            counts[0].load(Ordering::Relaxed),
+            sinks[0].upcast_ref::<gst::Element>().current_state(),
+        ),
+        (
+            counts[1].load(Ordering::Relaxed),
+            sinks[1].upcast_ref::<gst::Element>().current_state(),
+        ),
+    );
+
+    pipeline
+        .set_state(gst::State::Null)
+        .expect("pipeline to NULL");
+    out
+}
+
+/// The regression. Both of a session's branches must keep carrying data after
+/// being attached, back to back, to a pipeline that is already running.
+///
+/// Revert the fix and the branch attached second is left in READY having taken
+/// a single buffer, while the first runs normally. Which stream that is on the
+/// rig depends on the order whipserversrc exposes its pads, and both orders
+/// occur.
+#[test]
+fn both_session_branches_keep_running_when_attached_in_succession() {
+    gst::init().expect("gstreamer init");
+    if !plugins_available() {
+        eprintln!("skipping: required GStreamer elements missing");
+        return;
+    }
+
+    for round in 0..ROUNDS {
+        let ((video_samples, video_state), (audio_samples, audio_state)) = run_round();
+        assert!(
+            video_samples > 5 && audio_samples > 5,
+            "round {round}: a branch stopped carrying data — \
+             video {video_samples} samples in {video_state:?}, \
+             audio {audio_samples} samples in {audio_state:?}"
+        );
+        assert_eq!(
+            (video_state, audio_state),
+            (gst::State::Playing, gst::State::Playing),
+            "round {round}: a branch was left below PLAYING"
+        );
+    }
+}


### PR DESCRIPTION
## What was broken

On a five-seat meeting rig, a WHIP publisher failed to start roughly two runs in five. ICE completed, the seat came up, and then one of its two streams — sometimes audio, sometimes video — silently never arrived. The recorder and the vision mixer then waited on a track that would never come, so the seat was dead either way.

## Cause

Each WHIP session runs in its own pipeline, already PLAYING by the time `whipserversrc` adds its pads. Every pad gets a `tee -> fakesink + appsink` branch added and synced into that running pipeline.

The appsink was built with `sync=false` and nothing else, so it kept `GstBaseSink`'s default `async=true`. A sink in that mode will not complete its state change until it prerolls a buffer, and it announces the wait with ASYNC_START, which takes the pipeline back to PAUSED. The pads arrive one after the other within a millisecond, so the second branch is added while the first is still waiting — and the second never finishes. It is left at READY with its tee at PAUSED, accepts exactly one buffer, and blocks its streaming thread permanently.

Instrumented failure, six seconds after both pads appeared:

```
DBGSTATE video_0 tee=Some(Playing) appsink=Some(Playing)
DBGSTATE audio_0 tee=Some(Paused)  appsink=Some(Ready)
```

The audio appsink's `new_sample` had fired zero times. Nothing was logged, because `sync_state_with_parent` reports the state change as *accepted*, not completed, and returned `Ok(())` for all three elements.

The fix is to turn `async` off, which the `fakesink` next to it already did.

## Which base

The failure reproduces on `upstream/main`, not only on our stack:

| Arm | Froze |
| --- | --- |
| fork main (6d07e58) | 7 of 18 |
| upstream/main (95d7ccb) | 7 of 18 |
| upstream/main + this fix | 0 of 18 |

Each trial is a fresh server process, fresh data directory, fresh port, one headless `whipclientsink` publisher; the verdict is whether the recording grew by more than 200 KB across an 8-second window. Fisher's exact on 7/18 against 0/18 gives p = 0.0069. The rig flow uses `builtin.audioenc`, which exists only on the fork, so the upstream arms carry a cherry-pick of that block and nothing else; the fix itself is on plain `upstream/main`.

<details>
<summary>How we got here</summary>

**The two modes were one bug.**

Mode A (video never decodes) and Mode B (video links, recording stays empty) are the same defect from either side: the stream whose pad arrives second is the one that stalls.

The baseline data lines up exactly. The `Computed shared ts-offset ... from <audio|video> stream` line names the stream that delivered first, and in all 7 failures the stranded stream is the other one — 4 sessions where audio came first and video never decoded, 3 the reverse. Each failure has exactly one of the two `decodebin ... pad linked` lines; all 11 successes have both.

**The shared-timestamp-offset hypothesis.**

Killed. The offset is correct for both streams, since both leave the same session pipeline on one time base. That log line reports which pad delivered first, and the first pad is the one that starts. The correlation was real; the direction was wrong.

</details>

## Regression test

`backend/tests/whip_session_branch_test.rs` attaches two branches back to back to a running pipeline through `attach_session_branch` — the function the pad-added handler now calls, extracted so the test exercises the real code rather than a copy. Both pads carry media before their branch is attached, and the attaches are sequential on one thread, matching production on both counts.

With the fix reverted the second branch is left in READY having taken one buffer while the first runs normally, which is the rig's failure exactly. Twenty runs of each arm: 20 of 20 fail reverted, 20 of 20 pass with the fix. One round suffices; the three are insurance against a host where it turns probabilistic. Needs only `tee`, `fakesink`, `appsink`, `videotestsrc`, `audiotestsrc`, all in the CI package list.

## The same defect in the thumbnail tap

`thumbnail_tap.rs` builds its appsink the same way and attaches the branch to a flow pipeline that is already running. Fixed here too, one line.

Every precondition is present. The activation guard admits the pipeline in PAUSED with PLAYING pending, which is the window where an earlier branch's async wait is unresolved. Activation returns without waiting for a preroll, and a branch is created per block from an HTTP request, so a client asking for several blocks' thumbnails serializes on one mutex but not on the async cycles behind it. Two attaches inside one unresolved cycle is the WHIP failure again, on the main flow pipeline rather than a session one.

No separate regression test. Reaching `activate_branch` needs a live flow whose tee already carries caps, and the mechanism is the one `whip_session_branch_test` guards.

The other two appsinks are unaffected. The Media Player bridge only ever gets pads while its internal pipeline is moving from READY to PLAYING, on first start and on a file switch, which returns to READY first — both sinks are counted in one async cycle rather than interrupting a settled one. The audio analyzer's appsink is a static block element, built before the flow starts and never attached dynamically.

## A separate finding, not fixed here

The recorder's `splitmuxsink` is unlocked by whichever track produces caps first and then still has to preroll the pads of the tracks that have not. It has no `async-handling`, so that preroll drops the running flow pipeline back to PAUSED, stopping every live source in it. Visible in every trial on both bases as `Paused -> Paused (pending: Playing)`.

A healthy seat recovers, so this was a symptom here rather than the cause, but it is a real deadlock for a flow where a track genuinely never arrives. Setting `async-handling` removes the transition from all 18 logs; on its own it did not change the failure rate (9/18 against a 7/18 baseline), so it does not belong in this PR.

## What I ran

- `cargo test --test whip_session_branch_test` — 20 runs pass; 20 fail with the fix reverted.
- `cargo test --test whip_idle_slot_test --test recorder_idle_input_test --test recorder_unfed_track_test --test pipeline_lifecycle_test --test jitterbuffer_mute_test` — all pass.
- `cargo fmt --all -- --check`, `cargo clippy --all-targets`, `cargo check --all-targets` — clean after the thumbnail change.
- The 18-trial rig harness on each of the four arms above, before the thumbnail change.

Not run: the rest of the suite. The thumbnail path has no automated coverage and I did not exercise it by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

