### PR TITLE
feat(api): lease blocks of SRT listener ports to external orchestrators

### DIFF
--- a/.strom.toml.example
+++ b/.strom.toml.example
@@ -87,6 +87,19 @@ port = 8080
 # cef_cache_path = "/var/cache/strom/cef"
 
 # ============================================================================
+# Port Leases
+# ============================================================================
+[ports]
+# UDP ports the port lease API (POST /api/port-leases) may hand out. External
+# orchestrators such as Open Live reserve a block each for their SRT listener
+# inputs, so several of them can share this Strom without colliding. Open the
+# whole range inbound on the firewall. Ports a flow already listens on are never
+# handed out, whether or not they lie in this range.
+# Default: 47100-47999
+# Env: STROM_PORT_LEASE_RANGE=47100-47999
+# lease_range = "47100-47999"
+
+# ============================================================================
 # Logging Configuration
 # ============================================================================
 [logging]

--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -11,6 +11,7 @@ pub mod media;
 pub mod mediaplayer;
 pub mod network;
 pub mod osc;
+pub mod port_leases;
 pub mod probes;
 pub mod sdp_transform;
 pub mod system_clock;

--- a/backend/src/api/port_leases.rs
+++ b/backend/src/api/port_leases.rs
@@ -1,0 +1,187 @@
+//! Port lease API: blocks of UDP ports reserved for external orchestrators.
+//!
+//! A Strom shared by several Open Live instances is the only party that can
+//! keep their SRT listener ports apart. Each instance asks for a block under a
+//! stable `client_id`, renews it while alive, and lets it lapse when gone.
+//! Strom does not bind the ports; it promises not to hand the block to anyone
+//! else, and never allocates a port an existing flow already listens on.
+
+use axum::{
+    body::Bytes,
+    extract::{Path, State},
+    http::StatusCode,
+    Json,
+};
+use strom_types::api::ErrorResponse;
+use strom_types::port_lease::{PortLease, PortLeaseRequest, RenewPortLeaseRequest};
+use tracing::error;
+use uuid::Uuid;
+
+use crate::json_rejection::JsonBody;
+use crate::port_lease::{Acquired, PortLeaseError};
+use crate::state::AppState;
+
+type ApiError = (StatusCode, Json<ErrorResponse>);
+
+fn lease_error(err: PortLeaseError) -> ApiError {
+    let status = match err {
+        PortLeaseError::EmptyClientId | PortLeaseError::BadSize(_) | PortLeaseError::BadTtl(_) => {
+            StatusCode::BAD_REQUEST
+        }
+        PortLeaseError::Exhausted { .. } => StatusCode::CONFLICT,
+        PortLeaseError::NotFound => StatusCode::NOT_FOUND,
+    };
+    (status, Json(ErrorResponse::new(err.to_string())))
+}
+
+fn storage_error(err: anyhow::Error) -> ApiError {
+    error!("Failed to persist port leases: {}", err);
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(ErrorResponse::with_details(
+            "Failed to persist port leases",
+            err.to_string(),
+        )),
+    )
+}
+
+/// List live port leases.
+#[utoipa::path(
+    get,
+    path = "/api/port-leases",
+    tag = "port-leases",
+    responses(
+        (status = 200, description = "Every lease that has not expired", body = Vec<PortLease>)
+    )
+)]
+pub async fn list_port_leases(State(state): State<AppState>) -> Json<Vec<PortLease>> {
+    Json(state.list_port_leases().await)
+}
+
+/// Request a block of ports.
+#[utoipa::path(
+    post,
+    path = "/api/port-leases",
+    tag = "port-leases",
+    description = "Reserves `size` consecutive UDP ports from the server's lease pool for \
+                   `client_id`. The call is idempotent per client: a client that already \
+                   holds a lease gets it back, renewed, with a 200 instead of a 201, and \
+                   a changed `size` resizes the block in place when the neighbouring ports \
+                   are free. Ports an existing flow listens on are never handed out, even \
+                   when no lease covers them. The lease lapses `ttl_secs` after the last \
+                   request or renewal (default 600).",
+    request_body = PortLeaseRequest,
+    responses(
+        (status = 201, description = "A new lease was granted", body = PortLease),
+        (status = 200, description = "The client's existing lease, renewed", body = PortLease),
+        (status = 400, description = "Invalid client_id, size or ttl_secs", body = ErrorResponse),
+        (status = 409, description = "No block of that size is free in the pool", body = ErrorResponse),
+        (status = 500, description = "Lease could not be persisted", body = ErrorResponse)
+    )
+)]
+pub async fn create_port_lease(
+    State(state): State<AppState>,
+    JsonBody(req): JsonBody<PortLeaseRequest>,
+) -> Result<(StatusCode, Json<PortLease>), ApiError> {
+    let (lease, how) = state
+        .acquire_port_lease(&req.client_id, req.size, req.ttl_secs)
+        .await
+        .map_err(storage_error)?
+        .map_err(lease_error)?;
+    let status = match how {
+        Acquired::Created => StatusCode::CREATED,
+        Acquired::Renewed => StatusCode::OK,
+    };
+    Ok((status, Json(lease)))
+}
+
+/// Get one port lease.
+#[utoipa::path(
+    get,
+    path = "/api/port-leases/{id}",
+    tag = "port-leases",
+    params(("id" = Uuid, Path, description = "Lease id")),
+    responses(
+        (status = 200, description = "The lease", body = PortLease),
+        (status = 404, description = "No live lease with that id", body = ErrorResponse)
+    )
+)]
+pub async fn get_port_lease(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> Result<Json<PortLease>, ApiError> {
+    state
+        .get_port_lease(id)
+        .await
+        .map(Json)
+        .ok_or_else(|| lease_error(PortLeaseError::NotFound))
+}
+
+/// Extend a port lease.
+#[utoipa::path(
+    post,
+    path = "/api/port-leases/{id}/renew",
+    tag = "port-leases",
+    description = "Moves the lease's expiry to now plus `ttl_secs` (default 600). A lease \
+                   that has already lapsed is gone: re-request it with the same `client_id` \
+                   through `POST /api/port-leases` instead.",
+    params(("id" = Uuid, Path, description = "Lease id")),
+    request_body(content = RenewPortLeaseRequest, description = "Optional new lifetime"),
+    responses(
+        (status = 200, description = "The renewed lease", body = PortLease),
+        (status = 400, description = "Invalid ttl_secs", body = ErrorResponse),
+        (status = 404, description = "No live lease with that id", body = ErrorResponse),
+        (status = 500, description = "Lease could not be persisted", body = ErrorResponse)
+    )
+)]
+pub async fn renew_port_lease(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+    body: Bytes,
+) -> Result<Json<PortLease>, ApiError> {
+    // The body is optional: an empty request means "the default lifetime".
+    let req: RenewPortLeaseRequest = if body.iter().all(u8::is_ascii_whitespace) {
+        RenewPortLeaseRequest::default()
+    } else {
+        serde_json::from_slice(&body).map_err(|e| {
+            (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse::with_details(
+                    "Invalid JSON body",
+                    e.to_string(),
+                )),
+            )
+        })?
+    };
+    let ttl_secs = req.ttl_secs;
+    state
+        .renew_port_lease(id, ttl_secs)
+        .await
+        .map_err(storage_error)?
+        .map_err(lease_error)
+        .map(Json)
+}
+
+/// Release a port lease.
+#[utoipa::path(
+    delete,
+    path = "/api/port-leases/{id}",
+    tag = "port-leases",
+    params(("id" = Uuid, Path, description = "Lease id")),
+    responses(
+        (status = 204, description = "Lease released"),
+        (status = 404, description = "No live lease with that id", body = ErrorResponse),
+        (status = 500, description = "Lease could not be persisted", body = ErrorResponse)
+    )
+)]
+pub async fn delete_port_lease(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> Result<StatusCode, ApiError> {
+    state
+        .release_port_lease(id)
+        .await
+        .map_err(storage_error)?
+        .map_err(lease_error)?;
+    Ok(StatusCode::NO_CONTENT)
+}

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -19,6 +19,16 @@ struct ConfigFile {
     logging: LoggingConfig,
     #[serde(default)]
     discovery: DiscoveryConfig,
+    #[serde(default)]
+    ports: PortsConfig,
+}
+
+/// `[ports]` section: the pool the port lease API hands blocks out of.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+struct PortsConfig {
+    /// Written `first-last`, e.g. `47100-47999`. Defaults to
+    /// `strom_types::PortRange::default()`.
+    lease_range: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -152,6 +162,18 @@ pub struct Config {
     pub tls_cert: Option<PathBuf>,
     /// Path to TLS private key file (PEM format). Enables HTTPS when paired with tls_cert.
     pub tls_key: Option<PathBuf>,
+    /// UDP ports the port lease API may hand out to orchestrators such as Open Live.
+    pub port_lease_range: strom_types::PortRange,
+}
+
+/// Parse the `[ports] lease_range` setting, falling back to the default pool.
+fn port_lease_range(value: Option<String>) -> anyhow::Result<strom_types::PortRange> {
+    match strom_types::env::non_blank(value) {
+        Some(s) => s
+            .parse()
+            .map_err(|e| anyhow::anyhow!("invalid ports.lease_range: {e}")),
+        None => Ok(strom_types::PortRange::default()),
+    }
 }
 
 /// A blank path is not a path. Blank environment variables are gone before
@@ -201,6 +223,7 @@ impl Config {
             storage: StorageConfig::default(),
             logging: LoggingConfig::default(),
             discovery: DiscoveryConfig::default(),
+            ports: PortsConfig::default(),
         }));
 
         // 2. Merge user config file if it exists
@@ -248,6 +271,11 @@ impl Config {
         }
         if let Some(key) = strom_types::env::var_opt("STROM_TLS_KEY") {
             figment = figment.merge(Serialized::default("server.tls_key", PathBuf::from(key)));
+        }
+
+        // 4d. Handle STROM_PORT_LEASE_RANGE specially (same underscore problem)
+        if let Some(range) = strom_types::env::var_opt("STROM_PORT_LEASE_RANGE") {
+            figment = figment.merge(Serialized::default("ports.lease_range", range));
         }
 
         // 5. Merge CLI arguments (highest priority)
@@ -307,6 +335,7 @@ impl Config {
             cors_allowed_origins: config_file.server.cors_allowed_origins,
             tls_cert: non_blank_path(config_file.server.tls_cert),
             tls_key: non_blank_path(config_file.server.tls_key),
+            port_lease_range: port_lease_range(config_file.ports.lease_range)?,
         })
     }
 
@@ -357,6 +386,7 @@ impl Config {
             cors_allowed_origins: Vec::new(),
             tls_cert: None,
             tls_key: None,
+            port_lease_range: strom_types::PortRange::default(),
         })
     }
 
@@ -406,6 +436,7 @@ impl Default for Config {
                 cors_allowed_origins: Vec::new(),
                 tls_cert: None,
                 tls_key: None,
+                port_lease_range: strom_types::PortRange::default(),
             }
         })
     }

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -37,6 +37,7 @@ pub mod network;
 pub mod openapi;
 pub mod osc;
 pub mod paths;
+pub mod port_lease;
 pub mod ptp_monitor;
 pub mod rtsp_server;
 pub mod server_hardening;
@@ -119,6 +120,17 @@ pub async fn create_app_with_config(
     let protected_api_router = Router::new()
         .route("/flows", get(api::flows::list_flows))
         .route("/flows", post(api::flows::create_flow))
+        .route("/port-leases", get(api::port_leases::list_port_leases))
+        .route("/port-leases", post(api::port_leases::create_port_lease))
+        .route("/port-leases/{id}", get(api::port_leases::get_port_lease))
+        .route(
+            "/port-leases/{id}",
+            delete(api::port_leases::delete_port_lease),
+        )
+        .route(
+            "/port-leases/{id}/renew",
+            post(api::port_leases::renew_port_lease),
+        )
         .route("/flows/{id}", get(api::flows::get_flow))
         .route("/flows/{id}", post(api::flows::update_flow))
         .route("/flows/{id}", put(api::flows::update_flow_put))

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -531,6 +531,7 @@ fn run_with_gui(
                 config.sap_multicast_addresses.clone(),
             )
         };
+        state.set_port_lease_range(config.port_lease_range).await;
         state
             .load_from_storage()
             .await
@@ -755,6 +756,7 @@ async fn run_headless(
             config.sap_multicast_addresses.clone(),
         )
     };
+    state.set_port_lease_range(config.port_lease_range).await;
     state.load_from_storage().await?;
 
     // Store the log reload handle so log levels can be changed at runtime

--- a/backend/src/openapi.rs
+++ b/backend/src/openapi.rs
@@ -37,6 +37,7 @@ use strom_types::mediaplayer::{
 use strom_types::network::{
     Ipv4AddressInfo, Ipv6AddressInfo, NetworkInterfaceInfo, NetworkInterfacesResponse,
 };
+use strom_types::port_lease::{PortLease, PortLeaseRequest, RenewPortLeaseRequest};
 use strom_types::stats::{BlockStats, StatMetadata, StatValue, Statistic};
 use strom_types::whep::{IceServer, IceServersResponse, WhepStreamInfo, WhepStreamsResponse};
 use utoipa::openapi::schema::{Discriminator, Schema};
@@ -97,6 +98,11 @@ use utoipa::OpenApi;
         crate::api::gst_launch::parse_gst_launch,
         crate::api::gst_launch::export_gst_launch,
         crate::api::network::list_interfaces,
+        crate::api::port_leases::list_port_leases,
+        crate::api::port_leases::create_port_lease,
+        crate::api::port_leases::get_port_lease,
+        crate::api::port_leases::renew_port_lease,
+        crate::api::port_leases::delete_port_lease,
         crate::api::version::get_version,
         crate::api::system_clock::get_system_clock,
         crate::api::logging::get_log_level,
@@ -164,6 +170,9 @@ use utoipa::OpenApi;
     ),
     components(
         schemas(
+            PortLease,
+            PortLeaseRequest,
+            RenewPortLeaseRequest,
             FlowResponse,
             FlowListResponse,
             FlowProperties,
@@ -306,6 +315,7 @@ use utoipa::OpenApi;
         (name = "blocks", description = "Reusable block management endpoints"),
         (name = "gst-launch", description = "gst-launch-1.0 import/export endpoints"),
         (name = "Network", description = "Network interface discovery endpoints"),
+        (name = "port-leases", description = "UDP port blocks reserved for external orchestrators"),
         (name = "System", description = "System information endpoints"),
         (name = "Media", description = "Media file management endpoints"),
         (name = "auth", description = "Authentication endpoints"),

--- a/backend/src/port_lease.rs
+++ b/backend/src/port_lease.rs
@@ -1,0 +1,515 @@
+//! Port lease allocation.
+//!
+//! The pool is a single configured [`PortRange`]. A lease is the lowest block
+//! of consecutive free ports that fits the request, where "free" means not
+//! covered by a live lease and not bound by an SRT listener in any flow this
+//! Strom knows about. The second condition is the safety net: a lease can
+//! lapse while the flows that were built on it keep running, and those ports
+//! must not be handed to anyone else until the flows are gone.
+//!
+//! Leases are keyed by the client's stable `client_id`. Asking again under the
+//! same name renews the existing lease rather than allocating another block,
+//! so a client that restarts keeps the ports its peers already point at.
+
+use chrono::{DateTime, Duration, SecondsFormat, Utc};
+use std::collections::BTreeSet;
+use strom_types::port_lease::{
+    PortLease, PortRange, DEFAULT_PORT_LEASE_TTL_SECS, MAX_PORT_LEASE_SIZE, MAX_PORT_LEASE_TTL_SECS,
+};
+use uuid::Uuid;
+
+/// Why a lease could not be granted or changed.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum PortLeaseError {
+    #[error("client_id must not be empty")]
+    EmptyClientId,
+    #[error("size must be between 1 and {MAX_PORT_LEASE_SIZE}, got {0}")]
+    BadSize(u16),
+    #[error("ttl_secs must be between 1 and {MAX_PORT_LEASE_TTL_SECS}, got {0}")]
+    BadTtl(u64),
+    #[error("no block of {size} free ports left in the lease pool {pool}")]
+    Exhausted { size: u16, pool: PortRange },
+    #[error("port lease not found")]
+    NotFound,
+}
+
+/// One granted lease, with parsed timestamps.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Lease {
+    pub id: Uuid,
+    pub client_id: String,
+    pub range: PortRange,
+    pub created_at: DateTime<Utc>,
+    pub expires_at: DateTime<Utc>,
+}
+
+impl Lease {
+    pub fn is_expired(&self, now: DateTime<Utc>) -> bool {
+        self.expires_at <= now
+    }
+
+    /// The API view of the lease.
+    pub fn to_api(&self) -> PortLease {
+        PortLease {
+            id: self.id,
+            client_id: self.client_id.clone(),
+            first_port: self.range.first,
+            last_port: self.range.last,
+            created_at: rfc3339(self.created_at),
+            expires_at: rfc3339(self.expires_at),
+        }
+    }
+
+    /// Rebuild from a persisted record. Unparseable timestamps are treated as
+    /// already expired, which is the safe direction: the block is reclaimed
+    /// (unless flows still bind it) instead of being reserved forever.
+    pub fn from_api(lease: &PortLease) -> Self {
+        let parse = |s: &str| {
+            DateTime::parse_from_rfc3339(s)
+                .map(|t| t.with_timezone(&Utc))
+                .unwrap_or(DateTime::<Utc>::UNIX_EPOCH)
+        };
+        Self {
+            id: lease.id,
+            client_id: lease.client_id.clone(),
+            range: lease.range(),
+            created_at: parse(&lease.created_at),
+            expires_at: parse(&lease.expires_at),
+        }
+    }
+}
+
+fn rfc3339(t: DateTime<Utc>) -> String {
+    t.to_rfc3339_opts(SecondsFormat::Secs, true)
+}
+
+/// The lease table for one pool. Pure: every operation takes `now` and the
+/// set of ports flows currently bind, so it can be exercised without a clock
+/// or a pipeline. Persistence and locking live in `AppState`.
+#[derive(Debug, Clone)]
+pub struct PortLeaseTable {
+    pool: PortRange,
+    leases: Vec<Lease>,
+}
+
+/// What `acquire` did.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Acquired {
+    /// A new block was allocated.
+    Created,
+    /// The client already held a lease; it was renewed (and possibly resized).
+    Renewed,
+}
+
+impl PortLeaseTable {
+    pub fn new(pool: PortRange) -> Self {
+        Self {
+            pool,
+            leases: Vec::new(),
+        }
+    }
+
+    /// Replace the table's contents with persisted leases.
+    pub fn load(&mut self, leases: &[PortLease]) {
+        self.leases = leases.iter().map(Lease::from_api).collect();
+    }
+
+    pub fn pool(&self) -> PortRange {
+        self.pool
+    }
+
+    /// Change the pool. Existing leases outside the new pool are kept until
+    /// they expire; nothing new is cut from outside it.
+    pub fn set_pool(&mut self, pool: PortRange) {
+        self.pool = pool;
+    }
+
+    /// All live leases, in API form.
+    pub fn list(&self, now: DateTime<Utc>) -> Vec<PortLease> {
+        self.leases
+            .iter()
+            .filter(|l| !l.is_expired(now))
+            .map(Lease::to_api)
+            .collect()
+    }
+
+    pub fn get(&self, id: Uuid, now: DateTime<Utc>) -> Option<PortLease> {
+        self.leases
+            .iter()
+            .find(|l| l.id == id && !l.is_expired(now))
+            .map(Lease::to_api)
+    }
+
+    /// Drop lapsed leases. Returns how many went.
+    pub fn purge_expired(&mut self, now: DateTime<Utc>) -> usize {
+        let before = self.leases.len();
+        self.leases.retain(|l| !l.is_expired(now));
+        before - self.leases.len()
+    }
+
+    /// Grant or renew a lease for `client_id`.
+    ///
+    /// `bound_ports` are ports some flow binds as an SRT listener; they are
+    /// never allocated even when no lease covers them. A client that already
+    /// holds a lease gets it back renewed. If it now asks for a different
+    /// size, the block is grown in place when the ports after it are free,
+    /// shrunk in place when smaller, and otherwise moved to a fresh block; if
+    /// none fits, the old lease is kept and `Exhausted` is returned.
+    pub fn acquire(
+        &mut self,
+        client_id: &str,
+        size: u16,
+        ttl_secs: Option<u64>,
+        bound_ports: &BTreeSet<u16>,
+        now: DateTime<Utc>,
+    ) -> Result<(PortLease, Acquired), PortLeaseError> {
+        let client_id = client_id.trim();
+        if client_id.is_empty() {
+            return Err(PortLeaseError::EmptyClientId);
+        }
+        if size == 0 || size > MAX_PORT_LEASE_SIZE {
+            return Err(PortLeaseError::BadSize(size));
+        }
+        let ttl = Self::ttl(ttl_secs)?;
+        self.purge_expired(now);
+
+        if let Some(index) = self.leases.iter().position(|l| l.client_id == client_id) {
+            let current = self.leases[index].range;
+            let range = if u32::from(size) == current.len() {
+                current
+            } else {
+                // Try to keep the first port: peers already point at it.
+                let wanted_last = u32::from(current.first) + u32::from(size) - 1;
+                let in_place = u16::try_from(wanted_last)
+                    .ok()
+                    .and_then(|last| PortRange::new(current.first, last).ok())
+                    .filter(|r| {
+                        self.pool.contains(r.last)
+                            && r.iter()
+                                .filter(|p| !current.contains(*p))
+                                .all(|p| self.is_free(p, bound_ports, Some(index)))
+                    });
+                match in_place {
+                    Some(r) => r,
+                    None => self.find_block(size, bound_ports, Some(index)).ok_or(
+                        PortLeaseError::Exhausted {
+                            size,
+                            pool: self.pool,
+                        },
+                    )?,
+                }
+            };
+            let lease = &mut self.leases[index];
+            lease.range = range;
+            lease.expires_at = now + ttl;
+            return Ok((lease.to_api(), Acquired::Renewed));
+        }
+
+        let range = self
+            .find_block(size, bound_ports, None)
+            .ok_or(PortLeaseError::Exhausted {
+                size,
+                pool: self.pool,
+            })?;
+        let lease = Lease {
+            id: Uuid::new_v4(),
+            client_id: client_id.to_string(),
+            range,
+            created_at: now,
+            expires_at: now + ttl,
+        };
+        let api = lease.to_api();
+        self.leases.push(lease);
+        Ok((api, Acquired::Created))
+    }
+
+    /// Push a lease's expiry out to `now + ttl`.
+    pub fn renew(
+        &mut self,
+        id: Uuid,
+        ttl_secs: Option<u64>,
+        now: DateTime<Utc>,
+    ) -> Result<PortLease, PortLeaseError> {
+        let ttl = Self::ttl(ttl_secs)?;
+        self.purge_expired(now);
+        let lease = self
+            .leases
+            .iter_mut()
+            .find(|l| l.id == id)
+            .ok_or(PortLeaseError::NotFound)?;
+        lease.expires_at = now + ttl;
+        Ok(lease.to_api())
+    }
+
+    /// Give a lease back. Expired leases count as gone.
+    pub fn release(&mut self, id: Uuid, now: DateTime<Utc>) -> Result<(), PortLeaseError> {
+        self.purge_expired(now);
+        let before = self.leases.len();
+        self.leases.retain(|l| l.id != id);
+        if self.leases.len() == before {
+            return Err(PortLeaseError::NotFound);
+        }
+        Ok(())
+    }
+
+    /// The API form of every lease, expired or not, for persistence.
+    pub fn snapshot(&self) -> Vec<PortLease> {
+        self.leases.iter().map(Lease::to_api).collect()
+    }
+
+    fn ttl(ttl_secs: Option<u64>) -> Result<Duration, PortLeaseError> {
+        let secs = ttl_secs.unwrap_or(DEFAULT_PORT_LEASE_TTL_SECS);
+        if secs == 0 || secs > MAX_PORT_LEASE_TTL_SECS {
+            return Err(PortLeaseError::BadTtl(secs));
+        }
+        Ok(Duration::seconds(secs as i64))
+    }
+
+    /// Whether `port` is neither bound by a flow nor covered by a lease other
+    /// than the one at `except`.
+    fn is_free(&self, port: u16, bound_ports: &BTreeSet<u16>, except: Option<usize>) -> bool {
+        if bound_ports.contains(&port) {
+            return false;
+        }
+        !self
+            .leases
+            .iter()
+            .enumerate()
+            .any(|(i, l)| Some(i) != except && l.range.contains(port))
+    }
+
+    /// Lowest block of `size` consecutive free ports inside the pool.
+    fn find_block(
+        &self,
+        size: u16,
+        bound_ports: &BTreeSet<u16>,
+        except: Option<usize>,
+    ) -> Option<PortRange> {
+        let size = u32::from(size);
+        if size > self.pool.len() {
+            return None;
+        }
+        let mut run_start: Option<u16> = None;
+        let mut run_len: u32 = 0;
+        for port in self.pool.iter() {
+            if self.is_free(port, bound_ports, except) {
+                if run_start.is_none() {
+                    run_start = Some(port);
+                    run_len = 0;
+                }
+                run_len += 1;
+                if run_len == size {
+                    let first = run_start?;
+                    return PortRange::new(first, port).ok();
+                }
+            } else {
+                run_start = None;
+                run_len = 0;
+            }
+        }
+        None
+    }
+}
+
+/// The port an SRT URI listens on, if it is a listener.
+///
+/// Strom's SRT blocks describe their socket with a single `srt_uri` property,
+/// such as `srt://:47110?mode=listener` or `srt://0.0.0.0:47110?mode=listener`.
+/// Caller URIs (`srt://host:port?mode=caller`, or no mode at all, which
+/// libsrt treats as caller) bind an ephemeral local port and return `None`.
+pub fn srt_listener_port(uri: &str) -> Option<u16> {
+    let rest = uri.trim().strip_prefix("srt://")?;
+    let (authority, query) = rest.split_once('?').unwrap_or((rest, ""));
+    let is_listener = query
+        .split('&')
+        .filter_map(|kv| kv.split_once('='))
+        .any(|(k, v)| k.eq_ignore_ascii_case("mode") && v.eq_ignore_ascii_case("listener"));
+    if !is_listener {
+        return None;
+    }
+    // IPv6 literals carry their own colons: take the port after the closing
+    // bracket, otherwise after the last colon.
+    let port_str = match authority.rfind(']') {
+        Some(end) => authority[end + 1..].strip_prefix(':')?,
+        None => authority.rsplit_once(':')?.1,
+    };
+    port_str.parse().ok().filter(|p| *p != 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pool() -> PortRange {
+        PortRange::new(100, 119).unwrap()
+    }
+
+    fn t0() -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339("2026-09-10T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc)
+    }
+
+    fn range(l: &PortLease) -> (u16, u16) {
+        (l.first_port, l.last_port)
+    }
+
+    #[test]
+    fn allocates_lowest_blocks_first_and_is_idempotent_per_client() {
+        let mut t = PortLeaseTable::new(pool());
+        let none = BTreeSet::new();
+        let (a, how) = t.acquire("a", 5, None, &none, t0()).unwrap();
+        assert_eq!((range(&a), how), ((100, 104), Acquired::Created));
+        let (b, _) = t.acquire("b", 5, None, &none, t0()).unwrap();
+        assert_eq!(range(&b), (105, 109));
+        let (a2, how) = t
+            .acquire("a", 5, None, &none, t0() + Duration::seconds(30))
+            .unwrap();
+        assert_eq!((range(&a2), how), ((100, 104), Acquired::Renewed));
+        assert_eq!(a2.id, a.id);
+        assert!(a2.expires_at > a.expires_at);
+        assert_eq!(t.list(t0()).len(), 2);
+    }
+
+    #[test]
+    fn pool_exhaustion_is_reported() {
+        let mut t = PortLeaseTable::new(pool());
+        let none = BTreeSet::new();
+        t.acquire("a", 15, None, &none, t0()).unwrap();
+        let err = t.acquire("b", 6, None, &none, t0()).unwrap_err();
+        assert_eq!(
+            err,
+            PortLeaseError::Exhausted {
+                size: 6,
+                pool: pool()
+            }
+        );
+        // A smaller block still fits at the end.
+        let (b, _) = t.acquire("b", 5, None, &none, t0()).unwrap();
+        assert_eq!(range(&b), (115, 119));
+    }
+
+    #[test]
+    fn ports_bound_by_flows_are_skipped_even_without_a_lease() {
+        let mut t = PortLeaseTable::new(pool());
+        let bound: BTreeSet<u16> = [102, 110].into_iter().collect();
+        let (a, _) = t.acquire("a", 5, None, &bound, t0()).unwrap();
+        assert_eq!(range(&a), (103, 107));
+        let (b, _) = t.acquire("b", 5, None, &bound, t0()).unwrap();
+        assert_eq!(range(&b), (111, 115));
+    }
+
+    #[test]
+    fn expired_leases_are_reclaimed_but_bound_ports_are_not() {
+        let mut t = PortLeaseTable::new(pool());
+        let none = BTreeSet::new();
+        t.acquire("a", 5, Some(60), &none, t0()).unwrap();
+        let later = t0() + Duration::seconds(61);
+        assert!(t.list(later).is_empty());
+        // The old client's flows still listen on 100: the block moves past it.
+        let bound: BTreeSet<u16> = [100].into_iter().collect();
+        let (b, _) = t.acquire("b", 5, None, &bound, later).unwrap();
+        assert_eq!(range(&b), (101, 105));
+        // Without bound ports the whole block is reused.
+        let mut t = PortLeaseTable::new(pool());
+        t.acquire("a", 5, Some(60), &none, t0()).unwrap();
+        let (b, _) = t.acquire("b", 5, None, &none, later).unwrap();
+        assert_eq!(range(&b), (100, 104));
+    }
+
+    #[test]
+    fn resize_grows_in_place_when_possible_else_moves() {
+        let mut t = PortLeaseTable::new(pool());
+        let none = BTreeSet::new();
+        let (a, _) = t.acquire("a", 5, None, &none, t0()).unwrap();
+        let (a2, how) = t.acquire("a", 8, None, &none, t0()).unwrap();
+        assert_eq!((range(&a2), how), ((100, 107), Acquired::Renewed));
+        assert_eq!(a2.id, a.id);
+        // Shrinking keeps the first port too.
+        let (a3, _) = t.acquire("a", 3, None, &none, t0()).unwrap();
+        assert_eq!(range(&a3), (100, 102));
+        // A neighbour blocks growth in place, so the block moves.
+        t.acquire("b", 2, None, &none, t0()).unwrap(); // 103-104
+        let (a4, _) = t.acquire("a", 6, None, &none, t0()).unwrap();
+        assert_eq!(range(&a4), (105, 110));
+        // Growth that fits nowhere keeps the old lease.
+        let err = t.acquire("a", 19, None, &none, t0()).unwrap_err();
+        assert!(matches!(err, PortLeaseError::Exhausted { size: 19, .. }));
+        assert_eq!(range(&t.list(t0())[0]), (105, 110));
+    }
+
+    #[test]
+    fn renew_and_release() {
+        let mut t = PortLeaseTable::new(pool());
+        let none = BTreeSet::new();
+        let (a, _) = t.acquire("a", 5, Some(60), &none, t0()).unwrap();
+        let renewed = t
+            .renew(a.id, Some(120), t0() + Duration::seconds(30))
+            .unwrap();
+        assert_eq!(renewed.expires_at, "2026-09-10T12:02:30Z");
+        assert!(t.get(a.id, t0() + Duration::seconds(149)).is_some());
+        assert!(t.get(a.id, t0() + Duration::seconds(150)).is_none());
+        assert_eq!(
+            t.renew(a.id, None, t0() + Duration::seconds(150)),
+            Err(PortLeaseError::NotFound)
+        );
+        let (b, _) = t.acquire("b", 1, None, &none, t0()).unwrap();
+        t.release(b.id, t0()).unwrap();
+        assert_eq!(t.release(b.id, t0()), Err(PortLeaseError::NotFound));
+    }
+
+    #[test]
+    fn validates_input() {
+        let mut t = PortLeaseTable::new(pool());
+        let none = BTreeSet::new();
+        assert_eq!(
+            t.acquire("  ", 1, None, &none, t0()).unwrap_err(),
+            PortLeaseError::EmptyClientId
+        );
+        assert_eq!(
+            t.acquire("a", 0, None, &none, t0()).unwrap_err(),
+            PortLeaseError::BadSize(0)
+        );
+        assert_eq!(
+            t.acquire("a", 1, Some(0), &none, t0()).unwrap_err(),
+            PortLeaseError::BadTtl(0)
+        );
+        assert_eq!(
+            t.acquire("a", 1, Some(MAX_PORT_LEASE_TTL_SECS + 1), &none, t0())
+                .unwrap_err(),
+            PortLeaseError::BadTtl(MAX_PORT_LEASE_TTL_SECS + 1)
+        );
+    }
+
+    #[test]
+    fn survives_a_persistence_round_trip() {
+        let mut t = PortLeaseTable::new(pool());
+        let none = BTreeSet::new();
+        let (a, _) = t.acquire("a", 5, None, &none, t0()).unwrap();
+        let saved = t.snapshot();
+        let mut restored = PortLeaseTable::new(pool());
+        restored.load(&saved);
+        assert_eq!(restored.get(a.id, t0()), Some(a.clone()));
+        // Same client after a restart gets the same block back.
+        let (again, how) = restored.acquire("a", 5, None, &none, t0()).unwrap();
+        assert_eq!((again.id, how), (a.id, Acquired::Renewed));
+    }
+
+    #[test]
+    fn listener_port_is_read_from_srt_uris() {
+        assert_eq!(srt_listener_port("srt://:47110?mode=listener"), Some(47110));
+        assert_eq!(
+            srt_listener_port("srt://0.0.0.0:5000?mode=listener&latency=200"),
+            Some(5000)
+        );
+        assert_eq!(
+            srt_listener_port("srt://[::]:5001?latency=200&mode=Listener"),
+            Some(5001)
+        );
+        assert_eq!(srt_listener_port("srt://192.0.2.1:5000?mode=caller"), None);
+        assert_eq!(srt_listener_port("srt://192.0.2.1:5000"), None);
+        assert_eq!(srt_listener_port("udp://:5000"), None);
+        assert_eq!(srt_listener_port("srt://:0?mode=listener"), None);
+        assert_eq!(srt_listener_port("srt://?mode=listener"), None);
+    }
+}

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -5,6 +5,7 @@ use crate::blocks::BlockRegistry;
 use crate::discovery::DiscoveryService;
 use crate::events::EventBroadcaster;
 use crate::gst::{ElementDiscovery, PipelineError, PipelineManager};
+use crate::port_lease::{srt_listener_port, Acquired, PortLeaseError, PortLeaseTable};
 use crate::ptp_monitor::PtpMonitor;
 use crate::sharing::ChannelRegistry;
 use crate::storage::{JsonFileStorage, Storage};
@@ -13,16 +14,17 @@ use crate::thread_registry::ThreadRegistry;
 use crate::whep_registry::WhepRegistry;
 use crate::whip_registry::WhipRegistry;
 use crate::whip_session_manager::WhipSessionManager;
-use chrono::Local;
-use std::collections::{HashMap, HashSet};
+use chrono::{Local, Utc};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 use strom_types::element::{ElementInfo, PropertyValue};
-use strom_types::{Flow, FlowId, PipelineState, StromEvent};
+use strom_types::{Flow, FlowId, PipelineState, PortLease, PortRange, StromEvent};
 use tokio::sync::RwLock;
 use tracing::{debug, error, info, trace, warn};
 use tracing_subscriber::reload;
 use tracing_subscriber::EnvFilter;
+use uuid::Uuid;
 
 /// Handle for reloading the log filter at runtime.
 pub type LogReloadHandle = reload::Handle<EnvFilter, tracing_subscriber::Registry>;
@@ -105,6 +107,9 @@ struct AppStateInner {
     /// per-flow entry is cleared on `stop_flow`; a fresh start sees an empty
     /// set, which matches the build-time element defaults (gates closed).
     mixer_solo_state: RwLock<HashMap<FlowId, HashMap<String, HashSet<String>>>>,
+    /// Port leases handed to orchestrators. Guarded by one lock so an
+    /// allocation and its persistence cannot interleave with another.
+    port_leases: RwLock<PortLeaseTable>,
 }
 
 /// Pick the ramp_ms that should apply to a single property in a batched
@@ -160,8 +165,101 @@ impl AppState {
                 gst_debug_filter: parking_lot::Mutex::new(String::new()),
                 default_gst_debug_filter: parking_lot::Mutex::new(String::new()),
                 mixer_solo_state: RwLock::new(HashMap::new()),
+                port_leases: RwLock::new(PortLeaseTable::new(PortRange::default())),
             }),
         }
+    }
+
+    /// Set the pool the port lease API allocates from. Called once from main
+    /// after the configuration is loaded; existing leases are kept.
+    pub async fn set_port_lease_range(&self, range: PortRange) {
+        self.inner.port_leases.write().await.set_pool(range);
+        info!("Port lease pool set to {}", range);
+    }
+
+    /// The pool the port lease API allocates from.
+    pub async fn port_lease_range(&self) -> PortRange {
+        self.inner.port_leases.read().await.pool()
+    }
+
+    /// Ports any known flow binds as an SRT listener, whether or not it runs.
+    ///
+    /// A stopped flow binds its port the moment it starts, so the definition,
+    /// not the pipeline state, is what a lease must steer clear of.
+    pub async fn bound_srt_listener_ports(&self) -> BTreeSet<u16> {
+        let flows = self.inner.flows.read().await;
+        flows
+            .values()
+            .flat_map(|flow| flow.blocks.iter())
+            .filter_map(|block| match block.properties.get("srt_uri") {
+                Some(PropertyValue::String(uri)) => srt_listener_port(uri),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Grant or renew the lease for `client_id`.
+    pub async fn acquire_port_lease(
+        &self,
+        client_id: &str,
+        size: u16,
+        ttl_secs: Option<u64>,
+    ) -> anyhow::Result<Result<(PortLease, Acquired), PortLeaseError>> {
+        let bound = self.bound_srt_listener_ports().await;
+        let mut table = self.inner.port_leases.write().await;
+        let outcome = table.acquire(client_id, size, ttl_secs, &bound, Utc::now());
+        if let Ok((lease, how)) = &outcome {
+            info!(
+                "Port lease {} for '{}': {}-{} ({:?})",
+                lease.id, lease.client_id, lease.first_port, lease.last_port, how
+            );
+            self.inner
+                .storage
+                .save_port_leases(&table.snapshot())
+                .await?;
+        }
+        Ok(outcome)
+    }
+
+    /// Extend a lease.
+    pub async fn renew_port_lease(
+        &self,
+        id: Uuid,
+        ttl_secs: Option<u64>,
+    ) -> anyhow::Result<Result<PortLease, PortLeaseError>> {
+        let mut table = self.inner.port_leases.write().await;
+        let outcome = table.renew(id, ttl_secs, Utc::now());
+        if outcome.is_ok() {
+            self.inner
+                .storage
+                .save_port_leases(&table.snapshot())
+                .await?;
+        }
+        Ok(outcome)
+    }
+
+    /// Give a lease back.
+    pub async fn release_port_lease(&self, id: Uuid) -> anyhow::Result<Result<(), PortLeaseError>> {
+        let mut table = self.inner.port_leases.write().await;
+        let outcome = table.release(id, Utc::now());
+        if outcome.is_ok() {
+            info!("Port lease {} released", id);
+            self.inner
+                .storage
+                .save_port_leases(&table.snapshot())
+                .await?;
+        }
+        Ok(outcome)
+    }
+
+    /// Every live lease.
+    pub async fn list_port_leases(&self) -> Vec<PortLease> {
+        self.inner.port_leases.read().await.list(Utc::now())
+    }
+
+    /// One live lease.
+    pub async fn get_port_lease(&self, id: Uuid) -> Option<PortLease> {
+        self.inner.port_leases.read().await.get(id, Utc::now())
     }
 
     /// Set the log reload handle and default filter (called once from main after init_logging).
@@ -415,6 +513,16 @@ impl AppState {
 
     /// Load flows from storage into memory.
     pub async fn load_from_storage(&self) -> anyhow::Result<()> {
+        match self.inner.storage.load_port_leases().await {
+            Ok(leases) => {
+                if !leases.is_empty() {
+                    info!("Loaded {} port leases from storage", leases.len());
+                }
+                self.inner.port_leases.write().await.load(&leases);
+            }
+            Err(e) => warn!("Failed to load port leases from storage: {}", e),
+        }
+
         info!("Loading flows from storage...");
         match self.inner.storage.load_all().await {
             Ok(mut flows) => {

--- a/backend/src/storage/json_storage.rs
+++ b/backend/src/storage/json_storage.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use strom_types::{Flow, FlowId};
+use strom_types::{Flow, FlowId, PortLease};
 use tokio::fs;
 use tokio::sync::RwLock;
 use tracing::{debug, info, warn};
@@ -26,19 +26,38 @@ impl Default for StorageFormat {
     }
 }
 
+/// On-disk format of the port lease file.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct LeaseFileFormat {
+    version: u32,
+    leases: Vec<PortLease>,
+}
+
 /// Storage backend that persists flows to a JSON file.
+///
+/// Port leases live in a `port_leases.json` beside the flows file, so a data
+/// directory keeps holding one file per kind of thing.
 pub struct JsonFileStorage {
     path: PathBuf,
+    leases_path: PathBuf,
     cache: RwLock<Option<HashMap<FlowId, Flow>>>,
 }
 
 impl JsonFileStorage {
     /// Create a new JSON file storage.
     pub fn new(path: impl AsRef<Path>) -> Self {
+        let path = path.as_ref().to_path_buf();
+        let leases_path = path.with_file_name("port_leases.json");
         Self {
-            path: path.as_ref().to_path_buf(),
+            path,
+            leases_path,
             cache: RwLock::new(None),
         }
+    }
+
+    /// Where port leases are written.
+    pub fn leases_path(&self) -> &Path {
+        &self.leases_path
     }
 
     /// Load flows from file, using cache if available.
@@ -143,6 +162,45 @@ impl Storage for JsonFileStorage {
         let mut flows = self.load_all().await?;
         flows.insert(flow.id, flow.clone());
         self.save_all(&flows).await
+    }
+
+    async fn load_port_leases(&self) -> Result<Vec<PortLease>> {
+        if !self.leases_path.exists() {
+            return Ok(Vec::new());
+        }
+        let contents = fs::read_to_string(&self.leases_path).await?;
+        if contents.trim().is_empty() {
+            return Ok(Vec::new());
+        }
+        let file: LeaseFileFormat = serde_json::from_str(&contents)?;
+        debug!(
+            "Loaded {} port leases from {:?}",
+            file.leases.len(),
+            self.leases_path
+        );
+        Ok(file.leases)
+    }
+
+    async fn save_port_leases(&self, leases: &[PortLease]) -> Result<()> {
+        let file = LeaseFileFormat {
+            version: 1,
+            leases: leases.to_vec(),
+        };
+        let json = serde_json::to_string_pretty(&file)?;
+        if let Some(parent) = self.leases_path.parent() {
+            if !parent.exists() {
+                fs::create_dir_all(parent).await?;
+            }
+        }
+        let temp_path = self.leases_path.with_extension("tmp");
+        fs::write(&temp_path, json).await?;
+        fs::rename(&temp_path, &self.leases_path).await?;
+        debug!(
+            "Wrote {} port leases to {:?}",
+            leases.len(),
+            self.leases_path
+        );
+        Ok(())
     }
 
     async fn delete_flow(&self, id: &FlowId) -> Result<()> {

--- a/backend/src/storage/mod.rs
+++ b/backend/src/storage/mod.rs
@@ -8,7 +8,7 @@ pub use postgres_storage::PostgresStorage;
 
 use async_trait::async_trait;
 use std::collections::HashMap;
-use strom_types::{Flow, FlowId};
+use strom_types::{Flow, FlowId, PortLease};
 use tracing::info;
 
 /// Migrate a flow to handle deprecated blocks.
@@ -63,4 +63,10 @@ pub trait Storage: Send + Sync {
         flows.remove(id).ok_or(StorageError::NotFound(*id))?;
         self.save_all(&flows).await
     }
+
+    /// Load every persisted port lease, expired ones included.
+    async fn load_port_leases(&self) -> Result<Vec<PortLease>>;
+
+    /// Replace the persisted port leases with `leases`.
+    async fn save_port_leases(&self, leases: &[PortLease]) -> Result<()>;
 }

--- a/backend/src/storage/postgres_storage.rs
+++ b/backend/src/storage/postgres_storage.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use sqlx::postgres::{PgPool, PgPoolOptions};
 use sqlx::Row;
 use std::collections::HashMap;
-use strom_types::{Flow, FlowId};
+use strom_types::{Flow, FlowId, PortLease};
 use tracing::{debug, info, warn};
 
 /// Storage backend that persists flows to PostgreSQL.
@@ -86,6 +86,19 @@ impl PostgresStorage {
         .execute(&self.pool)
         .await?;
 
+        sqlx::query(
+            r#"
+            CREATE TABLE IF NOT EXISTS port_leases (
+                id UUID PRIMARY KEY,
+                client_id TEXT NOT NULL,
+                data JSONB NOT NULL,
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            )
+            "#,
+        )
+        .execute(&self.pool)
+        .await?;
+
         info!("Database migrations completed");
         Ok(())
     }
@@ -98,6 +111,52 @@ impl PostgresStorage {
 
 #[async_trait]
 impl Storage for PostgresStorage {
+    async fn load_port_leases(&self) -> Result<Vec<PortLease>> {
+        let rows = sqlx::query("SELECT data FROM port_leases")
+            .fetch_all(&self.pool)
+            .await
+            .map_err(|e| StorageError::Io(std::io::Error::other(e)))?;
+        let mut leases = Vec::with_capacity(rows.len());
+        for row in rows {
+            let data: serde_json::Value = row.get("data");
+            leases.push(serde_json::from_value(data)?);
+        }
+        debug!("Loaded {} port leases from PostgreSQL", leases.len());
+        Ok(leases)
+    }
+
+    async fn save_port_leases(&self, leases: &[PortLease]) -> Result<()> {
+        let mut tx = self
+            .pool
+            .begin()
+            .await
+            .map_err(|e| StorageError::Io(std::io::Error::other(e)))?;
+        sqlx::query("DELETE FROM port_leases")
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| StorageError::Io(std::io::Error::other(e)))?;
+        for lease in leases {
+            let data = serde_json::to_value(lease)?;
+            sqlx::query(
+                r#"
+                INSERT INTO port_leases (id, client_id, data, updated_at)
+                VALUES ($1, $2, $3, NOW())
+                "#,
+            )
+            .bind(lease.id)
+            .bind(&lease.client_id)
+            .bind(&data)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| StorageError::Io(std::io::Error::other(e)))?;
+        }
+        tx.commit()
+            .await
+            .map_err(|e| StorageError::Io(std::io::Error::other(e)))?;
+        debug!("Saved {} port leases to PostgreSQL", leases.len());
+        Ok(())
+    }
+
     async fn load_all(&self) -> Result<HashMap<FlowId, Flow>> {
         debug!("Loading all flows from PostgreSQL");
 

--- a/backend/tests/port_lease_api_test.rs
+++ b/backend/tests/port_lease_api_test.rs
@@ -1,0 +1,236 @@
+//! The port lease API end to end: allocation through the router, persistence
+//! across a restart, and the guard that keeps a lease off ports a flow
+//! already listens on.
+
+use axum::{
+    body::Body,
+    http::{header, Method, Request, StatusCode},
+    Router,
+};
+use serde_json::{json, Value};
+use std::collections::HashMap;
+use strom::create_app_with_state;
+use strom::state::AppState;
+use strom::storage::JsonFileStorage;
+use strom_types::block::{BlockInstance, Position};
+use strom_types::{Flow, PortLease, PortRange, PropertyValue};
+use tempfile::TempDir;
+use tower::ServiceExt;
+
+fn new_state(dir: &TempDir) -> AppState {
+    AppState::new(
+        JsonFileStorage::new(dir.path().join("flows.json")),
+        dir.path().join("blocks.json"),
+        dir.path(),
+        vec![],
+        "all".to_string(),
+        vec![],
+    )
+}
+
+async fn app_with_pool(state: &AppState, first: u16, last: u16) -> Router {
+    state
+        .set_port_lease_range(PortRange::new(first, last).unwrap())
+        .await;
+    state.load_from_storage().await.unwrap();
+    create_app_with_state(state.clone()).await
+}
+
+async fn call(app: &Router, method: Method, uri: &str, body: Option<Value>) -> (StatusCode, Value) {
+    let mut req = Request::builder().method(method).uri(uri);
+    let body = match body {
+        Some(v) => {
+            req = req.header(header::CONTENT_TYPE, "application/json");
+            Body::from(v.to_string())
+        }
+        None => Body::empty(),
+    };
+    let response = app.clone().oneshot(req.body(body).unwrap()).await.unwrap();
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let value = if bytes.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&bytes).unwrap()
+    };
+    (status, value)
+}
+
+fn lease(v: &Value) -> PortLease {
+    serde_json::from_value(v.clone()).unwrap()
+}
+
+fn srt_listener_flow(port: u16) -> Flow {
+    let mut flow = Flow::new("ingest");
+    let mut properties = HashMap::new();
+    properties.insert(
+        "srt_uri".to_string(),
+        PropertyValue::String(format!("srt://:{port}?mode=listener")),
+    );
+    flow.blocks.push(BlockInstance {
+        id: "srt_in".to_string(),
+        block_definition_id: "builtin.mpegtssrt_input".to_string(),
+        name: None,
+        properties,
+        position: Position { x: 0.0, y: 0.0 },
+        runtime_data: None,
+        computed_external_pads: None,
+    });
+    flow
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn leases_are_allocated_per_client_and_idempotent() {
+    gstreamer::init().unwrap();
+    let dir = TempDir::new().unwrap();
+    let state = new_state(&dir);
+    let app = app_with_pool(&state, 47100, 47139).await;
+
+    let (status, a) = call(
+        &app,
+        Method::POST,
+        "/api/port-leases",
+        Some(json!({"client_id": "open-live-a", "size": 20})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "{a}");
+    let a = lease(&a);
+    assert_eq!((a.first_port, a.last_port), (47100, 47119));
+
+    // The same client asking again gets the same block back, renewed.
+    let (status, again) = call(
+        &app,
+        Method::POST,
+        "/api/port-leases",
+        Some(json!({"client_id": "open-live-a", "size": 20})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(lease(&again).id, a.id);
+
+    let (status, b) = call(
+        &app,
+        Method::POST,
+        "/api/port-leases",
+        Some(json!({"client_id": "open-live-b", "size": 20})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    let b = lease(&b);
+    assert_eq!((b.first_port, b.last_port), (47120, 47139));
+
+    // The pool is now full.
+    let (status, err) = call(
+        &app,
+        Method::POST,
+        "/api/port-leases",
+        Some(json!({"client_id": "open-live-c", "size": 1})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT, "{err}");
+
+    let (status, list) = call(&app, Method::GET, "/api/port-leases", None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(list.as_array().unwrap().len(), 2);
+
+    // Renew with and without a body.
+    let renew_uri = format!("/api/port-leases/{}/renew", a.id);
+    let (status, renewed) = call(&app, Method::POST, &renew_uri, None).await;
+    assert_eq!(status, StatusCode::OK, "{renewed}");
+    let (status, renewed) = call(
+        &app,
+        Method::POST,
+        &renew_uri,
+        Some(json!({"ttl_secs": 30})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{renewed}");
+    assert_eq!(lease(&renewed).id, a.id);
+
+    // Release b and the block is free again.
+    let (status, _) = call(
+        &app,
+        Method::DELETE,
+        &format!("/api/port-leases/{}", b.id),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::NO_CONTENT);
+    let (status, _) = call(
+        &app,
+        Method::GET,
+        &format!("/api/port-leases/{}", b.id),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    let (status, c) = call(
+        &app,
+        Method::POST,
+        "/api/port-leases",
+        Some(json!({"client_id": "open-live-c", "size": 20})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    assert_eq!(lease(&c).first_port, 47120);
+
+    // Invalid input is a 400, not a 500.
+    let (status, _) = call(
+        &app,
+        Method::POST,
+        "/api/port-leases",
+        Some(json!({"client_id": "", "size": 20})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn leases_survive_a_restart_and_avoid_ports_flows_listen_on() {
+    gstreamer::init().unwrap();
+    let dir = TempDir::new().unwrap();
+
+    let first_lease = {
+        let state = new_state(&dir);
+        let app = app_with_pool(&state, 47100, 47119).await;
+        // A flow already listens on 47100: the block must start after it.
+        state.upsert_flow(srt_listener_flow(47100)).await.unwrap();
+        let (status, a) = call(
+            &app,
+            Method::POST,
+            "/api/port-leases",
+            Some(json!({"client_id": "open-live-a", "size": 5})),
+        )
+        .await;
+        assert_eq!(status, StatusCode::CREATED, "{a}");
+        let a = lease(&a);
+        assert_eq!((a.first_port, a.last_port), (47101, 47105));
+        a
+    };
+
+    // A new process over the same data directory still knows the lease, so
+    // the client gets its block back rather than a new one.
+    let state = new_state(&dir);
+    let app = app_with_pool(&state, 47100, 47119).await;
+    let (status, got) = call(
+        &app,
+        Method::GET,
+        &format!("/api/port-leases/{}", first_lease.id),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{got}");
+    assert_eq!(lease(&got), first_lease);
+
+    let (status, again) = call(
+        &app,
+        Method::POST,
+        "/api/port-leases",
+        Some(json!({"client_id": "open-live-a", "size": 5})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(lease(&again).first_port, 47101);
+}

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -46,6 +46,7 @@ full list and the CLI equivalents):
 | `STROM_DATABASE_URL` | PostgreSQL connection string (optional) — see [POSTGRESQL.md](POSTGRESQL.md) |
 | `STROM_ADMIN_USER` / `STROM_ADMIN_PASSWORD_HASH` / `STROM_API_KEY` | Authentication — see [AUTHENTICATION.md](AUTHENTICATION.md) |
 | `STROM_SERVER_ICE_SERVERS` | STUN/TURN servers for WebRTC |
+| `STROM_PORT_LEASE_RANGE` | UDP ports the port lease API hands to orchestrators (default `47100-47999`) — see [OPEN_LIVE_SETUP.md](OPEN_LIVE_SETUP.md) |
 | `STROM_TLS_CERT` / `STROM_TLS_KEY` | Built-in TLS (PEM) |
 | `RUST_LOG` | Logging level (default `info`) |
 

--- a/docs/OPEN_LIVE_SETUP.md
+++ b/docs/OPEN_LIVE_SETUP.md
@@ -218,6 +218,12 @@ This is the port Open Live needs reachable. Override it with `STROM_PORT` or `--
 
 Media-plane ports (RTP/SRT/WHIP/WHEP/AES67/NDI) are determined by the flows you build inside Strom and are independent of the control port — open those on the firewall as needed for each flow.
 
+### SRT port leases for a shared Strom
+
+When several Open Live instances share one Strom, each of them leases a block of SRT listener ports from Strom at startup (`POST /api/port-leases`) and only registers sources inside its block, so two instances never bind the same UDP port. Strom cuts the blocks from one pool, `47100-47999` by default. Override it with `STROM_PORT_LEASE_RANGE=first-last` or `[ports] lease_range` in `.strom.toml`, and open that whole UDP range inbound on the firewall. Size it for the number of instances times the ports each one asks for (Open Live's `STROM_PORT_LEASE_SIZE`, 20 by default). Live leases are listed at `GET /api/port-leases`.
+
+Code is the source of truth — this may have drifted; read the code for the current implementation.
+
 ---
 
 ## 7. ICE Servers (STUN / TURN) for WebRTC

--- a/openapi.json
+++ b/openapi.json
@@ -4158,6 +4158,262 @@
         }
       }
     },
+    "/api/port-leases": {
+      "get": {
+        "tags": [
+          "port-leases"
+        ],
+        "summary": "List live port leases.",
+        "operationId": "list_port_leases",
+        "responses": {
+          "200": {
+            "description": "Every lease that has not expired",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PortLease"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "port-leases"
+        ],
+        "summary": "Request a block of ports.",
+        "description": "Reserves `size` consecutive UDP ports from the server's lease pool for `client_id`. The call is idempotent per client: a client that already holds a lease gets it back, renewed, with a 200 instead of a 201, and a changed `size` resizes the block in place when the neighbouring ports are free. Ports an existing flow listens on are never handed out, even when no lease covers them. The lease lapses `ttl_secs` after the last request or renewal (default 600).",
+        "operationId": "create_port_lease",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PortLeaseRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "The client's existing lease, renewed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PortLease"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "A new lease was granted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PortLease"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid client_id, size or ttl_secs",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "No block of that size is free in the pool",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Lease could not be persisted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/port-leases/{id}": {
+      "get": {
+        "tags": [
+          "port-leases"
+        ],
+        "summary": "Get one port lease.",
+        "operationId": "get_port_lease",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Lease id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The lease",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PortLease"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No live lease with that id",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "port-leases"
+        ],
+        "summary": "Release a port lease.",
+        "operationId": "delete_port_lease",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Lease id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Lease released"
+          },
+          "404": {
+            "description": "No live lease with that id",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Lease could not be persisted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/port-leases/{id}/renew": {
+      "post": {
+        "tags": [
+          "port-leases"
+        ],
+        "summary": "Extend a port lease.",
+        "description": "Moves the lease's expiry to now plus `ttl_secs` (default 600). A lease that has already lapsed is gone: re-request it with the same `client_id` through `POST /api/port-leases` instead.",
+        "operationId": "renew_port_lease",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Lease id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Optional new lifetime",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RenewPortLeaseRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "The renewed lease",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PortLease"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid ttl_secs",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No live lease with that id",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Lease could not be persisted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/sources": {
       "get": {
         "tags": [
@@ -7385,6 +7641,78 @@
           }
         }
       },
+      "PortLease": {
+        "type": "object",
+        "description": "A block of ports reserved for one client.",
+        "required": [
+          "id",
+          "client_id",
+          "first_port",
+          "last_port",
+          "created_at",
+          "expires_at"
+        ],
+        "properties": {
+          "client_id": {
+            "type": "string",
+            "description": "The client's stable name. One lease per client; asking again returns it."
+          },
+          "created_at": {
+            "type": "string",
+            "description": "When the lease was first granted (RFC 3339, UTC)."
+          },
+          "expires_at": {
+            "type": "string",
+            "description": "When the lease lapses unless renewed (RFC 3339, UTC)."
+          },
+          "first_port": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Lowest leased port.",
+            "minimum": 0
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Lease identifier, used to renew and release it."
+          },
+          "last_port": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Highest leased port, inclusive.",
+            "minimum": 0
+          }
+        }
+      },
+      "PortLeaseRequest": {
+        "type": "object",
+        "description": "Ask for a block of ports.",
+        "required": [
+          "client_id",
+          "size"
+        ],
+        "properties": {
+          "client_id": {
+            "type": "string",
+            "description": "Stable name of the requesting client, such as an instance hostname.\nA repeat request under the same name renews and returns the existing\nlease instead of allocating a second one."
+          },
+          "size": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Number of consecutive ports wanted.",
+            "minimum": 0
+          },
+          "ttl_secs": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "Lifetime in seconds. Defaults to `DEFAULT_PORT_LEASE_TTL_SECS`.",
+            "minimum": 0
+          }
+        }
+      },
       "Position": {
         "type": "object",
         "description": "Position in the visual editor",
@@ -7761,6 +8089,21 @@
           "old_path": {
             "type": "string",
             "description": "Current path (relative to media root)"
+          }
+        }
+      },
+      "RenewPortLeaseRequest": {
+        "type": "object",
+        "description": "Extend a lease's lifetime.",
+        "properties": {
+          "ttl_secs": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "New lifetime in seconds, counted from now. Defaults to\n`DEFAULT_PORT_LEASE_TTL_SECS`.",
+            "minimum": 0
           }
         }
       },
@@ -11817,6 +12160,10 @@
     {
       "name": "Network",
       "description": "Network interface discovery endpoints"
+    },
+    {
+      "name": "port-leases",
+      "description": "UDP port blocks reserved for external orchestrators"
     },
     {
       "name": "System",

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -22,6 +22,7 @@ pub mod flow;
 pub mod mediaplayer;
 pub mod mixer;
 pub mod network;
+pub mod port_lease;
 pub mod routing;
 pub mod state;
 pub mod stats;
@@ -51,6 +52,7 @@ pub use flow::{CpuAffinity, Flow, FlowId, ThreadPriority, ThreadPriorityStatus};
 pub use network::{
     Ipv4AddressInfo, Ipv6AddressInfo, NetworkInterfaceInfo, NetworkInterfacesResponse,
 };
+pub use port_lease::{PortLease, PortLeaseRequest, PortRange, RenewPortLeaseRequest};
 pub use state::PipelineState;
 pub use stats::{
     BlockStats, BlockStatsResponse, FlowStats, FlowStatsAvailability, RtpJitterbufferStats,

--- a/types/src/port_lease.rs
+++ b/types/src/port_lease.rs
@@ -1,0 +1,240 @@
+//! Port leases: contiguous UDP port ranges handed out to API clients.
+//!
+//! A Strom shared by several orchestrators (for example, several Open Live
+//! instances) is the only place that knows which SRT listener ports are
+//! already spoken for. Each client asks for a block of ports under a stable
+//! `client_id`, renews it while it is alive, and lets it expire when it is
+//! gone. The server never binds the ports itself; a lease is a promise not to
+//! hand the same block to anyone else.
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
+use uuid::Uuid;
+
+#[cfg(feature = "openapi")]
+use utoipa::ToSchema;
+
+/// First port of the pool leases are cut from when nothing else is configured.
+pub const DEFAULT_PORT_LEASE_RANGE_FIRST: u16 = 47100;
+/// Last port of the default pool.
+pub const DEFAULT_PORT_LEASE_RANGE_LAST: u16 = 47999;
+/// How long a lease lives when the client does not say.
+pub const DEFAULT_PORT_LEASE_TTL_SECS: u64 = 600;
+/// Longest lifetime a client may ask for in one request or renewal.
+pub const MAX_PORT_LEASE_TTL_SECS: u64 = 86_400;
+/// Largest block one lease may cover.
+pub const MAX_PORT_LEASE_SIZE: u16 = 1000;
+
+/// An inclusive range of ports, written `first-last`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct PortRange {
+    /// Lowest port in the range.
+    pub first: u16,
+    /// Highest port in the range, inclusive.
+    pub last: u16,
+}
+
+impl PortRange {
+    /// Build a range, refusing port 0 and an inverted pair.
+    pub fn new(first: u16, last: u16) -> Result<Self, PortRangeError> {
+        if first == 0 {
+            return Err(PortRangeError::Zero);
+        }
+        if first > last {
+            return Err(PortRangeError::Inverted { first, last });
+        }
+        Ok(Self { first, last })
+    }
+
+    /// Number of ports in the range.
+    pub fn len(&self) -> u32 {
+        u32::from(self.last) - u32::from(self.first) + 1
+    }
+
+    /// A range always holds at least one port; this exists for clippy's sake.
+    pub fn is_empty(&self) -> bool {
+        false
+    }
+
+    /// Whether `port` lies inside the range.
+    pub fn contains(&self, port: u16) -> bool {
+        self.first <= port && port <= self.last
+    }
+
+    /// Whether the two ranges share at least one port.
+    pub fn overlaps(&self, other: &PortRange) -> bool {
+        self.first <= other.last && other.first <= self.last
+    }
+
+    /// Every port in the range, ascending.
+    pub fn iter(&self) -> impl Iterator<Item = u16> {
+        self.first..=self.last
+    }
+}
+
+impl Default for PortRange {
+    fn default() -> Self {
+        Self {
+            first: DEFAULT_PORT_LEASE_RANGE_FIRST,
+            last: DEFAULT_PORT_LEASE_RANGE_LAST,
+        }
+    }
+}
+
+impl fmt::Display for PortRange {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}-{}", self.first, self.last)
+    }
+}
+
+/// Why a `first-last` string is not a port range.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PortRangeError {
+    /// The text is not two numbers joined by a dash.
+    Syntax(String),
+    /// A bound is not a port number.
+    NotAPort(String),
+    /// Port 0 cannot be listened on.
+    Zero,
+    /// The first port is above the last.
+    Inverted { first: u16, last: u16 },
+}
+
+impl fmt::Display for PortRangeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Syntax(s) => write!(f, "expected a port range like 47100-47999, got '{s}'"),
+            Self::NotAPort(s) => write!(f, "'{s}' is not a port number (1-65535)"),
+            Self::Zero => write!(f, "port 0 cannot be part of a port range"),
+            Self::Inverted { first, last } => {
+                write!(f, "port range {first}-{last} runs backwards")
+            }
+        }
+    }
+}
+
+impl std::error::Error for PortRangeError {}
+
+impl FromStr for PortRange {
+    type Err = PortRangeError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = s.trim();
+        let (first, last) = s
+            .split_once('-')
+            .ok_or_else(|| PortRangeError::Syntax(s.to_string()))?;
+        let parse = |p: &str| {
+            p.trim()
+                .parse::<u16>()
+                .map_err(|_| PortRangeError::NotAPort(p.trim().to_string()))
+        };
+        Self::new(parse(first)?, parse(last)?)
+    }
+}
+
+/// A block of ports reserved for one client.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct PortLease {
+    /// Lease identifier, used to renew and release it.
+    pub id: Uuid,
+    /// The client's stable name. One lease per client; asking again returns it.
+    pub client_id: String,
+    /// Lowest leased port.
+    pub first_port: u16,
+    /// Highest leased port, inclusive.
+    pub last_port: u16,
+    /// When the lease was first granted (RFC 3339, UTC).
+    pub created_at: String,
+    /// When the lease lapses unless renewed (RFC 3339, UTC).
+    pub expires_at: String,
+}
+
+impl PortLease {
+    /// The leased ports as a range.
+    pub fn range(&self) -> PortRange {
+        PortRange {
+            first: self.first_port,
+            last: self.last_port,
+        }
+    }
+}
+
+/// Ask for a block of ports.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct PortLeaseRequest {
+    /// Stable name of the requesting client, such as an instance hostname.
+    /// A repeat request under the same name renews and returns the existing
+    /// lease instead of allocating a second one.
+    pub client_id: String,
+    /// Number of consecutive ports wanted.
+    pub size: u16,
+    /// Lifetime in seconds. Defaults to `DEFAULT_PORT_LEASE_TTL_SECS`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ttl_secs: Option<u64>,
+}
+
+/// Extend a lease's lifetime.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct RenewPortLeaseRequest {
+    /// New lifetime in seconds, counted from now. Defaults to
+    /// `DEFAULT_PORT_LEASE_TTL_SECS`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ttl_secs: Option<u64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_a_range() {
+        let r: PortRange = "47100-47999".parse().unwrap();
+        assert_eq!(r, PortRange::new(47100, 47999).unwrap());
+        assert_eq!(r.len(), 900);
+        assert_eq!(r.to_string(), "47100-47999");
+        assert_eq!(" 10 - 12 ".parse::<PortRange>().unwrap().len(), 3);
+    }
+
+    #[test]
+    fn rejects_bad_ranges() {
+        assert_eq!(
+            "47100".parse::<PortRange>(),
+            Err(PortRangeError::Syntax("47100".into()))
+        );
+        assert_eq!(
+            "a-b".parse::<PortRange>(),
+            Err(PortRangeError::NotAPort("a".into()))
+        );
+        assert_eq!("0-10".parse::<PortRange>(), Err(PortRangeError::Zero));
+        assert_eq!(
+            "20-10".parse::<PortRange>(),
+            Err(PortRangeError::Inverted {
+                first: 20,
+                last: 10
+            })
+        );
+        assert!("1-70000".parse::<PortRange>().is_err());
+    }
+
+    #[test]
+    fn overlap_and_contains() {
+        let a = PortRange::new(10, 20).unwrap();
+        let b = PortRange::new(20, 30).unwrap();
+        let c = PortRange::new(21, 30).unwrap();
+        assert!(a.overlaps(&b));
+        assert!(!a.overlaps(&c));
+        assert!(a.contains(10) && a.contains(20) && !a.contains(21));
+    }
+
+    #[test]
+    fn request_ttl_is_optional_in_json() {
+        let req: PortLeaseRequest = serde_json::from_str(r#"{"client_id":"a","size":20}"#).unwrap();
+        assert_eq!(req.ttl_secs, None);
+        assert_eq!(req.size, 20);
+    }
+}


### PR DESCRIPTION
## Why

A Strom shared by several Open Live instances is the only party that can keep their SRT listener ports apart. Today each orchestrator picks ports on its own, so two instances (or two venue gateways behind them) can both bind the same UDP port on the shared Strom and the second pipeline fails at start.

## What

A port lease resource. A client asks for a block of consecutive ports under a stable `client_id`, renews it while alive, and lets it lapse when gone. Asking again under the same `client_id` returns the same block renewed (200 instead of 201), so a restarting orchestrator keeps the ports its gateways already point at. A changed `size` resizes in place when the neighbouring ports are free, otherwise moves the block.

- `POST /api/port-leases`, `GET /api/port-leases`, `GET /api/port-leases/{id}`, `POST /api/port-leases/{id}/renew` (body optional), `DELETE /api/port-leases/{id}`; all behind the usual auth, all with utoipa annotations, `openapi.json` updated
- Allocation never hands out a port any known flow binds as an SRT listener (`srt_uri` with `mode=listener`), whether or not a lease covers it and whether or not the flow runs, so a lapsed lease cannot pull the rug from under a pipeline
- Pool configured with `[ports] lease_range` / `STROM_PORT_LEASE_RANGE`, default `47100-47999`
- Leases persist beside flows: `port_leases.json` next to `flows.json`, or a `port_leases` table on PostgreSQL (created in `run_migrations`)
- Default TTL 600 s, max 86400 s; expired leases are reclaimed lazily on the next call
- New types in `strom-types` (`PortRange`, `PortLease`, `PortLeaseRequest`, `RenewPortLeaseRequest`); the allocation table in `backend/src/port_lease.rs` is pure and takes `now` and the bound-port set as arguments

Consumers: Eyevinn/open-live `feat/strom-port-lease` acquires and renews a lease at boot and publishes the range to gateways; Eyevinn/open-live-ingest#1 uses it.

Docs: a short operator note in `OPEN_LIVE_SETUP.md` (with the drift disclaimer), a row in `DOCKER.md`, and a `[ports]` section in `.strom.toml.example`. No frontend changes in this PR.

## Tests

Ran:
- `cargo test -p strom-types` equivalent via `cargo test --lib` in `types` (62 passed, 4 new for `PortRange`)
- `cargo test --lib` in the backend: 550 passed, 9 new in `port_lease::tests` (lowest-block allocation, per-client idempotency, exhaustion, bound-port avoidance, expiry reclaim, resize in place and move, renew/release, validation, persistence round trip, `srt_listener_port` parsing)
- `cargo test --test port_lease_api_test`: 2 passed, end to end through the router including persistence across a second `AppState` on the same data dir and a flow already listening on a pool port
- `cargo test --test openapi_test` after updating `openapi.json`
- `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check`: clean

Not run: PostgreSQL storage against a live database (the new table and queries mirror the `flows` ones); anything against a live Open Live.