### PR TITLE
fix(bus): remove exactly as many bus signal watches as were added

### DIFF
--- a/backend/src/blocks/builtin/latency.rs
+++ b/backend/src/blocks/builtin/latency.rs
@@ -90,8 +90,8 @@ fn connect_latency_message_handler(
 
     debug!("Connecting latency message handler via connect_message");
 
-    // First ensure signal watch is enabled (this is ref-counted, safe to call multiple times)
-    bus.add_signal_watch();
+    // No add_signal_watch() here: setup_bus_watch takes the single watch this
+    // bus needs, and matches it with exactly one remove on teardown.
 
     // Connect to message signal - this allows multiple handlers unlike add_watch
     bus.connect_message(None, move |_bus, msg| {

--- a/backend/src/blocks/builtin/loudness.rs
+++ b/backend/src/blocks/builtin/loudness.rs
@@ -91,7 +91,8 @@ fn connect_loudness_message_handler(
         flow_id, expected_element_id
     );
 
-    bus.add_signal_watch();
+    // No add_signal_watch() here: setup_bus_watch takes the single watch this
+    // bus needs, and matches it with exactly one remove on teardown.
 
     bus.connect_message(None, move |_bus, msg| {
         if let MessageView::Element(element_msg) = msg.view() {

--- a/backend/src/blocks/builtin/meter.rs
+++ b/backend/src/blocks/builtin/meter.rs
@@ -105,8 +105,8 @@ fn connect_level_message_handler(
         flow_id, expected_element_id
     );
 
-    // First ensure signal watch is enabled (this is ref-counted, safe to call multiple times)
-    bus.add_signal_watch();
+    // No add_signal_watch() here: setup_bus_watch takes the single watch this
+    // bus needs, and matches it with exactly one remove on teardown.
 
     // Connect to message signal - this allows multiple handlers unlike add_watch
     bus.connect_message(None, move |_bus, msg| {

--- a/backend/src/blocks/builtin/mixer/metering.rs
+++ b/backend/src/blocks/builtin/mixer/metering.rs
@@ -29,7 +29,8 @@ pub(super) fn connect_mixer_meter_handler(
         flow_id, instance_id
     );
 
-    bus.add_signal_watch();
+    // No add_signal_watch() here: setup_bus_watch takes the single watch this
+    // bus needs, and matches it with exactly one remove on teardown.
 
     let level_prefix = format!("{}:level_", instance_id);
     let main_level_id = format!("{}:main_level", instance_id);

--- a/backend/src/blocks/builtin/spectrum.rs
+++ b/backend/src/blocks/builtin/spectrum.rs
@@ -234,7 +234,8 @@ fn connect_spectrum_message_handler(
         flow_id, expected_element_id, multi_channel
     );
 
-    bus.add_signal_watch();
+    // No add_signal_watch() here: setup_bus_watch takes the single watch this
+    // bus needs, and matches it with exactly one remove on teardown.
 
     bus.connect_message(None, move |_bus, msg| {
         if let MessageView::Element(element_msg) = msg.view() {

--- a/backend/src/blocks/builtin/vision_mixer/builder/audio_meter.rs
+++ b/backend/src/blocks/builtin/vision_mixer/builder/audio_meter.rs
@@ -99,7 +99,9 @@ pub(super) fn build_meter_bus_handler(
               _flow_id: FlowId,
               _events: EventBroadcaster|
               -> gst::glib::SignalHandlerId {
-            bus.add_signal_watch();
+            // No add_signal_watch() here: setup_bus_watch takes the single
+            // watch this bus needs, and matches it with exactly one remove on
+            // teardown.
             let state = overlay_state;
             bus.connect_message(None, move |_bus, msg| {
                 use gst::MessageView;

--- a/backend/src/gst/pipeline/bus.rs
+++ b/backend/src/gst/pipeline/bus.rs
@@ -37,8 +37,9 @@ impl PipelineManager {
         // Take the connect functions (they're FnOnce, so we consume them)
         let connect_fns = std::mem::take(&mut self.block_message_connect_fns);
         for connect_fn in connect_fns {
-            // Each block's connect_fn calls bus.add_signal_watch() and bus.connect_message()
-            // add_signal_watch is ref-counted so multiple calls are safe
+            // Each block's connect_fn calls bus.connect_message(). It does not
+            // take a signal watch of its own — the single one below covers
+            // every handler on this bus.
             let handler_id = connect_fn(&bus, flow_id, events_for_blocks.clone());
             debug!("Successfully connected block message handler");
             self.block_message_handlers.push(handler_id);
@@ -51,9 +52,10 @@ impl PipelineManager {
             debug!("Successfully called element signal setup");
         }
 
-        // Enable signal watch on the bus (ref-counted, safe to call multiple times)
-        // This allows using connect_message for multiple handlers
+        // Enable signal watch on the bus. This is what makes connect_message
+        // fire at all, for every handler connected above and below.
         bus.add_signal_watch();
+        self.bus_signal_watches += 1;
 
         // Set up main pipeline message handler using connect_message
         let flow_name = self.flow_name.clone();
@@ -231,16 +233,19 @@ impl PipelineManager {
                 "Disconnecting {} message handler(s) for flow: {}",
                 handler_count, self.flow_name
             );
+            // remove_signal_watch is ref-counted — each add_signal_watch call
+            // needs exactly one matching remove, and a surplus one is a
+            // GStreamer CRITICAL. Take the count from the adds; the handler
+            // count is a different number, since a block may register a
+            // message handler without taking a watch of its own.
+            let watch_count = std::mem::take(&mut self.bus_signal_watches);
+
             // Disconnect signal handlers from the bus
             if let Some(bus) = self.pipeline.bus() {
                 for handler_id in self.block_message_handlers.drain(..) {
                     bus.disconnect(handler_id);
                 }
-                // remove_signal_watch is ref-counted — each add_signal_watch call
-                // needs a matching remove. handler_count matches the number of
-                // add_signal_watch calls: one per block connect_fn plus one in
-                // setup_bus_watch (which also adds the main handler to the list).
-                for _ in 0..handler_count {
+                for _ in 0..watch_count {
                     bus.remove_signal_watch();
                 }
             } else {

--- a/backend/src/gst/pipeline/construction.rs
+++ b/backend/src/gst/pipeline/construction.rs
@@ -81,6 +81,7 @@ impl PipelineManager {
             properties: flow.properties.clone(),
             pad_properties: HashMap::new(),
             block_message_handlers: Vec::new(),
+            bus_signal_watches: 0,
             block_message_connect_fns: Vec::new(),
             element_setup_fns: Vec::new(),
             thread_priority_state: None,

--- a/backend/src/gst/pipeline/mod.rs
+++ b/backend/src/gst/pipeline/mod.rs
@@ -175,6 +175,12 @@ pub struct PipelineManager {
     pad_properties: HashMap<String, HashMap<String, HashMap<String, PropertyValue>>>,
     /// Block-specific bus message handler IDs (allows blocks to register their own bus message handlers)
     block_message_handlers: Vec<gst::glib::SignalHandlerId>,
+    /// Number of `add_signal_watch()` calls made on the flow bus, counted at
+    /// the call site. `remove_signal_watch()` is ref-counted and one call past
+    /// the matching add is a GStreamer CRITICAL, so the removes are driven by
+    /// this rather than by the handler count — a block may register a message
+    /// handler without taking a watch of its own.
+    bus_signal_watches: usize,
     /// Bus message handler connection functions from blocks (called when pipeline starts)
     block_message_connect_fns: Vec<crate::blocks::BusMessageConnectFn>,
     /// Element signal setup functions from blocks (called when pipeline starts)

--- a/backend/tests/bus_signal_watch_balance_test.rs
+++ b/backend/tests/bus_signal_watch_balance_test.rs
@@ -1,0 +1,141 @@
+//! Regression test: stopping a flow must not remove more bus signal watches
+//! than were added.
+//!
+//! `remove_bus_watch()` derived its remove count from the number of registered
+//! block message handlers, but only some blocks add a signal watch of their
+//! own. A flow holding a Media Player block therefore removed twice against a
+//! single add, and the surplus call logged
+//!
+//! ```text
+//! GStreamer-CRITICAL **: Bus bus0 has no signal watches attached
+//! ```
+//!
+//! Nothing leaks — the error direction is over-removal — but a GLib critical in
+//! production logs teaches operators to ignore criticals, and the same call
+//! aborts the process under `G_DEBUG=fatal-criticals`.
+//!
+//! That critical is the only externally observable difference the imbalance
+//! makes, so the test captures GLib log output across a start/stop cycle and
+//! asserts the message never arrives. It lives in its own test binary because
+//! the log handler it installs is process-global.
+
+use gstreamer::glib;
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+use strom::state::AppState;
+use strom::storage::JsonFileStorage;
+use strom_types::{Flow, Link, PropertyValue};
+use tempfile::NamedTempFile;
+
+/// The GStreamer text for one remove_signal_watch() past the matching add.
+const SURPLUS_REMOVE: &str = "has no signal watches attached";
+
+fn captured() -> &'static Mutex<Vec<String>> {
+    static CAPTURED: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
+    CAPTURED.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+/// A startable flow holding a block that registers a bus message handler
+/// without adding a signal watch of its own.
+///
+/// The Media Player is such a block: its handler is a no-op on the flow bus
+/// (all its real work happens on its own internal bus), so it adds nothing,
+/// while still occupying an entry in the handler list the old remove count was
+/// read from. An empty playlist is enough — the block registers while the
+/// pipeline is built, which is all this test needs from it.
+fn build_flow_with_a_media_player(name: &str) -> Flow {
+    let mut flow = Flow::new(name);
+
+    flow.elements.push(strom_types::Element {
+        id: "src".to_string(),
+        element_type: "audiotestsrc".to_string(),
+        properties: HashMap::new(),
+        position: [100.0, 200.0].into(),
+        pad_properties: HashMap::new(),
+    });
+
+    flow.elements.push(strom_types::Element {
+        id: "sink".to_string(),
+        element_type: "fakesink".to_string(),
+        properties: HashMap::new(),
+        position: [300.0, 200.0].into(),
+        pad_properties: HashMap::new(),
+    });
+
+    flow.links.push(Link {
+        from: "src:src".to_string(),
+        to: "sink:sink".to_string(),
+    });
+
+    flow.blocks.push(strom_types::BlockInstance {
+        id: "player".to_string(),
+        block_definition_id: "builtin.media_player".to_string(),
+        name: None,
+        properties: {
+            let mut p = HashMap::new();
+            p.insert(
+                "playlist".to_string(),
+                PropertyValue::String("[]".to_string()),
+            );
+            p
+        },
+        position: strom_types::block::Position { x: 100.0, y: 400.0 },
+        runtime_data: None,
+        computed_external_pads: None,
+    });
+
+    flow
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stopping_a_flow_removes_no_more_bus_watches_than_it_added() {
+    gstreamer::init().unwrap();
+
+    glib::log_set_default_handler(|domain, level, message| {
+        captured()
+            .lock()
+            .expect("log capture lock poisoned")
+            .push(format!(
+                "{}-{:?}: {}",
+                domain.unwrap_or("<none>"),
+                level,
+                message
+            ));
+    });
+
+    let storage_file = NamedTempFile::new().unwrap();
+    let blocks_file = NamedTempFile::new().unwrap();
+    let state = AppState::new(
+        JsonFileStorage::new(storage_file.path()),
+        blocks_file.path(),
+        std::env::temp_dir(),
+        vec![],
+        "all".to_string(),
+        vec![],
+    );
+
+    let flow = build_flow_with_a_media_player("bus_signal_watch_balance");
+    let flow_id = flow.id;
+    state.upsert_flow(flow).await.expect("upsert_flow failed");
+
+    state.start_flow(&flow_id).await.expect("start_flow failed");
+    state.stop_flow(&flow_id).await.expect("stop_flow failed");
+
+    let surplus: Vec<String> = captured()
+        .lock()
+        .expect("log capture lock poisoned")
+        .iter()
+        .filter(|message| message.contains(SURPLUS_REMOVE))
+        .cloned()
+        .collect();
+
+    assert!(
+        surplus.is_empty(),
+        "stopping the flow removed more bus signal watches than it added, and \
+         GStreamer logged a critical for each surplus call: {:?}. The remove \
+         count must come from the adds, not from the number of registered block \
+         message handlers — blocks that register a handler without taking a \
+         watch of their own make those two numbers different.",
+        surplus
+    );
+}


### PR DESCRIPTION
Class A — the test below fails without this fix.

Fixes #719

Implements **Option 1**, chosen by `/agent-fix 1` on 2026-09-09. The triage's marker (`work=bug radius=LOCAL excluded=none`) describes the option that was chosen, so I inherit it — with one thing to flag: the diff sits on the teardown path, which is normally an excluded area. It changes no object reference and no pipeline lifetime, only how many times an already-called API is called, so I read `excluded=none` as still right. Overrule me if you disagree.

## Problem

`remove_bus_watch()` derived the remove count from the number of registered block message handlers, on the assumption that each one added a watch. Only some do. The Media Player's handler is a deliberate no-op on the flow bus — `backend/src/blocks/builtin/mediaplayer/builder.rs:404` — `    main_bus.connect_message(None, |_bus, _msg| {})` — so a flow holding one removes twice against a single add. `remove_signal_watch()` is ref-counted and the surplus call logs `Bus busN has no signal watches attached`. Over-removal, so nothing leaks; but it trains operators to ignore criticals, and it aborts under `G_DEBUG=fatal-criticals`.

## Change

`PipelineManager` now counts the adds at the call site — `backend/src/gst/pipeline/bus.rs:58` — `        self.bus_signal_watches += 1;` — and teardown removes exactly that many — `backend/src/gst/pipeline/bus.rs:241` — `            let watch_count = std::mem::take(&mut self.bus_signal_watches);`.

The six per-block `add_signal_watch()` calls (meter, latency, loudness, spectrum, mixer metering, vision mixer audio meter) are deleted as redundant: `setup_bus_watch()` runs every `connect_fn` and then takes one watch unconditionally, and one watch is what makes `connect_message` fire for all of them. Option 2 — rebalance while keeping "handler count equals adds" as the invariant — reaches the same state today but leaves a tenth block free to break it again.

## Evidence

`backend/tests/bus_signal_watch_balance_test.rs` starts and stops a flow holding a Media Player block and asserts no `has no signal watches attached` critical reaches its GLib log handler — the only externally observable difference the imbalance makes. Its own binary, because that handler is process-global.

Both runs have concluded. **The red run is the proof the test guards the fix, not a broken PR** — commit 1 is the test alone, and it fails on exactly the critical commit 2 removes.

- `ec88b11` — `Check (Linux)` failed: `test stopping_a_flow_removes_no_more_bus_watches_than_it_added ... FAILED`, panicking on `["GStreamer-Critical: Bus bus1 has no signal watches attached"]` — https://github.com/Eyevinn/strom/actions/runs/34464816007
- `ecda0d9` — every check passes; the same test reports `... ok` in `Check (Linux)` — https://github.com/Eyevinn/strom/actions/runs/34464826075

## Not verified

Nothing ran on this runner and CI covers Linux only — untested: message-text differences across GStreamer versions, non-Linux platforms, and metering in the six blocks that lose their redundant add.

## Blast radius

LOCAL. `remove_bus_watch()` has one caller, on the stop path — `backend/src/gst/pipeline/lifecycle.rs:201` — `        self.remove_bus_watch();`. The deleted adds were redundant everywhere: `setup_bus_watch()` always takes a watch after running the connect functions. No API, WebSocket or config surface.

<!-- strom-agent protocol=v3 kind=fix issue=719 pr=788 class=A -->
