### PR TITLE
feat(liveaudiorouter): give an output bus headroom and a ceiling

### DIFF
--- a/backend/src/blocks/builtin/liveaudiorouter.rs
+++ b/backend/src/blocks/builtin/liveaudiorouter.rs
@@ -26,8 +26,22 @@
 //!            → mixer_O sink pad           the pad placing the mono
 //!                                         on output channel D
 //!
-//!   mixer_O → caps_out_O → capssetter_out_O → queue_out_O → audio_out_O
+//!   mixer_O → caps_out_O → capssetter_out_O → trim_out_O (volume)
+//!           → [limiter_out_O (rglimiter)] → queue_out_O → audio_out_O
 //! ```
+//!
+//! An output bus sums every crosspoint routed to it, so a mix-minus return
+//! carries N-1 talkers at unity and goes over full scale long before any one
+//! of them does. `trim_out_O` and `limiter_out_O` are what it has to catch
+//! that, in the order a console applies them.
+//!
+//! Both are off by default, and while they are off the bus is left alone down
+//! to its negotiation: `caps_out_O` pins `F32LE` only once one of them is
+//! engaged. That pin is the load-bearing part. An `audiomixer` saturates at
+//! the sum in a fixed-point format, so with the format left open whether a
+//! fan-in overload clipped inside the router or reached the output intact
+//! depended on what the next block negotiated — and neither stage can undo a
+//! sum that has already been saturated upstream of it.
 //!
 //! There is no queue on a crosspoint branch. A tee branch normally needs one
 //! so it cannot block its siblings, but every branch here ends on a
@@ -49,7 +63,7 @@ use gstreamer::prelude::*;
 use std::collections::HashMap;
 use strom_types::routing::{self, Crosspoint, RoutingGains};
 use strom_types::{block::*, element::ElementPadRef, PropertyValue, *};
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 /// Maximum number of input/output streams.
 const MAX_STREAMS: usize = 8;
@@ -110,6 +124,24 @@ const CROSSPOINT_PREFIX: &str = ":xp_";
 /// The `GstAudioConverter` option that maps a mixer sink pad's channels onto
 /// the mixer's output channels.
 const MIX_MATRIX_KEY: &str = "GstAudioConverter.mix-matrix";
+
+/// Name of the output trim property.
+pub const OUTPUT_HEADROOM_PROPERTY: &str = "output_headroom";
+
+/// Name of the output limiter property.
+pub const OUTPUT_LIMITER_PROPERTY: &str = "output_limiter_enabled";
+
+/// The element every output bus is limited by. `rglimiter` is a waveshaper:
+/// unity below -6 dBFS, a `tanh` knee above it, and an asymptote at full
+/// scale, so nothing it emits can reach 0 dBFS whatever goes in.
+///
+/// Not `lsp-rs-limiter`, which `builtin.mixer` uses through
+/// `make_limiter_element`. That one rides gain on an envelope, and on speech
+/// its attack loses the transient it was pointed at: measured on a four-seat
+/// return 5 dB over, it still let 0.05% of samples past full scale at a -3 dB
+/// threshold and 0.0007% at -10 dB, where it also costs 7.5 dB of level. A
+/// ceiling that is usually held is not a ceiling on a headphone feed.
+const LIMITER_FACTORY: &str = "rglimiter";
 
 /// Element naming for a crosspoint. The wire format itself lives in
 /// `strom_types::routing`, shared with the graph editor.
@@ -290,6 +322,18 @@ impl BlockBuilder for LiveAudioRouterBuilder {
             DEFAULT_OUTPUT_BUFFER_MS,
         )
         .max(1);
+        let headroom_db = output_headroom_db(properties);
+        let limiter_enabled = parse_bool(
+            properties,
+            OUTPUT_LIMITER_PROPERTY,
+            routing::DEFAULT_OUTPUT_LIMITER_ENABLED,
+        );
+        // A bus that has been asked for headroom has to sum in float, and a
+        // bus that has not must negotiate exactly as it did before: neither
+        // stage is any use after an `audiomixer` has already saturated the sum
+        // in a fixed-point format, and pinning a format nobody asked for would
+        // change what every existing flow negotiates.
+        let headroom_active = limiter_enabled || headroom_db != 0.0;
 
         // A matrix that has never been set gets the straight-through default,
         // so a router that has just been dropped in passes audio. An empty
@@ -339,15 +383,15 @@ impl BlockBuilder for LiveAudioRouterBuilder {
             // mix-matrix is only applied when the converter is not asked to do
             // positional mapping as well.
             let caps_id = format!("{instance_id}:caps_out_{out_idx}");
+            let mut bus_caps = gst::Caps::builder("audio/x-raw")
+                .field("channels", channels as i32)
+                .field("channel-mask", gst::Bitmask::new(0));
+            if headroom_active {
+                bus_caps = bus_caps.field("format", "F32LE");
+            }
             let caps = gst::ElementFactory::make("capsfilter")
                 .name(&caps_id)
-                .property(
-                    "caps",
-                    gst::Caps::builder("audio/x-raw")
-                        .field("channels", channels as i32)
-                        .field("channel-mask", gst::Bitmask::new(0))
-                        .build(),
-                )
+                .property("caps", bus_caps.build())
                 .build()
                 .map_err(|e| BlockBuildError::ElementCreation(format!("caps_out: {e}")))?;
             elements.push((caps_id.clone(), caps));
@@ -357,6 +401,26 @@ impl BlockBuilder for LiveAudioRouterBuilder {
             let setter_id = format!("{instance_id}:capssetter_out_{out_idx}");
             let setter = make_capssetter(&setter_id, channels)?;
             elements.push((setter_id.clone(), setter));
+
+            // Headroom, in the order a console applies it: trim the bus so
+            // the sum fits, then cap what is left. The trim is a `volume`,
+            // which passes any raw format through untouched at unity, so it
+            // costs a disengaged bus nothing and is always built.
+            let trim_id = format!("{instance_id}:trim_out_{out_idx}");
+            let trim = gst::ElementFactory::make("volume")
+                .name(&trim_id)
+                .property("volume", db_to_linear(headroom_db))
+                .build()
+                .map_err(|e| BlockBuildError::ElementCreation(format!("trim_out: {e}")))?;
+            elements.push((trim_id.clone(), trim));
+
+            // The limiter is not. `rglimiter` accepts `F32LE` and nothing
+            // else, so leaving a disabled one in the chain would pin the whole
+            // output to float for a flow that never asked to be limited.
+            let limiter_id = format!("{instance_id}:limiter_out_{out_idx}");
+            if limiter_enabled {
+                elements.push((limiter_id.clone(), make_output_limiter(&limiter_id)?));
+            }
 
             let queue_id = format!("{instance_id}:queue_out_{out_idx}");
             let queue = gst::ElementFactory::make("queue")
@@ -375,8 +439,23 @@ impl BlockBuilder for LiveAudioRouterBuilder {
             ));
             internal_links.push((
                 ElementPadRef::pad(&setter_id, "src"),
-                ElementPadRef::pad(&queue_id, "sink"),
+                ElementPadRef::pad(&trim_id, "sink"),
             ));
+            if limiter_enabled {
+                internal_links.push((
+                    ElementPadRef::pad(&trim_id, "src"),
+                    ElementPadRef::pad(&limiter_id, "sink"),
+                ));
+                internal_links.push((
+                    ElementPadRef::pad(&limiter_id, "src"),
+                    ElementPadRef::pad(&queue_id, "sink"),
+                ));
+            } else {
+                internal_links.push((
+                    ElementPadRef::pad(&trim_id, "src"),
+                    ElementPadRef::pad(&queue_id, "sink"),
+                ));
+            }
         }
 
         // ------------------------------------------------------------------
@@ -532,10 +611,13 @@ impl BlockBuilder for LiveAudioRouterBuilder {
         }
 
         info!(
-            "LiveAudioRouter '{}' built: {} crosspoints, {} open at build time",
+            "LiveAudioRouter '{}' built: {} crosspoints, {} open at build time, \
+             output trim {:.1} dB, limiter {}",
             instance_id,
             crosspoints,
-            gains.values().filter(|g| **g > 0.0).count()
+            gains.values().filter(|g| **g > 0.0).count(),
+            headroom_db,
+            if limiter_enabled { "on" } else { "off" }
         );
 
         Ok(BlockBuildResult {
@@ -559,6 +641,49 @@ fn set_pad_placement(pad: &gst::Pad, out_channel: usize, out_channels: usize) {
     let mut config = gst::Structure::new_empty("GstAudioConverter");
     config.set(MIX_MATRIX_KEY, gst::Array::new(rows));
     pad.set_property("converter-config", &config);
+}
+
+/// The output limiter for one bus, built only where one was asked for.
+fn make_output_limiter(id: &str) -> Result<gst::Element, BlockBuildError> {
+    gst::ElementFactory::make(LIMITER_FACTORY)
+        .name(id)
+        .property("enabled", true)
+        .build()
+        .map_err(|e| {
+            // gst-plugins-good is a hard dependency everywhere this runs, so a
+            // missing `rglimiter` is a broken install. Substituting a
+            // passthrough would leave the operator believing the return is
+            // protected when it is not.
+            error!("Live Audio Router: {LIMITER_FACTORY} is unavailable for {id}: {e}");
+            BlockBuildError::ElementCreation(format!(
+                "Live Audio Router: the output limiter needs the {LIMITER_FACTORY} element from \
+                 gst-plugins-good, which is not installed"
+            ))
+        })
+}
+
+/// dB to a linear `volume` coefficient.
+fn db_to_linear(db: f64) -> f64 {
+    10f64.powf(db / 20.0)
+}
+
+/// Read the output trim, clamped to the range the block advertises. A trim
+/// that boosts would add to the overload it exists to remove, so the ceiling
+/// is unity.
+fn output_headroom_db(properties: &HashMap<String, PropertyValue>) -> f64 {
+    properties
+        .get(OUTPUT_HEADROOM_PROPERTY)
+        .and_then(|v| match v {
+            PropertyValue::Float(f) => Some(*f),
+            PropertyValue::Int(i) => Some(*i as f64),
+            PropertyValue::UInt(u) => Some(*u as f64),
+            _ => None,
+        })
+        .unwrap_or(routing::DEFAULT_OUTPUT_HEADROOM_DB)
+        .clamp(
+            routing::MIN_OUTPUT_HEADROOM_DB,
+            routing::MAX_OUTPUT_HEADROOM_DB,
+        )
 }
 
 /// capssetter fixing the channel-mask the way `builtin.audiorouter` does:
@@ -763,6 +888,49 @@ fn liveaudiorouter_definition() -> BlockDefinition {
         mapping: PropertyMapping {
             element_id: "_block".to_string(),
             property_name: "output_buffer_duration".to_string(),
+            transform: None,
+        },
+        live: false,
+        persist: None,
+    });
+
+    exposed_properties.push(ExposedProperty {
+        name: OUTPUT_HEADROOM_PROPERTY.to_string(),
+        label: "Output Trim (dB)".to_string(),
+        description: format!(
+            "Attenuation applied to every output bus, in dB ({} to {}). An output sums every \
+             crosspoint routed to it, so a mix-minus return carries every other seat at once and \
+             goes over full scale long before any one of them does. {:.0} dB is the starting \
+             point for a return carrying 4 seats. Construction-time only.",
+            routing::MIN_OUTPUT_HEADROOM_DB,
+            routing::MAX_OUTPUT_HEADROOM_DB,
+            routing::headroom_for_sources(4),
+        ),
+        property_type: PropertyType::Float,
+        default_value: Some(PropertyValue::Float(routing::DEFAULT_OUTPUT_HEADROOM_DB)),
+        mapping: PropertyMapping {
+            element_id: "_block".to_string(),
+            property_name: OUTPUT_HEADROOM_PROPERTY.to_string(),
+            transform: None,
+        },
+        live: false,
+        persist: None,
+    });
+    exposed_properties.push(ExposedProperty {
+        name: OUTPUT_LIMITER_PROPERTY.to_string(),
+        label: "Output Limiter".to_string(),
+        description: "Put a ceiling on every output bus so a fan-in overload cannot reach full \
+                      scale. Transparent below -6 dBFS and progressively soft above it, and it \
+                      adds no latency. The ceiling is full scale itself, which leaves nothing \
+                      for a lossy return leg to overshoot into, so this catches a trim set for \
+                      fewer seats than turned up rather than replacing the trim. \
+                      Construction-time only."
+            .to_string(),
+        property_type: PropertyType::Bool,
+        default_value: Some(PropertyValue::Bool(routing::DEFAULT_OUTPUT_LIMITER_ENABLED)),
+        mapping: PropertyMapping {
+            element_id: "_block".to_string(),
+            property_name: OUTPUT_LIMITER_PROPERTY.to_string(),
             transform: None,
         },
         live: false,

--- a/backend/tests/liveaudiorouter_test.rs
+++ b/backend/tests/liveaudiorouter_test.rs
@@ -70,6 +70,10 @@ fn liveaudiorouter_exposes_the_same_property_set_as_audiorouter() {
         "latency".to_string(),
         "min_upstream_latency".to_string(),
         "output_buffer_duration".to_string(),
+        // ...including the two that give the bus somewhere to put a fan-in
+        // sum. `builtin.audiorouter` has neither and clips the same way.
+        liveaudiorouter::OUTPUT_HEADROOM_PROPERTY.to_string(),
+        liveaudiorouter::OUTPUT_LIMITER_PROPERTY.to_string(),
     ]
     .into();
     let extra: Vec<_> = new_names
@@ -197,6 +201,7 @@ fn liveaudiorouter_definition_pad_shape_matches_audiorouter() {
 /// reason to skip — a skipped test guards nothing.
 const REQUIRED_ELEMENTS: &[&str] = &[
     "volume",
+    "rglimiter",
     "audiomixer",
     "deinterleave",
     "tee",
@@ -992,4 +997,293 @@ fn the_original_audiorouter_keeps_its_silent_default() {
         !result.elements.iter().any(|(id, _)| id.contains(":xp_")),
         "the old block has no crosspoint elements at all"
     );
+}
+
+// ============================================================================
+// Output headroom
+//
+// A mix-minus return carries every seat but its own, so an output bus sums
+// N-1 sources at unity. Speech from independent talkers sums in power: four
+// seats each aligned to leave 16 dB of peak headroom still put the bus over
+// full scale. These tests drive that overload through the block's own builder
+// output and measure what leaves the output pad.
+// ============================================================================
+
+/// Four inputs, each a sine at `amplitude`, all routed onto output 0 channel 0.
+/// Four times 0.5 is 2.0, so the bus is 6 dB over full scale by construction.
+fn four_into_one(instance: &str, amplitude: f64, extra: &[(&str, PropertyValue)]) -> Harness {
+    let mut pairs: Vec<(&str, PropertyValue)> = vec![
+        ("num_inputs", PropertyValue::UInt(4)),
+        ("num_outputs", PropertyValue::UInt(1)),
+        ("input_0_channels", PropertyValue::UInt(1)),
+        ("input_1_channels", PropertyValue::UInt(1)),
+        ("input_2_channels", PropertyValue::UInt(1)),
+        ("input_3_channels", PropertyValue::UInt(1)),
+        ("output_0_channels", PropertyValue::UInt(1)),
+        (
+            "routing_matrix",
+            PropertyValue::String(
+                r#"{"i0c0":["o0c0"],"i1c0":["o0c0"],"i2c0":["o0c0"],"i3c0":["o0c0"]}"#.to_string(),
+            ),
+        ),
+    ];
+    pairs.extend(extra.iter().cloned());
+
+    let h = assemble(instance, &props(&pairs));
+    for input in 0..4 {
+        feed(&h, instance, input, &[(440.0, amplitude)]);
+    }
+    h
+}
+
+#[test]
+fn a_fan_in_overload_leaves_the_output_over_full_scale_when_nothing_catches_it() {
+    let h = four_into_one("headroom_none", 0.5, &[]);
+    tap(&h, "headroom_none", 0);
+    h.pipeline
+        .set_state(gst::State::Playing)
+        .expect("set Playing");
+
+    let peaks = observe_peaks(&h.pipeline, 1, Duration::from_secs(3));
+
+    // Two things at once: the exposure is real, and the bus carries it in
+    // float. Were the sum happening in a fixed-point format it would saturate
+    // inside `audiomixer` and this would read 0.0 dB, not the sum.
+    assert!(
+        peaks[0] > 4.0,
+        "four unity crosspoints summing 0.5 amplitude must leave the output around \
+         +6 dBFS with no trim and no limiter, got {peaks:?} dBFS"
+    );
+}
+
+#[test]
+fn the_output_limiter_holds_a_fan_in_overload_below_full_scale() {
+    let h = four_into_one(
+        "headroom_limited",
+        0.5,
+        &[("output_limiter_enabled", PropertyValue::Bool(true))],
+    );
+    tap(&h, "headroom_limited", 0);
+    h.pipeline
+        .set_state(gst::State::Playing)
+        .expect("set Playing");
+
+    let peaks = observe_peaks(&h.pipeline, 1, Duration::from_secs(3));
+
+    assert!(
+        peaks[0] <= 0.0,
+        "the output limiter must keep the same overload at or below full scale, \
+         got {peaks:?} dBFS"
+    );
+    // A limiter, not a mute: what it holds down it must still pass.
+    assert!(
+        peaks[0] > -6.0,
+        "the limiter must hold the bus just under full scale, not attenuate it away, \
+         got {peaks:?} dBFS"
+    );
+}
+
+#[test]
+fn the_output_trim_attenuates_every_output_bus() {
+    let h = four_into_one(
+        "headroom_trimmed",
+        0.5,
+        &[("output_headroom", PropertyValue::Float(-12.0))],
+    );
+    tap(&h, "headroom_trimmed", 0);
+    h.pipeline
+        .set_state(gst::State::Playing)
+        .expect("set Playing");
+
+    let peaks = observe_peaks(&h.pipeline, 1, Duration::from_secs(3));
+
+    // +6 dBFS of sum, trimmed 12 dB, is -6 dBFS.
+    assert!(
+        (peaks[0] - -6.0).abs() < 1.5,
+        "a -12 dB output trim must bring the +6 dBFS sum to about -6 dBFS, got {peaks:?} dBFS"
+    );
+}
+
+#[test]
+fn a_trim_cannot_be_used_to_boost_a_bus_that_is_already_summing() {
+    let h = four_into_one(
+        "headroom_boost",
+        0.5,
+        &[("output_headroom", PropertyValue::Float(12.0))],
+    );
+    let trim = h
+        .elements
+        .get("headroom_boost:trim_out_0")
+        .expect("no trim_out_0");
+
+    assert!(
+        (trim.property::<f64>("volume") - 1.0).abs() < 1e-9,
+        "a positive trim must clamp to unity, got {}",
+        trim.property::<f64>("volume")
+    );
+}
+
+#[test]
+fn an_engaged_output_bus_sums_in_float() {
+    let h = four_into_one(
+        "headroom_float",
+        0.5,
+        &[("output_limiter_enabled", PropertyValue::Bool(true))],
+    );
+
+    // The pin, at the element that carries it. `audiomixer` saturates at the
+    // sum in a fixed-point format, so an output bus that is about to be
+    // trimmed or limited has to be told to stay in float — by the time the
+    // overload reaches either stage, a saturated sum is already gone.
+    let caps = h
+        .elements
+        .get("headroom_float:caps_out_0")
+        .expect("no caps_out_0")
+        .property::<gst::Caps>("caps");
+    assert_eq!(
+        caps.structure(0)
+            .and_then(|s| s.get::<String>("format").ok())
+            .unwrap_or_default(),
+        "F32LE",
+        "an engaged output bus must be pinned to float, got {caps}"
+    );
+
+    // And what it negotiates once running, with a consumer that would rather
+    // have S16.
+    let convert = gst::ElementFactory::make("audioconvert")
+        .build()
+        .expect("audioconvert");
+    let s16 = gst::ElementFactory::make("capsfilter")
+        .property(
+            "caps",
+            gst::Caps::builder("audio/x-raw")
+                .field("format", "S16LE")
+                .field("rate", 48000i32)
+                .field("channels", 1i32)
+                .build(),
+        )
+        .build()
+        .expect("capsfilter");
+    let sink = gst::ElementFactory::make("fakesink")
+        .property("sync", false)
+        .build()
+        .expect("fakesink");
+    h.pipeline
+        .add_many([&convert, &s16, &sink])
+        .expect("add consumer");
+    gst::Element::link_many([&convert, &s16, &sink]).expect("link consumer");
+    h.elements
+        .get("headroom_float:queue_out_0")
+        .expect("no queue_out_0")
+        .link(&convert)
+        .expect("link output to consumer");
+
+    h.pipeline
+        .set_state(gst::State::Playing)
+        .expect("set Playing");
+    h.pipeline
+        .state(gst::ClockTime::from_seconds(5))
+        .0
+        .expect("reach Playing");
+
+    for element in ["mixer_0", "trim_out_0", "limiter_out_0"] {
+        let negotiated = h
+            .elements
+            .get(&format!("headroom_float:{element}"))
+            .unwrap_or_else(|| panic!("no {element}"))
+            .static_pad("src")
+            .expect("src pad")
+            .current_caps()
+            .unwrap_or_else(|| panic!("{element} never negotiated caps"));
+        assert_eq!(
+            negotiated
+                .structure(0)
+                .and_then(|s| s.get::<String>("format").ok())
+                .unwrap_or_default(),
+            "F32LE",
+            "{element} must carry float however the consumer would prefer to be fed, \
+             got {negotiated}"
+        );
+    }
+}
+
+#[test]
+fn a_router_that_has_not_asked_for_headroom_is_left_exactly_as_it_was() {
+    let h = four_into_one("headroom_default", 0.5, &[]);
+
+    let trim = h
+        .elements
+        .get("headroom_default:trim_out_0")
+        .expect("no trim_out_0");
+    assert!(
+        (trim.property::<f64>("volume") - 1.0).abs() < 1e-9,
+        "the output trim must default to unity, got {}",
+        trim.property::<f64>("volume")
+    );
+
+    // No limiter in the chain at all, not a disabled one. `rglimiter` takes
+    // F32LE and nothing else, so a disabled one left in place would still pin
+    // the whole output to float for a flow that never asked to be limited.
+    assert!(
+        !h.elements.contains_key("headroom_default:limiter_out_0"),
+        "a router with no headroom configured must not have a limiter in its output chain"
+    );
+
+    let caps = h
+        .elements
+        .get("headroom_default:caps_out_0")
+        .expect("no caps_out_0")
+        .property::<gst::Caps>("caps");
+    assert!(
+        caps.structure(0)
+            .map(|s| !s.has_field("format"))
+            .unwrap_or(false),
+        "a disengaged output bus must negotiate its format the way it always did, got {caps}"
+    );
+}
+
+#[test]
+fn the_headroom_properties_are_offered_and_default_to_no_op() {
+    let def = definition(liveaudiorouter::get_blocks(), "builtin.liveaudiorouter");
+    let by_name: HashMap<_, _> = def
+        .exposed_properties
+        .iter()
+        .map(|p| (p.name.as_str(), p))
+        .collect();
+
+    let headroom = by_name
+        .get("output_headroom")
+        .expect("output_headroom is not exposed");
+    // PropertyValue does not implement PartialEq; compare Debug, as the
+    // parity tests above do.
+    assert_eq!(
+        format!("{:?}", headroom.default_value),
+        format!(
+            "{:?}",
+            Some(PropertyValue::Float(
+                strom_types::routing::DEFAULT_OUTPUT_HEADROOM_DB
+            ))
+        ),
+        "the output trim must default to no attenuation"
+    );
+
+    let limiter = by_name
+        .get("output_limiter_enabled")
+        .expect("output_limiter_enabled is not exposed");
+    assert_eq!(
+        format!("{:?}", limiter.default_value),
+        format!(
+            "{:?}",
+            Some(PropertyValue::Bool(
+                strom_types::routing::DEFAULT_OUTPUT_LIMITER_ENABLED
+            ))
+        ),
+        "the output limiter must default to off"
+    );
+    const {
+        assert!(
+            !strom_types::routing::DEFAULT_OUTPUT_LIMITER_ENABLED,
+            "defaulting the limiter on would change what every existing flow sounds like"
+        )
+    };
 }

--- a/backend/tests/liveaudiorouter_test.rs
+++ b/backend/tests/liveaudiorouter_test.rs
@@ -1033,6 +1033,13 @@ fn four_into_one(instance: &str, amplitude: f64, extra: &[(&str, PropertyValue)]
                 r#"{"i0c0":["o0c0"],"i1c0":["o0c0"],"i2c0":["o0c0"],"i3c0":["o0c0"]}"#.to_string(),
             ),
         ),
+        // An output bus emits after `latency` whether or not every pad has
+        // delivered, and `make_audiomixer` also sets `ignore-inactive-pads`.
+        // At the 30 ms default a loaded machine starves a source past the
+        // deadline and the bus emits three of the four sources, which is a
+        // measurement of the runner rather than of the router. These tests are
+        // about what four sources add up to, so let the bus wait for four.
+        ("latency", PropertyValue::UInt(500)),
     ];
     pairs.extend(extra.iter().cloned());
 

--- a/backend/tests/liveaudiorouter_test.rs
+++ b/backend/tests/liveaudiorouter_test.rs
@@ -1009,6 +1009,13 @@ fn the_original_audiorouter_keeps_its_silent_default() {
 // output and measure what leaves the output pad.
 // ============================================================================
 
+/// Tones for the four seats of a fan-in test, one per input. Four different
+/// frequencies, because each `audiotestsrc` starts its sine at its own first
+/// buffer: four copies of one tone sum at whatever relative phase the machine
+/// hands out. Spread frequencies sweep through alignment hundreds of times a
+/// second, so the loudest moment in a window lands near the coherent sum.
+const FAN_IN_TONES: [f64; 4] = [440.0, 557.0, 691.0, 823.0];
+
 /// Four inputs, each a sine at `amplitude`, all routed onto output 0 channel 0.
 /// Four times 0.5 is 2.0, so the bus is 6 dB over full scale by construction.
 fn four_into_one(instance: &str, amplitude: f64, extra: &[(&str, PropertyValue)]) -> Harness {
@@ -1030,77 +1037,73 @@ fn four_into_one(instance: &str, amplitude: f64, extra: &[(&str, PropertyValue)]
     pairs.extend(extra.iter().cloned());
 
     let h = assemble(instance, &props(&pairs));
-    for input in 0..4 {
-        feed(&h, instance, input, &[(440.0, amplitude)]);
+    for (input, freq) in FAN_IN_TONES.iter().enumerate() {
+        feed(&h, instance, input, &[(*freq, amplitude)]);
     }
     h
 }
 
-#[test]
-fn a_fan_in_overload_leaves_the_output_over_full_scale_when_nothing_catches_it() {
-    let h = four_into_one("headroom_none", 0.5, &[]);
-    tap(&h, "headroom_none", 0);
+/// Loudest peak on output 0 of a four-into-one router with these settings.
+fn fan_in_peak(instance: &str, extra: &[(&str, PropertyValue)]) -> f64 {
+    let h = four_into_one(instance, 0.5, extra);
+    tap(&h, instance, 0);
     h.pipeline
         .set_state(gst::State::Playing)
         .expect("set Playing");
+    observe_peaks(&h.pipeline, 1, Duration::from_secs(3))[0]
+}
 
-    let peaks = observe_peaks(&h.pipeline, 1, Duration::from_secs(3));
+#[test]
+fn a_fan_in_overload_leaves_the_output_over_full_scale_when_nothing_catches_it() {
+    let peak = fan_in_peak("headroom_none", &[]);
 
     // Two things at once: the exposure is real, and the bus carries it in
     // float. Were the sum happening in a fixed-point format it would saturate
-    // inside `audiomixer` and this would read 0.0 dB, not the sum.
+    // inside `audiomixer` and this would read 0.0 dB, not the sum. The bound is
+    // well under the +6 dBFS of a perfectly coherent sum, which no machine owes
+    // this test.
     assert!(
-        peaks[0] > 4.0,
-        "four unity crosspoints summing 0.5 amplitude must leave the output around \
-         +6 dBFS with no trim and no limiter, got {peaks:?} dBFS"
+        peak > 2.0,
+        "four unity crosspoints summing 0.5 amplitude must leave the output clear of \
+         full scale with no trim and no limiter, got {peak} dBFS"
     );
 }
 
 #[test]
 fn the_output_limiter_holds_a_fan_in_overload_below_full_scale() {
-    let h = four_into_one(
+    let peak = fan_in_peak(
         "headroom_limited",
-        0.5,
         &[("output_limiter_enabled", PropertyValue::Bool(true))],
     );
-    tap(&h, "headroom_limited", 0);
-    h.pipeline
-        .set_state(gst::State::Playing)
-        .expect("set Playing");
-
-    let peaks = observe_peaks(&h.pipeline, 1, Duration::from_secs(3));
 
     assert!(
-        peaks[0] <= 0.0,
+        peak <= 0.0,
         "the output limiter must keep the same overload at or below full scale, \
-         got {peaks:?} dBFS"
+         got {peak} dBFS"
     );
     // A limiter, not a mute: what it holds down it must still pass.
     assert!(
-        peaks[0] > -6.0,
+        peak > -6.0,
         "the limiter must hold the bus just under full scale, not attenuate it away, \
-         got {peaks:?} dBFS"
+         got {peak} dBFS"
     );
 }
 
 #[test]
 fn the_output_trim_attenuates_every_output_bus() {
-    let h = four_into_one(
+    // Measured against the same router without the trim rather than against an
+    // absolute level, so what is asserted is what the trim does and not what
+    // four live sources happened to sum to on this machine.
+    let untrimmed = fan_in_peak("headroom_untrimmed", &[]);
+    let trimmed = fan_in_peak(
         "headroom_trimmed",
-        0.5,
         &[("output_headroom", PropertyValue::Float(-12.0))],
     );
-    tap(&h, "headroom_trimmed", 0);
-    h.pipeline
-        .set_state(gst::State::Playing)
-        .expect("set Playing");
 
-    let peaks = observe_peaks(&h.pipeline, 1, Duration::from_secs(3));
-
-    // +6 dBFS of sum, trimmed 12 dB, is -6 dBFS.
     assert!(
-        (peaks[0] - -6.0).abs() < 1.5,
-        "a -12 dB output trim must bring the +6 dBFS sum to about -6 dBFS, got {peaks:?} dBFS"
+        ((untrimmed - trimmed) - 12.0).abs() < 1.5,
+        "a -12 dB output trim must take 12 dB off the bus: untrimmed {untrimmed} dBFS, \
+         trimmed {trimmed} dBFS"
     );
 }
 

--- a/types/src/routing.rs
+++ b/types/src/routing.rs
@@ -12,9 +12,11 @@ use std::collections::{BTreeMap, HashMap};
 ///
 /// The `volume` element carrying it would go to +20 dB, but boost belongs
 /// somewhere with a meter and a limiter in front of it — `builtin.audiogain`
-/// or the mixer block — not on a routing crosspoint. The output bus sums
-/// without headroom, so a boosted crosspoint plus fan-in clips with nothing
-/// to catch it. Attenuation is the useful half and cannot clip.
+/// or the mixer block — not on a routing crosspoint. A boosted crosspoint
+/// plus fan-in clips, and fan-in alone can clip without any boost at all:
+/// `DEFAULT_OUTPUT_HEADROOM_DB` and `DEFAULT_OUTPUT_LIMITER_ENABLED` below are
+/// what the output bus has to catch that. Attenuation is the useful half of a
+/// crosspoint and cannot clip.
 pub const MAX_CROSSPOINT_GAIN: f64 = 1.0;
 
 /// Ceiling expressed in dB — `20 * log10(MAX_CROSSPOINT_GAIN)`.
@@ -22,6 +24,41 @@ pub const MAX_CROSSPOINT_GAIN_DB: f64 = 0.0;
 
 /// Anything at or below this reads as fully closed.
 pub const GAIN_FLOOR_DB: f64 = -60.0;
+
+// Output bus headroom. A router output sums every crosspoint routed to it, so
+// on a mix-minus rig it carries N-1 talkers at unity. Four seats each aligned
+// to leave 16 dB of peak headroom still put that bus over full scale. The two
+// knobs below are applied in that order: trim the bus so the sum fits, then
+// put a ceiling on what is left.
+
+/// Default output trim: none. Existing flows keep their level.
+pub const DEFAULT_OUTPUT_HEADROOM_DB: f64 = 0.0;
+
+/// Most attenuation the output trim will apply. Below this the return is too
+/// quiet to be a usable headphone feed whatever the fan-in.
+pub const MIN_OUTPUT_HEADROOM_DB: f64 = -24.0;
+
+/// The trim attenuates; it does not make up gain. Boost on a bus that is
+/// already summing without headroom is the problem, not the fix.
+pub const MAX_OUTPUT_HEADROOM_DB: f64 = 0.0;
+
+/// Default for the output limiter: off, so nothing about an existing flow
+/// changes until someone asks for it.
+pub const DEFAULT_OUTPUT_LIMITER_ENABLED: bool = false;
+
+/// Trim, in dB, that makes an N-source sum of independent speech fit where one
+/// source fitted: `10 * log10(n)`. Power, not amplitude — two independent
+/// talkers are 3 dB louder than one, not 6 dB.
+///
+/// A starting point, not a guarantee: this tracks the sum's energy, and what
+/// clips is its peaks.
+pub fn headroom_for_sources(n: usize) -> f64 {
+    if n <= 1 {
+        0.0
+    } else {
+        -10.0 * (n as f64).log10()
+    }
+}
 
 /// One crosspoint of a routing matrix: an input channel feeding an output
 /// channel.


### PR DESCRIPTION
`builtin.liveaudiorouter` sums every crosspoint routed to an output with nothing on the bus to catch the result. In a mix-minus return, two seats talking over each other can go over full scale when neither alone does. `MAX_CROSSPOINT_GAIN` already named the exposure, but only covered boost.

## What this adds

Two construction-time properties per output bus. Both default to no-ops.

- **`output_fader_db`** is a bus master fader: a `volume` from 0 down to -24 dB.
- **`output_soft_clip_enabled`** adds an `rglimiter`. It has no attack or release; it is a fixed per-sample `tanh` curve with an asymptote at full scale, so it is named for what it does. The mixer block's Main Limiter is a true limiter and behaves differently.

When either stage is engaged, `caps_out_O` pins `F32LE`. `audiomixer` saturates the sum in a fixed-point format: two in-phase 0.8 sines give +4.08 dBFS with F32 downstream and exactly 0.00 dBFS with S16. Without the pin, whether an overload survived to reach the fader depended on what the next block negotiated.

A router that asks for neither is unchanged down to negotiation: no clipper element, the fader at unity, and no format field on `caps_out_O`.

## How much headroom

The help text suggests **-3 dB with the soft clipper on, whatever the seat count** (`routing::SUGGESTED_OUTPUT_FADER_DB`). The fader is sized for two voices, because that is what overlap in conversation looks like:

- **Two-party:** simultaneous speech is 3.8% of Switchboard, with a median overlap of 205 ms. 73% of sampled overlaps involve a backchannel ([Levinson & Torreira 2015](https://www.frontiersin.org/journals/psychology/articles/10.3389/fpsyg.2015.00731/full)).
- **Meetings of 3-9 people:** 11.6% of speaking time overlaps. Over 90% of overlapped time has a single other talker ([Çetin & Shriberg 2006](https://www.isca-archive.org/interspeech_2006/cetin06_interspeech.pdf)).
- **A two-person rehearsal on this rig:** 3.3% of speaking time overlapped, median 200 ms. The real two-voice sum peaked at -1.65 dBFS with no fader.
  - Adding time-shifted copies to make four voices: no fader gave a median of 0 clipped seconds per minute and a worst case of 0.74.
  - At -3 dB, none of the 12 trials clipped.

**Why -3 dB.** WebRTC's default AGC targets a -3 dBFS peak. Two such voices reach +3 dBFS where their peaks coincide, so -3 dB puts that at full scale and the clipper handles the rare remainder. Sizing the fader for N-1 simultaneous voices would cost every lone voice that much level, all the time, to cover a case that barely occurs.

**Stress test.** Five WHIP publishers all sending speech continuously, which is not a conversation. All five returns were captured over WHEP for 48 s, with a fresh backend for each arm:

| router settings | seconds containing a clipped sample |
| --- | --- |
| no fader, no clipper | 40-45 of 48 |
| soft clipper only | 4-18 of 48 |
| fader -6 dB | 0 of 48 |

-3 dB was not run on this rig.

## Risks a reviewer should weigh

- **The soft clipper alone is not enough.** It delivers -0.05 dBFS, and the Opus leg takes that to -0.00. EBU Tech 3343 keeps lossy codec input at or below -2 dBTP for the same reason: decoding overshoots. The fader is what creates that margin.
- **Why not `lsp-rs-limiter`.** It is statically linked, so present in every build even though `gst-inspect-1.0` cannot see it. Its envelope attack misses speech transients: on a four-seat mix 5 dB over, it passed 0.05% of samples above full scale at a -3 dB threshold. `rglimiter` passes 0.0000%.
- **Latency is zero** for both elements. An impulse comes out at the same sample, and the pipeline latency query is unchanged.
- **The fader is always built; the clipper only when enabled.** At unity `volume` refuses only unsigned formats, and every crosspoint is a `volume` already, so an unconfigured bus loses nothing. `rglimiter` is F32LE-only even when disabled.
- **Construction-time only**, like `latency` and `force_live`. A live per-output fader needs a fan-out like `routing_matrix`'s, and is left for a follow-up.

## Tests

Nine new tests in `backend/tests/liveaudiorouter_test.rs`, driven through the block's real builder output. Each guard was checked by reverting the piece it covers:

- **`an_engaged_output_bus_sums_in_float`** fails without the format pin.
- **`the_output_soft_clipper_holds_a_fan_in_overload_below_full_scale`** fails without the clipper.
- **`the_output_fader_attenuates_every_output_bus`** fails without the fader gain.
- **`a_fader_alone_keeps_a_fixed_point_bus_summing_in_float`** uses S16 sources and an S16 consumer. With the fader half of the pin removed, it reads -12 dBFS instead of about -6. The clipper test cannot catch this, because `rglimiter` forces float on its own.
- **`an_unconfigured_bus_still_feeds_an_integer_consumer_without_a_converter`** fails at the link if the bus is pinned to float or carries a clipper by default.

`rglimiter` ships in `gstreamer1.0-plugins-good`, which CI already installs, so nothing skips.

**What was run:**
- The full suite ran locally on macOS earlier in the branch: 791 passed, 7 ignored.
- On the latest commit: `liveaudiorouter_test` (28 passed), `openapi_test`, and `cargo clippy --all-targets -- -D warnings`. The router tests also passed three consecutive runs at `--test-threads=8` on the commit before it, which differs only in help text. The full suite was not re-run.
- Not run: CI on the latest commit. The rig and rehearsal measurements are macOS-only and not part of any suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
