### PR TITLE
feat(gst): report a branch whose link never formed

### DIFF
--- a/backend/src/gst/pipeline/construction.rs
+++ b/backend/src/gst/pipeline/construction.rs
@@ -90,6 +90,8 @@ impl PipelineManager {
             cached_state: std::sync::Arc::new(std::sync::RwLock::new(PipelineState::Null)),
             qos_aggregator: QoSAggregator::new(),
             qos_broadcast_task: None,
+            block_health: std::sync::Arc::new(std::sync::RwLock::new(Vec::new())),
+            block_health_task: None,
             ptp_clock: None,
             ptp_stats: std::sync::Arc::new(std::sync::RwLock::new(None)),
             ntp_clock: None,

--- a/backend/src/gst/pipeline/health.rs
+++ b/backend/src/gst/pipeline/health.rs
@@ -49,14 +49,21 @@ fn first_stalled_pad(element: &gst::Element) -> Option<StalledPad> {
 
 /// Find the first paused pad task on `element` itself.
 ///
-/// Two kinds of legitimately paused task are excluded. An element held below
-/// `PLAYING` - a webrtcbin added for a newly connected WHEP consumer, say -
-/// pauses its tasks as part of that transition. And a pad that has seen EOS is
-/// finished by definition:
-/// `gst_base_src_loop` pauses its task on the way out for *every* reason
-/// including end of stream, and the element stays `PLAYING` afterwards, so a
-/// finite source that has played out would otherwise be reported as failed
-/// forever. The stall this looks for pushes no EOS.
+/// Three kinds of legitimately paused task are excluded.
+///
+/// An element held below `PLAYING` - a webrtcbin added for a newly connected
+/// WHEP consumer, say - pauses its tasks as part of that transition.
+///
+/// A pad that has seen EOS is finished by definition: `gst_base_src_loop` pauses
+/// its task on the way out for *every* reason including end of stream, and the
+/// element stays `PLAYING` afterwards, so a finite source that has played out
+/// would otherwise be reported as failed forever. The stall this looks for
+/// pushes no EOS.
+///
+/// An unlinked pad has no branch to report on. A `queue` feeding a block output
+/// that the flow leaves unconnected gets `not-linked` from its loop and parks
+/// the task there permanently - the vision mixer's `multiview_out` does exactly
+/// this whenever a flow uses only the program output.
 fn stalled_pad_on(element: &gst::Element) -> Option<StalledPad> {
     if element.current_state() != gst::State::Playing {
         return None;
@@ -67,6 +74,7 @@ fn stalled_pad_on(element: &gst::Element) -> Option<StalledPad> {
         .find(|pad| {
             pad.task_state() == gst::TaskState::Paused
                 && !pad.pad_flags().contains(gst::PadFlags::EOS)
+                && pad.peer().is_some()
         })
         .map(|pad| StalledPad {
             element: element.name().to_string(),
@@ -309,6 +317,46 @@ mod tests {
         flow
     }
 
+    /// videotestsrc -> tee, with one tee branch queued and left unconnected.
+    ///
+    /// Mirrors a block output the flow does not wire up - the vision mixer's
+    /// `multiview_out` is exactly this - where the queue's loop takes
+    /// `not-linked` and parks its task for good.
+    fn unwired_output_flow() -> Flow {
+        let mut flow = Flow::new("unwired output health test");
+        flow.elements = vec![
+            element(
+                "src",
+                "videotestsrc",
+                &[("is-live", PropertyValue::Bool(true))],
+            ),
+            element("split", "tee", &[]),
+            element("q_used", "queue", &[]),
+            element("sink", "fakesink", &[("sync", PropertyValue::Bool(false))]),
+            // Fed by the tee, going nowhere.
+            element("q_dangling", "queue", &[]),
+        ];
+        flow.links = vec![
+            Link {
+                from: "src".to_string(),
+                to: "split".to_string(),
+            },
+            Link {
+                from: "split".to_string(),
+                to: "q_used".to_string(),
+            },
+            Link {
+                from: "q_used".to_string(),
+                to: "sink".to_string(),
+            },
+            Link {
+                from: "split".to_string(),
+                to: "q_dangling".to_string(),
+            },
+        ];
+        flow
+    }
+
     /// videotestsrc with a fixed buffer count -> fakesink. Runs to EOS.
     fn finite_source_flow() -> Flow {
         let mut flow = Flow::new("eos health test");
@@ -336,6 +384,53 @@ mod tests {
             std::thread::sleep(Duration::from_millis(100));
         }
         condition()
+    }
+
+    /// A `queue` whose source pad is left unconnected takes `not-linked` from its
+    /// loop and parks the task while the element stays `PLAYING`. Blocks expose
+    /// optional outputs built this way, so reporting it would mark most flows
+    /// using them permanently failed.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn an_unwired_output_branch_is_not_reported_as_failed() {
+        gst::init().unwrap();
+
+        let mut manager = PipelineManager::new(
+            &unwired_output_flow(),
+            EventBroadcaster::default(),
+            &BlockRegistry::new("test_blocks.json"),
+            vec!["stun:stun.l.google.com:19302".to_string()],
+            "all".to_string(),
+            None,
+            std::path::PathBuf::from("./media"),
+            std::sync::Arc::new(std::sync::Mutex::new(HashMap::new())),
+        )
+        .expect("pipeline should build");
+
+        manager.start().expect("pipeline should start");
+        assert!(
+            wait_for(
+                || manager.get_state() == strom_types::PipelineState::Playing,
+                Duration::from_secs(10)
+            ),
+            "pipeline never reached Playing"
+        );
+
+        let went_failed = wait_for(
+            || {
+                manager
+                    .get_block_health()
+                    .iter()
+                    .any(|h| h.status == BlockHealthStatus::Failed)
+            },
+            HEALTH_POLL_INTERVAL * (CONFIRMATIONS_BEFORE_FAILED + 3),
+        );
+        assert!(
+            !went_failed,
+            "an unwired output branch must not read as failed: {:?}",
+            manager.get_block_health()
+        );
+
+        manager.stop().expect("pipeline should stop");
     }
 
     /// `gst_base_src_loop` pauses its pad task on the way out for every reason,

--- a/backend/src/gst/pipeline/health.rs
+++ b/backend/src/gst/pipeline/health.rs
@@ -41,9 +41,13 @@ fn first_stalled_pad(element: &gst::Element) -> Option<StalledPad> {
 
 /// Find the first paused pad task on `element` itself.
 ///
-/// Only elements that are themselves playing are considered. A sub-bin held in
-/// `PAUSED` inside a playing pipeline - a WebRTC session bin mid-setup, say -
-/// has paused pad tasks legitimately.
+/// Two kinds of legitimately paused task are excluded. An element held below
+/// `PLAYING` - a WebRTC session bin mid-setup, say - pauses its tasks as part of
+/// that transition. And a pad that has seen EOS is finished by definition:
+/// `gst_base_src_loop` pauses its task on the way out for *every* reason
+/// including end of stream, and the element stays `PLAYING` afterwards, so a
+/// finite source that has played out would otherwise be reported as failed
+/// forever. The stall this looks for pushes no EOS.
 fn stalled_pad_on(element: &gst::Element) -> Option<StalledPad> {
     if element.current_state() != gst::State::Playing {
         return None;
@@ -51,7 +55,10 @@ fn stalled_pad_on(element: &gst::Element) -> Option<StalledPad> {
     element
         .pads()
         .into_iter()
-        .find(|pad| pad.task_state() == gst::TaskState::Paused)
+        .find(|pad| {
+            pad.task_state() == gst::TaskState::Paused
+                && !pad.pad_flags().contains(gst::PadFlags::EOS)
+        })
         .map(|pad| StalledPad {
             element: element.name().to_string(),
             pad: pad.name().to_string(),
@@ -90,7 +97,7 @@ pub(crate) fn scan_block_health(elements: &HashMap<String, gst::Element>) -> Vec
         if let Some(stalled) = first_stalled_pad(element) {
             entry.status = BlockHealthStatus::Failed;
             entry.detail = Some(format!(
-                "pad task stopped on {}:{} - this branch is not passing data",
+                "pad task paused on {}:{} - this branch is not passing data",
                 stalled.element, stalled.pad
             ));
         }
@@ -101,6 +108,13 @@ pub(crate) fn scan_block_health(elements: &HashMap<String, gst::Element>) -> Vec
 
 /// How often the running pipeline is scanned for stalled pad tasks.
 const HEALTH_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// Consecutive scans a block must look stalled before it is reported.
+///
+/// Pad tasks are briefly paused for legitimate reasons - a flushing seek, a
+/// dynamic bin being linked in - so a single sample is not enough to call a
+/// block failed. Costs one extra poll interval of detection latency.
+const CONFIRMATIONS_BEFORE_FAILED: u32 = 2;
 
 impl super::PipelineManager {
     /// Current per-block health. Empty until the health task has run once.
@@ -129,6 +143,7 @@ impl super::PipelineManager {
         let task = tokio::spawn(async move {
             let mut interval = tokio::time::interval(HEALTH_POLL_INTERVAL);
             let mut failed: std::collections::HashSet<String> = std::collections::HashSet::new();
+            let mut strikes: HashMap<String, u32> = HashMap::new();
 
             loop {
                 interval.tick().await;
@@ -136,9 +151,8 @@ impl super::PipelineManager {
                 // Only meaningful while playing - a paused task is expected in
                 // every other state, including during startup and shutdown.
                 if *cached_state.read().unwrap() != strom_types::PipelineState::Playing {
-                    if !failed.is_empty() {
-                        failed.clear();
-                    }
+                    failed.clear();
+                    strikes.clear();
                     block_health.write().unwrap().clear();
                     continue;
                 }
@@ -151,7 +165,29 @@ impl super::PipelineManager {
                     continue;
                 }
 
-                let snapshot = scan_block_health(&elements);
+                let mut snapshot = scan_block_health(&elements);
+
+                // A block is only reported once it has looked stalled on
+                // CONFIRMATIONS_BEFORE_FAILED scans in a row. Downgrade the
+                // unconfirmed ones before anything observes the snapshot.
+                for health in &mut snapshot {
+                    if health.status.is_failed() {
+                        let count = strikes.entry(health.block_id.clone()).or_insert(0);
+                        *count += 1;
+                        if *count < CONFIRMATIONS_BEFORE_FAILED {
+                            health.status = BlockHealthStatus::Ok;
+                            health.detail = None;
+                        }
+                    } else {
+                        strikes.remove(&health.block_id);
+                    }
+                }
+
+                // Blocks whose elements have gone away drop out of the scan
+                // entirely; forget them rather than leaving a stale entry that
+                // no later iteration can clear.
+                failed.retain(|block_id| snapshot.iter().any(|h| &h.block_id == block_id));
+                strikes.retain(|block_id, _| snapshot.iter().any(|h| &h.block_id == block_id));
 
                 for health in &snapshot {
                     let was_failed = failed.contains(&health.block_id);
@@ -264,6 +300,24 @@ mod tests {
         flow
     }
 
+    /// videotestsrc with a fixed buffer count -> fakesink. Runs to EOS.
+    fn finite_source_flow() -> Flow {
+        let mut flow = Flow::new("eos health test");
+        flow.elements = vec![
+            element(
+                "src",
+                "videotestsrc",
+                &[("num-buffers", PropertyValue::Int(5))],
+            ),
+            element("sink", "fakesink", &[("sync", PropertyValue::Bool(false))]),
+        ];
+        flow.links = vec![Link {
+            from: "src".to_string(),
+            to: "sink".to_string(),
+        }];
+        flow
+    }
+
     fn wait_for(condition: impl Fn() -> bool, timeout: Duration) -> bool {
         let start = Instant::now();
         while start.elapsed() < timeout {
@@ -273,6 +327,64 @@ mod tests {
             std::thread::sleep(Duration::from_millis(100));
         }
         condition()
+    }
+
+    /// `gst_base_src_loop` pauses its pad task on the way out for every reason,
+    /// end of stream included, and leaves the element in `PLAYING`. Playing a
+    /// finite source to completion must not read as a failure.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_source_that_reaches_eos_is_not_reported_as_failed() {
+        gst::init().unwrap();
+
+        let mut manager = PipelineManager::new(
+            &finite_source_flow(),
+            EventBroadcaster::default(),
+            &BlockRegistry::new("test_blocks.json"),
+            vec!["stun:stun.l.google.com:19302".to_string()],
+            "all".to_string(),
+            None,
+            std::path::PathBuf::from("./media"),
+            std::sync::Arc::new(std::sync::Mutex::new(HashMap::new())),
+        )
+        .expect("pipeline should build");
+
+        manager.start().expect("pipeline should start");
+
+        // Let the source play out and the scan run several times over the
+        // drained pipeline.
+        assert!(
+            wait_for(
+                || manager
+                    .elements
+                    .get("src")
+                    .map(|e| e.static_pad("src").unwrap().pad_flags())
+                    .is_some_and(|f| f.contains(gst::PadFlags::EOS)),
+                Duration::from_secs(15)
+            ),
+            "source never reached EOS"
+        );
+        // Watch across several scans - long enough that a block would clear the
+        // confirmation threshold - and assert it never flips to failed.
+        let went_failed = wait_for(
+            || {
+                manager
+                    .get_block_health()
+                    .iter()
+                    .any(|h| h.status == BlockHealthStatus::Failed)
+            },
+            HEALTH_POLL_INTERVAL * (CONFIRMATIONS_BEFORE_FAILED + 3),
+        );
+        assert!(
+            !went_failed,
+            "a drained finite source must not read as failed: {:?}",
+            manager.get_block_health()
+        );
+        assert!(
+            !manager.get_block_health().is_empty(),
+            "health scan never produced a snapshot"
+        );
+
+        manager.stop().expect("pipeline should stop");
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/backend/src/gst/pipeline/health.rs
+++ b/backend/src/gst/pipeline/health.rs
@@ -11,6 +11,14 @@
 //! `GstBaseSrc` is the exception: it posts a flow error before pausing, so
 //! source-side failures already reach the bus handler.
 //!
+//! Scope: the scan reaches the flow pipeline's own elements and the bins beneath
+//! them, and nothing else. Blocks that run an isolated `gst::Pipeline` of their
+//! own - WHIP ingest sessions, a Media Player's decode chain - are siblings of
+//! that pipeline rather than children of it, so `iterate_recurse` never enters
+//! them. An `Ok` here therefore means "no stalled pad task among this flow
+//! pipeline's elements", not "this flow is passing data". Sinks that live in the
+//! flow pipeline, `whepserversink` included, are covered.
+//!
 //! A paused task on an element that is itself `PLAYING` is always wrong, so
 //! that is the signal used here. `gst_pad_get_task_state()` returns `Stopped`
 //! both for a pad whose task was stopped and for a pad that never had one, so
@@ -42,8 +50,9 @@ fn first_stalled_pad(element: &gst::Element) -> Option<StalledPad> {
 /// Find the first paused pad task on `element` itself.
 ///
 /// Two kinds of legitimately paused task are excluded. An element held below
-/// `PLAYING` - a WebRTC session bin mid-setup, say - pauses its tasks as part of
-/// that transition. And a pad that has seen EOS is finished by definition:
+/// `PLAYING` - a webrtcbin added for a newly connected WHEP consumer, say -
+/// pauses its tasks as part of that transition. And a pad that has seen EOS is
+/// finished by definition:
 /// `gst_base_src_loop` pauses its task on the way out for *every* reason
 /// including end of stream, and the element stays `PLAYING` afterwards, so a
 /// finite source that has played out would otherwise be reported as failed

--- a/backend/src/gst/pipeline/health.rs
+++ b/backend/src/gst/pipeline/health.rs
@@ -168,12 +168,18 @@ pub(crate) fn scan_block_health(
     // Reported against the block owning the source element, which is where the
     // branch dies, and allowed to overwrite a stall found above: a task parked
     // behind a link that never formed is the symptom, and the link is the cause.
+    // Where a block has several, the first names it, as in the scan above.
+    let mut named_by_link: std::collections::HashSet<String> = std::collections::HashSet::new();
     for link in pending_links {
         if !unformed_link(elements, link) {
             continue;
         }
         let (from_ref, _) = link.to_pad_refs();
-        let Some(entry) = by_block.get_mut(owning_block(&from_ref.element_id)) else {
+        let block_id = owning_block(&from_ref.element_id);
+        if !named_by_link.insert(block_id.to_string()) {
+            continue;
+        }
+        let Some(entry) = by_block.get_mut(block_id) else {
             continue;
         };
         entry.status = BlockHealthStatus::Failed;

--- a/backend/src/gst/pipeline/health.rs
+++ b/backend/src/gst/pipeline/health.rs
@@ -23,11 +23,18 @@
 //! that is the signal used here. `gst_pad_get_task_state()` returns `Stopped`
 //! both for a pad whose task was stopped and for a pad that never had one, so
 //! `Stopped` cannot be told apart from the common case and is not reported.
+//!
+//! A branch that never started is the other thing reported here, and the scan
+//! above cannot see it: with no link there is no pad task to pause, and a tee
+//! with `allow-not-linked=true` - what every block output bus ends in - absorbs
+//! the `not-linked` that would otherwise surface upstream. The flow reaches
+//! `PLAYING` carrying nothing on that branch.
 
 use gstreamer as gst;
 use gstreamer::prelude::*;
 use std::collections::{BTreeMap, HashMap};
 use strom_types::flow::{BlockHealth, BlockHealthStatus};
+use strom_types::Link;
 
 /// A pad whose task has been paused while the pipeline is playing.
 struct StalledPad {
@@ -91,11 +98,49 @@ fn owning_block(element_id: &str) -> &str {
     element_id.split(':').next().unwrap_or(element_id)
 }
 
+/// Whether a deferred link has missed its only chance to form.
+///
+/// `pending_links` holds every link `try_link_elements` refused, and the only
+/// thing that retries one is the `pad-added` handler on its source element. A
+/// pad that is already there will not be added again, so a deferred link whose
+/// named source pad exists and has no peer is unformed for the life of the
+/// pipeline, not merely slow.
+///
+/// The converse is deliberately not reported. A source pad that does not exist
+/// yet - `decodebin` before it has typefound, a `whipserversrc` before a
+/// publisher arrives - is the case the deferral was built for, and the handler
+/// will link it when it appears.
+///
+/// Two links are outside what this can judge, and both read as formed. One
+/// whose source pad appeared under a different name than the link asked for
+/// (`src` matching `src_0`) is linked through the handler's pattern match, and
+/// one whose unlinked dynamic pad picked up an auto-tee has a peer that is not
+/// the declared destination.
+fn unformed_link(elements: &HashMap<String, gst::Element>, link: &Link) -> bool {
+    let (from_ref, _) = link.to_pad_refs();
+    let Some(element) = elements.get(&from_ref.element_id) else {
+        return false;
+    };
+    // An element-level link names no pad; GStreamer would have used the
+    // element's own `src` pad, so that is what is checked.
+    let pad_name = from_ref.pad_name.as_deref().unwrap_or("src");
+    let Some(pad) = element.static_pad(pad_name) else {
+        return false;
+    };
+    pad.direction() == gst::PadDirection::Src && pad.peer().is_none()
+}
+
 /// Report health for every block with at least one element in `elements`.
+///
+/// `pending_links` are the links construction could not make, carried from the
+/// `PipelineManager` unchanged.
 ///
 /// Call only while the pipeline is playing; a paused task is expected in any
 /// other pipeline state.
-pub(crate) fn scan_block_health(elements: &HashMap<String, gst::Element>) -> Vec<BlockHealth> {
+pub(crate) fn scan_block_health(
+    elements: &HashMap<String, gst::Element>,
+    pending_links: &[Link],
+) -> Vec<BlockHealth> {
     let mut by_block: BTreeMap<&str, BlockHealth> = BTreeMap::new();
 
     for (element_id, element) in elements {
@@ -118,6 +163,24 @@ pub(crate) fn scan_block_health(elements: &HashMap<String, gst::Element>) -> Vec
                 stalled.element, stalled.pad
             ));
         }
+    }
+
+    // Reported against the block owning the source element, which is where the
+    // branch dies, and allowed to overwrite a stall found above: a task parked
+    // behind a link that never formed is the symptom, and the link is the cause.
+    for link in pending_links {
+        if !unformed_link(elements, link) {
+            continue;
+        }
+        let (from_ref, _) = link.to_pad_refs();
+        let Some(entry) = by_block.get_mut(owning_block(&from_ref.element_id)) else {
+            continue;
+        };
+        entry.status = BlockHealthStatus::Failed;
+        entry.detail = Some(format!(
+            "link {} -> {} never formed - this branch has carried no data since the flow started",
+            link.from, link.to
+        ));
     }
 
     by_block.into_values().collect()
@@ -151,6 +214,9 @@ impl super::PipelineManager {
             .map(|(id, element)| (id.clone(), element.downgrade()))
             .collect();
 
+        // Construction is the only writer of pending_links, and it has finished
+        // by the time this task starts.
+        let pending_links = self.pending_links.clone();
         let cached_state = self.cached_state.clone();
         let block_health = self.block_health.clone();
         let events = self.events.clone();
@@ -182,7 +248,7 @@ impl super::PipelineManager {
                     continue;
                 }
 
-                let mut snapshot = scan_block_health(&elements);
+                let mut snapshot = scan_block_health(&elements, &pending_links);
 
                 // A block is only reported once it has looked stalled on
                 // CONFIRMATIONS_BEFORE_FAILED scans in a row. Downgrade the
@@ -212,7 +278,7 @@ impl super::PipelineManager {
                         (true, false) => {
                             failed.insert(health.block_id.clone());
                             tracing::error!(
-                                "Block '{}' in flow '{}' has stopped: {}. The pipeline still reports Playing",
+                                "Block '{}' in flow '{}' is not passing data: {}. The pipeline still reports Playing",
                                 health.block_id,
                                 flow_name,
                                 health.detail.as_deref().unwrap_or("no detail")
@@ -266,6 +332,108 @@ mod tests {
     use crate::gst::pipeline::PipelineManager;
     use std::time::{Duration, Instant};
     use strom_types::{Element, Flow, Link, PropertyValue};
+
+    /// `videoconvert:src` and `audioconvert:sink` have no format in common, so
+    /// a link between them is refused, now and on every retry.
+    fn unlinkable_pair() -> (HashMap<String, gst::Element>, Link) {
+        gst::init().unwrap();
+        let elements: HashMap<String, gst::Element> = [
+            ("vconv", "videoconvert"),
+            ("aconv", "audioconvert"),
+            ("holder", "fakesink"),
+        ]
+        .into_iter()
+        .map(|(id, factory)| {
+            (
+                id.to_string(),
+                gst::ElementFactory::make(factory)
+                    .name(id)
+                    .build()
+                    .expect("element should build"),
+            )
+        })
+        .collect();
+        let link = Link {
+            from: "vconv:src".to_string(),
+            to: "aconv:sink".to_string(),
+        };
+        (elements, link)
+    }
+
+    fn failure_detail(health: &[BlockHealth], block_id: &str) -> Option<String> {
+        health
+            .iter()
+            .find(|h| h.block_id == block_id && h.status == BlockHealthStatus::Failed)
+            .and_then(|h| h.detail.clone())
+    }
+
+    #[test]
+    fn a_deferred_link_that_never_formed_fails_its_block() {
+        let (elements, link) = unlinkable_pair();
+
+        assert!(
+            scan_block_health(&elements, &[])
+                .iter()
+                .all(|h| h.status == BlockHealthStatus::Ok),
+            "nothing is stalled, so the pad-task scan must find nothing"
+        );
+
+        let detail = failure_detail(&scan_block_health(&elements, &[link]), "vconv")
+            .expect("the unformed link must fail the block owning its source");
+        assert!(
+            detail.contains("vconv:src -> aconv:sink"),
+            "the detail must name the link: {}",
+            detail
+        );
+    }
+
+    /// The deferral exists for a source pad that is not there yet. Reporting one
+    /// would mark every `decodebin` failed for as long as it takes to typefind.
+    #[test]
+    fn a_deferred_link_waiting_on_a_dynamic_pad_is_not_reported() {
+        gst::init().unwrap();
+        let elements: HashMap<String, gst::Element> = [(
+            "dec".to_string(),
+            gst::ElementFactory::make("decodebin")
+                .name("dec")
+                .build()
+                .expect("decodebin should build"),
+        )]
+        .into_iter()
+        .collect();
+        let pending = [Link {
+            from: "dec:src_0".to_string(),
+            to: "sink:sink".to_string(),
+        }];
+
+        assert!(
+            scan_block_health(&elements, &pending)
+                .iter()
+                .all(|h| h.status == BlockHealthStatus::Ok),
+            "a source pad that has not appeared yet is not a failure"
+        );
+    }
+
+    /// A link the `pad-added` handler resolved is still in `pending_links`, so a
+    /// linked source pad has to read as healthy.
+    #[test]
+    fn a_deferred_link_that_did_form_is_not_reported() {
+        let (elements, link) = unlinkable_pair();
+        let vconv = elements.get("vconv").unwrap();
+        let holder = elements.get("holder").unwrap();
+        vconv
+            .static_pad("src")
+            .unwrap()
+            .link(&holder.static_pad("sink").unwrap())
+            .expect("videoconvert should link to fakesink");
+
+        assert!(
+            scan_block_health(&elements, &[link])
+                .iter()
+                .all(|h| h.status == BlockHealthStatus::Ok),
+            "a linked source pad means the deferred link resolved"
+        );
+    }
 
     #[test]
     fn block_elements_are_attributed_to_their_block() {
@@ -352,6 +520,38 @@ mod tests {
             Link {
                 from: "split".to_string(),
                 to: "q_dangling".to_string(),
+            },
+        ];
+        flow
+    }
+
+    /// A live chain that keeps the pipeline running, plus a declared link between
+    /// two elements with no format in common.
+    ///
+    /// Nothing feeds the unlinkable pair, so no pad task parks and the pad-task
+    /// scan has nothing to find - the same blind spot a real flow presents when
+    /// a block's `allow-not-linked` output tee absorbs the `not-linked` from
+    /// below an unformed link.
+    fn unformed_link_flow() -> Flow {
+        let mut flow = Flow::new("unformed link health test");
+        flow.elements = vec![
+            element(
+                "src",
+                "videotestsrc",
+                &[("is-live", PropertyValue::Bool(true))],
+            ),
+            element("sink", "fakesink", &[("sync", PropertyValue::Bool(false))]),
+            element("vconv", "videoconvert", &[]),
+            element("aconv", "audioconvert", &[]),
+        ];
+        flow.links = vec![
+            Link {
+                from: "src".to_string(),
+                to: "sink".to_string(),
+            },
+            Link {
+                from: "vconv:src".to_string(),
+                to: "aconv:sink".to_string(),
             },
         ];
         flow
@@ -487,6 +687,65 @@ mod tests {
             !manager.get_block_health().is_empty(),
             "health scan never produced a snapshot"
         );
+
+        manager.stop().expect("pipeline should stop");
+    }
+
+    /// A link that construction could not make and nothing retried. The branch
+    /// below it carries no data, and with no pad task to pause there is nothing
+    /// for the stalled-pad scan to find.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_link_that_never_formed_is_reported_on_a_playing_pipeline() {
+        gst::init().unwrap();
+
+        let mut manager = PipelineManager::new(
+            &unformed_link_flow(),
+            EventBroadcaster::default(),
+            &BlockRegistry::new("test_blocks.json"),
+            vec!["stun:stun.l.google.com:19302".to_string()],
+            "all".to_string(),
+            None,
+            std::path::PathBuf::from("./media"),
+            std::sync::Arc::new(std::sync::Mutex::new(HashMap::new())),
+        )
+        .expect("pipeline should build");
+
+        manager.start().expect("pipeline should start");
+        assert!(
+            wait_for(
+                || manager.get_state() == strom_types::PipelineState::Playing,
+                Duration::from_secs(10)
+            ),
+            "pipeline never reached Playing"
+        );
+
+        assert!(
+            wait_for(
+                || failure_detail(&manager.get_block_health(), "vconv").is_some(),
+                HEALTH_POLL_INTERVAL * (CONFIRMATIONS_BEFORE_FAILED + 4),
+            ),
+            "the unformed link was not reported: {:?}",
+            manager.get_block_health()
+        );
+
+        let health = manager.get_block_health();
+        let detail = failure_detail(&health, "vconv").unwrap();
+        assert!(
+            detail.contains("vconv:src -> aconv:sink"),
+            "the detail must name the link: {}",
+            detail
+        );
+        // Nothing is stalled: the pad-task scan contributes no failure here, so
+        // removing the unformed-link check leaves this flow reading healthy.
+        assert!(
+            health
+                .iter()
+                .filter(|h| h.status == BlockHealthStatus::Failed)
+                .all(|h| h.block_id == "vconv"),
+            "only the block owning the unformed link should fail: {:?}",
+            health
+        );
+        assert_eq!(manager.get_state(), strom_types::PipelineState::Playing);
 
         manager.stop().expect("pipeline should stop");
     }

--- a/backend/src/gst/pipeline/health.rs
+++ b/backend/src/gst/pipeline/health.rs
@@ -1,0 +1,368 @@
+//! Detection of stalled pad tasks in a running pipeline.
+//!
+//! A pad task is the thread that drives data out of a pad. Elements pause their
+//! own task when a downstream push fails with a non-fatal flow return such as
+//! `not-negotiated` - video encoders do this, and so does `GstAggregator`,
+//! which additionally marks all its sink pads flushing, stalling everything
+//! upstream of it. Neither posts to the bus, and pausing a task is not a state
+//! change, so the pipeline and every element in it stay `PLAYING` while that
+//! branch carries nothing.
+//!
+//! `GstBaseSrc` is the exception: it posts a flow error before pausing, so
+//! source-side failures already reach the bus handler.
+//!
+//! A paused task on an element that is itself `PLAYING` is always wrong, so
+//! that is the signal used here. `gst_pad_get_task_state()` returns `Stopped`
+//! both for a pad whose task was stopped and for a pad that never had one, so
+//! `Stopped` cannot be told apart from the common case and is not reported.
+
+use gstreamer as gst;
+use gstreamer::prelude::*;
+use std::collections::{BTreeMap, HashMap};
+use strom_types::flow::{BlockHealth, BlockHealthStatus};
+
+/// A pad whose task has been paused while the pipeline is playing.
+struct StalledPad {
+    element: String,
+    pad: String,
+}
+
+/// Find the first paused pad task on `element`, and on its children if it is a bin.
+fn first_stalled_pad(element: &gst::Element) -> Option<StalledPad> {
+    if let Some(stalled) = stalled_pad_on(element) {
+        return Some(stalled);
+    }
+    let bin = element.downcast_ref::<gst::Bin>()?;
+    bin.iterate_recurse()
+        .into_iter()
+        .flatten()
+        .find_map(|child| stalled_pad_on(&child))
+}
+
+/// Find the first paused pad task on `element` itself.
+///
+/// Only elements that are themselves playing are considered. A sub-bin held in
+/// `PAUSED` inside a playing pipeline - a WebRTC session bin mid-setup, say -
+/// has paused pad tasks legitimately.
+fn stalled_pad_on(element: &gst::Element) -> Option<StalledPad> {
+    if element.current_state() != gst::State::Playing {
+        return None;
+    }
+    element
+        .pads()
+        .into_iter()
+        .find(|pad| pad.task_state() == gst::TaskState::Paused)
+        .map(|pad| StalledPad {
+            element: element.name().to_string(),
+            pad: pad.name().to_string(),
+        })
+}
+
+/// Block instance ID owning `element_id`.
+///
+/// Block elements are namespaced `block_id:internal_id` by `BlockBuildResult`.
+/// A standalone element has no prefix and is reported under its own ID so that
+/// a stall outside a block is not silently dropped.
+fn owning_block(element_id: &str) -> &str {
+    element_id.split(':').next().unwrap_or(element_id)
+}
+
+/// Report health for every block with at least one element in `elements`.
+///
+/// Call only while the pipeline is playing; a paused task is expected in any
+/// other pipeline state.
+pub(crate) fn scan_block_health(elements: &HashMap<String, gst::Element>) -> Vec<BlockHealth> {
+    let mut by_block: BTreeMap<&str, BlockHealth> = BTreeMap::new();
+
+    for (element_id, element) in elements {
+        let block_id = owning_block(element_id);
+        let entry = by_block.entry(block_id).or_insert_with(|| BlockHealth {
+            block_id: block_id.to_string(),
+            status: BlockHealthStatus::Ok,
+            detail: None,
+        });
+
+        // A block is failed if any of its elements has a stalled pad; the first
+        // one found names the failure.
+        if entry.status.is_failed() {
+            continue;
+        }
+        if let Some(stalled) = first_stalled_pad(element) {
+            entry.status = BlockHealthStatus::Failed;
+            entry.detail = Some(format!(
+                "pad task stopped on {}:{} - this branch is not passing data",
+                stalled.element, stalled.pad
+            ));
+        }
+    }
+
+    by_block.into_values().collect()
+}
+
+/// How often the running pipeline is scanned for stalled pad tasks.
+const HEALTH_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);
+
+impl super::PipelineManager {
+    /// Current per-block health. Empty until the health task has run once.
+    pub fn get_block_health(&self) -> Vec<BlockHealth> {
+        self.block_health.read().unwrap().clone()
+    }
+
+    /// Start the periodic scan for stalled pad tasks.
+    pub(super) fn start_block_health_task(&mut self) {
+        self.stop_block_health_task();
+
+        // WeakRef, not a clone: a task holding strong element references would
+        // keep the pipeline alive past drop.
+        let weak_elements: Vec<(String, gst::glib::WeakRef<gst::Element>)> = self
+            .elements
+            .iter()
+            .map(|(id, element)| (id.clone(), element.downgrade()))
+            .collect();
+
+        let cached_state = self.cached_state.clone();
+        let block_health = self.block_health.clone();
+        let events = self.events.clone();
+        let flow_id = self.flow_id;
+        let flow_name = self.flow_name.clone();
+
+        let task = tokio::spawn(async move {
+            let mut interval = tokio::time::interval(HEALTH_POLL_INTERVAL);
+            let mut failed: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+            loop {
+                interval.tick().await;
+
+                // Only meaningful while playing - a paused task is expected in
+                // every other state, including during startup and shutdown.
+                if *cached_state.read().unwrap() != strom_types::PipelineState::Playing {
+                    if !failed.is_empty() {
+                        failed.clear();
+                    }
+                    block_health.write().unwrap().clear();
+                    continue;
+                }
+
+                let elements: HashMap<String, gst::Element> = weak_elements
+                    .iter()
+                    .filter_map(|(id, weak)| weak.upgrade().map(|el| (id.clone(), el)))
+                    .collect();
+                if elements.is_empty() {
+                    continue;
+                }
+
+                let snapshot = scan_block_health(&elements);
+
+                for health in &snapshot {
+                    let was_failed = failed.contains(&health.block_id);
+                    match (health.status.is_failed(), was_failed) {
+                        (true, false) => {
+                            failed.insert(health.block_id.clone());
+                            tracing::error!(
+                                "Block '{}' in flow '{}' has stopped: {}. The pipeline still reports Playing",
+                                health.block_id,
+                                flow_name,
+                                health.detail.as_deref().unwrap_or("no detail")
+                            );
+                            events.broadcast(strom_types::StromEvent::BlockHealthChanged {
+                                flow_id,
+                                block_id: health.block_id.clone(),
+                                status: health.status,
+                                detail: health.detail.clone(),
+                            });
+                        }
+                        (false, true) => {
+                            failed.remove(&health.block_id);
+                            tracing::info!(
+                                "Block '{}' in flow '{}' resumed passing data",
+                                health.block_id,
+                                flow_name
+                            );
+                            events.broadcast(strom_types::StromEvent::BlockHealthChanged {
+                                flow_id,
+                                block_id: health.block_id.clone(),
+                                status: health.status,
+                                detail: None,
+                            });
+                        }
+                        _ => {}
+                    }
+                }
+
+                *block_health.write().unwrap() = snapshot;
+            }
+        });
+
+        self.block_health_task = Some(task);
+    }
+
+    /// Stop the periodic health scan and drop the last snapshot.
+    pub(super) fn stop_block_health_task(&mut self) {
+        if let Some(task) = self.block_health_task.take() {
+            task.abort();
+        }
+        self.block_health.write().unwrap().clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::blocks::BlockRegistry;
+    use crate::events::EventBroadcaster;
+    use crate::gst::pipeline::PipelineManager;
+    use std::time::{Duration, Instant};
+    use strom_types::{Element, Flow, Link, PropertyValue};
+
+    #[test]
+    fn block_elements_are_attributed_to_their_block() {
+        assert_eq!(owning_block("whep:videoenc"), "whep");
+        assert_eq!(owning_block("whep:sink:inner"), "whep");
+        assert_eq!(owning_block("standalone_element"), "standalone_element");
+    }
+
+    fn element(id: &str, element_type: &str, props: &[(&str, PropertyValue)]) -> Element {
+        Element {
+            id: id.to_string(),
+            element_type: element_type.to_string(),
+            properties: props
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.clone()))
+                .collect(),
+            pad_properties: HashMap::new(),
+            position: (0.0, 0.0),
+        }
+    }
+
+    /// videotestsrc -> compositor -> capsfilter -> fakesink, as a real flow.
+    fn stall_flow() -> Flow {
+        let mut flow = Flow::new("block health test");
+        flow.elements = vec![
+            element(
+                "src",
+                "videotestsrc",
+                &[("is-live", PropertyValue::Bool(true))],
+            ),
+            element("comp", "compositor", &[]),
+            element("filter", "capsfilter", &[]),
+            element("sink", "fakesink", &[("sync", PropertyValue::Bool(false))]),
+        ];
+        flow.links = vec![
+            Link {
+                from: "src".to_string(),
+                to: "comp".to_string(),
+            },
+            Link {
+                from: "comp".to_string(),
+                to: "filter".to_string(),
+            },
+            Link {
+                from: "filter".to_string(),
+                to: "sink".to_string(),
+            },
+        ];
+        flow
+    }
+
+    fn wait_for(condition: impl Fn() -> bool, timeout: Duration) -> bool {
+        let start = Instant::now();
+        while start.elapsed() < timeout {
+            if condition() {
+                return true;
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+        condition()
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stalled_branch_is_reported_while_the_pipeline_still_says_playing() {
+        gst::init().unwrap();
+
+        let mut manager = PipelineManager::new(
+            &stall_flow(),
+            EventBroadcaster::default(),
+            &BlockRegistry::new("test_blocks.json"),
+            vec!["stun:stun.l.google.com:19302".to_string()],
+            "all".to_string(),
+            None,
+            std::path::PathBuf::from("./media"),
+            std::sync::Arc::new(std::sync::Mutex::new(HashMap::new())),
+        )
+        .expect("pipeline should build");
+
+        manager.start().expect("pipeline should start");
+        assert!(
+            wait_for(
+                || manager.get_state() == strom_types::PipelineState::Playing,
+                Duration::from_secs(10)
+            ),
+            "pipeline never reached Playing"
+        );
+        assert!(
+            wait_for(
+                || !manager.get_block_health().is_empty(),
+                Duration::from_secs(10)
+            ),
+            "health scan never produced a snapshot"
+        );
+        assert!(
+            manager
+                .get_block_health()
+                .iter()
+                .all(|h| h.status == BlockHealthStatus::Ok),
+            "a healthy pipeline should report no failures: {:?}",
+            manager.get_block_health()
+        );
+
+        // Retighten the capsfilter to a format the compositor cannot produce.
+        // The next push fails negotiation and the compositor pauses its source
+        // pad task without posting anything to the bus.
+        manager
+            .elements
+            .get("filter")
+            .expect("capsfilter should exist")
+            .set_property(
+                "caps",
+                gst::Caps::builder("video/x-bayer")
+                    .field("format", "bggr")
+                    .build(),
+            );
+
+        assert!(
+            wait_for(
+                || manager
+                    .get_block_health()
+                    .iter()
+                    .any(|h| h.block_id == "comp" && h.status == BlockHealthStatus::Failed),
+                Duration::from_secs(15)
+            ),
+            "stalled compositor was not reported: {:?}",
+            manager.get_block_health()
+        );
+
+        // The failure has to be visible without the pipeline state changing,
+        // which is the case the scan exists for.
+        assert_eq!(manager.get_state(), strom_types::PipelineState::Playing);
+
+        // An element deliberately held below Playing has paused pad tasks for a
+        // legitimate reason and must not be reported. Upstream elements that
+        // are still Playing and now blocked behind it are a real stall and stay
+        // reported, so only the paused element itself is checked here.
+        let compositor = manager.elements.get("comp").unwrap().clone();
+        compositor.set_state(gst::State::Paused).unwrap();
+        assert!(
+            wait_for(
+                || manager
+                    .get_block_health()
+                    .iter()
+                    .any(|h| h.block_id == "comp" && h.status == BlockHealthStatus::Ok),
+                Duration::from_secs(15)
+            ),
+            "a paused element should not be reported as failed: {:?}",
+            manager.get_block_health()
+        );
+
+        manager.stop().expect("pipeline should stop");
+    }
+}

--- a/backend/src/gst/pipeline/lifecycle.rs
+++ b/backend/src/gst/pipeline/lifecycle.rs
@@ -47,6 +47,9 @@ impl PipelineManager {
         self.start_qos_broadcast_task();
         info!("QoS stats task started");
 
+        // Start the scan for stalled pad tasks
+        self.start_block_health_task();
+
         // Configure clock before starting
         info!(
             "Configuring clock (type: {:?})...",
@@ -202,6 +205,7 @@ impl PipelineManager {
 
         // Stop QoS broadcast task
         self.stop_qos_broadcast_task();
+        self.stop_block_health_task();
 
         // Stop thumbnail deactivation task
         if let Some(task) = self.thumbnail_deactivation_task.take() {

--- a/backend/src/gst/pipeline/mod.rs
+++ b/backend/src/gst/pipeline/mod.rs
@@ -3,6 +3,7 @@
 mod bus;
 mod construction;
 pub(crate) mod effects;
+mod health;
 mod lifecycle;
 mod linking;
 mod properties;
@@ -195,6 +196,10 @@ pub struct PipelineManager {
     qos_aggregator: QoSAggregator,
     /// Handle for the periodic QoS stats broadcast task
     qos_broadcast_task: Option<tokio::task::JoinHandle<()>>,
+    /// Latest per-block health snapshot from the stalled-pad-task scan
+    block_health: std::sync::Arc<std::sync::RwLock<Vec<strom_types::flow::BlockHealth>>>,
+    /// Handle for the periodic block health scan task
+    block_health_task: Option<tokio::task::JoinHandle<()>>,
     /// PTP clock reference (stored for querying grandmaster/master info)
     ptp_clock: Option<gst_net::PtpClock>,
     /// PTP statistics (updated by statistics callback)
@@ -244,6 +249,7 @@ impl Drop for PipelineManager {
         self.probe_manager.stop_broadcast_task();
         self.probe_manager.deactivate_all();
         self.stop_qos_broadcast_task();
+        self.stop_block_health_task();
 
         // Ensure pipeline is in Null state before releasing references.
         // If stop() was already called this is a no-op.

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -609,9 +609,11 @@ impl AppState {
                     }
                     flow.properties.ntp_info = pipeline.get_ntp_info();
                     flow.properties.thread_priority_status = pipeline.get_thread_priority_status();
+                    flow.block_health = pipeline.get_block_health();
                 } else {
                     // Clear runtime-only status when no pipeline is running
                     flow.set_gst_state(None);
+                    flow.block_health.clear();
                     flow.properties.thread_priority_status = None;
                     flow.properties.clock_sync_status = None;
                     flow.properties.ptp_info = None;
@@ -643,9 +645,11 @@ impl AppState {
                 }
                 flow.properties.ntp_info = pipeline.get_ntp_info();
                 flow.properties.thread_priority_status = pipeline.get_thread_priority_status();
+                flow.block_health = pipeline.get_block_health();
             } else {
                 // Clear runtime-only status when no pipeline is running
                 flow.set_gst_state(None);
+                flow.block_health.clear();
                 flow.properties.thread_priority_status = None;
                 flow.properties.clock_sync_status = None;
                 flow.properties.ptp_info = None;

--- a/backend/tests/block_health_test.rs
+++ b/backend/tests/block_health_test.rs
@@ -1,0 +1,146 @@
+//! A pipeline branch can stop dead while the pipeline still reports Playing.
+//!
+//! When a downstream push fails with `not-negotiated`, `GstAggregator` marks
+//! its sink pads flushing and pauses its source pad task. Nothing is posted to
+//! the bus and no element changes state, so the failure is invisible in
+//! `gst_state`. These tests pin both halves: that the stall is silent, and
+//! that the block health scan reports it.
+
+use gstreamer as gst;
+use gstreamer::prelude::*;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+fn init() {
+    gst::init().unwrap();
+}
+
+/// Poll `condition` until true or `timeout` elapses. Returns whether it held.
+fn wait_for(condition: impl Fn() -> bool, timeout: Duration) -> bool {
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        if condition() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    condition()
+}
+
+/// videotestsrc -> compositor -> capsfilter -> fakesink.
+///
+/// The capsfilter is the lever: retightening it to a caps the compositor
+/// cannot produce makes the next push fail negotiation.
+struct StallRig {
+    pipeline: gst::Pipeline,
+    compositor: gst::Element,
+    capsfilter: gst::Element,
+    bus_errors: Arc<Mutex<Vec<String>>>,
+}
+
+impl StallRig {
+    fn build() -> Self {
+        let pipeline = gst::Pipeline::new();
+        let src = gst::ElementFactory::make("videotestsrc")
+            .property("is-live", true)
+            .build()
+            .unwrap();
+        let compositor = gst::ElementFactory::make("compositor").build().unwrap();
+        let capsfilter = gst::ElementFactory::make("capsfilter")
+            .property(
+                "caps",
+                gst::Caps::builder("video/x-raw")
+                    .field("width", 320i32)
+                    .field("height", 240i32)
+                    .build(),
+            )
+            .build()
+            .unwrap();
+        let sink = gst::ElementFactory::make("fakesink")
+            .property("sync", false)
+            .build()
+            .unwrap();
+
+        pipeline
+            .add_many([&src, &compositor, &capsfilter, &sink])
+            .unwrap();
+        src.link(&compositor).unwrap();
+        gst::Element::link_many([&compositor, &capsfilter, &sink]).unwrap();
+
+        let bus_errors = Arc::new(Mutex::new(Vec::new()));
+        let collected = bus_errors.clone();
+        let bus = pipeline.bus().unwrap();
+        bus.add_signal_watch();
+        bus.connect_message(Some("error"), move |_, msg| {
+            if let gst::MessageView::Error(err) = msg.view() {
+                collected.lock().unwrap().push(err.error().to_string());
+            }
+        });
+
+        Self {
+            pipeline,
+            compositor,
+            capsfilter,
+            bus_errors,
+        }
+    }
+
+    fn compositor_task_state(&self) -> gst::TaskState {
+        self.compositor.static_pad("src").unwrap().task_state()
+    }
+
+    /// Force the next compositor push to fail negotiation.
+    fn break_negotiation(&self) {
+        self.capsfilter.set_property(
+            "caps",
+            gst::Caps::builder("video/x-bayer")
+                .field("format", "bggr")
+                .build(),
+        );
+    }
+}
+
+impl Drop for StallRig {
+    fn drop(&mut self) {
+        let _ = self.pipeline.set_state(gst::State::Null);
+    }
+}
+
+#[test]
+fn aggregator_stall_is_silent_and_leaves_pipeline_playing() {
+    init();
+    let rig = StallRig::build();
+    rig.pipeline.set_state(gst::State::Playing).unwrap();
+
+    // videotestsrc is live, so the transition is async. Block until it settles:
+    // the compositor task starts before the pipeline finishes reaching Playing,
+    // so waiting on the task state alone races the state change.
+    let (res, current, _) = rig.pipeline.state(gst::ClockTime::from_seconds(10));
+    assert_eq!(res, Ok(gst::StateChangeSuccess::Success));
+    assert_eq!(current, gst::State::Playing);
+    assert_eq!(rig.compositor_task_state(), gst::TaskState::Started);
+
+    rig.break_negotiation();
+
+    assert!(
+        wait_for(
+            || rig.compositor_task_state() == gst::TaskState::Paused,
+            Duration::from_secs(10)
+        ),
+        "compositor task never stalled after negotiation was broken"
+    );
+
+    // The whole point: the stall reports nothing where a caller would look.
+    let (_, current, _) = rig.pipeline.state(gst::ClockTime::from_seconds(1));
+    assert_eq!(
+        current,
+        gst::State::Playing,
+        "pipeline should still report Playing while the branch is dead"
+    );
+    let errors = rig.bus_errors.lock().unwrap();
+    assert!(
+        errors.is_empty(),
+        "expected no bus error, got: {:?}",
+        errors
+    );
+}

--- a/backend/tests/block_health_test.rs
+++ b/backend/tests/block_health_test.rs
@@ -1,10 +1,11 @@
-//! A pipeline branch can stop dead while the pipeline still reports Playing.
+//! A pipeline branch can carry nothing while the pipeline still reports Playing.
 //!
-//! When a downstream push fails with `not-negotiated`, `GstAggregator` marks
-//! its sink pads flushing and pauses its source pad task. Nothing is posted to
-//! the bus and no element changes state, so the failure is invisible in
-//! `gst_state`. These tests pin both halves: that the stall is silent, and
-//! that the block health scan reports it.
+//! Two ways in. When a downstream push fails with `not-negotiated`,
+//! `GstAggregator` marks its sink pads flushing and pauses its source pad task.
+//! When a link is refused for having no format in common, the branch below it
+//! never starts at all. Neither posts to the bus and neither changes any
+//! element's state, so both are invisible in `gst_state`. These tests pin that
+//! silence; `gst::pipeline::health` covers the detection.
 
 use gstreamer as gst;
 use gstreamer::prelude::*;
@@ -142,5 +143,135 @@ fn aggregator_stall_is_silent_and_leaves_pipeline_playing() {
         errors.is_empty(),
         "expected no bus error, got: {:?}",
         errors
+    );
+}
+
+/// videotestsrc -> tee -> videoconvert, with videoconvert's output meant to go
+/// to audioconvert - a pair with no format in common.
+///
+/// The shape a vision mixer takes when its output caps cannot be negotiated
+/// across `gldownload`: a tee with `allow-not-linked=true` above a branch whose
+/// link was refused.
+struct UnformedLinkRig {
+    pipeline: gst::Pipeline,
+    videoconvert: gst::Element,
+    audioconvert: gst::Element,
+    bus_errors: Arc<Mutex<Vec<String>>>,
+}
+
+impl UnformedLinkRig {
+    fn build() -> Self {
+        let pipeline = gst::Pipeline::new();
+        let src = gst::ElementFactory::make("videotestsrc")
+            .property("is-live", true)
+            .build()
+            .unwrap();
+        let tee = gst::ElementFactory::make("tee")
+            .property("allow-not-linked", true)
+            .build()
+            .unwrap();
+        let videoconvert = gst::ElementFactory::make("videoconvert").build().unwrap();
+        let audioconvert = gst::ElementFactory::make("audioconvert").build().unwrap();
+        let sink = gst::ElementFactory::make("fakesink")
+            .property("sync", false)
+            .build()
+            .unwrap();
+
+        pipeline
+            .add_many([&src, &tee, &videoconvert, &audioconvert, &sink])
+            .unwrap();
+        src.link(&tee).unwrap();
+        tee.link(&sink).unwrap();
+        tee.link(&videoconvert).unwrap();
+
+        let bus_errors = Arc::new(Mutex::new(Vec::new()));
+        let collected = bus_errors.clone();
+        let bus = pipeline.bus().unwrap();
+        bus.add_signal_watch();
+        bus.connect_message(Some("error"), move |_, msg| {
+            if let gst::MessageView::Error(err) = msg.view() {
+                collected.lock().unwrap().push(err.error().to_string());
+            }
+        });
+
+        Self {
+            pipeline,
+            videoconvert,
+            audioconvert,
+            bus_errors,
+        }
+    }
+
+    /// Pads parked in the state the stalled-pad-task scan looks for, across the
+    /// whole pipeline.
+    fn paused_pads(&self) -> Vec<String> {
+        self.pipeline
+            .iterate_recurse()
+            .into_iter()
+            .flatten()
+            .flat_map(|element| {
+                element
+                    .pads()
+                    .into_iter()
+                    .filter(|pad| pad.task_state() == gst::TaskState::Paused)
+                    .map(|pad| format!("{}:{}", element.name(), pad.name()))
+                    .collect::<Vec<_>>()
+            })
+            .collect()
+    }
+}
+
+impl Drop for UnformedLinkRig {
+    fn drop(&mut self) {
+        let _ = self.pipeline.set_state(gst::State::Null);
+    }
+}
+
+#[test]
+fn an_unformed_link_is_silent_and_leaves_no_paused_task() {
+    init();
+    let rig = UnformedLinkRig::build();
+
+    let refused = rig
+        .videoconvert
+        .static_pad("src")
+        .unwrap()
+        .link(&rig.audioconvert.static_pad("sink").unwrap());
+    assert_eq!(
+        refused,
+        Err(gst::PadLinkError::Noformat),
+        "the pair must be unlinkable for the rest of this test to mean anything"
+    );
+
+    rig.pipeline.set_state(gst::State::Playing).unwrap();
+    let (res, current, _) = rig.pipeline.state(gst::ClockTime::from_seconds(10));
+    assert_eq!(res, Ok(gst::StateChangeSuccess::Success));
+    assert_eq!(current, gst::State::Playing);
+
+    // Let the source push into the dead branch for a while.
+    std::thread::sleep(Duration::from_millis(500));
+
+    let (_, current, _) = rig.pipeline.state(gst::ClockTime::from_seconds(1));
+    assert_eq!(
+        current,
+        gst::State::Playing,
+        "pipeline should still report Playing while the branch carries nothing"
+    );
+    let errors = rig.bus_errors.lock().unwrap();
+    assert!(
+        errors.is_empty(),
+        "expected no bus error, got: {:?}",
+        errors
+    );
+    assert!(
+        rig.videoconvert.static_pad("src").unwrap().peer().is_none(),
+        "videoconvert should still be unlinked"
+    );
+    // The reason the stalled-pad-task scan cannot find this: the tee absorbs
+    // the not-linked return, so no task anywhere is paused.
+    assert!(
+        rig.paused_pads().is_empty(),
+        "expected no paused pad task, got: {:?}",
+        rig.paused_pads()
     );
 }

--- a/frontend/src/app/rendering.rs
+++ b/frontend/src/app/rendering.rs
@@ -8,6 +8,9 @@ use strom_types::Flow;
 
 use super::*;
 use super::{FocusTarget, ThemePreference};
+
+/// Colour for a block that has stopped passing data.
+const FAILED_BLOCK_COLOR: Color32 = Color32::from_rgb(220, 60, 60);
 impl StromApp {
     /// Render the top toolbar.
     pub(super) fn render_toolbar(&mut self, ui: &mut egui::Ui) {
@@ -762,14 +765,42 @@ impl StromApp {
                                 );
                                 child_ui.add_space(4.0);
 
-                                // Show running state icon
+                                // Show running state icon. A flow with a failed
+                                // block is not running even though GStreamer
+                                // still reports Playing, so it must not read as
+                                // healthy here.
+                                let failed_blocks: Vec<_> = flow.failed_blocks().collect();
                                 let state_icon = if flow.running { "▶" } else { "■" };
-                                let state_color = if flow.running {
+                                let state_color = if !failed_blocks.is_empty() {
+                                    FAILED_BLOCK_COLOR
+                                } else if flow.running {
                                     Color32::from_rgb(0, 200, 0)
                                 } else {
                                     Color32::GRAY
                                 };
                                 child_ui.colored_label(state_color, state_icon);
+
+                                if !failed_blocks.is_empty() {
+                                    child_ui
+                                        .colored_label(FAILED_BLOCK_COLOR, "⚠")
+                                        .on_hover_ui(|ui| {
+                                            ui.label(
+                                                egui::RichText::new("Stopped passing data")
+                                                    .strong(),
+                                            );
+                                            ui.separator();
+                                            for health in &failed_blocks {
+                                                ui.label(format!(
+                                                    "{}: {}",
+                                                    health.block_id,
+                                                    health
+                                                        .detail
+                                                        .as_deref()
+                                                        .unwrap_or("no detail")
+                                                ));
+                                            }
+                                        });
+                                }
 
                                 // Show QoS indicator if there are issues - make it clickable to open log
                                 if let Some(qos_health) = self.qos_stats.get_flow_health(&flow.id) {
@@ -898,12 +929,24 @@ impl StromApp {
                                     }
 
                                     ui.add_space(5.0);
-                                    let state_text = if flow.running {
+                                    let state_text = if flow.has_failed_block() {
+                                        "Failed"
+                                    } else if flow.running {
                                         "Running"
                                     } else {
                                         "Stopped"
                                     };
                                     ui.label(format!("State: {}", state_text));
+                                    for health in flow.failed_blocks() {
+                                        ui.colored_label(
+                                            FAILED_BLOCK_COLOR,
+                                            format!(
+                                                "{} stopped: {}",
+                                                health.block_id,
+                                                health.detail.as_deref().unwrap_or("no detail")
+                                            ),
+                                        );
+                                    }
 
                                     // Show timestamps
                                     if flow.properties.started_at.is_some()

--- a/frontend/src/app/update.rs
+++ b/frontend/src/app/update.rs
@@ -395,6 +395,46 @@ impl eframe::App for StromApp {
                                 }
                             });
                         }
+                        StromEvent::BlockHealthChanged {
+                            flow_id,
+                            block_id,
+                            status,
+                            detail,
+                        } => {
+                            // block_health rides on the Flow payload, so the
+                            // indicator only updates if the flow is refetched.
+                            match status {
+                                strom_types::BlockHealthStatus::Failed => tracing::error!(
+                                    "Block {} in flow {} stopped passing data: {}",
+                                    block_id,
+                                    flow_id,
+                                    detail.as_deref().unwrap_or("no detail")
+                                ),
+                                strom_types::BlockHealthStatus::Ok => {
+                                    tracing::info!("Block {} in flow {} resumed", block_id, flow_id)
+                                }
+                            }
+                            let api = self.api.clone();
+                            let tx = self.channels.sender();
+                            let ctx = ui.ctx().clone();
+
+                            spawn_task(async move {
+                                match api.get_flow(flow_id).await {
+                                    Ok(flow) => {
+                                        let _ = tx.send(AppMessage::FlowFetched(Box::new(flow)));
+                                        ctx.request_repaint();
+                                    }
+                                    Err(e) => {
+                                        tracing::error!(
+                                            "Failed to fetch flow after block health change: {}",
+                                            e
+                                        );
+                                        let _ = tx.send(AppMessage::RefreshNeeded);
+                                        ctx.request_repaint();
+                                    }
+                                }
+                            });
+                        }
                         StromEvent::FlowUpdated { flow_id } => {
                             // For updates, fetch the specific flow to update it in-place
                             tracing::info!("Flow {} updated, fetching updated flow", flow_id);

--- a/openapi.json
+++ b/openapi.json
@@ -4907,6 +4907,39 @@
           }
         }
       },
+      "BlockHealth": {
+        "type": "object",
+        "description": "Runtime health of one block in a running flow.",
+        "required": [
+          "block_id",
+          "status"
+        ],
+        "properties": {
+          "block_id": {
+            "type": "string",
+            "description": "Block instance ID this health report belongs to."
+          },
+          "detail": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Human-readable detail naming the element and pad whose task stopped.\n`None` when the block is healthy."
+          },
+          "status": {
+            "$ref": "#/components/schemas/BlockHealthStatus",
+            "description": "Whether the block's element chain is running or has stopped."
+          }
+        }
+      },
+      "BlockHealthStatus": {
+        "type": "string",
+        "description": "Health of a single block's element chain while the flow is running.\n\nPausing a pad task is not a state change: the pipeline and every element in\nit stay `PLAYING` while that branch stops passing data, so the failure does\nnot show up in the flow's `gst_state`.",
+        "enum": [
+          "ok",
+          "failed"
+        ]
+      },
       "BlockInstance": {
         "type": "object",
         "description": "Block instance in a flow",
@@ -5991,6 +6024,13 @@
           "name"
         ],
         "properties": {
+          "block_health": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BlockHealth"
+            },
+            "description": "Per-block runtime health. Populated only while a pipeline is running;\nempty otherwise. An entry with a failed status means that block has\nstopped passing data even though `gst_state` is still `Playing`."
+          },
           "blocks": {
             "type": "array",
             "items": {
@@ -9553,6 +9593,52 @@
                 "type": "string",
                 "enum": [
                   "SubscriptionStatusChanged"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "A block's element chain stopped passing data, or resumed.\n\nEmitted only on a change of status, not on every health poll.",
+            "required": [
+              "data",
+              "type"
+            ],
+            "properties": {
+              "data": {
+                "type": "object",
+                "description": "A block's element chain stopped passing data, or resumed.\n\nEmitted only on a change of status, not on every health poll.",
+                "required": [
+                  "flow_id",
+                  "block_id",
+                  "status"
+                ],
+                "properties": {
+                  "block_id": {
+                    "type": "string",
+                    "description": "Block instance ID, or element ID for a standalone element"
+                  },
+                  "detail": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Element and pad whose task stopped; None when the block recovered"
+                  },
+                  "flow_id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "status": {
+                    "$ref": "#/components/schemas/BlockHealthStatus",
+                    "description": "Whether the block is passing data or has stopped"
+                  }
+                }
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "BlockHealthChanged"
                 ]
               }
             }

--- a/types/src/events.rs
+++ b/types/src/events.rs
@@ -1,6 +1,7 @@
 //! Events for real-time updates across clients.
 
 use crate::element::PropertyValue;
+use crate::flow::BlockHealthStatus;
 use crate::system_monitor::SystemStats;
 use crate::thread_stats::ThreadStats;
 use crate::FlowId;
@@ -182,6 +183,19 @@ pub enum StromEvent {
         source_flow_id: FlowId,
         output_name: String,
         connected: bool,
+    },
+    /// A block's element chain stopped passing data, or resumed.
+    ///
+    /// Emitted only on a change of status, not on every health poll.
+    BlockHealthChanged {
+        #[cfg_attr(feature = "openapi", schema(value_type = String, format = Uuid))]
+        flow_id: FlowId,
+        /// Block instance ID, or element ID for a standalone element
+        block_id: String,
+        /// Whether the block is passing data or has stopped
+        status: BlockHealthStatus,
+        /// Element and pad whose task stopped; None when the block recovered
+        detail: Option<String>,
     },
     /// Quality of Service statistics (aggregated buffer drop info)
     QoSStats {
@@ -541,6 +555,22 @@ impl StromEvent {
             StromEvent::ThreadStats(stats) => {
                 format!("Thread stats: {} active threads", stats.threads.len())
             }
+            StromEvent::BlockHealthChanged {
+                flow_id,
+                block_id,
+                status,
+                detail,
+            } => match status {
+                BlockHealthStatus::Failed => format!(
+                    "Block {} in flow {} stopped passing data: {}",
+                    block_id,
+                    flow_id,
+                    detail.as_deref().unwrap_or("no detail")
+                ),
+                BlockHealthStatus::Ok => {
+                    format!("Block {} in flow {} resumed", block_id, flow_id)
+                }
+            },
             StromEvent::QoSStats {
                 flow_id,
                 block_id,

--- a/types/src/flow.rs
+++ b/types/src/flow.rs
@@ -419,6 +419,11 @@ pub struct Flow {
     /// Prefer [`running`](Self::running) for logic and display.
     #[serde(default)]
     pub gst_state: Option<PipelineState>,
+    /// Per-block runtime health. Populated only while a pipeline is running;
+    /// empty otherwise. An entry with a failed status means that block has
+    /// stopped passing data even though `gst_state` is still `Playing`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub block_health: Vec<BlockHealth>,
     /// Flow configuration properties
     #[serde(default)]
     pub properties: FlowProperties,
@@ -435,6 +440,7 @@ impl Flow {
             links: Vec::new(),
             running: false,
             gst_state: Some(PipelineState::Null),
+            block_health: Vec::new(),
             properties: FlowProperties::default(),
         }
     }
@@ -449,6 +455,7 @@ impl Flow {
             links: Vec::new(),
             running: false,
             gst_state: Some(PipelineState::Null),
+            block_health: Vec::new(),
             properties: FlowProperties::default(),
         }
     }
@@ -458,6 +465,57 @@ impl Flow {
         self.running = state.is_some_and(|s| s.is_active());
         self.gst_state = state;
     }
+
+    /// Blocks whose element chain has stopped passing data.
+    pub fn failed_blocks(&self) -> impl Iterator<Item = &BlockHealth> {
+        self.block_health.iter().filter(|h| h.status.is_failed())
+    }
+
+    /// Whether any block in this flow has failed.
+    ///
+    /// `running` only reports that the pipeline reached `Playing`; it stays
+    /// `true` when a block underneath has stopped. Callers deciding whether a
+    /// flow is actually working need both.
+    pub fn has_failed_block(&self) -> bool {
+        self.failed_blocks().next().is_some()
+    }
+}
+
+/// Health of a single block's element chain while the flow is running.
+///
+/// Pausing a pad task is not a state change: the pipeline and every element in
+/// it stay `PLAYING` while that branch stops passing data, so the failure does
+/// not show up in the flow's `gst_state`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[serde(rename_all = "lowercase")]
+pub enum BlockHealthStatus {
+    /// No stopped pad task was found in this block's element chain.
+    Ok,
+    /// A pad task in this block's element chain has stopped. The block is not
+    /// passing data, regardless of what the pipeline state says.
+    Failed,
+}
+
+impl BlockHealthStatus {
+    /// Whether this status means the block has failed.
+    pub fn is_failed(&self) -> bool {
+        matches!(self, BlockHealthStatus::Failed)
+    }
+}
+
+/// Runtime health of one block in a running flow.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct BlockHealth {
+    /// Block instance ID this health report belongs to.
+    pub block_id: String,
+    /// Whether the block's element chain is running or has stopped.
+    pub status: BlockHealthStatus,
+    /// Human-readable detail naming the element and pad whose task stopped.
+    /// `None` when the block is healthy.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
 }
 
 #[cfg(test)]

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -47,7 +47,9 @@ pub use block::{
 };
 pub use element::{Element, ElementId, Link, MediaType, PropertyValue};
 pub use events::StromEvent;
-pub use flow::{CpuAffinity, Flow, FlowId, ThreadPriority, ThreadPriorityStatus};
+pub use flow::{
+    BlockHealth, BlockHealthStatus, CpuAffinity, Flow, FlowId, ThreadPriority, ThreadPriorityStatus,
+};
 pub use network::{
     Ipv4AddressInfo, Ipv6AddressInfo, NetworkInterfaceInfo, NetworkInterfacesResponse,
 };


### PR DESCRIPTION
## The case

A flow can reach Playing, carry audio correctly, report every block healthy, and have no video at all, because two elements never linked. The scan in #786 cannot see it: it looks for a pad task that was paused, and where no link was made there is no task to pause.

A GPU-backend vision mixer with `output_format: NV12` and `gl_download: true` does this. `gldownload` moves GL memory to system memory without converting pixel format, so its RGBA output has no format in common with the NV12 capsfilter below it:

```
Could not link immediately: vmix:gldownload_dist:src -> vmix:capsfilter_dist:sink
  (error: Failed to link elements ... Pads do not have common format). Will retry when pad becomes available.
```

Both the distribution and multiview branches stay unlinked. The mixer's output tee has `allow-not-linked=true`, so the `not-linked` return never surfaces, no task parks, and nothing reaches the bus.

## What this reports

`pending_links` holds every link construction could not make, and the only thing that retries one is the `pad-added` handler on the link's source element. A pad that is already there will not be added again, so a deferred link whose named source pad exists and has no peer has missed its only retry: it is unformed for the life of the pipeline, not merely slow. The scan now checks that alongside the pad tasks and fails the block owning the source element.

A source pad that has not appeared yet is left alone: that is the case deferral exists for, and reporting it would fail every `decodebin` until it has typefound. Two shapes also read as formed and go unreported, both because the pad has a peer: one linked through the handler's pattern match, one that picked up an auto-tee.

## Failed rather than degraded

The branch carries nothing and will until the flow is rebuilt, so there is no reduced capability to describe. That is what `Failed` already means here: not passing data while the pipeline says Playing.

The check lives in the scan rather than behind a block-supplied hook because an unformed link is not private to a block: the `PipelineManager` already holds the state that proves it.

## Tests

New in `health.rs`: an unformed pair is reported against the block owning its source with the link named in the detail; a link still waiting on a dynamic pad is not; a link the handler resolved is not; and a flow through `PipelineManager` reaches Playing with only that one block failed. New in `block_health_test.rs`: an unlinkable pair under an `allow-not-linked` tee leaves the pipeline Playing with no bus error and no paused pad task anywhere. Both detector tests fail when `unformed_link` is stubbed to return false.

Ran locally: the full `cargo test` suite on the integration branch this was written on (677 lib tests plus every integration test, green), then `--lib gst::pipeline::health`, `--test block_health_test`, `--test openapi_test` and `--test pipeline_lifecycle_test` here.

## On a real flow

Five runs of a headless instance driving videotestsrc into a vision mixer, out to a WHEP output and through a video encoder to a recorder, with `multiview_out` left unwired. The repro above fires and names `vmix:gldownload_mv:src -> vmix:capsfilter_mv:sink`, with the distribution link deferred in the same startup log. The two healthy configurations, CPU backend and GPU backend with a working output format, report every block ok, the unwired `multiview_out` included. The scan also named a real unrelated defect: on the GPU backend with `gl_download: false`, `pgm_out` carries GL memory that the Video Encoder block's `videoconvert` cannot accept, so the recorder branch never links and records nothing. That is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
