### PR TITLE
DO NOT MERGE (premise under revision): report codecs whepserversink drops from the offer

### DIFF
--- a/backend/src/blocks/builder.rs
+++ b/backend/src/blocks/builder.rs
@@ -2,7 +2,7 @@
 
 use crate::discovery::device::GstDeviceMap;
 use crate::events::EventBroadcaster;
-use crate::gst::SessionThreadConfig;
+use crate::gst::{BlockDiagnostic, BlockDiagnostics, SessionThreadConfig};
 use crate::whip_registry::WhipRegistry;
 use crate::whip_session_manager::WhipEndpointConfig;
 use gstreamer as gst;
@@ -115,6 +115,8 @@ pub struct BlockBuildContext {
     whip_registry: Option<WhipRegistry>,
     /// Element signal setup functions queued for connection at pipeline start
     element_setups: RefCell<Vec<ElementSetupFn>>,
+    /// Self-reported degradation checks queued for the block health scan
+    block_diagnostics: RefCell<BlockDiagnostics>,
     /// Thread priority config for dynamically created session pipelines (WHEP/WebRTC)
     session_thread_config: SessionThreadConfig,
     /// Live `gst::Device` map shared with the long-running `DeviceDiscovery`.
@@ -136,6 +138,7 @@ impl BlockBuildContext {
             dynamic_webrtcbins: Arc::new(Mutex::new(HashMap::new())),
             whip_registry: None,
             element_setups: RefCell::new(Vec::new()),
+            block_diagnostics: RefCell::new(Vec::new()),
             session_thread_config: SessionThreadConfig::new(),
             local_devices: Arc::new(Mutex::new(HashMap::new())),
         }
@@ -159,6 +162,7 @@ impl BlockBuildContext {
             dynamic_webrtcbins,
             whip_registry,
             element_setups: RefCell::new(Vec::new()),
+            block_diagnostics: RefCell::new(Vec::new()),
             session_thread_config,
             local_devices,
         }
@@ -340,6 +344,19 @@ impl BlockBuildContext {
     /// Called after block expansion to process the setups.
     pub fn take_element_setups(&self) -> Vec<ElementSetupFn> {
         self.element_setups.borrow_mut().drain(..).collect()
+    }
+
+    /// Register a degradation check the block health scan should poll.
+    ///
+    /// For failures the scan cannot see for itself, which means failures with
+    /// no stalled pad task in the flow pipeline behind them.
+    pub fn register_block_diagnostic(&self, diagnostic: Arc<dyn BlockDiagnostic>) {
+        self.block_diagnostics.borrow_mut().push(diagnostic);
+    }
+
+    /// Take all queued degradation checks.
+    pub fn take_block_diagnostics(&self) -> BlockDiagnostics {
+        self.block_diagnostics.borrow_mut().drain(..).collect()
     }
 }
 

--- a/backend/src/blocks/builtin/whep.rs
+++ b/backend/src/blocks/builtin/whep.rs
@@ -24,6 +24,10 @@ use strom_types::{block::*, element::ElementPadRef, PropertyValue, *};
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
+pub mod codec_report;
+
+use codec_report::CodecDiscoveryReport;
+
 /// WHEP Input block builder.
 pub struct WHEPInputBuilder;
 
@@ -1130,6 +1134,14 @@ fn build_whepserversink(
         whepserversink.set_property("video-caps", gst::Caps::new_empty());
     }
 
+    // Watch which of the requested video codecs survive whepserversink's codec
+    // discovery. A codec that fails is dropped from the offer with nothing on
+    // the bus and no change of state, so without this the block looks healthy
+    // while viewers silently fall back to a codec nobody chose.
+    let codec_report = CodecDiscoveryReport::new(instance_id.to_string());
+    codec_report.attach(&whepserversink);
+    ctx.register_block_diagnostic(codec_report.clone());
+
     // Install thread priority on session pipelines via pad probes.
     //
     // consumer-pipeline-created fires BEFORE webrtcsink sets its bus sync handler,
@@ -1602,6 +1614,7 @@ fn build_whepserversink(
             let whepserversink_weak = whepserversink.downgrade();
             let video_caps_set_clone = video_caps_set.clone();
             let instance_id_owned = instance_id.to_string();
+            let codec_report_probe = codec_report.clone();
 
             let video_queue_sink = video_queue.static_pad("sink").expect("queue has sink pad");
             video_queue_sink.add_probe(gst::PadProbeType::EVENT_DOWNSTREAM, move |_pad, info| {
@@ -1682,10 +1695,17 @@ fn build_whepserversink(
                                     }
                                 };
 
-                                if let Some(caps) = video_caps {
-                                    if let Some(whepserversink) = whepserversink_weak.upgrade() {
+                                if let Some(whepserversink) = whepserversink_weak.upgrade() {
+                                    if let Some(caps) = video_caps {
                                         whepserversink.set_property("video-caps", &caps);
                                     }
+                                    // Read the property back rather than using
+                                    // the value above: an unrecognised input
+                                    // codec leaves the element's own default in
+                                    // place, and that is what discovery tries.
+                                    codec_report_probe.set_requested(
+                                        &whepserversink.property::<gst::Caps>("video-caps"),
+                                    );
                                 }
                             }
                         }

--- a/backend/src/blocks/builtin/whep/codec_report.rs
+++ b/backend/src/blocks/builtin/whep/codec_report.rs
@@ -16,6 +16,16 @@
 //! `identity` handed over there sees a CAPS event exactly when that codec got
 //! past the encoder, and sees nothing when it did not.
 //!
+//! Only the first round of discovery counts. That is the one that runs when
+//! the input caps arrive, with output caps of `ANY`, and its result becomes the
+//! codec list the sink will answer a viewer with. Every later round belongs to
+//! a viewer that has already connected and is asked a different question - its
+//! output caps come from that viewer's SDP, so `force_profile` is false and the
+//! `codec-parser-caps` filter stops demanding `constrained-baseline`. H.264
+//! therefore passes on the viewer path even when it failed at startup, and
+//! letting that clear the verdict would report the block healthy while its
+//! answer still has no H.264 in it.
+//!
 //! Audio is left alone. There is one audio codec to discover, and a WHEP
 //! output that loses it stalls a pad task in the flow pipeline, which the
 //! health scan already finds.
@@ -60,9 +70,11 @@ struct Inner {
     attempts: BTreeMap<String, Attempt>,
     /// When the most recent discovery pipeline was built.
     last_attempt_at: Option<Instant>,
-    /// Last verdict reached, held while a later round of discovery settles so
-    /// that a viewer connecting does not flap the block's health.
+    /// Verdict on the first round of discovery. Held from the moment it is
+    /// reached; later rounds answer a different question and cannot revise it.
     verdict: Option<String>,
+    /// Whether `verdict` is final.
+    decided: bool,
 }
 
 /// Per-block record of which requested video codecs `whepserversink` kept.
@@ -154,6 +166,9 @@ impl CodecDiscoveryReport {
             return;
         };
         let mut inner = self.inner.lock().unwrap();
+        if inner.decided {
+            return;
+        }
         inner
             .attempts
             .entry(codec)
@@ -178,14 +193,14 @@ impl CodecDiscoveryReport {
 
         let negotiated = {
             let mut inner = self.inner.lock().unwrap();
+            if inner.decided {
+                return None;
+            }
             inner.last_attempt_at = Some(Instant::now());
             let attempt = inner.attempts.entry(codec.to_string()).or_insert(Attempt {
                 encoder: None,
                 negotiated: Arc::new(AtomicBool::new(false)),
             });
-            // A fresh round of discovery re-runs the same codecs. Reuse the
-            // flag rather than clearing it: a codec that has ever negotiated is
-            // one whepserversink can offer.
             Arc::clone(&attempt.negotiated)
         };
 
@@ -233,11 +248,14 @@ impl BlockDiagnostic for CodecDiscoveryReport {
     fn degraded(&self) -> Option<String> {
         let settled = {
             let inner = self.inner.lock().unwrap();
+            if inner.decided {
+                return inner.verdict.clone();
+            }
             // No discovery yet means nothing to conclude, not "all missing".
             inner.last_attempt_at?.elapsed() >= self.settle_after
         };
         if !settled {
-            return self.inner.lock().unwrap().verdict.clone();
+            return None;
         }
 
         let missing = self.missing();
@@ -246,7 +264,9 @@ impl BlockDiagnostic for CodecDiscoveryReport {
         } else {
             Some(missing.join("; "))
         };
-        self.inner.lock().unwrap().verdict = verdict.clone();
+        let mut inner = self.inner.lock().unwrap();
+        inner.verdict = verdict.clone();
+        inner.decided = true;
         verdict
     }
 }
@@ -335,16 +355,44 @@ mod tests {
         assert_eq!(report.degraded(), None);
     }
 
-    /// A viewer connecting makes whepserversink run discovery again. The
-    /// verdict has to hold across that, or the block flaps back to healthy for
-    /// as long as the new round takes to settle.
+    /// A viewer connecting makes whepserversink run discovery again, with the
+    /// viewer's own SDP caps instead of ANY, so `codec-parser-caps` stops
+    /// demanding constrained-baseline and H.264 passes where it failed at
+    /// startup. That says nothing about what the sink will answer with, so it
+    /// must not revise the verdict.
     #[test]
-    fn verdict_holds_while_a_later_round_settles() {
+    fn a_later_round_cannot_revise_the_verdict() {
+        let report = report_for(&["video/x-h264"]);
+        record(&report, "video/x-h264", "vtenc_h264", false);
+        let first = report.degraded();
+        assert_eq!(
+            first.as_deref(),
+            Some("H.264 was dropped from the offer: vtenc_h264 failed codec discovery")
+        );
+
+        // The viewer's round negotiates the same codec.
+        record(&report, "video/x-h264", "vtenc_h264", true);
+        assert_eq!(report.degraded(), first);
+    }
+
+    /// A codec that has not finished negotiating is not yet a dropped codec.
+    #[test]
+    fn an_unsettled_round_reports_nothing() {
         let report = CodecDiscoveryReport::with_settle("whep".to_string(), Duration::from_secs(60));
         report.inner.lock().unwrap().requested = vec!["video/x-h264".to_string()];
-        report.inner.lock().unwrap().verdict = Some("H.264 was dropped".to_string());
         record(&report, "video/x-h264", "vtenc_h264", false);
-        assert_eq!(report.degraded().as_deref(), Some("H.264 was dropped"));
+        assert_eq!(report.degraded(), None);
+    }
+
+    /// Once the first round has been judged healthy it stays healthy, and the
+    /// probe stops instrumenting later rounds.
+    #[test]
+    fn a_healthy_first_round_is_also_final() {
+        let report = report_for(&["video/x-h264"]);
+        record(&report, "video/x-h264", "vtenc_h264", true);
+        assert_eq!(report.degraded(), None);
+        assert!(report.inner.lock().unwrap().decided);
+        assert!(report.make_probe_filter("video/x-h264").is_none());
     }
 
     #[test]

--- a/backend/src/blocks/builtin/whep/codec_report.rs
+++ b/backend/src/blocks/builtin/whep/codec_report.rs
@@ -1,0 +1,367 @@
+//! Which of the video codecs a WHEP output asked for actually survived
+//! `whepserversink`'s codec discovery.
+//!
+//! Before it will offer a codec, `whepserversink` builds a throwaway pipeline
+//! per codec - encoder, parser, a `codec-parser-caps` capsfilter, payloader,
+//! appsink - and keeps the codec only if payloaded caps come out the far end.
+//! A codec whose pipeline errors is dropped from the offer and the element
+//! carries on with whatever is left. Nothing observable comes out of that:
+//! the discovery pipeline's bus sync handler returns `Drop` for every message,
+//! no property lists the surviving codecs, and the sink still reaches
+//! `PLAYING` and passes data on the codecs that did work.
+//!
+//! The one hook into that pipeline is `request-encoded-filter`, which asks for
+//! an element to splice in immediately downstream of `codec-parser-caps` -
+//! the capsfilter that rejects the encoder output when discovery fails. An
+//! `identity` handed over there sees a CAPS event exactly when that codec got
+//! past the encoder, and sees nothing when it did not.
+//!
+//! Audio is left alone. There is one audio codec to discover, and a WHEP
+//! output that loses it stalls a pad task in the flow pipeline, which the
+//! health scan already finds.
+
+use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use gstreamer as gst;
+use gstreamer::prelude::*;
+
+use crate::gst::BlockDiagnostic;
+
+/// How long after the last discovery pipeline was built before its outcome is
+/// treated as final.
+///
+/// Discovery pipelines for every codec are built back to back and then run
+/// concurrently, so the clock starts at the last one. A codec that is simply
+/// slow to negotiate - a software AV1 encoder on a loaded machine - must not
+/// be reported as dropped, and the cost of waiting is only that an operator
+/// sees the warning a few seconds later than it happened.
+const SETTLE_AFTER: Duration = Duration::from_secs(15);
+
+/// What became of one codec's discovery pipeline.
+struct Attempt {
+    /// Encoder factory `whepserversink` picked for this codec, once
+    /// `encoder-setup` has named it.
+    encoder: Option<String>,
+    /// Set when a CAPS event reaches the spliced-in filter, which only happens
+    /// if the encoder output was accepted.
+    negotiated: Arc<AtomicBool>,
+}
+
+#[derive(Default)]
+struct Inner {
+    /// Video codec media types the block asked `whepserversink` to offer, in
+    /// the order they appear in `video-caps`.
+    requested: Vec<String>,
+    /// Codec media type to the outcome of its discovery. Codecs discovery
+    /// never attempted are absent.
+    attempts: BTreeMap<String, Attempt>,
+    /// When the most recent discovery pipeline was built.
+    last_attempt_at: Option<Instant>,
+    /// Last verdict reached, held while a later round of discovery settles so
+    /// that a viewer connecting does not flap the block's health.
+    verdict: Option<String>,
+}
+
+/// Per-block record of which requested video codecs `whepserversink` kept.
+pub struct CodecDiscoveryReport {
+    block_id: String,
+    settle_after: Duration,
+    inner: Mutex<Inner>,
+}
+
+impl CodecDiscoveryReport {
+    pub fn new(block_id: String) -> Arc<Self> {
+        Self::with_settle(block_id, SETTLE_AFTER)
+    }
+
+    /// As [`new`](Self::new) with the settling delay overridden, so tests do
+    /// not have to wait out a real discovery round.
+    pub fn with_settle(block_id: String, settle_after: Duration) -> Arc<Self> {
+        Arc::new(Self {
+            block_id,
+            settle_after,
+            inner: Mutex::new(Inner::default()),
+        })
+    }
+
+    /// Record the codecs `video-caps` asks for. Call once the block has decided
+    /// what to put on the sink, reading the property back rather than the
+    /// intended value so that the element's own default is recorded when the
+    /// block leaves it alone.
+    pub fn set_requested(&self, video_caps: &gst::Caps) {
+        let requested: Vec<String> = (0..video_caps.size())
+            .filter_map(|i| video_caps.structure(i))
+            .map(|s| s.name().to_string())
+            .filter(|name| name.starts_with("video/") && name != "video/x-raw")
+            .collect();
+        self.inner.lock().unwrap().requested = requested;
+    }
+
+    /// Install the signal handlers this report reads.
+    ///
+    /// Both handlers capture only this `Arc`, never the sink, so the element
+    /// owning them does not end up in a reference cycle.
+    pub fn attach(self: &Arc<Self>, sink: &gst::Element) {
+        let encoder_report = Arc::clone(self);
+        sink.connect("encoder-setup", false, move |values| {
+            // Discovery names its consumer "discovery"; a real session names
+            // the peer. Only discovery decides what gets offered.
+            let consumer = values[1].get::<Option<String>>().unwrap_or(None);
+            if consumer.as_deref() != Some("discovery") {
+                return Some(false.to_value());
+            }
+            if let Ok(encoder) = values[3].get::<gst::Element>() {
+                encoder_report.record_encoder(&encoder);
+            }
+            // False leaves webrtcsink's own encoder configuration in place.
+            Some(false.to_value())
+        });
+
+        let filter_report = Arc::clone(self);
+        sink.connect("request-encoded-filter", false, move |values| {
+            // Discovery passes no consumer id, a real session does. Splicing an
+            // element into a session pipeline would change what viewers get.
+            let consumer = values[1].get::<Option<String>>().unwrap_or(None);
+            if consumer.is_some() {
+                return Some(None::<gst::Element>.to_value());
+            }
+            let codec = values[3]
+                .get::<gst::Caps>()
+                .ok()
+                .and_then(|caps| caps.structure(0).map(|s| s.name().to_string()));
+            let Some(codec) = codec.filter(|c| c.starts_with("video/")) else {
+                return Some(None::<gst::Element>.to_value());
+            };
+            Some(
+                filter_report
+                    .make_probe_filter(&codec)
+                    .map(|e| e.to_value())
+                    .unwrap_or_else(|| None::<gst::Element>.to_value()),
+            )
+        });
+    }
+
+    /// Note the encoder discovery picked, keyed by what that encoder produces
+    /// rather than by call order, since discovery runs per codec concurrently.
+    fn record_encoder(&self, encoder: &gst::Element) {
+        let Some(factory) = encoder.factory() else {
+            return;
+        };
+        let Some(codec) = encoder_output_media_type(&factory) else {
+            return;
+        };
+        let mut inner = self.inner.lock().unwrap();
+        inner
+            .attempts
+            .entry(codec)
+            .or_insert_with(|| Attempt {
+                encoder: None,
+                negotiated: Arc::new(AtomicBool::new(false)),
+            })
+            .encoder = Some(factory.name().to_string());
+    }
+
+    /// Build the `identity` spliced in below `codec-parser-caps` for `codec`,
+    /// and register the flag its pad probe sets.
+    fn make_probe_filter(&self, codec: &str) -> Option<gst::Element> {
+        let identity = gst::ElementFactory::make("identity")
+            .name(format!(
+                "{}:codec-probe:{}",
+                self.block_id,
+                codec.replace('/', "-")
+            ))
+            .build()
+            .ok()?;
+
+        let negotiated = {
+            let mut inner = self.inner.lock().unwrap();
+            inner.last_attempt_at = Some(Instant::now());
+            let attempt = inner.attempts.entry(codec.to_string()).or_insert(Attempt {
+                encoder: None,
+                negotiated: Arc::new(AtomicBool::new(false)),
+            });
+            // A fresh round of discovery re-runs the same codecs. Reuse the
+            // flag rather than clearing it: a codec that has ever negotiated is
+            // one whepserversink can offer.
+            Arc::clone(&attempt.negotiated)
+        };
+
+        let sink_pad = identity.static_pad("sink")?;
+        sink_pad.add_probe(gst::PadProbeType::EVENT_DOWNSTREAM, move |_pad, info| {
+            if let Some(gst::PadProbeData::Event(ref event)) = info.data {
+                if event.type_() == gst::EventType::Caps {
+                    negotiated.store(true, Ordering::SeqCst);
+                }
+            }
+            gst::PadProbeReturn::Ok
+        });
+
+        Some(identity)
+    }
+
+    /// Requested codecs that discovery did not deliver, with the reason for
+    /// each. Empty while discovery is still settling or nothing is missing.
+    fn missing(&self) -> Vec<String> {
+        let inner = self.inner.lock().unwrap();
+        inner
+            .requested
+            .iter()
+            .filter_map(|codec| match inner.attempts.get(codec) {
+                None => Some(format!(
+                    "{} was not offered: no encoder for it is installed",
+                    codec_label(codec)
+                )),
+                Some(attempt) if !attempt.negotiated.load(Ordering::SeqCst) => Some(format!(
+                    "{} was dropped from the offer: {} failed codec discovery",
+                    codec_label(codec),
+                    attempt.encoder.as_deref().unwrap_or("its encoder"),
+                )),
+                Some(_) => None,
+            })
+            .collect()
+    }
+}
+
+impl BlockDiagnostic for CodecDiscoveryReport {
+    fn block_id(&self) -> &str {
+        &self.block_id
+    }
+
+    fn degraded(&self) -> Option<String> {
+        let settled = {
+            let inner = self.inner.lock().unwrap();
+            // No discovery yet means nothing to conclude, not "all missing".
+            inner.last_attempt_at?.elapsed() >= self.settle_after
+        };
+        if !settled {
+            return self.inner.lock().unwrap().verdict.clone();
+        }
+
+        let missing = self.missing();
+        let verdict = if missing.is_empty() {
+            None
+        } else {
+            Some(missing.join("; "))
+        };
+        self.inner.lock().unwrap().verdict = verdict.clone();
+        verdict
+    }
+}
+
+/// The media type an encoder produces, read from its factory's src pad
+/// template. This is what ties an `encoder-setup` callback to the codec being
+/// discovered without relying on the order the concurrent discoveries run in.
+fn encoder_output_media_type(factory: &gst::ElementFactory) -> Option<String> {
+    factory
+        .static_pad_templates()
+        .into_iter()
+        .find(|t| t.direction() == gst::PadDirection::Src)
+        .and_then(|t| t.caps().structure(0).map(|s| s.name().to_string()))
+}
+
+/// Codec media type as an operator would name it.
+fn codec_label(media_type: &str) -> &str {
+    match media_type {
+        "video/x-h264" => "H.264",
+        "video/x-h265" => "H.265",
+        "video/x-vp8" => "VP8",
+        "video/x-vp9" => "VP9",
+        "video/x-av1" => "AV1",
+        other => other,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Stand in for a discovery round: `codec` was tried with `encoder`, and
+    /// `negotiated` says whether its caps got past the parser capsfilter.
+    fn record(report: &CodecDiscoveryReport, codec: &str, encoder: &str, negotiated: bool) {
+        let mut inner = report.inner.lock().unwrap();
+        inner.last_attempt_at = Some(Instant::now());
+        inner.attempts.insert(
+            codec.to_string(),
+            Attempt {
+                encoder: Some(encoder.to_string()),
+                negotiated: Arc::new(AtomicBool::new(negotiated)),
+            },
+        );
+    }
+
+    fn report_for(requested: &[&str]) -> Arc<CodecDiscoveryReport> {
+        let report = CodecDiscoveryReport::with_settle("whep".to_string(), Duration::ZERO);
+        report.inner.lock().unwrap().requested = requested.iter().map(|c| c.to_string()).collect();
+        report
+    }
+
+    #[test]
+    fn every_requested_codec_negotiating_is_not_degraded() {
+        let report = report_for(&["video/x-h264", "video/x-vp9"]);
+        record(&report, "video/x-h264", "x264enc", true);
+        record(&report, "video/x-vp9", "vp9enc", true);
+        assert_eq!(report.degraded(), None);
+    }
+
+    #[test]
+    fn a_codec_whose_discovery_failed_names_its_encoder() {
+        let report = report_for(&["video/x-h264", "video/x-vp9"]);
+        record(&report, "video/x-h264", "vtenc_h264", false);
+        record(&report, "video/x-vp9", "vp9enc", true);
+        assert_eq!(
+            report.degraded().as_deref(),
+            Some("H.264 was dropped from the offer: vtenc_h264 failed codec discovery")
+        );
+    }
+
+    #[test]
+    fn a_codec_discovery_never_tried_reads_as_missing_encoder() {
+        let report = report_for(&["video/x-h264", "video/x-av1"]);
+        record(&report, "video/x-h264", "x264enc", true);
+        assert_eq!(
+            report.degraded().as_deref(),
+            Some("AV1 was not offered: no encoder for it is installed")
+        );
+    }
+
+    /// Nothing has been discovered yet, so there is no verdict to give - not
+    /// even "everything is missing".
+    #[test]
+    fn no_discovery_yet_is_not_degraded() {
+        let report = report_for(&["video/x-h264"]);
+        assert_eq!(report.degraded(), None);
+    }
+
+    /// A viewer connecting makes whepserversink run discovery again. The
+    /// verdict has to hold across that, or the block flaps back to healthy for
+    /// as long as the new round takes to settle.
+    #[test]
+    fn verdict_holds_while_a_later_round_settles() {
+        let report = CodecDiscoveryReport::with_settle("whep".to_string(), Duration::from_secs(60));
+        report.inner.lock().unwrap().requested = vec!["video/x-h264".to_string()];
+        report.inner.lock().unwrap().verdict = Some("H.264 was dropped".to_string());
+        record(&report, "video/x-h264", "vtenc_h264", false);
+        assert_eq!(report.degraded().as_deref(), Some("H.264 was dropped"));
+    }
+
+    #[test]
+    fn requested_codecs_come_from_the_caps_the_sink_was_given() {
+        gst::init().unwrap();
+        let report = CodecDiscoveryReport::new("whep".to_string());
+        let mut caps = gst::Caps::new_empty();
+        {
+            let m = caps.get_mut().unwrap();
+            m.append(gst::Caps::builder("video/x-h264").build());
+            m.append(gst::Caps::builder("video/x-raw").build());
+            m.append(gst::Caps::builder("video/x-vp9").build());
+        }
+        report.set_requested(&caps);
+        assert_eq!(
+            report.inner.lock().unwrap().requested,
+            vec!["video/x-h264".to_string(), "video/x-vp9".to_string()]
+        );
+    }
+}

--- a/backend/src/gst/block_diagnostics.rs
+++ b/backend/src/gst/block_diagnostics.rs
@@ -1,0 +1,31 @@
+//! Degradation a block reports about itself.
+//!
+//! The stalled-pad-task scan in `gst::pipeline::health` sees pads in the flow
+//! pipeline and nothing else. A block whose failure happens inside a
+//! third-party element's private pipeline has to report it, because there is no
+//! pad in the flow pipeline that shows the failure and no bus message carrying
+//! it. `whepserversink`'s codec discovery is the case this exists for: it runs
+//! one throwaway pipeline per codec on a bus whose sync handler drops every
+//! message, and drops any codec that fails.
+//!
+//! Only degradation belongs here. A block that has stopped passing data
+//! entirely stalls a pad task in the flow pipeline, which the scan already
+//! finds.
+
+use std::sync::Arc;
+
+/// A block-supplied check for degradation that is invisible from the outside.
+pub trait BlockDiagnostic: Send + Sync {
+    /// Block instance ID this diagnostic reports for.
+    fn block_id(&self) -> &str;
+
+    /// `Some(detail)` once the block has settled into a degraded state, `None`
+    /// while it is healthy or still settling.
+    ///
+    /// Polled from the health scan every couple of seconds, so it must return
+    /// promptly and must not wait on the streaming threads.
+    fn degraded(&self) -> Option<String>;
+}
+
+/// Diagnostics collected from every block in one flow.
+pub type BlockDiagnostics = Vec<Arc<dyn BlockDiagnostic>>;

--- a/backend/src/gst/block_expansion.rs
+++ b/backend/src/gst/block_expansion.rs
@@ -5,7 +5,7 @@ use crate::blocks::{
     BlockBuildContext, BusMessageConnectFn, DynamicWebrtcbinStore, ElementSetupFn,
     WhepEndpointInfo, WhipEndpointInfo,
 };
-use crate::gst::SessionThreadConfig;
+use crate::gst::{BlockDiagnostics, SessionThreadConfig};
 use crate::whip_registry::WhipRegistry;
 use crate::whip_session_manager::WhipEndpointConfig;
 use gstreamer as gst;
@@ -35,6 +35,8 @@ pub struct ExpandedPipeline {
     pub whip_endpoints: Vec<WhipEndpointInfo>,
     /// WHIP endpoint configs for session manager registration
     pub whip_endpoint_configs: Vec<(String, WhipEndpointConfig)>,
+    /// Degradation checks blocks reported for the block health scan
+    pub block_diagnostics: BlockDiagnostics,
 }
 
 /// Expand block instances into GStreamer elements using BlockBuilder trait.
@@ -202,6 +204,15 @@ pub async fn expand_blocks(
         }
     }
 
+    // Collect degradation checks blocks want the health scan to poll
+    let block_diagnostics = ctx.take_block_diagnostics();
+    if !block_diagnostics.is_empty() {
+        debug!(
+            "Collected {} block diagnostic(s) for the health scan",
+            block_diagnostics.len()
+        );
+    }
+
     // Collect WHIP endpoint configs for session manager
     let whip_endpoint_configs = ctx.take_whip_endpoint_configs();
     if !whip_endpoint_configs.is_empty() {
@@ -231,6 +242,7 @@ pub async fn expand_blocks(
         whep_endpoints,
         whip_endpoints,
         whip_endpoint_configs,
+        block_diagnostics,
     })
 }
 

--- a/backend/src/gst/mod.rs
+++ b/backend/src/gst/mod.rs
@@ -1,5 +1,6 @@
 //! GStreamer integration.
 
+pub mod block_diagnostics;
 mod block_expansion;
 pub mod buffer_age_probe;
 pub(crate) mod control_bindings;
@@ -20,6 +21,7 @@ pub mod video_frame;
 pub mod volume_ramp;
 pub mod whep_probe;
 
+pub use block_diagnostics::{BlockDiagnostic, BlockDiagnostics};
 pub use discovery::ElementDiscovery;
 pub use pipeline::{PipelineError, PipelineManager};
 pub use thread_priority::{

--- a/backend/src/gst/pipeline/construction.rs
+++ b/backend/src/gst/pipeline/construction.rs
@@ -90,6 +90,8 @@ impl PipelineManager {
             cached_state: std::sync::Arc::new(std::sync::RwLock::new(PipelineState::Null)),
             qos_aggregator: QoSAggregator::new(),
             qos_broadcast_task: None,
+            block_health: std::sync::Arc::new(std::sync::RwLock::new(Vec::new())),
+            block_health_task: None,
             ptp_clock: None,
             ptp_stats: std::sync::Arc::new(std::sync::RwLock::new(None)),
             ntp_clock: None,

--- a/backend/src/gst/pipeline/construction.rs
+++ b/backend/src/gst/pipeline/construction.rs
@@ -92,6 +92,7 @@ impl PipelineManager {
             qos_broadcast_task: None,
             block_health: std::sync::Arc::new(std::sync::RwLock::new(Vec::new())),
             block_health_task: None,
+            block_diagnostics: Vec::new(),
             ptp_clock: None,
             ptp_stats: std::sync::Arc::new(std::sync::RwLock::new(None)),
             ntp_clock: None,
@@ -235,6 +236,7 @@ impl PipelineManager {
         }
         manager.whip_endpoints = expanded.whip_endpoints;
         manager.whip_endpoint_configs = expanded.whip_endpoint_configs;
+        manager.block_diagnostics = expanded.block_diagnostics;
 
         // Analyze links and auto-insert tee elements where needed
         let all_links = expanded.links;

--- a/backend/src/gst/pipeline/health.rs
+++ b/backend/src/gst/pipeline/health.rs
@@ -49,14 +49,21 @@ fn first_stalled_pad(element: &gst::Element) -> Option<StalledPad> {
 
 /// Find the first paused pad task on `element` itself.
 ///
-/// Two kinds of legitimately paused task are excluded. An element held below
-/// `PLAYING` - a webrtcbin added for a newly connected WHEP consumer, say -
-/// pauses its tasks as part of that transition. And a pad that has seen EOS is
-/// finished by definition:
-/// `gst_base_src_loop` pauses its task on the way out for *every* reason
-/// including end of stream, and the element stays `PLAYING` afterwards, so a
-/// finite source that has played out would otherwise be reported as failed
-/// forever. The stall this looks for pushes no EOS.
+/// Three kinds of legitimately paused task are excluded.
+///
+/// An element held below `PLAYING` - a webrtcbin added for a newly connected
+/// WHEP consumer, say - pauses its tasks as part of that transition.
+///
+/// A pad that has seen EOS is finished by definition: `gst_base_src_loop` pauses
+/// its task on the way out for *every* reason including end of stream, and the
+/// element stays `PLAYING` afterwards, so a finite source that has played out
+/// would otherwise be reported as failed forever. The stall this looks for
+/// pushes no EOS.
+///
+/// An unlinked pad has no branch to report on. A `queue` feeding a block output
+/// that the flow leaves unconnected gets `not-linked` from its loop and parks
+/// the task there permanently - the vision mixer's `multiview_out` does exactly
+/// this whenever a flow uses only the program output.
 fn stalled_pad_on(element: &gst::Element) -> Option<StalledPad> {
     if element.current_state() != gst::State::Playing {
         return None;
@@ -67,6 +74,7 @@ fn stalled_pad_on(element: &gst::Element) -> Option<StalledPad> {
         .find(|pad| {
             pad.task_state() == gst::TaskState::Paused
                 && !pad.pad_flags().contains(gst::PadFlags::EOS)
+                && pad.peer().is_some()
         })
         .map(|pad| StalledPad {
             element: element.name().to_string(),
@@ -309,6 +317,46 @@ mod tests {
         flow
     }
 
+    /// videotestsrc -> tee, with one tee branch queued and left unconnected.
+    ///
+    /// Mirrors a block output the flow does not wire up - the vision mixer's
+    /// `multiview_out` is exactly this - where the queue's loop takes
+    /// `not-linked` and parks its task for good.
+    fn unwired_output_flow() -> Flow {
+        let mut flow = Flow::new("unwired output health test");
+        flow.elements = vec![
+            element(
+                "src",
+                "videotestsrc",
+                &[("is-live", PropertyValue::Bool(true))],
+            ),
+            element("split", "tee", &[]),
+            element("q_used", "queue", &[]),
+            element("sink", "fakesink", &[("sync", PropertyValue::Bool(false))]),
+            // Fed by the tee, going nowhere.
+            element("q_dangling", "queue", &[]),
+        ];
+        flow.links = vec![
+            Link {
+                from: "src".to_string(),
+                to: "split".to_string(),
+            },
+            Link {
+                from: "split".to_string(),
+                to: "q_used".to_string(),
+            },
+            Link {
+                from: "q_used".to_string(),
+                to: "sink".to_string(),
+            },
+            Link {
+                from: "split".to_string(),
+                to: "q_dangling".to_string(),
+            },
+        ];
+        flow
+    }
+
     /// videotestsrc with a fixed buffer count -> fakesink. Runs to EOS.
     fn finite_source_flow() -> Flow {
         let mut flow = Flow::new("eos health test");
@@ -336,6 +384,53 @@ mod tests {
             std::thread::sleep(Duration::from_millis(100));
         }
         condition()
+    }
+
+    /// A `queue` whose source pad is left unconnected takes `not-linked` from its
+    /// loop and parks the task while the element stays `PLAYING`. Blocks expose
+    /// optional outputs built this way, so reporting it would mark most flows
+    /// using them permanently failed.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn an_unwired_output_branch_is_not_reported_as_failed() {
+        gst::init().unwrap();
+
+        let mut manager = PipelineManager::new(
+            &unwired_output_flow(),
+            EventBroadcaster::default(),
+            &BlockRegistry::new("test_blocks.json"),
+            vec!["stun:stun.l.google.com:19302".to_string()],
+            "all".to_string(),
+            None,
+            std::path::PathBuf::from("./media"),
+            std::sync::Arc::new(std::sync::Mutex::new(HashMap::new())),
+        )
+        .expect("pipeline should build");
+
+        manager.start().expect("pipeline should start");
+        assert!(
+            wait_for(
+                || manager.get_state() == strom_types::PipelineState::Playing,
+                Duration::from_secs(10)
+            ),
+            "pipeline never reached Playing"
+        );
+
+        let went_failed = wait_for(
+            || {
+                manager
+                    .get_block_health()
+                    .iter()
+                    .any(|h| h.status == BlockHealthStatus::Failed)
+            },
+            HEALTH_POLL_INTERVAL * (CONFIRMATIONS_BEFORE_FAILED + 3),
+        );
+        assert!(
+            !went_failed,
+            "an unwired output branch must not read as failed: {:?}",
+            manager.get_block_health()
+        );
+
+        manager.stop().expect("pipeline should stop");
     }
 
     /// `gst_base_src_loop` pauses its pad task on the way out for every reason,

--- a/backend/src/gst/pipeline/health.rs
+++ b/backend/src/gst/pipeline/health.rs
@@ -41,9 +41,13 @@ fn first_stalled_pad(element: &gst::Element) -> Option<StalledPad> {
 
 /// Find the first paused pad task on `element` itself.
 ///
-/// Only elements that are themselves playing are considered. A sub-bin held in
-/// `PAUSED` inside a playing pipeline - a WebRTC session bin mid-setup, say -
-/// has paused pad tasks legitimately.
+/// Two kinds of legitimately paused task are excluded. An element held below
+/// `PLAYING` - a WebRTC session bin mid-setup, say - pauses its tasks as part of
+/// that transition. And a pad that has seen EOS is finished by definition:
+/// `gst_base_src_loop` pauses its task on the way out for *every* reason
+/// including end of stream, and the element stays `PLAYING` afterwards, so a
+/// finite source that has played out would otherwise be reported as failed
+/// forever. The stall this looks for pushes no EOS.
 fn stalled_pad_on(element: &gst::Element) -> Option<StalledPad> {
     if element.current_state() != gst::State::Playing {
         return None;
@@ -51,7 +55,10 @@ fn stalled_pad_on(element: &gst::Element) -> Option<StalledPad> {
     element
         .pads()
         .into_iter()
-        .find(|pad| pad.task_state() == gst::TaskState::Paused)
+        .find(|pad| {
+            pad.task_state() == gst::TaskState::Paused
+                && !pad.pad_flags().contains(gst::PadFlags::EOS)
+        })
         .map(|pad| StalledPad {
             element: element.name().to_string(),
             pad: pad.name().to_string(),
@@ -90,7 +97,7 @@ pub(crate) fn scan_block_health(elements: &HashMap<String, gst::Element>) -> Vec
         if let Some(stalled) = first_stalled_pad(element) {
             entry.status = BlockHealthStatus::Failed;
             entry.detail = Some(format!(
-                "pad task stopped on {}:{} - this branch is not passing data",
+                "pad task paused on {}:{} - this branch is not passing data",
                 stalled.element, stalled.pad
             ));
         }
@@ -101,6 +108,13 @@ pub(crate) fn scan_block_health(elements: &HashMap<String, gst::Element>) -> Vec
 
 /// How often the running pipeline is scanned for stalled pad tasks.
 const HEALTH_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// Consecutive scans a block must look stalled before it is reported.
+///
+/// Pad tasks are briefly paused for legitimate reasons - a flushing seek, a
+/// dynamic bin being linked in - so a single sample is not enough to call a
+/// block failed. Costs one extra poll interval of detection latency.
+const CONFIRMATIONS_BEFORE_FAILED: u32 = 2;
 
 impl super::PipelineManager {
     /// Current per-block health. Empty until the health task has run once.
@@ -129,6 +143,7 @@ impl super::PipelineManager {
         let task = tokio::spawn(async move {
             let mut interval = tokio::time::interval(HEALTH_POLL_INTERVAL);
             let mut failed: std::collections::HashSet<String> = std::collections::HashSet::new();
+            let mut strikes: HashMap<String, u32> = HashMap::new();
 
             loop {
                 interval.tick().await;
@@ -136,9 +151,8 @@ impl super::PipelineManager {
                 // Only meaningful while playing - a paused task is expected in
                 // every other state, including during startup and shutdown.
                 if *cached_state.read().unwrap() != strom_types::PipelineState::Playing {
-                    if !failed.is_empty() {
-                        failed.clear();
-                    }
+                    failed.clear();
+                    strikes.clear();
                     block_health.write().unwrap().clear();
                     continue;
                 }
@@ -151,7 +165,29 @@ impl super::PipelineManager {
                     continue;
                 }
 
-                let snapshot = scan_block_health(&elements);
+                let mut snapshot = scan_block_health(&elements);
+
+                // A block is only reported once it has looked stalled on
+                // CONFIRMATIONS_BEFORE_FAILED scans in a row. Downgrade the
+                // unconfirmed ones before anything observes the snapshot.
+                for health in &mut snapshot {
+                    if health.status.is_failed() {
+                        let count = strikes.entry(health.block_id.clone()).or_insert(0);
+                        *count += 1;
+                        if *count < CONFIRMATIONS_BEFORE_FAILED {
+                            health.status = BlockHealthStatus::Ok;
+                            health.detail = None;
+                        }
+                    } else {
+                        strikes.remove(&health.block_id);
+                    }
+                }
+
+                // Blocks whose elements have gone away drop out of the scan
+                // entirely; forget them rather than leaving a stale entry that
+                // no later iteration can clear.
+                failed.retain(|block_id| snapshot.iter().any(|h| &h.block_id == block_id));
+                strikes.retain(|block_id, _| snapshot.iter().any(|h| &h.block_id == block_id));
 
                 for health in &snapshot {
                     let was_failed = failed.contains(&health.block_id);
@@ -264,6 +300,24 @@ mod tests {
         flow
     }
 
+    /// videotestsrc with a fixed buffer count -> fakesink. Runs to EOS.
+    fn finite_source_flow() -> Flow {
+        let mut flow = Flow::new("eos health test");
+        flow.elements = vec![
+            element(
+                "src",
+                "videotestsrc",
+                &[("num-buffers", PropertyValue::Int(5))],
+            ),
+            element("sink", "fakesink", &[("sync", PropertyValue::Bool(false))]),
+        ];
+        flow.links = vec![Link {
+            from: "src".to_string(),
+            to: "sink".to_string(),
+        }];
+        flow
+    }
+
     fn wait_for(condition: impl Fn() -> bool, timeout: Duration) -> bool {
         let start = Instant::now();
         while start.elapsed() < timeout {
@@ -273,6 +327,64 @@ mod tests {
             std::thread::sleep(Duration::from_millis(100));
         }
         condition()
+    }
+
+    /// `gst_base_src_loop` pauses its pad task on the way out for every reason,
+    /// end of stream included, and leaves the element in `PLAYING`. Playing a
+    /// finite source to completion must not read as a failure.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_source_that_reaches_eos_is_not_reported_as_failed() {
+        gst::init().unwrap();
+
+        let mut manager = PipelineManager::new(
+            &finite_source_flow(),
+            EventBroadcaster::default(),
+            &BlockRegistry::new("test_blocks.json"),
+            vec!["stun:stun.l.google.com:19302".to_string()],
+            "all".to_string(),
+            None,
+            std::path::PathBuf::from("./media"),
+            std::sync::Arc::new(std::sync::Mutex::new(HashMap::new())),
+        )
+        .expect("pipeline should build");
+
+        manager.start().expect("pipeline should start");
+
+        // Let the source play out and the scan run several times over the
+        // drained pipeline.
+        assert!(
+            wait_for(
+                || manager
+                    .elements
+                    .get("src")
+                    .map(|e| e.static_pad("src").unwrap().pad_flags())
+                    .is_some_and(|f| f.contains(gst::PadFlags::EOS)),
+                Duration::from_secs(15)
+            ),
+            "source never reached EOS"
+        );
+        // Watch across several scans - long enough that a block would clear the
+        // confirmation threshold - and assert it never flips to failed.
+        let went_failed = wait_for(
+            || {
+                manager
+                    .get_block_health()
+                    .iter()
+                    .any(|h| h.status == BlockHealthStatus::Failed)
+            },
+            HEALTH_POLL_INTERVAL * (CONFIRMATIONS_BEFORE_FAILED + 3),
+        );
+        assert!(
+            !went_failed,
+            "a drained finite source must not read as failed: {:?}",
+            manager.get_block_health()
+        );
+        assert!(
+            !manager.get_block_health().is_empty(),
+            "health scan never produced a snapshot"
+        );
+
+        manager.stop().expect("pipeline should stop");
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/backend/src/gst/pipeline/health.rs
+++ b/backend/src/gst/pipeline/health.rs
@@ -11,6 +11,14 @@
 //! `GstBaseSrc` is the exception: it posts a flow error before pausing, so
 //! source-side failures already reach the bus handler.
 //!
+//! Scope: the scan reaches the flow pipeline's own elements and the bins beneath
+//! them, and nothing else. Blocks that run an isolated `gst::Pipeline` of their
+//! own - WHIP ingest sessions, a Media Player's decode chain - are siblings of
+//! that pipeline rather than children of it, so `iterate_recurse` never enters
+//! them. An `Ok` here therefore means "no stalled pad task among this flow
+//! pipeline's elements", not "this flow is passing data". Sinks that live in the
+//! flow pipeline, `whepserversink` included, are covered.
+//!
 //! A paused task on an element that is itself `PLAYING` is always wrong, so
 //! that is the signal used here. `gst_pad_get_task_state()` returns `Stopped`
 //! both for a pad whose task was stopped and for a pad that never had one, so
@@ -42,8 +50,9 @@ fn first_stalled_pad(element: &gst::Element) -> Option<StalledPad> {
 /// Find the first paused pad task on `element` itself.
 ///
 /// Two kinds of legitimately paused task are excluded. An element held below
-/// `PLAYING` - a WebRTC session bin mid-setup, say - pauses its tasks as part of
-/// that transition. And a pad that has seen EOS is finished by definition:
+/// `PLAYING` - a webrtcbin added for a newly connected WHEP consumer, say -
+/// pauses its tasks as part of that transition. And a pad that has seen EOS is
+/// finished by definition:
 /// `gst_base_src_loop` pauses its task on the way out for *every* reason
 /// including end of stream, and the element stays `PLAYING` afterwards, so a
 /// finite source that has played out would otherwise be reported as failed

--- a/backend/src/gst/pipeline/health.rs
+++ b/backend/src/gst/pipeline/health.rs
@@ -1,0 +1,368 @@
+//! Detection of stalled pad tasks in a running pipeline.
+//!
+//! A pad task is the thread that drives data out of a pad. Elements pause their
+//! own task when a downstream push fails with a non-fatal flow return such as
+//! `not-negotiated` - video encoders do this, and so does `GstAggregator`,
+//! which additionally marks all its sink pads flushing, stalling everything
+//! upstream of it. Neither posts to the bus, and pausing a task is not a state
+//! change, so the pipeline and every element in it stay `PLAYING` while that
+//! branch carries nothing.
+//!
+//! `GstBaseSrc` is the exception: it posts a flow error before pausing, so
+//! source-side failures already reach the bus handler.
+//!
+//! A paused task on an element that is itself `PLAYING` is always wrong, so
+//! that is the signal used here. `gst_pad_get_task_state()` returns `Stopped`
+//! both for a pad whose task was stopped and for a pad that never had one, so
+//! `Stopped` cannot be told apart from the common case and is not reported.
+
+use gstreamer as gst;
+use gstreamer::prelude::*;
+use std::collections::{BTreeMap, HashMap};
+use strom_types::flow::{BlockHealth, BlockHealthStatus};
+
+/// A pad whose task has been paused while the pipeline is playing.
+struct StalledPad {
+    element: String,
+    pad: String,
+}
+
+/// Find the first paused pad task on `element`, and on its children if it is a bin.
+fn first_stalled_pad(element: &gst::Element) -> Option<StalledPad> {
+    if let Some(stalled) = stalled_pad_on(element) {
+        return Some(stalled);
+    }
+    let bin = element.downcast_ref::<gst::Bin>()?;
+    bin.iterate_recurse()
+        .into_iter()
+        .flatten()
+        .find_map(|child| stalled_pad_on(&child))
+}
+
+/// Find the first paused pad task on `element` itself.
+///
+/// Only elements that are themselves playing are considered. A sub-bin held in
+/// `PAUSED` inside a playing pipeline - a WebRTC session bin mid-setup, say -
+/// has paused pad tasks legitimately.
+fn stalled_pad_on(element: &gst::Element) -> Option<StalledPad> {
+    if element.current_state() != gst::State::Playing {
+        return None;
+    }
+    element
+        .pads()
+        .into_iter()
+        .find(|pad| pad.task_state() == gst::TaskState::Paused)
+        .map(|pad| StalledPad {
+            element: element.name().to_string(),
+            pad: pad.name().to_string(),
+        })
+}
+
+/// Block instance ID owning `element_id`.
+///
+/// Block elements are namespaced `block_id:internal_id` by `BlockBuildResult`.
+/// A standalone element has no prefix and is reported under its own ID so that
+/// a stall outside a block is not silently dropped.
+fn owning_block(element_id: &str) -> &str {
+    element_id.split(':').next().unwrap_or(element_id)
+}
+
+/// Report health for every block with at least one element in `elements`.
+///
+/// Call only while the pipeline is playing; a paused task is expected in any
+/// other pipeline state.
+pub(crate) fn scan_block_health(elements: &HashMap<String, gst::Element>) -> Vec<BlockHealth> {
+    let mut by_block: BTreeMap<&str, BlockHealth> = BTreeMap::new();
+
+    for (element_id, element) in elements {
+        let block_id = owning_block(element_id);
+        let entry = by_block.entry(block_id).or_insert_with(|| BlockHealth {
+            block_id: block_id.to_string(),
+            status: BlockHealthStatus::Ok,
+            detail: None,
+        });
+
+        // A block is failed if any of its elements has a stalled pad; the first
+        // one found names the failure.
+        if entry.status.is_failed() {
+            continue;
+        }
+        if let Some(stalled) = first_stalled_pad(element) {
+            entry.status = BlockHealthStatus::Failed;
+            entry.detail = Some(format!(
+                "pad task stopped on {}:{} - this branch is not passing data",
+                stalled.element, stalled.pad
+            ));
+        }
+    }
+
+    by_block.into_values().collect()
+}
+
+/// How often the running pipeline is scanned for stalled pad tasks.
+const HEALTH_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);
+
+impl super::PipelineManager {
+    /// Current per-block health. Empty until the health task has run once.
+    pub fn get_block_health(&self) -> Vec<BlockHealth> {
+        self.block_health.read().unwrap().clone()
+    }
+
+    /// Start the periodic scan for stalled pad tasks.
+    pub(super) fn start_block_health_task(&mut self) {
+        self.stop_block_health_task();
+
+        // WeakRef, not a clone: a task holding strong element references would
+        // keep the pipeline alive past drop.
+        let weak_elements: Vec<(String, gst::glib::WeakRef<gst::Element>)> = self
+            .elements
+            .iter()
+            .map(|(id, element)| (id.clone(), element.downgrade()))
+            .collect();
+
+        let cached_state = self.cached_state.clone();
+        let block_health = self.block_health.clone();
+        let events = self.events.clone();
+        let flow_id = self.flow_id;
+        let flow_name = self.flow_name.clone();
+
+        let task = tokio::spawn(async move {
+            let mut interval = tokio::time::interval(HEALTH_POLL_INTERVAL);
+            let mut failed: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+            loop {
+                interval.tick().await;
+
+                // Only meaningful while playing - a paused task is expected in
+                // every other state, including during startup and shutdown.
+                if *cached_state.read().unwrap() != strom_types::PipelineState::Playing {
+                    if !failed.is_empty() {
+                        failed.clear();
+                    }
+                    block_health.write().unwrap().clear();
+                    continue;
+                }
+
+                let elements: HashMap<String, gst::Element> = weak_elements
+                    .iter()
+                    .filter_map(|(id, weak)| weak.upgrade().map(|el| (id.clone(), el)))
+                    .collect();
+                if elements.is_empty() {
+                    continue;
+                }
+
+                let snapshot = scan_block_health(&elements);
+
+                for health in &snapshot {
+                    let was_failed = failed.contains(&health.block_id);
+                    match (health.status.is_failed(), was_failed) {
+                        (true, false) => {
+                            failed.insert(health.block_id.clone());
+                            tracing::error!(
+                                "Block '{}' in flow '{}' has stopped: {}. The pipeline still reports Playing",
+                                health.block_id,
+                                flow_name,
+                                health.detail.as_deref().unwrap_or("no detail")
+                            );
+                            events.broadcast(strom_types::StromEvent::BlockHealthChanged {
+                                flow_id,
+                                block_id: health.block_id.clone(),
+                                status: health.status,
+                                detail: health.detail.clone(),
+                            });
+                        }
+                        (false, true) => {
+                            failed.remove(&health.block_id);
+                            tracing::info!(
+                                "Block '{}' in flow '{}' resumed passing data",
+                                health.block_id,
+                                flow_name
+                            );
+                            events.broadcast(strom_types::StromEvent::BlockHealthChanged {
+                                flow_id,
+                                block_id: health.block_id.clone(),
+                                status: health.status,
+                                detail: None,
+                            });
+                        }
+                        _ => {}
+                    }
+                }
+
+                *block_health.write().unwrap() = snapshot;
+            }
+        });
+
+        self.block_health_task = Some(task);
+    }
+
+    /// Stop the periodic health scan and drop the last snapshot.
+    pub(super) fn stop_block_health_task(&mut self) {
+        if let Some(task) = self.block_health_task.take() {
+            task.abort();
+        }
+        self.block_health.write().unwrap().clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::blocks::BlockRegistry;
+    use crate::events::EventBroadcaster;
+    use crate::gst::pipeline::PipelineManager;
+    use std::time::{Duration, Instant};
+    use strom_types::{Element, Flow, Link, PropertyValue};
+
+    #[test]
+    fn block_elements_are_attributed_to_their_block() {
+        assert_eq!(owning_block("whep:videoenc"), "whep");
+        assert_eq!(owning_block("whep:sink:inner"), "whep");
+        assert_eq!(owning_block("standalone_element"), "standalone_element");
+    }
+
+    fn element(id: &str, element_type: &str, props: &[(&str, PropertyValue)]) -> Element {
+        Element {
+            id: id.to_string(),
+            element_type: element_type.to_string(),
+            properties: props
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.clone()))
+                .collect(),
+            pad_properties: HashMap::new(),
+            position: (0.0, 0.0),
+        }
+    }
+
+    /// videotestsrc -> compositor -> capsfilter -> fakesink, as a real flow.
+    fn stall_flow() -> Flow {
+        let mut flow = Flow::new("block health test");
+        flow.elements = vec![
+            element(
+                "src",
+                "videotestsrc",
+                &[("is-live", PropertyValue::Bool(true))],
+            ),
+            element("comp", "compositor", &[]),
+            element("filter", "capsfilter", &[]),
+            element("sink", "fakesink", &[("sync", PropertyValue::Bool(false))]),
+        ];
+        flow.links = vec![
+            Link {
+                from: "src".to_string(),
+                to: "comp".to_string(),
+            },
+            Link {
+                from: "comp".to_string(),
+                to: "filter".to_string(),
+            },
+            Link {
+                from: "filter".to_string(),
+                to: "sink".to_string(),
+            },
+        ];
+        flow
+    }
+
+    fn wait_for(condition: impl Fn() -> bool, timeout: Duration) -> bool {
+        let start = Instant::now();
+        while start.elapsed() < timeout {
+            if condition() {
+                return true;
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+        condition()
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stalled_branch_is_reported_while_the_pipeline_still_says_playing() {
+        gst::init().unwrap();
+
+        let mut manager = PipelineManager::new(
+            &stall_flow(),
+            EventBroadcaster::default(),
+            &BlockRegistry::new("test_blocks.json"),
+            vec!["stun:stun.l.google.com:19302".to_string()],
+            "all".to_string(),
+            None,
+            std::path::PathBuf::from("./media"),
+            std::sync::Arc::new(std::sync::Mutex::new(HashMap::new())),
+        )
+        .expect("pipeline should build");
+
+        manager.start().expect("pipeline should start");
+        assert!(
+            wait_for(
+                || manager.get_state() == strom_types::PipelineState::Playing,
+                Duration::from_secs(10)
+            ),
+            "pipeline never reached Playing"
+        );
+        assert!(
+            wait_for(
+                || !manager.get_block_health().is_empty(),
+                Duration::from_secs(10)
+            ),
+            "health scan never produced a snapshot"
+        );
+        assert!(
+            manager
+                .get_block_health()
+                .iter()
+                .all(|h| h.status == BlockHealthStatus::Ok),
+            "a healthy pipeline should report no failures: {:?}",
+            manager.get_block_health()
+        );
+
+        // Retighten the capsfilter to a format the compositor cannot produce.
+        // The next push fails negotiation and the compositor pauses its source
+        // pad task without posting anything to the bus.
+        manager
+            .elements
+            .get("filter")
+            .expect("capsfilter should exist")
+            .set_property(
+                "caps",
+                gst::Caps::builder("video/x-bayer")
+                    .field("format", "bggr")
+                    .build(),
+            );
+
+        assert!(
+            wait_for(
+                || manager
+                    .get_block_health()
+                    .iter()
+                    .any(|h| h.block_id == "comp" && h.status == BlockHealthStatus::Failed),
+                Duration::from_secs(15)
+            ),
+            "stalled compositor was not reported: {:?}",
+            manager.get_block_health()
+        );
+
+        // The failure has to be visible without the pipeline state changing,
+        // which is the case the scan exists for.
+        assert_eq!(manager.get_state(), strom_types::PipelineState::Playing);
+
+        // An element deliberately held below Playing has paused pad tasks for a
+        // legitimate reason and must not be reported. Upstream elements that
+        // are still Playing and now blocked behind it are a real stall and stay
+        // reported, so only the paused element itself is checked here.
+        let compositor = manager.elements.get("comp").unwrap().clone();
+        compositor.set_state(gst::State::Paused).unwrap();
+        assert!(
+            wait_for(
+                || manager
+                    .get_block_health()
+                    .iter()
+                    .any(|h| h.block_id == "comp" && h.status == BlockHealthStatus::Ok),
+                Duration::from_secs(15)
+            ),
+            "a paused element should not be reported as failed: {:?}",
+            manager.get_block_health()
+        );
+
+        manager.stop().expect("pipeline should stop");
+    }
+}

--- a/backend/src/gst/pipeline/health.rs
+++ b/backend/src/gst/pipeline/health.rs
@@ -91,11 +91,18 @@ fn owning_block(element_id: &str) -> &str {
     element_id.split(':').next().unwrap_or(element_id)
 }
 
-/// Report health for every block with at least one element in `elements`.
+/// Report health for every block with at least one element in `elements`, plus
+/// every block that supplied a diagnostic.
+///
+/// A stalled pad task outranks a block's own report: a block that has stopped
+/// passing data altogether is failed, whatever else it is missing.
 ///
 /// Call only while the pipeline is playing; a paused task is expected in any
 /// other pipeline state.
-pub(crate) fn scan_block_health(elements: &HashMap<String, gst::Element>) -> Vec<BlockHealth> {
+pub(crate) fn scan_block_health(
+    elements: &HashMap<String, gst::Element>,
+    diagnostics: &crate::gst::BlockDiagnostics,
+) -> Vec<BlockHealth> {
     let mut by_block: BTreeMap<&str, BlockHealth> = BTreeMap::new();
 
     for (element_id, element) in elements {
@@ -118,6 +125,24 @@ pub(crate) fn scan_block_health(elements: &HashMap<String, gst::Element>) -> Vec
                 stalled.element, stalled.pad
             ));
         }
+    }
+
+    for diagnostic in diagnostics {
+        let Some(detail) = diagnostic.degraded() else {
+            continue;
+        };
+        let entry = by_block
+            .entry(diagnostic.block_id())
+            .or_insert_with(|| BlockHealth {
+                block_id: diagnostic.block_id().to_string(),
+                status: BlockHealthStatus::Ok,
+                detail: None,
+            });
+        if entry.status.is_failed() {
+            continue;
+        }
+        entry.status = BlockHealthStatus::Degraded;
+        entry.detail = Some(detail);
     }
 
     by_block.into_values().collect()
@@ -156,10 +181,12 @@ impl super::PipelineManager {
         let events = self.events.clone();
         let flow_id = self.flow_id;
         let flow_name = self.flow_name.clone();
+        let diagnostics = self.block_diagnostics.clone();
 
         let task = tokio::spawn(async move {
             let mut interval = tokio::time::interval(HEALTH_POLL_INTERVAL);
-            let mut failed: std::collections::HashSet<String> = std::collections::HashSet::new();
+            // Last status broadcast per block, so only changes are reported.
+            let mut reported: HashMap<String, BlockHealthStatus> = HashMap::new();
             let mut strikes: HashMap<String, u32> = HashMap::new();
 
             loop {
@@ -168,7 +195,7 @@ impl super::PipelineManager {
                 // Only meaningful while playing - a paused task is expected in
                 // every other state, including during startup and shutdown.
                 if *cached_state.read().unwrap() != strom_types::PipelineState::Playing {
-                    failed.clear();
+                    reported.clear();
                     strikes.clear();
                     block_health.write().unwrap().clear();
                     continue;
@@ -182,11 +209,13 @@ impl super::PipelineManager {
                     continue;
                 }
 
-                let mut snapshot = scan_block_health(&elements);
+                let mut snapshot = scan_block_health(&elements, &diagnostics);
 
-                // A block is only reported once it has looked stalled on
+                // A block is only reported failed once it has looked stalled on
                 // CONFIRMATIONS_BEFORE_FAILED scans in a row. Downgrade the
                 // unconfirmed ones before anything observes the snapshot.
+                // Degraded needs no confirmation: the diagnostics that produce
+                // it wait for their own subject to settle before saying so.
                 for health in &mut snapshot {
                     if health.status.is_failed() {
                         let count = strikes.entry(health.block_id.clone()).or_insert(0);
@@ -203,43 +232,46 @@ impl super::PipelineManager {
                 // Blocks whose elements have gone away drop out of the scan
                 // entirely; forget them rather than leaving a stale entry that
                 // no later iteration can clear.
-                failed.retain(|block_id| snapshot.iter().any(|h| &h.block_id == block_id));
+                reported.retain(|block_id, _| snapshot.iter().any(|h| &h.block_id == block_id));
                 strikes.retain(|block_id, _| snapshot.iter().any(|h| &h.block_id == block_id));
 
                 for health in &snapshot {
-                    let was_failed = failed.contains(&health.block_id);
-                    match (health.status.is_failed(), was_failed) {
-                        (true, false) => {
-                            failed.insert(health.block_id.clone());
-                            tracing::error!(
-                                "Block '{}' in flow '{}' has stopped: {}. The pipeline still reports Playing",
-                                health.block_id,
-                                flow_name,
-                                health.detail.as_deref().unwrap_or("no detail")
-                            );
-                            events.broadcast(strom_types::StromEvent::BlockHealthChanged {
-                                flow_id,
-                                block_id: health.block_id.clone(),
-                                status: health.status,
-                                detail: health.detail.clone(),
-                            });
-                        }
-                        (false, true) => {
-                            failed.remove(&health.block_id);
-                            tracing::info!(
-                                "Block '{}' in flow '{}' resumed passing data",
-                                health.block_id,
-                                flow_name
-                            );
-                            events.broadcast(strom_types::StromEvent::BlockHealthChanged {
-                                flow_id,
-                                block_id: health.block_id.clone(),
-                                status: health.status,
-                                detail: None,
-                            });
-                        }
-                        _ => {}
+                    let was = reported
+                        .get(&health.block_id)
+                        .copied()
+                        .unwrap_or(BlockHealthStatus::Ok);
+                    if was == health.status {
+                        continue;
                     }
+                    reported.insert(health.block_id.clone(), health.status);
+
+                    let detail = health.detail.as_deref().unwrap_or("no detail");
+                    match health.status {
+                        BlockHealthStatus::Failed => tracing::error!(
+                            "Block '{}' in flow '{}' has stopped: {}. The pipeline still reports Playing",
+                            health.block_id,
+                            flow_name,
+                            detail
+                        ),
+                        BlockHealthStatus::Degraded => tracing::warn!(
+                            "Block '{}' in flow '{}' is degraded: {}. The pipeline still reports Playing",
+                            health.block_id,
+                            flow_name,
+                            detail
+                        ),
+                        BlockHealthStatus::Ok => tracing::info!(
+                            "Block '{}' in flow '{}' is healthy again",
+                            health.block_id,
+                            flow_name
+                        ),
+                    }
+
+                    events.broadcast(strom_types::StromEvent::BlockHealthChanged {
+                        flow_id,
+                        block_id: health.block_id.clone(),
+                        status: health.status,
+                        detail: health.detail.clone(),
+                    });
                 }
 
                 *block_health.write().unwrap() = snapshot;

--- a/backend/src/gst/pipeline/health.rs
+++ b/backend/src/gst/pipeline/health.rs
@@ -27,6 +27,7 @@
 use gstreamer as gst;
 use gstreamer::prelude::*;
 use std::collections::{BTreeMap, HashMap};
+use std::sync::Arc;
 use strom_types::flow::{BlockHealth, BlockHealthStatus};
 
 /// A pad whose task has been paused while the pipeline is playing.
@@ -101,7 +102,7 @@ fn owning_block(element_id: &str) -> &str {
 /// other pipeline state.
 pub(crate) fn scan_block_health(
     elements: &HashMap<String, gst::Element>,
-    diagnostics: &crate::gst::BlockDiagnostics,
+    diagnostics: &[Arc<dyn crate::gst::BlockDiagnostic>],
 ) -> Vec<BlockHealth> {
     let mut by_block: BTreeMap<&str, BlockHealth> = BTreeMap::new();
 

--- a/backend/src/gst/pipeline/lifecycle.rs
+++ b/backend/src/gst/pipeline/lifecycle.rs
@@ -47,6 +47,9 @@ impl PipelineManager {
         self.start_qos_broadcast_task();
         info!("QoS stats task started");
 
+        // Start the scan for stalled pad tasks
+        self.start_block_health_task();
+
         // Configure clock before starting
         info!(
             "Configuring clock (type: {:?})...",
@@ -202,6 +205,7 @@ impl PipelineManager {
 
         // Stop QoS broadcast task
         self.stop_qos_broadcast_task();
+        self.stop_block_health_task();
 
         // Stop thumbnail deactivation task
         if let Some(task) = self.thumbnail_deactivation_task.take() {

--- a/backend/src/gst/pipeline/mod.rs
+++ b/backend/src/gst/pipeline/mod.rs
@@ -3,6 +3,7 @@
 mod bus;
 mod construction;
 pub(crate) mod effects;
+mod health;
 mod lifecycle;
 mod linking;
 mod properties;
@@ -195,6 +196,10 @@ pub struct PipelineManager {
     qos_aggregator: QoSAggregator,
     /// Handle for the periodic QoS stats broadcast task
     qos_broadcast_task: Option<tokio::task::JoinHandle<()>>,
+    /// Latest per-block health snapshot from the stalled-pad-task scan
+    block_health: std::sync::Arc<std::sync::RwLock<Vec<strom_types::flow::BlockHealth>>>,
+    /// Handle for the periodic block health scan task
+    block_health_task: Option<tokio::task::JoinHandle<()>>,
     /// PTP clock reference (stored for querying grandmaster/master info)
     ptp_clock: Option<gst_net::PtpClock>,
     /// PTP statistics (updated by statistics callback)
@@ -244,6 +249,7 @@ impl Drop for PipelineManager {
         self.probe_manager.stop_broadcast_task();
         self.probe_manager.deactivate_all();
         self.stop_qos_broadcast_task();
+        self.stop_block_health_task();
 
         // Ensure pipeline is in Null state before releasing references.
         // If stop() was already called this is a no-op.

--- a/backend/src/gst/pipeline/mod.rs
+++ b/backend/src/gst/pipeline/mod.rs
@@ -200,6 +200,8 @@ pub struct PipelineManager {
     block_health: std::sync::Arc<std::sync::RwLock<Vec<strom_types::flow::BlockHealth>>>,
     /// Handle for the periodic block health scan task
     block_health_task: Option<tokio::task::JoinHandle<()>>,
+    /// Degradation checks blocks report for themselves, polled by that scan
+    block_diagnostics: crate::gst::BlockDiagnostics,
     /// PTP clock reference (stored for querying grandmaster/master info)
     ptp_clock: Option<gst_net::PtpClock>,
     /// PTP statistics (updated by statistics callback)

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -609,9 +609,11 @@ impl AppState {
                     }
                     flow.properties.ntp_info = pipeline.get_ntp_info();
                     flow.properties.thread_priority_status = pipeline.get_thread_priority_status();
+                    flow.block_health = pipeline.get_block_health();
                 } else {
                     // Clear runtime-only status when no pipeline is running
                     flow.set_gst_state(None);
+                    flow.block_health.clear();
                     flow.properties.thread_priority_status = None;
                     flow.properties.clock_sync_status = None;
                     flow.properties.ptp_info = None;
@@ -643,9 +645,11 @@ impl AppState {
                 }
                 flow.properties.ntp_info = pipeline.get_ntp_info();
                 flow.properties.thread_priority_status = pipeline.get_thread_priority_status();
+                flow.block_health = pipeline.get_block_health();
             } else {
                 // Clear runtime-only status when no pipeline is running
                 flow.set_gst_state(None);
+                flow.block_health.clear();
                 flow.properties.thread_priority_status = None;
                 flow.properties.clock_sync_status = None;
                 flow.properties.ptp_info = None;

--- a/backend/tests/block_health_test.rs
+++ b/backend/tests/block_health_test.rs
@@ -1,0 +1,146 @@
+//! A pipeline branch can stop dead while the pipeline still reports Playing.
+//!
+//! When a downstream push fails with `not-negotiated`, `GstAggregator` marks
+//! its sink pads flushing and pauses its source pad task. Nothing is posted to
+//! the bus and no element changes state, so the failure is invisible in
+//! `gst_state`. These tests pin both halves: that the stall is silent, and
+//! that the block health scan reports it.
+
+use gstreamer as gst;
+use gstreamer::prelude::*;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+fn init() {
+    gst::init().unwrap();
+}
+
+/// Poll `condition` until true or `timeout` elapses. Returns whether it held.
+fn wait_for(condition: impl Fn() -> bool, timeout: Duration) -> bool {
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        if condition() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    condition()
+}
+
+/// videotestsrc -> compositor -> capsfilter -> fakesink.
+///
+/// The capsfilter is the lever: retightening it to a caps the compositor
+/// cannot produce makes the next push fail negotiation.
+struct StallRig {
+    pipeline: gst::Pipeline,
+    compositor: gst::Element,
+    capsfilter: gst::Element,
+    bus_errors: Arc<Mutex<Vec<String>>>,
+}
+
+impl StallRig {
+    fn build() -> Self {
+        let pipeline = gst::Pipeline::new();
+        let src = gst::ElementFactory::make("videotestsrc")
+            .property("is-live", true)
+            .build()
+            .unwrap();
+        let compositor = gst::ElementFactory::make("compositor").build().unwrap();
+        let capsfilter = gst::ElementFactory::make("capsfilter")
+            .property(
+                "caps",
+                gst::Caps::builder("video/x-raw")
+                    .field("width", 320i32)
+                    .field("height", 240i32)
+                    .build(),
+            )
+            .build()
+            .unwrap();
+        let sink = gst::ElementFactory::make("fakesink")
+            .property("sync", false)
+            .build()
+            .unwrap();
+
+        pipeline
+            .add_many([&src, &compositor, &capsfilter, &sink])
+            .unwrap();
+        src.link(&compositor).unwrap();
+        gst::Element::link_many([&compositor, &capsfilter, &sink]).unwrap();
+
+        let bus_errors = Arc::new(Mutex::new(Vec::new()));
+        let collected = bus_errors.clone();
+        let bus = pipeline.bus().unwrap();
+        bus.add_signal_watch();
+        bus.connect_message(Some("error"), move |_, msg| {
+            if let gst::MessageView::Error(err) = msg.view() {
+                collected.lock().unwrap().push(err.error().to_string());
+            }
+        });
+
+        Self {
+            pipeline,
+            compositor,
+            capsfilter,
+            bus_errors,
+        }
+    }
+
+    fn compositor_task_state(&self) -> gst::TaskState {
+        self.compositor.static_pad("src").unwrap().task_state()
+    }
+
+    /// Force the next compositor push to fail negotiation.
+    fn break_negotiation(&self) {
+        self.capsfilter.set_property(
+            "caps",
+            gst::Caps::builder("video/x-bayer")
+                .field("format", "bggr")
+                .build(),
+        );
+    }
+}
+
+impl Drop for StallRig {
+    fn drop(&mut self) {
+        let _ = self.pipeline.set_state(gst::State::Null);
+    }
+}
+
+#[test]
+fn aggregator_stall_is_silent_and_leaves_pipeline_playing() {
+    init();
+    let rig = StallRig::build();
+    rig.pipeline.set_state(gst::State::Playing).unwrap();
+
+    // videotestsrc is live, so the transition is async. Block until it settles:
+    // the compositor task starts before the pipeline finishes reaching Playing,
+    // so waiting on the task state alone races the state change.
+    let (res, current, _) = rig.pipeline.state(gst::ClockTime::from_seconds(10));
+    assert_eq!(res, Ok(gst::StateChangeSuccess::Success));
+    assert_eq!(current, gst::State::Playing);
+    assert_eq!(rig.compositor_task_state(), gst::TaskState::Started);
+
+    rig.break_negotiation();
+
+    assert!(
+        wait_for(
+            || rig.compositor_task_state() == gst::TaskState::Paused,
+            Duration::from_secs(10)
+        ),
+        "compositor task never stalled after negotiation was broken"
+    );
+
+    // The whole point: the stall reports nothing where a caller would look.
+    let (_, current, _) = rig.pipeline.state(gst::ClockTime::from_seconds(1));
+    assert_eq!(
+        current,
+        gst::State::Playing,
+        "pipeline should still report Playing while the branch is dead"
+    );
+    let errors = rig.bus_errors.lock().unwrap();
+    assert!(
+        errors.is_empty(),
+        "expected no bus error, got: {:?}",
+        errors
+    );
+}

--- a/backend/tests/whep_codec_discovery_test.rs
+++ b/backend/tests/whep_codec_discovery_test.rs
@@ -1,0 +1,152 @@
+//! A WHEP output that asks `whepserversink` for a codec it does not get must
+//! say so.
+//!
+//! `whepserversink` proves out each codec in a throwaway pipeline of its own
+//! before offering it, and drops the ones that fail. That pipeline's bus sync
+//! handler returns `Drop` for every message, no property lists the survivors,
+//! and the sink still reaches `PLAYING` on whatever is left - so a lost codec
+//! is invisible from the flow pipeline. On macOS this is not hypothetical:
+//! `vtenc_h264` emits `profile=baseline` where the discovery pipeline's
+//! `codec-parser-caps` filter demands `constrained-baseline`, H.264 drops out,
+//! and Chrome viewers fall back to VP9 encoded in software per viewer.
+//!
+//! That specific failure needs Apple's VideoToolbox encoder, so it cannot be
+//! reproduced on CI. Removing `h264parse` from the registry fails H.264
+//! discovery the same way and on every platform: `request-encoded-filter` has
+//! already fired for the codec by the time `build_parser` errors, so the block
+//! sees a codec that was attempted and never negotiated, which is exactly the
+//! shape of the macOS failure.
+//!
+//! Reverting the report leaves the block reporting `Ok` here.
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use gstreamer as gst;
+use gstreamer::prelude::*;
+
+use strom::blocks::builtin::whep::WHEPOutputBuilder;
+use strom::blocks::{BlockBuildContext, BlockBuilder};
+use strom_types::PropertyValue;
+
+/// Elements this test needs beyond core GStreamer.
+const REQUIRED: &[&str] = &["videotestsrc", "whepserversink", "h264parse"];
+
+/// Skipping on a missing element passes green and guards nothing, so CI sets
+/// `STROM_REQUIRE_GST_PLUGINS=1` to turn a skip into a failure.
+fn plugins_available() -> bool {
+    let missing: Vec<&str> = REQUIRED
+        .iter()
+        .copied()
+        .filter(|e| gst::ElementFactory::find(e).is_none())
+        .collect();
+    if missing.is_empty() {
+        return true;
+    }
+    assert!(
+        strom_types::env::var_opt("STROM_REQUIRE_GST_PLUGINS").is_none(),
+        "STROM_REQUIRE_GST_PLUGINS is set but these elements are missing: {}",
+        missing.join(", ")
+    );
+    false
+}
+
+/// Fail H.264 discovery without needing the platform encoder that fails it for
+/// real. Process-global and irreversible, which is why this file holds one
+/// test: `whepserversink` builds its codec list once per process.
+fn break_h264_discovery() {
+    let registry = gst::Registry::get();
+    let factory = gst::ElementFactory::find("h264parse").expect("checked above");
+    registry.remove_feature(factory.upcast_ref::<gst::PluginFeature>());
+}
+
+#[test]
+fn a_codec_that_fails_discovery_is_reported_as_degraded() {
+    gst::init().unwrap();
+    gstrswebrtc::plugin_register_static().unwrap();
+    if !plugins_available() {
+        eprintln!("skipping: required GStreamer elements are missing");
+        return;
+    }
+    break_h264_discovery();
+
+    let mut properties = HashMap::new();
+    properties.insert("mode".to_string(), PropertyValue::String("av".to_string()));
+    properties.insert(
+        "endpoint_id".to_string(),
+        PropertyValue::String("codec-report-test".to_string()),
+    );
+
+    let ctx = BlockBuildContext::new(Vec::new(), "all".to_string());
+    let built = WHEPOutputBuilder
+        .build("whep_out", &properties, &ctx)
+        .expect("WHEP output builds");
+    let diagnostics = ctx.take_block_diagnostics();
+    assert_eq!(
+        diagnostics.len(),
+        1,
+        "the WHEP output block should register exactly one diagnostic"
+    );
+    let report = &diagnostics[0];
+    assert_eq!(report.block_id(), "whep_out");
+
+    let pipeline = gst::Pipeline::new();
+    let by_id: HashMap<String, gst::Element> = built.elements.iter().cloned().collect();
+    for (_, element) in &built.elements {
+        pipeline.add(element).unwrap();
+    }
+    for (from, to) in &built.internal_links {
+        let src = &by_id[&from.element_id];
+        let sink = &by_id[&to.element_id];
+        src.link_pads(from.pad_name.as_deref(), sink, to.pad_name.as_deref())
+            .unwrap_or_else(|e| panic!("linking {:?} -> {:?}: {e}", from, to));
+    }
+
+    // Raw video into the block's video input, which is what makes it ask for
+    // all four codecs rather than pinning the one already on the wire.
+    let src = gst::ElementFactory::make("videotestsrc")
+        .property("is-live", true)
+        .build()
+        .unwrap();
+    let caps = gst::ElementFactory::make("capsfilter")
+        .property(
+            "caps",
+            gst::Caps::builder("video/x-raw")
+                .field("width", 320i32)
+                .field("height", 180i32)
+                .field("framerate", gst::Fraction::new(15, 1))
+                .build(),
+        )
+        .build()
+        .unwrap();
+    pipeline.add_many([&src, &caps]).unwrap();
+    src.link(&caps).unwrap();
+    caps.link(&by_id["whep_out:video_queue"]).unwrap();
+
+    pipeline.set_state(gst::State::Playing).unwrap();
+
+    // The report holds off until discovery has settled, so poll rather than
+    // sampling once.
+    let deadline = Instant::now() + Duration::from_secs(45);
+    let mut verdict = None;
+    while Instant::now() < deadline {
+        if let Some(detail) = report.degraded() {
+            verdict = Some(detail);
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(250));
+    }
+    pipeline.set_state(gst::State::Null).unwrap();
+
+    let verdict = verdict.expect(
+        "H.264 discovery cannot succeed without h264parse, so the block should report degraded",
+    );
+    assert!(
+        verdict.contains("H.264"),
+        "the report should name the codec that was lost, got: {verdict}"
+    );
+    assert!(
+        !verdict.contains("VP9") && !verdict.contains("AV1") && !verdict.contains("H.265"),
+        "only H.264 discovery was broken, got: {verdict}"
+    );
+}

--- a/frontend/src/app/rendering.rs
+++ b/frontend/src/app/rendering.rs
@@ -8,6 +8,9 @@ use strom_types::Flow;
 
 use super::*;
 use super::{FocusTarget, ThemePreference};
+
+/// Colour for a block that has stopped passing data.
+const FAILED_BLOCK_COLOR: Color32 = Color32::from_rgb(220, 60, 60);
 impl StromApp {
     /// Render the top toolbar.
     pub(super) fn render_toolbar(&mut self, ui: &mut egui::Ui) {
@@ -762,14 +765,42 @@ impl StromApp {
                                 );
                                 child_ui.add_space(4.0);
 
-                                // Show running state icon
+                                // Show running state icon. A flow with a failed
+                                // block is not running even though GStreamer
+                                // still reports Playing, so it must not read as
+                                // healthy here.
+                                let failed_blocks: Vec<_> = flow.failed_blocks().collect();
                                 let state_icon = if flow.running { "▶" } else { "■" };
-                                let state_color = if flow.running {
+                                let state_color = if !failed_blocks.is_empty() {
+                                    FAILED_BLOCK_COLOR
+                                } else if flow.running {
                                     Color32::from_rgb(0, 200, 0)
                                 } else {
                                     Color32::GRAY
                                 };
                                 child_ui.colored_label(state_color, state_icon);
+
+                                if !failed_blocks.is_empty() {
+                                    child_ui
+                                        .colored_label(FAILED_BLOCK_COLOR, "⚠")
+                                        .on_hover_ui(|ui| {
+                                            ui.label(
+                                                egui::RichText::new("Stopped passing data")
+                                                    .strong(),
+                                            );
+                                            ui.separator();
+                                            for health in &failed_blocks {
+                                                ui.label(format!(
+                                                    "{}: {}",
+                                                    health.block_id,
+                                                    health
+                                                        .detail
+                                                        .as_deref()
+                                                        .unwrap_or("no detail")
+                                                ));
+                                            }
+                                        });
+                                }
 
                                 // Show QoS indicator if there are issues - make it clickable to open log
                                 if let Some(qos_health) = self.qos_stats.get_flow_health(&flow.id) {
@@ -898,12 +929,24 @@ impl StromApp {
                                     }
 
                                     ui.add_space(5.0);
-                                    let state_text = if flow.running {
+                                    let state_text = if flow.has_failed_block() {
+                                        "Failed"
+                                    } else if flow.running {
                                         "Running"
                                     } else {
                                         "Stopped"
                                     };
                                     ui.label(format!("State: {}", state_text));
+                                    for health in flow.failed_blocks() {
+                                        ui.colored_label(
+                                            FAILED_BLOCK_COLOR,
+                                            format!(
+                                                "{} stopped: {}",
+                                                health.block_id,
+                                                health.detail.as_deref().unwrap_or("no detail")
+                                            ),
+                                        );
+                                    }
 
                                     // Show timestamps
                                     if flow.properties.started_at.is_some()

--- a/frontend/src/app/rendering.rs
+++ b/frontend/src/app/rendering.rs
@@ -11,6 +11,9 @@ use super::{FocusTarget, ThemePreference};
 
 /// Colour for a block that has stopped passing data.
 const FAILED_BLOCK_COLOR: Color32 = Color32::from_rgb(220, 60, 60);
+/// Colour for a block that still passes data without everything it was
+/// configured to produce.
+const DEGRADED_BLOCK_COLOR: Color32 = Color32::from_rgb(220, 160, 40);
 impl StromApp {
     /// Render the top toolbar.
     pub(super) fn render_toolbar(&mut self, ui: &mut egui::Ui) {
@@ -770,9 +773,12 @@ impl StromApp {
                                 // still reports Playing, so it must not read as
                                 // healthy here.
                                 let failed_blocks: Vec<_> = flow.failed_blocks().collect();
+                                let degraded_blocks: Vec<_> = flow.degraded_blocks().collect();
                                 let state_icon = if flow.running { "▶" } else { "■" };
                                 let state_color = if !failed_blocks.is_empty() {
                                     FAILED_BLOCK_COLOR
+                                } else if !degraded_blocks.is_empty() {
+                                    DEGRADED_BLOCK_COLOR
                                 } else if flow.running {
                                     Color32::from_rgb(0, 200, 0)
                                 } else {
@@ -790,6 +796,27 @@ impl StromApp {
                                             );
                                             ui.separator();
                                             for health in &failed_blocks {
+                                                ui.label(format!(
+                                                    "{}: {}",
+                                                    health.block_id,
+                                                    health
+                                                        .detail
+                                                        .as_deref()
+                                                        .unwrap_or("no detail")
+                                                ));
+                                            }
+                                        });
+                                }
+
+                                if !degraded_blocks.is_empty() {
+                                    child_ui
+                                        .colored_label(DEGRADED_BLOCK_COLOR, "⚠")
+                                        .on_hover_ui(|ui| {
+                                            ui.label(
+                                                egui::RichText::new("Running degraded").strong(),
+                                            );
+                                            ui.separator();
+                                            for health in &degraded_blocks {
                                                 ui.label(format!(
                                                     "{}: {}",
                                                     health.block_id,
@@ -931,6 +958,9 @@ impl StromApp {
                                     ui.add_space(5.0);
                                     let state_text = if flow.has_failed_block() {
                                         "Failed"
+                                    } else if flow.running && flow.degraded_blocks().next().is_some()
+                                    {
+                                        "Running (degraded)"
                                     } else if flow.running {
                                         "Running"
                                     } else {
@@ -942,6 +972,16 @@ impl StromApp {
                                             FAILED_BLOCK_COLOR,
                                             format!(
                                                 "{} stopped: {}",
+                                                health.block_id,
+                                                health.detail.as_deref().unwrap_or("no detail")
+                                            ),
+                                        );
+                                    }
+                                    for health in flow.degraded_blocks() {
+                                        ui.colored_label(
+                                            DEGRADED_BLOCK_COLOR,
+                                            format!(
+                                                "{} degraded: {}",
                                                 health.block_id,
                                                 health.detail.as_deref().unwrap_or("no detail")
                                             ),

--- a/frontend/src/app/update.rs
+++ b/frontend/src/app/update.rs
@@ -395,6 +395,46 @@ impl eframe::App for StromApp {
                                 }
                             });
                         }
+                        StromEvent::BlockHealthChanged {
+                            flow_id,
+                            block_id,
+                            status,
+                            detail,
+                        } => {
+                            // block_health rides on the Flow payload, so the
+                            // indicator only updates if the flow is refetched.
+                            match status {
+                                strom_types::BlockHealthStatus::Failed => tracing::error!(
+                                    "Block {} in flow {} stopped passing data: {}",
+                                    block_id,
+                                    flow_id,
+                                    detail.as_deref().unwrap_or("no detail")
+                                ),
+                                strom_types::BlockHealthStatus::Ok => {
+                                    tracing::info!("Block {} in flow {} resumed", block_id, flow_id)
+                                }
+                            }
+                            let api = self.api.clone();
+                            let tx = self.channels.sender();
+                            let ctx = ui.ctx().clone();
+
+                            spawn_task(async move {
+                                match api.get_flow(flow_id).await {
+                                    Ok(flow) => {
+                                        let _ = tx.send(AppMessage::FlowFetched(Box::new(flow)));
+                                        ctx.request_repaint();
+                                    }
+                                    Err(e) => {
+                                        tracing::error!(
+                                            "Failed to fetch flow after block health change: {}",
+                                            e
+                                        );
+                                        let _ = tx.send(AppMessage::RefreshNeeded);
+                                        ctx.request_repaint();
+                                    }
+                                }
+                            });
+                        }
                         StromEvent::FlowUpdated { flow_id } => {
                             // For updates, fetch the specific flow to update it in-place
                             tracing::info!("Flow {} updated, fetching updated flow", flow_id);

--- a/frontend/src/app/update.rs
+++ b/frontend/src/app/update.rs
@@ -410,6 +410,12 @@ impl eframe::App for StromApp {
                                     flow_id,
                                     detail.as_deref().unwrap_or("no detail")
                                 ),
+                                strom_types::BlockHealthStatus::Degraded => tracing::warn!(
+                                    "Block {} in flow {} is degraded: {}",
+                                    block_id,
+                                    flow_id,
+                                    detail.as_deref().unwrap_or("no detail")
+                                ),
                                 strom_types::BlockHealthStatus::Ok => {
                                     tracing::info!("Block {} in flow {} resumed", block_id, flow_id)
                                 }

--- a/openapi.json
+++ b/openapi.json
@@ -4907,6 +4907,39 @@
           }
         }
       },
+      "BlockHealth": {
+        "type": "object",
+        "description": "Runtime health of one block in a running flow.",
+        "required": [
+          "block_id",
+          "status"
+        ],
+        "properties": {
+          "block_id": {
+            "type": "string",
+            "description": "Block instance ID this health report belongs to."
+          },
+          "detail": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Human-readable detail naming the element and pad whose task stopped.\n`None` when the block is healthy."
+          },
+          "status": {
+            "$ref": "#/components/schemas/BlockHealthStatus",
+            "description": "Whether the block's element chain is running or has stopped."
+          }
+        }
+      },
+      "BlockHealthStatus": {
+        "type": "string",
+        "description": "Health of a single block's element chain while the flow is running.\n\nPausing a pad task is not a state change: the pipeline and every element in\nit stay `PLAYING` while that branch stops passing data, so the failure does\nnot show up in the flow's `gst_state`.",
+        "enum": [
+          "ok",
+          "failed"
+        ]
+      },
       "BlockInstance": {
         "type": "object",
         "description": "Block instance in a flow",
@@ -5991,6 +6024,13 @@
           "name"
         ],
         "properties": {
+          "block_health": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BlockHealth"
+            },
+            "description": "Per-block runtime health. Populated only while a pipeline is running;\nempty otherwise. An entry with a failed status means that block has\nstopped passing data even though `gst_state` is still `Playing`."
+          },
           "blocks": {
             "type": "array",
             "items": {
@@ -9553,6 +9593,52 @@
                 "type": "string",
                 "enum": [
                   "SubscriptionStatusChanged"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "A block's element chain stopped passing data, or resumed.\n\nEmitted only on a change of status, not on every health poll.",
+            "required": [
+              "data",
+              "type"
+            ],
+            "properties": {
+              "data": {
+                "type": "object",
+                "description": "A block's element chain stopped passing data, or resumed.\n\nEmitted only on a change of status, not on every health poll.",
+                "required": [
+                  "flow_id",
+                  "block_id",
+                  "status"
+                ],
+                "properties": {
+                  "block_id": {
+                    "type": "string",
+                    "description": "Block instance ID, or element ID for a standalone element"
+                  },
+                  "detail": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Element and pad whose task stopped; None when the block recovered"
+                  },
+                  "flow_id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "status": {
+                    "$ref": "#/components/schemas/BlockHealthStatus",
+                    "description": "Whether the block is passing data or has stopped"
+                  }
+                }
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "BlockHealthChanged"
                 ]
               }
             }

--- a/openapi.json
+++ b/openapi.json
@@ -4924,7 +4924,7 @@
               "string",
               "null"
             ],
-            "description": "Human-readable detail naming the element and pad whose task stopped.\n`None` when the block is healthy."
+            "description": "Human-readable detail: the element and pad whose task stopped, or what\nthe block is missing. `None` when the block is healthy."
           },
           "status": {
             "$ref": "#/components/schemas/BlockHealthStatus",
@@ -4937,6 +4937,7 @@
         "description": "Health of a single block's element chain while the flow is running.\n\nPausing a pad task is not a state change: the pipeline and every element in\nit stay `PLAYING` while that branch stops passing data, so the failure does\nnot show up in the flow's `gst_state`.",
         "enum": [
           "ok",
+          "degraded",
           "failed"
         ]
       },

--- a/types/src/events.rs
+++ b/types/src/events.rs
@@ -1,6 +1,7 @@
 //! Events for real-time updates across clients.
 
 use crate::element::PropertyValue;
+use crate::flow::BlockHealthStatus;
 use crate::system_monitor::SystemStats;
 use crate::thread_stats::ThreadStats;
 use crate::FlowId;
@@ -182,6 +183,19 @@ pub enum StromEvent {
         source_flow_id: FlowId,
         output_name: String,
         connected: bool,
+    },
+    /// A block's element chain stopped passing data, or resumed.
+    ///
+    /// Emitted only on a change of status, not on every health poll.
+    BlockHealthChanged {
+        #[cfg_attr(feature = "openapi", schema(value_type = String, format = Uuid))]
+        flow_id: FlowId,
+        /// Block instance ID, or element ID for a standalone element
+        block_id: String,
+        /// Whether the block is passing data or has stopped
+        status: BlockHealthStatus,
+        /// Element and pad whose task stopped; None when the block recovered
+        detail: Option<String>,
     },
     /// Quality of Service statistics (aggregated buffer drop info)
     QoSStats {
@@ -541,6 +555,22 @@ impl StromEvent {
             StromEvent::ThreadStats(stats) => {
                 format!("Thread stats: {} active threads", stats.threads.len())
             }
+            StromEvent::BlockHealthChanged {
+                flow_id,
+                block_id,
+                status,
+                detail,
+            } => match status {
+                BlockHealthStatus::Failed => format!(
+                    "Block {} in flow {} stopped passing data: {}",
+                    block_id,
+                    flow_id,
+                    detail.as_deref().unwrap_or("no detail")
+                ),
+                BlockHealthStatus::Ok => {
+                    format!("Block {} in flow {} resumed", block_id, flow_id)
+                }
+            },
             StromEvent::QoSStats {
                 flow_id,
                 block_id,

--- a/types/src/events.rs
+++ b/types/src/events.rs
@@ -567,6 +567,12 @@ impl StromEvent {
                     flow_id,
                     detail.as_deref().unwrap_or("no detail")
                 ),
+                BlockHealthStatus::Degraded => format!(
+                    "Block {} in flow {} is degraded: {}",
+                    block_id,
+                    flow_id,
+                    detail.as_deref().unwrap_or("no detail")
+                ),
                 BlockHealthStatus::Ok => {
                     format!("Block {} in flow {} resumed", block_id, flow_id)
                 }

--- a/types/src/flow.rs
+++ b/types/src/flow.rs
@@ -419,6 +419,11 @@ pub struct Flow {
     /// Prefer [`running`](Self::running) for logic and display.
     #[serde(default)]
     pub gst_state: Option<PipelineState>,
+    /// Per-block runtime health. Populated only while a pipeline is running;
+    /// empty otherwise. An entry with a failed status means that block has
+    /// stopped passing data even though `gst_state` is still `Playing`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub block_health: Vec<BlockHealth>,
     /// Flow configuration properties
     #[serde(default)]
     pub properties: FlowProperties,
@@ -435,6 +440,7 @@ impl Flow {
             links: Vec::new(),
             running: false,
             gst_state: Some(PipelineState::Null),
+            block_health: Vec::new(),
             properties: FlowProperties::default(),
         }
     }
@@ -449,6 +455,7 @@ impl Flow {
             links: Vec::new(),
             running: false,
             gst_state: Some(PipelineState::Null),
+            block_health: Vec::new(),
             properties: FlowProperties::default(),
         }
     }
@@ -458,6 +465,57 @@ impl Flow {
         self.running = state.is_some_and(|s| s.is_active());
         self.gst_state = state;
     }
+
+    /// Blocks whose element chain has stopped passing data.
+    pub fn failed_blocks(&self) -> impl Iterator<Item = &BlockHealth> {
+        self.block_health.iter().filter(|h| h.status.is_failed())
+    }
+
+    /// Whether any block in this flow has failed.
+    ///
+    /// `running` only reports that the pipeline reached `Playing`; it stays
+    /// `true` when a block underneath has stopped. Callers deciding whether a
+    /// flow is actually working need both.
+    pub fn has_failed_block(&self) -> bool {
+        self.failed_blocks().next().is_some()
+    }
+}
+
+/// Health of a single block's element chain while the flow is running.
+///
+/// Pausing a pad task is not a state change: the pipeline and every element in
+/// it stay `PLAYING` while that branch stops passing data, so the failure does
+/// not show up in the flow's `gst_state`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[serde(rename_all = "lowercase")]
+pub enum BlockHealthStatus {
+    /// No stopped pad task was found in this block's element chain.
+    Ok,
+    /// A pad task in this block's element chain has stopped. The block is not
+    /// passing data, regardless of what the pipeline state says.
+    Failed,
+}
+
+impl BlockHealthStatus {
+    /// Whether this status means the block has failed.
+    pub fn is_failed(&self) -> bool {
+        matches!(self, BlockHealthStatus::Failed)
+    }
+}
+
+/// Runtime health of one block in a running flow.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct BlockHealth {
+    /// Block instance ID this health report belongs to.
+    pub block_id: String,
+    /// Whether the block's element chain is running or has stopped.
+    pub status: BlockHealthStatus,
+    /// Human-readable detail naming the element and pad whose task stopped.
+    /// `None` when the block is healthy.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
 }
 
 #[cfg(test)]

--- a/types/src/flow.rs
+++ b/types/src/flow.rs
@@ -471,6 +471,13 @@ impl Flow {
         self.block_health.iter().filter(|h| h.status.is_failed())
     }
 
+    /// Blocks that are passing data without everything they were configured to
+    /// produce. Separate from [`failed_blocks`](Self::failed_blocks): a
+    /// degraded block still works, so it must not make the flow read as broken.
+    pub fn degraded_blocks(&self) -> impl Iterator<Item = &BlockHealth> {
+        self.block_health.iter().filter(|h| h.status.is_degraded())
+    }
+
     /// Whether any block in this flow has failed.
     ///
     /// `running` only reports that the pipeline reached `Playing`; it stays
@@ -490,8 +497,13 @@ impl Flow {
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 #[serde(rename_all = "lowercase")]
 pub enum BlockHealthStatus {
-    /// No stopped pad task was found in this block's element chain.
+    /// No stopped pad task was found in this block's element chain, and the
+    /// block reports nothing missing.
     Ok,
+    /// The block is passing data, but not everything it was configured to
+    /// produce. A WHEP output that asked for four video codecs and got three
+    /// still serves every viewer that can decode one of the three.
+    Degraded,
     /// A pad task in this block's element chain has stopped. The block is not
     /// passing data, regardless of what the pipeline state says.
     Failed,
@@ -501,6 +513,12 @@ impl BlockHealthStatus {
     /// Whether this status means the block has failed.
     pub fn is_failed(&self) -> bool {
         matches!(self, BlockHealthStatus::Failed)
+    }
+
+    /// Whether this status means the block works but is missing something it
+    /// was configured to produce.
+    pub fn is_degraded(&self) -> bool {
+        matches!(self, BlockHealthStatus::Degraded)
     }
 }
 
@@ -512,8 +530,8 @@ pub struct BlockHealth {
     pub block_id: String,
     /// Whether the block's element chain is running or has stopped.
     pub status: BlockHealthStatus,
-    /// Human-readable detail naming the element and pad whose task stopped.
-    /// `None` when the block is healthy.
+    /// Human-readable detail: the element and pad whose task stopped, or what
+    /// the block is missing. `None` when the block is healthy.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub detail: Option<String>,
 }

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -47,7 +47,9 @@ pub use block::{
 };
 pub use element::{Element, ElementId, Link, MediaType, PropertyValue};
 pub use events::StromEvent;
-pub use flow::{CpuAffinity, Flow, FlowId, ThreadPriority, ThreadPriorityStatus};
+pub use flow::{
+    BlockHealth, BlockHealthStatus, CpuAffinity, Flow, FlowId, ThreadPriority, ThreadPriorityStatus,
+};
 pub use network::{
     Ipv4AddressInfo, Ipv6AddressInfo, NetworkInterfaceInfo, NetworkInterfacesResponse,
 };


### PR DESCRIPTION
> [!CAUTION]
> **Hold. The premise below is wrong and this must not merge as written.**
>
> The startup codec discovery does fail for H.264 on macOS, exactly as described. But its result (`stream.out_caps`) is read only by `request_webrtcbin_pad`'s `media: None` branch — the branch taken when webrtcsink *creates* the offer. In WHEP the client offers: `whep_signaller`'s `send_counter_offer` defaults to false and Strom never sets it, so `select_codec` runs instead. That builds its candidates from the client's `media.formats()` against the global codec table, never consulting `stream.out_caps`, and re-runs discovery with the client's SDP caps — where `force_profile` is false, the `constrained-baseline` demand disappears, and vtenc passes.
>
> So H.264 is dropped from a list nothing downstream reads, and consumers that ask for H.264 get it. Verified two ways: a `whepclientsrc` restricted to `video-codecs="<H264>"` negotiated to stable and got `rtph264pay`, and a separate session put real Chrome on a WHEP feed with no rank override and saw `rtph264pay` decoding at 1280x720 while 6 discovery failures were logged.
>
> This PR would therefore report "H.264 was dropped from the offer" on every macOS WHEP flow while viewers are receiving H.264 — a false alarm, which is worse than the silence it set out to fix. The reporting mechanism and `BlockDiagnostic` are sound; what they are pointed at is not. Being reworked to report a codec a *consumer* asked for and did not get.

---

**Stacked on #786**, which this needs for `BlockHealth`. The first four commits are that PR; review it first. Only `feat(whep): report codecs whepserversink drops from the offer` is new here.

Long body: it carries the verbatim upstream evidence for a bug that belongs in gst-plugins-rs, and the measurements behind deciding *not* to ship the obvious workaround.

## The defect

`whepserversink` proves each codec in a throwaway pipeline before offering it — encoder, parser, a `codec-parser-caps` capsfilter, payloader, appsink — and `lookup_caps` swallows each failure with a `gst::warning!`, "as long as we end up with one potential codec for each input stream".

None of that escapes the element. The discovery pipeline's bus sync handler returns `BusSyncReply::Drop`, `consumer-pipeline-created` fires only for real sessions, no property lists the survivors, and the sink still reaches `PLAYING` on whatever is left. A WHEP output that asked for four codecs and got three is indistinguishable from one that got four.

Verified 2026-09-10 on the five-seat rig, GStreamer 1.28.6, Apple Silicon, changing one environment variable between two runs of the same flow:

| server env | discovery failures | codecs actually offered |
|---|---|---|
| default | 4 (2 per WHEP sink) | AV1, H265, VP9 |
| `GST_PLUGIN_FEATURE_RANK=x264enc:300` | 0 | AV1, H264, H265, VP9 |

Chrome will not decode H265 over WebRTC in most builds, so Chrome viewers fall back to VP9, encoded per consumer in software: 31% of one core at rest to 91% with five viewers.

## What this changes

The block hands an `identity` to `request-encoded-filter`. `PayloadChainBuilder::build` links that element immediately downstream of `codec-parser-caps` — the capsfilter that does the rejecting — so an `EVENT_DOWNSTREAM` probe on its sink pad sees a CAPS event exactly when that codec got past the encoder, and nothing when it did not. `encoder-setup` names the encoder per codec, keyed by the media type the encoder factory's src pad template produces, since the discoveries run concurrently and call order proves nothing.

Worth a reviewer's eye: discovery passes `None` as the consumer id to `request-encoded-filter` but the string `"discovery"` to `encoder-setup`. The filter is returned only when that id is `None`, so nothing is spliced into a live viewer's pipeline.

The verdict reaches block health as a new `BlockHealthStatus::Degraded`, logged at `warn!`, broadcast as `BlockHealthChanged`, and shown in amber in the flow list and detail panel:

```
Block 'whep_out' in flow 'Meeting' is degraded: H.264 was dropped from the offer:
vtenc_h264 failed codec discovery. The pipeline still reports Playing
```

Degraded deliberately does not satisfy `has_failed_block()` — the output still serves every viewer that can decode a surviving codec.

`BlockDiagnostic` is the general hook. The stalled-pad-task scan reaches the flow pipeline's own elements and nothing else; a codec that fails discovery stalls no pad anywhere in it.

The report waits 15 s after the last discovery pipeline is built before calling a verdict, so a slow software AV1 encoder is not mistaken for a dropped codec.

**Only the first round of discovery counts, and that is load-bearing.** The first round runs when the input caps arrive, with output caps of `ANY`; its result becomes the codec list the sink will answer a viewer with. Every later round belongs to a viewer that has already connected, and asks a different question: its output caps come from that viewer's SDP, so `force_profile` is false, `codec-parser-caps` stops demanding `constrained-baseline`, and **H.264 negotiates on the viewer path even though it failed at startup**. Folding that in cleared the verdict. Live on a real backend, before the fix: degraded at 16 s after the flow started, then healthy again 16 s after a viewer connected, while the codec list the sink answers with still had no H.264 in it. The first round's verdict is now final and later rounds are not instrumented at all.

## Root cause, for a human to file upstream

Isolated with no webrtcsink in the pipeline. With no profile requested, `Codec::parser_caps(force_profile=true)` builds `video/x-h264, stream-format=avc, profile=constrained-baseline`. `vtenc_h264` has no profile property and cannot emit it:

```
gst-launch-1.0 videotestsrc num-buffers=30 ! video/x-raw,width=640,height=360,framerate=30/1 \
  ! videoconvert ! vtenc_h264 ! h264parse \
  ! video/x-h264,stream-format=avc,alignment=au,profile=constrained-baseline ! fakesink
```

Fails with `flow-return=(int)-4`. The same line with `profile=baseline` or `profile=main` passes. Inside webrtcsink:

```
vtenc  gst_vtenc_encode_frame:<vtenc_h264-0> Output loop stopped with error (not-negotiated)
GST_CAPS pre_eventfunc_check:<codec-parser-caps:sink> caps video/x-h264, ...,
  stream-format=(string)avc, ..., profile=(string)baseline, ..., lcevc=(boolean)false
  not accepted
webrtcsink lookup_caps: Codec discovery pipeline failed: Internal data stream error.
```

`force_profile` is `output_caps.is_any() && needs_encoding`, and the startup discovery call site passes a hardcoded `gst::Caps::new_any()`, so nothing outside the element can relax it. gst-plugins-rs does not accept AI-written issues or merge requests, so this is written out for a human to file rather than filed from here. Standalone repro:

```
gst-launch-1.0 videotestsrc is-live=true pattern=smpte \
  ! video/x-raw,width=1920,height=1080,framerate=30/1 ! whepserversink
```

## Why no workaround ships

Ranking `x264enc` above `vtenc_h264` restores H.264 to the offer but not the reason to want it: x264enc is software, and the hardware encode is the thing that is broken. Total CPU for 30 s of 1080p30, each encoder configured as `configure_encoder` configures it, two passes in both orders to control for order bias:

| encoder | CPU seconds (pass 1 / pass 2) |
|---|---|
| no encoder: source, videoconvert, fakesink | 6.2 / 5.2 |
| `vp9enc` — today's Chrome fallback | 15.5 / 11.4 |
| `x264enc` — what the rank override selects | 16.2 / 15.0 |
| `vtenc_h264` — what is broken | 5.1 / 4.8 |

x264enc was dearer than the vp9enc it would replace in both passes. vtenc sits at the no-encoder floor. So the rank change swaps one software encoder for another, process-globally across ingest and recording too, for no measurable server gain — consistent with the earlier rig finding that both arms landed at ~90% of a core for five viewers. Constraining vtenc's caps has no lever either: no profile property, and the demand comes from a hardcoded `Caps::new_any()` inside the element.

Setting `GST_PLUGIN_FEATURE_RANK=x264enc:300` still makes sense for viewer-side decode and battery, but that is a deployment decision, not something to hardcode.

## Tests

`backend/tests/whep_codec_discovery_test.rs` builds a real WHEP Output block through `WHEPOutputBuilder`, feeds raw video into a real `whepserversink`, and asserts H.264 is reported as dropped. It forces the failure by removing `h264parse` from the registry rather than relying on Apple's encoder, so it runs on Linux CI — the same shape, not a different path: `request-encoded-filter` has already fired for H.264 by the time `build_parser` errors, so the block sees a codec attempted and never negotiated, exactly as vtenc produces. `CODECS` is a `LazyLock` built once per process, so the registry surgery keeps this file to one test.

Ran, green on this branch:

- the integration guard, and confirmed it guards: with `attach()` stubbed to a no-op it fails; with it, passes
- six unit tests in `whep/codec_report.rs` (verdict text, missing-encoder branch, no-discovery-yet, hold-across-a-later-round)
- full backend suite with `STROM_REQUIRE_GST_PLUGINS=1`: 684 passed, 0 failed
- `cargo test --test openapi_test` after updating the snapshot; types suite; `cargo clippy --all-targets -D warnings`; frontend clippy for `wasm32-unknown-unknown`

Verified on this machine but **not** shipped as a test: the unmodified block against the real `vtenc_h264` reports `H.264 was dropped from the offer: vtenc_h264 failed codec discovery`. CI runs tests on Linux only, so a vtenc assertion would guard nothing there and would start failing the day upstream fixes it.

Also verified end to end on a running headless backend, which is what caught the viewer-round bug above: a flow of `videotestsrc` into a WHEP Output reports `degraded` in `flow.block_health` and in a `warn!` line 16 s after start, stays `running: true` with `gst_state: Playing`, and now holds that verdict across a connecting viewer for 50 s and six discovery rounds with a single health transition logged.

## Risk

`BlockHealthStatus` gains a `degraded` variant, so `openapi.json` is regenerated. Additive, but the contract check may flag a new enum value on a response type, and any client matching exhaustively on that enum needs the arm.

`backend/src/blocks/builtin/whep.rs` is now 2758 lines and wants splitting like `pipeline.rs` and `app.rs`. New code went into `whep/codec_report.rs` rather than growing it further; the split is not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


