### PR TITLE
feat(whip): make drop-on-latency configurable on WHIP and WHEP Input

### DIFF
--- a/backend/src/blocks/builtin/whep.rs
+++ b/backend/src/blocks/builtin/whep.rs
@@ -183,6 +183,21 @@ fn parse_do_retransmission(properties: &HashMap<String, PropertyValue>) -> bool 
         .unwrap_or(true)
 }
 
+/// Parse drop_on_latency from properties (default: true).
+///
+/// True works around a GStreamer rtpjitterbuffer bug (see `build_whepsrc`'s
+/// iterate_recurse). False keeps late packets for a downstream WebRTC endpoint
+/// that buffers adaptively, and reinstates the stall.
+fn parse_drop_on_latency(properties: &HashMap<String, PropertyValue>) -> bool {
+    properties
+        .get("drop_on_latency")
+        .and_then(|v| match v {
+            PropertyValue::Bool(b) => Some(*b),
+            _ => None,
+        })
+        .unwrap_or(true)
+}
+
 /// Migrate a legacy `mode` property on a WHEP Output block to explicit
 /// `num_audio_tracks` / `num_video_tracks` counts, and drop `mode`.
 ///
@@ -317,6 +332,7 @@ fn build_whepsrc(
             }
         })
         .unwrap_or(DEFAULT_JITTERBUFFER_LATENCY_MS as u32);
+    let drop_on_latency = parse_drop_on_latency(properties);
 
     // Create namespaced element IDs
     let instance_id_owned = instance_id.to_string();
@@ -369,13 +385,15 @@ fn build_whepsrc(
             // of the mute gap instead of being output immediately.
             // Setting drop-on-latency on rtpbin propagates to all its
             // jitterbuffers, making them drop queued packets that exceed the
-            // configured latency — breaking the stall.
+            // configured latency — breaking the stall. Configurable because the
+            // workaround costs late packets a downstream WebRTC endpoint could
+            // still have used.
             // Upstream: https://gitlab.freedesktop.org/gstreamer/gst-plugins-good/-/merge_requests/951
             if name.starts_with("rtpbin") && element.has_property("drop-on-latency") {
-                element.set_property("drop-on-latency", true);
+                element.set_property("drop-on-latency", drop_on_latency);
                 info!(
-                    "WHEP Input (whepsrc): Set drop-on-latency=true on existing {}",
-                    name
+                    "WHEP Input (whepsrc): Set drop-on-latency={} on existing {}",
+                    drop_on_latency, name
                 );
             }
         }
@@ -586,6 +604,7 @@ fn build_whepclientsrc(
             }
         })
         .unwrap_or(DEFAULT_JITTERBUFFER_LATENCY_MS as u32);
+    let drop_on_latency = parse_drop_on_latency(properties);
 
     // Create namespaced element IDs
     let instance_id_owned = instance_id.to_string();
@@ -725,10 +744,10 @@ fn build_whepclientsrc(
                 // Workaround for GStreamer rtpjitterbuffer packet_spacing bug:
                 // see comment in build_whepsrc iterate_recurse for details.
                 if element_name.starts_with("rtpbin") && element.has_property("drop-on-latency") {
-                    element.set_property("drop-on-latency", true);
+                    element.set_property("drop-on-latency", drop_on_latency);
                     info!(
-                        "WHEP Input (whepclientsrc): Set drop-on-latency=true on {}",
-                        element_name
+                        "WHEP Input (whepclientsrc): Set drop-on-latency={} on {}",
+                        drop_on_latency, element_name
                     );
                 }
 
@@ -2290,6 +2309,20 @@ fn whep_input_definition() -> BlockDefinition {
                 live: false,
                 persist: None,
             },
+            ExposedProperty {
+                name: "drop_on_latency".to_string(),
+                label: "Drop On Latency".to_string(),
+                description: "Drop queued packets that exceed the jitterbuffer latency instead of holding them. On by default: it works around a jitterbuffer bug that otherwise stalls the stream for the length of a mute gap. Turn it off when a downstream WebRTC endpoint has its own adaptive buffer and should decide what is too late.".to_string(),
+                property_type: PropertyType::Bool,
+                default_value: Some(PropertyValue::Bool(true)),
+                mapping: PropertyMapping {
+                    element_id: "_block".to_string(),
+                    property_name: "drop_on_latency".to_string(),
+                    transform: None,
+                },
+                live: false,
+                persist: None,
+            },
         ],
         external_pads: ExternalPads {
             inputs: vec![],
@@ -2489,6 +2522,19 @@ mod tests {
         assert!(parse_do_retransmission(&raw_props(&[(
             "do_retransmission",
             PropertyValue::Bool(true)
+        )])));
+    }
+
+    #[test]
+    fn drop_on_latency_defaults_to_true() {
+        assert!(parse_drop_on_latency(&raw_props(&[])));
+    }
+
+    #[test]
+    fn drop_on_latency_respects_explicit_false() {
+        assert!(!parse_drop_on_latency(&raw_props(&[(
+            "drop_on_latency",
+            PropertyValue::Bool(false)
         )])));
     }
 

--- a/backend/src/blocks/builtin/whip.rs
+++ b/backend/src/blocks/builtin/whip.rs
@@ -165,6 +165,21 @@ fn parse_do_retransmission(properties: &HashMap<String, PropertyValue>) -> bool 
         .unwrap_or(true)
 }
 
+/// Parse drop_on_latency from properties (default: true).
+///
+/// True works around a GStreamer rtpjitterbuffer bug (see the comment in
+/// `whep.rs` `build_whepsrc` iterate_recurse). False keeps late packets for a
+/// downstream WebRTC endpoint that buffers adaptively, and reinstates the stall.
+fn parse_drop_on_latency(properties: &HashMap<String, PropertyValue>) -> bool {
+    properties
+        .get("drop_on_latency")
+        .and_then(|v| match v {
+            PropertyValue::Bool(b) => Some(*b),
+            _ => None,
+        })
+        .unwrap_or(true)
+}
+
 /// Keep a slot with no publisher from holding the pipeline out of PLAYING.
 ///
 /// A `decodebin` cannot complete READY->PAUSED until data arrives and it can
@@ -237,6 +252,7 @@ fn build_whipserversrc(
     // even though the packets arrived fine over the network.
     let jitterbuffer_latency_ms = parse_jitterbuffer_latency_ms(properties);
     let do_retransmission = parse_do_retransmission(properties);
+    let drop_on_latency = parse_drop_on_latency(properties);
 
     let max_video_bitrate_kbps = properties
         .get("max_video_bitrate")
@@ -496,8 +512,8 @@ fn build_whipserversrc(
     let turn_server = ctx.turn_server();
 
     info!(
-        "WHIP Input configured: endpoint_id='{}', stun={:?}, turn={:?}, mode={:?}, decode={}, do_retransmission={}, max_sessions={} (whipserversrc created per-session)",
-        endpoint_id, stun_server, turn_server, mode, decode, do_retransmission, max_sessions
+        "WHIP Input configured: endpoint_id='{}', stun={:?}, turn={:?}, mode={:?}, decode={}, do_retransmission={}, drop_on_latency={}, max_sessions={} (whipserversrc created per-session)",
+        endpoint_id, stun_server, turn_server, mode, decode, do_retransmission, drop_on_latency, max_sessions
     );
 
     // Register WHIP endpoint with the build context (port=0 placeholder, sessions get their own ports)
@@ -520,6 +536,7 @@ fn build_whipserversrc(
             video_decoding,
             jitterbuffer_latency_ms,
             do_retransmission,
+            drop_on_latency,
             dynamic_webrtcbin_store: ctx.dynamic_webrtcbin_store(),
             max_video_bitrate_kbps,
             max_sessions,
@@ -685,6 +702,7 @@ pub fn create_whipserversrc_for_session(
     let block_id_for_callback = config.instance_id.clone();
     let ice_transport_policy = config.ice_transport_policy.clone();
     let jitterbuffer_latency_ms = config.jitterbuffer_latency_ms;
+    let drop_on_latency = config.drop_on_latency;
     // `cleanup_sent` ensures only one cleanup request per session (shared across the
     // ICE callback, the inactivity watchdog and the session manager's teardown paths).
     let cleanup_sent_for_ice = cleanup_sent.clone();
@@ -697,9 +715,14 @@ pub fn create_whipserversrc_for_session(
 
             // Workaround for GStreamer rtpjitterbuffer packet_spacing bug:
             // see comment in whep.rs build_whepsrc iterate_recurse for details.
+            // Configurable because the workaround costs late packets a
+            // downstream WebRTC endpoint could still have used.
             if element_name.starts_with("rtpbin") && element.has_property("drop-on-latency") {
-                element.set_property("drop-on-latency", true);
-                info!("WHIP Input: Set drop-on-latency=true on {}", element_name);
+                element.set_property("drop-on-latency", drop_on_latency);
+                info!(
+                    "WHIP Input: Set drop-on-latency={} on {}",
+                    drop_on_latency, element_name
+                );
             }
 
             if element_name.starts_with("webrtcbin") {
@@ -1650,6 +1673,20 @@ fn whip_input_definition() -> BlockDefinition {
                 persist: None,
             },
             ExposedProperty {
+                name: "drop_on_latency".to_string(),
+                label: "Drop On Latency".to_string(),
+                description: "Drop queued packets that exceed the jitterbuffer latency instead of holding them. On by default: it works around a jitterbuffer bug that otherwise stalls the stream for the length of a mute gap. Turn it off when a downstream WebRTC endpoint has its own adaptive buffer and should decide what is too late.".to_string(),
+                property_type: PropertyType::Bool,
+                default_value: Some(PropertyValue::Bool(true)),
+                mapping: PropertyMapping {
+                    element_id: "_block".to_string(),
+                    property_name: "drop_on_latency".to_string(),
+                    transform: None,
+                },
+                live: false,
+                persist: None,
+            },
+            ExposedProperty {
                 name: "max_video_bitrate".to_string(),
                 label: "Max Video Bitrate (kbps)".to_string(),
                 description: "Maximum video bitrate hint sent to the browser via SDP. The browser's encoder will ramp up to this value.".to_string(),
@@ -1883,6 +1920,19 @@ mod tests {
     }
 
     #[test]
+    fn drop_on_latency_defaults_to_true() {
+        assert!(parse_drop_on_latency(&props(&[])));
+    }
+
+    #[test]
+    fn drop_on_latency_respects_explicit_false() {
+        assert!(!parse_drop_on_latency(&props(&[(
+            "drop_on_latency",
+            PropertyValue::Bool(false)
+        )])));
+    }
+
+    #[test]
     fn do_retransmission_respects_explicit_false() {
         assert!(!parse_do_retransmission(&props(&[(
             "do_retransmission",
@@ -2026,6 +2076,27 @@ mod tests {
             let configs = ctx.take_whip_endpoint_configs();
             assert_eq!(configs.len(), 1, "expected exactly one endpoint config");
             assert_eq!(configs[0].1.do_retransmission, expected);
+        }
+    }
+
+    /// Same contract for `drop_on_latency`: hardcoding the rtpbin workaround
+    /// back to a literal `true` fails the `false` case.
+    #[test]
+    fn drop_on_latency_reaches_whip_endpoint_config() {
+        let _ = gst::init();
+
+        for expected in [true, false] {
+            let ctx = BlockBuildContext::new(Vec::new(), "all".to_string());
+            build_whipserversrc(
+                "whip-drop-on-latency-test",
+                &props(&[("drop_on_latency", PropertyValue::Bool(expected))]),
+                &ctx,
+            )
+            .expect("build_whipserversrc failed");
+
+            let configs = ctx.take_whip_endpoint_configs();
+            assert_eq!(configs.len(), 1, "expected exactly one endpoint config");
+            assert_eq!(configs[0].1.drop_on_latency, expected);
         }
     }
 }

--- a/backend/src/whip_session_manager.rs
+++ b/backend/src/whip_session_manager.rs
@@ -46,6 +46,9 @@ pub struct WhipEndpointConfig {
     /// Whether whipserversrc should request retransmission (NACK) of lost
     /// packets from the publisher.
     pub do_retransmission: bool,
+    /// Whether the per-session rtpbin's jitterbuffers drop queued packets that
+    /// exceed `jitterbuffer_latency_ms` rather than holding them.
+    pub drop_on_latency: bool,
     /// Shared dynamic webrtcbin store for ICE policy tracking
     pub dynamic_webrtcbin_store: DynamicWebrtcbinStore,
     /// Maximum video bitrate hint for Chrome (kbps). Injected into the SDP


### PR DESCRIPTION
## Problem

`drop-on-latency` is set unconditionally on the per-session `rtpbin` inside WHIP Input, and on both WHEP Input transports. There is no way to turn it off.

It is there for a reason and stays on by default: after a mute gap, `rtpjitterbuffer`'s `calculate_packet_spacing` reads the large RTP timestamp jump as huge packet spacing, corrupting lost-timer scheduling so packets are held for the length of the gap instead of released. Setting `drop-on-latency` on `rtpbin` propagates to its jitterbuffers, which then drop queued packets exceeding the configured latency and break the stall. Upstream: [gst-plugins-good MR 951](https://gitlab.freedesktop.org/gstreamer/gst-plugins-good/-/merge_requests/951).

The cost shows up when Strom sits between two WebRTC endpoints. A middle box with a small jitterbuffer *and* `drop-on-latency` discards late packets the receiving browser could still have used and would have absorbed with its own adaptive buffer. What that path wants is a small buffer that passes everything, letting the endpoint absorb jitter once. That combination is not expressible today.

## Change

A `drop_on_latency` block property, default `true`, so existing flows behave exactly as they do now. Construction-time, not live, following `do_retransmission`:

- **WHIP Input**: `parse_drop_on_latency` → `WhipEndpointConfig.drop_on_latency` → applied in `create_whipserversrc_for_session`'s `deep-element-added` handler.
- **WHEP Input**: applied at both sites, the `iterate_recurse` sweep in `build_whepsrc` and the `deep-element-added` handler in `build_whepclientsrc`.

The workaround is unchanged and the default is unchanged. No new shared types, so the OpenAPI schema is untouched.

## Tests

Added:

- `drop_on_latency_defaults_to_true` and `drop_on_latency_respects_explicit_false` in both modules — parse-level.
- `drop_on_latency_reaches_whip_endpoint_config` — a real guard. It calls `build_whipserversrc` and asserts the value in the `WhipEndpointConfig` handed to the session manager. Verified it fails on revert: replacing the parse call with a literal `true` produces `left: true, right: false`.

That guard covers property → config. The last hop, config → `rtpbin`, is **not** covered: the `rtpbin` only exists inside `whipserversrc` after a session negotiates, so reaching it needs a live WHIP publisher with ICE. The existing `do_retransmission_reaches_whip_endpoint_config` stops at the same boundary.

The two WHEP Input sites have **no** guard beyond the parse tests. Both apply the value inside a `whepsrc` / `whepclientsrc` element tree that needs a live WHEP server to populate. Hardcoding either back to a literal would not fail any test in this PR. Called out rather than papered over with a test that always passes.

### Run locally (macOS, Darwin 25.6.0)

| Command | Result |
| --- | --- |
| `cargo test --lib` | 581 passed, 0 failed |
| `cargo test --test openapi_test` | 1 passed |
| `cargo clippy --all-targets` | clean |
| `cargo fmt --check` | clean |

Not run: the integration tests under `backend/tests/`, and anything requiring a live WHIP or WHEP peer. No manual verification against a real publisher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
