### PR TITLE
docs(vision mixer): add a producer switching guide for the HTTP API

### DIFF
--- a/docs/PRODUCER_SWITCHING_API_GUIDE.md
+++ b/docs/PRODUCER_SWITCHING_API_GUIDE.md
@@ -1,0 +1,318 @@
+# Producer Switching over the API — Operator Guide
+
+> **Code is the source of truth — this may have drifted; read the code for the current
+> implementation.** This guide describes behaviour observed on a running rig at one point
+> in time. When in doubt, read the code and check the in-app UI.
+
+How a producer changes what the audience sees — all participants, one participant, or
+anything in between — by driving the vision mixer block over HTTP instead of the operator
+page. Companion to the [Vision Mixer Operator Guide](VISION_MIXER_OPERATOR_GUIDE.md),
+which covers the same mixer from the GUI. Read that one first for the concepts; this one
+is the call-by-call recipe, the on-air behaviour of each move, and what breaks.
+
+Everything below was exercised against a live five-seat meeting flow and checked against
+captured program frames, not against HTTP status codes. Where a claim is about what the
+audience sees, it was read off a frame.
+
+---
+
+## 1. The model in one minute
+
+The mixer has two buses, **PGM** (on air) and **PVW** (preview). Each bus holds one
+**source**, and a source is one of two things:
+
+- `{"input": N}` — a single input, full frame.
+- `{"pip": K}` — a **PiP**, which despite the name is a whole composition: an optional
+  full-region background input plus a list of **zones**. Each zone is a rectangle holding
+  one or more inputs that auto-tile inside it.
+
+So "all five up" and "one participant full frame" are not different features. They are
+two sources you can put on either bus. Cutting between them is an ordinary take.
+
+Three endpoints do all the work:
+
+| Call | What it does |
+|---|---|
+| `PUT /api/flows/{flow_id}/blocks/{block_id}/pip/{pip_idx}` | Replace a PiP's composition. Applies live. |
+| `PUT /api/flows/{flow_id}/blocks/{block_id}/preview` | Put a source on PVW. |
+| `POST /api/flows/{flow_id}/blocks/{block_id}/transition` | Take: swap PGM and PVW. |
+| `GET  /api/flows/{flow_id}/blocks/{block_id}/state` | Read back both buses and every PiP. |
+
+The broadcast pattern is: build the next look on a PiP that is **not** on air, preview it,
+take it. A mixer with `num_pips: 2` supports this indefinitely, because the take swaps the
+buses and hands the previous PGM composition back to you on preview to rebuild.
+
+### The take is a swap, and it ignores half its own request body
+
+`POST .../transition` takes `from_input` and `to_input`, but whenever the block has live
+state the engine ignores them and swaps whatever is currently on PGM and PVW. Send `0` for
+both. What matters is `transition_type` and `duration_ms`.
+
+```bash
+FLOW=945fa329-...   BLOCK=vmix
+API=http://127.0.0.1:8123/api/flows/$FLOW/blocks/$BLOCK
+
+curl -X POST -H 'content-type: application/json' \
+  -d '{"from_input":0,"to_input":0,"transition_type":"cut","duration_ms":0}' \
+  $API/transition
+```
+
+After a take, `GET .../state` reports the swap: the composition that was on air is now on
+`preview_pip` (or `preview_input`), ready to be rebuilt for the next move.
+
+One reporting quirk: when a PiP with a background is on air, `program_input` reports that
+background's index rather than `null`. Read `program_pip` to know which composition is on
+air.
+
+---
+
+## 2. The four layouts, verified
+
+All examples assume a five-input mixer with two PiPs, inputs `0..4` fed by participants
+P1..P5. Every layout below was taken to air and read off a captured program frame.
+
+### All five up
+
+One zone, no rect (fills the PiP region), all five inputs. The zone auto-tiles them.
+
+```bash
+curl -X PUT -H 'content-type: application/json' -d '{
+  "bg": null, "transforms": {},
+  "zones": [ { "rect": null, "sources": [0,1,2,3,4] } ]
+}' $API/pip/0
+
+curl -X PUT -H 'content-type: application/json' -d '{"source":{"pip":0}}' $API/preview
+curl -X POST -H 'content-type: application/json' \
+  -d '{"from_input":0,"to_input":0,"transition_type":"cut","duration_ms":0}' $API/transition
+```
+
+Result: three tiles across the top, two on the second row. The tiling is a
+`cols = ceil(sqrt(N))` by `rows = ceil(N/cols)` grid, so five sources give a 3×2 grid with
+one empty cell. The grid **as a block** is centred in the region, but cells fill row-major
+left to right, so the short last row sits to the **left**, not centred under the row above.
+If you want the odd participant centred, do not use a single auto-tiling zone — give each
+row its own zone, or each source its own zone.
+
+### One participant full frame
+
+No PiP involved. Preview the input and take.
+
+```bash
+curl -X PUT -H 'content-type: application/json' -d '{"source":{"input":2}}' $API/preview
+curl -X POST -H 'content-type: application/json' \
+  -d '{"from_input":0,"to_input":0,"transition_type":"cut","duration_ms":0}' $API/transition
+```
+
+### Two up
+
+Same as five up with two sources. Two sources tile side by side, each cell aspect-fitted,
+the pair vertically centred with black above and below when the region is wider than two
+16:9 cells.
+
+```bash
+curl -X PUT -H 'content-type: application/json' -d '{
+  "bg": null, "transforms": {},
+  "zones": [ { "rect": null, "sources": [0,1] } ]
+}' $API/pip/1
+```
+
+### One plus three
+
+Do **not** express this as one big zone plus one auto-tiling zone of three. Three sources
+in a zone tile as a 2×2 grid with a hole, not as a vertical stack. Give each small box its
+own zone. Rects are normalised to the PiP region, `x`/`y` is the top-left corner.
+
+```bash
+curl -X PUT -H 'content-type: application/json' -d '{
+  "bg": null, "transforms": {},
+  "zones": [
+    {"rect": {"x":0.02,"y":0.14,"w":0.64,"h":0.72}, "sources":[0]},
+    {"rect": {"x":0.68,"y":0.06,"w":0.30,"h":0.28}, "sources":[1]},
+    {"rect": {"x":0.68,"y":0.36,"w":0.30,"h":0.28}, "sources":[2]},
+    {"rect": {"x":0.68,"y":0.66,"w":0.30,"h":0.28}, "sources":[3]}
+  ]
+}' $API/pip/0
+```
+
+### Background plus boxes
+
+Set `bg` to fill the whole region behind the zones. Useful for a full-frame speaker with
+two guests boxed over the corner. Zones can carry a border, which draws outside the picture
+edge so it never covers content.
+
+```bash
+curl -X PUT -H 'content-type: application/json' -d '{
+  "bg": 0, "transforms": {},
+  "zones": [
+    {"rect": {"x":0.62,"y":0.06,"w":0.34,"h":0.26}, "sources":[1],
+     "border": {"color":"#FFCC00","width":4}},
+    {"rect": {"x":0.62,"y":0.36,"w":0.34,"h":0.26}, "sources":[2],
+     "border": {"color":"#FFCC00","width":4}}
+  ]
+}' $API/pip/1
+```
+
+---
+
+## 3. Editing the PiP that is on air
+
+**It is safe, and it is not a cut.** Changing zones on the PiP currently on PGM produces an
+animated re-tile: every source that stays in the composition slides and scales from its old
+box to its new one over about 250 ms, sources that are leaving fade out, sources that are
+arriving fade in. No black frame, no flash, no dropped frame. Frame-by-frame inspection of
+a full mirror-image layout change (big box moved from left to right, three small boxes moved
+from right to left) showed a smooth eight-frame move with every source visible throughout.
+
+So the choice between editing on air and preview-then-take is editorial, not technical:
+
+- **Edit on air** when you want the audience to see the move — opening a box for a guest who
+  just joined, dropping a box when someone leaves. It reads as a deliberate animated
+  rearrangement, which is what a viewer expects from a video call layout.
+- **Preview then take** when you want the change to be invisible until you commit, or when
+  you are building something complex and do not want half-finished states on air. Editing
+  the PiP that is on PVW provably does not touch PGM: a full re-layout of the preview PiP
+  left every program frame unchanged.
+
+Preview-then-take is therefore **not mandatory**. It is the right habit for anything you
+are still composing, and unnecessary for a single deliberate move.
+
+---
+
+## 4. What each take actually looks like
+
+`transition_type` accepts `cut`, `fade`, `slide_left`, `slide_right`, `slide_up`,
+`slide_down`. What you get depends on whether a PiP is involved.
+
+| From → To | `transition_type` | What the audience sees |
+|---|---|---|
+| anything → anything | `cut` (or `duration_ms: 0`) | One-frame switch. Verified: last frame of the old look, next frame the new look, nothing between. |
+| input → input | `fade` | A true dissolve. Frames mid-transition show both pictures blended. |
+| PiP → PiP, **no shared sources** | `fade` | A true dissolve between the two compositions. |
+| PiP → anything, **sharing a source** | `fade` | **Not a dissolve.** The shared source animates from its old box to its new one — going from a four-up to that participant full frame reads as a zoom-in, with the other tiles covered as the box grows. |
+| either bus is a PiP | `slide_*` | Silently downgraded to `fade`. The server logs the downgrade; the HTTP response reports the transition that actually ran in `actual_transition_type`. |
+
+The shared-source case is the one that surprises people. The engine animates pads, not
+pictures: a source present in both the outgoing and incoming composition is treated as
+*moving*, and only sources exclusive to one side cross-fade. If you want a genuine dissolve
+out of a multi-box layout, take to a composition that shares no inputs with it, or use a
+cut.
+
+Check `actual_transition_type` in the response if you care which one ran.
+
+---
+
+## 5. Failure modes
+
+### A zone names a seat that is not publishing
+
+**Nothing warns you, and the layout does not re-flow.** The call succeeds, the layout keeps
+a cell for that participant, and the cell is simply empty. A five-up including one absent
+seat renders as a 3×2 grid with a black hole where they would be — not as a tidy four-up.
+
+The fix is to rebuild the zone without that source, which re-tiles the remaining
+participants into a full 2×2. There is no automatic compaction.
+
+### A seat drops while it is on air
+
+**The tile freezes on its last frame and stays there indefinitely.** It does not go black,
+it is not removed, and the composition does not re-flow. On the rig the freeze followed the
+publisher's death within about two seconds — the measurement cannot separate the jitter
+buffer from the mixer's own output latency, so treat it as immediate. The frozen frame was
+still on air minutes later, long after the ingest session had been reaped for inactivity.
+
+This is the most dangerous failure in the set, because a frozen participant looks exactly
+like a still one. Two consequences for a live show:
+
+- Do not trust the program picture to tell you a seat is gone. Watch the ingest session
+  state or the per-seat block health instead.
+- The recovery is automatic: when the participant rejoins, their tile resumes in place with
+  no operator action and no layout change.
+
+If you need the seat gone from the picture, you must remove it from the zone yourself —
+which is a live edit and animates as described in §3.
+
+### A zone holds more sources than its capacity
+
+**Silently truncated, oldest first, and the API lies to you about it.** A zone with
+`"capacity": 2` and `"sources": [0,1,2]` renders inputs 1 and 2 only — input 0 is dropped
+because it is the oldest entry. No error, no warning. `GET .../pip/{idx}` reads back all
+three sources, so state and picture disagree: the state is the intent, the picture is the
+newest `capacity` entries.
+
+Capacity is a feature, not a guard — capacity 1 is "swap mode", where pushing a new source
+cross-fades it over the old one. If you do not want eviction, leave `capacity` unset.
+
+### Things that *are* rejected
+
+These all return HTTP 400 with a readable reason, before anything reaches the picture:
+
+| Request | Response |
+|---|---|
+| Zone source index ≥ number of inputs | `Zone source 5 out of range (num_inputs=5)` |
+| A zone source that is also the background | `Zone source 1 duplicates bg` |
+| The same source in two zones of one PiP | `Zone source 1 appears in more than one zone` |
+| Border colour that is not `#RRGGBB`/`#RRGGBBAA` | `Invalid border color "red"` |
+| PiP index ≥ `num_pips` | `PiP index 7 out of range (configured: 2)` |
+| Preview to an input or PiP that does not exist | `Input 9 out of range (max 4)` |
+
+Rects are **clamped**, not rejected — a rect running past the region edge is silently
+pulled back inside. More than 15 overlay sources across all zones of one PiP is rejected,
+but that ceiling is unreachable on a mixer with fewer than 16 inputs.
+
+---
+
+## 6. Verifying what is actually on air
+
+**A 200 is not evidence.** Every claim in this guide was checked against program frames,
+and two of the findings (the shared-source "fade", the frozen dropped seat) look completely
+correct from the API side.
+
+Two things make verification reliable:
+
+1. **Give every source a visible clock.** A frozen tile is indistinguishable from a live
+   one unless the picture itself is moving. Burning a running timecode into each
+   participant feed turns "is this seat alive?" into something you can read off a single
+   frame. Two seats reading the same time and one reading an older time is the whole
+   diagnosis.
+2. **Tap the program output to a file** rather than capturing it over the network. Adding a
+   video encoder plus a recorder block fed from the mixer's PGM output gives frame-accurate
+   material with no transport in the way, and the recorder's split endpoint closes a
+   segment on demand so you can read it while the show continues.
+
+Expect the recording to sit a couple of seconds behind your API calls — the mixer's output
+queue plus the encoder. Wait 6–10 s after a move before closing the segment, or the moment
+you care about lands in the next file.
+
+One environment caveat worth knowing: on the macOS development rig, pulling the program
+with a GStreamer WHEP client failed ICE negotiation every time, roughly two seconds into
+the session, after the first connectivity check had already succeeded. The same client
+against a plain standalone WHEP sink on the same machine worked. This was not chased down;
+it is a capture-path problem, not a mixer problem, and the file tap sidesteps it entirely.
+
+---
+
+## 7. Quick reference
+
+```bash
+API=http://127.0.0.1:8123/api/flows/$FLOW/blocks/$BLOCK
+
+# Read everything: both buses, every PiP composition
+curl -s $API/state
+
+# Read one PiP (useful for saving a look you want to restore later)
+curl -s $API/pip/0
+
+# Build a look on an off-air PiP
+curl -X PUT -H 'content-type: application/json' -d '{"bg":null,"transforms":{},"zones":[...]}' $API/pip/0
+
+# Preview it
+curl -X PUT -H 'content-type: application/json' -d '{"source":{"pip":0}}' $API/preview
+
+# Take it
+curl -X POST -H 'content-type: application/json' \
+  -d '{"from_input":0,"to_input":0,"transition_type":"cut","duration_ms":0}' $API/transition
+```
+
+`GET .../pip/{idx}` and `PUT .../pip/{idx}` use the same shape, so a GET is how you snapshot
+a look and a PUT is how you restore it. Saving the four or five looks a show needs as JSON
+files, and replaying them by PUT, is the whole of a producer's cue stack.

--- a/docs/PRODUCER_SWITCHING_API_GUIDE.md
+++ b/docs/PRODUCER_SWITCHING_API_GUIDE.md
@@ -38,11 +38,13 @@ The broadcast pattern is: build the next look on a PiP that is **not** on air, p
 take it. A mixer with `num_pips: 2` supports this indefinitely, because the take swaps the
 buses and hands the previous PGM composition back to you on preview to rebuild.
 
-### The take is a swap, and it ignores half its own request body
+### On a vision mixer, the take is a swap
 
-`POST .../transition` takes `from_input` and `to_input`, but whenever the block has live
-state the engine ignores them and swaps whatever is currently on PGM and PVW. Send `0` for
-both. What matters is `transition_type` and `duration_ms`.
+`POST .../transition` takes `from_input` and `to_input`, but a vision mixer ignores them
+and swaps whatever is currently on PGM and PVW. The block's own bus state is authoritative,
+because an index you computed before the call can be stale by the time it arrives. Send `0`
+for both. What matters is `transition_type` and `duration_ms`. The same endpoint on a plain
+compositor block, which has no PGM/PVW state, does use the two indices.
 
 ```bash
 FLOW=945fa329-...   BLOCK=vmix

--- a/docs/PRODUCER_SWITCHING_API_GUIDE.md
+++ b/docs/PRODUCER_SWITCHING_API_GUIDE.md
@@ -279,11 +279,6 @@ Expect the recording to sit a couple of seconds behind your API calls — the mi
 queue plus the encoder. Wait 6–10 s after a move before closing the segment, or the moment
 you care about lands in the next file.
 
-Capturing the program with a GStreamer WHEP client failed ICE negotiation on the macOS
-rig, about two seconds in, while the same client against a plain standalone WHEP sink on
-the same machine worked. That is a capture-path problem, not a mixer one, and the file tap
-sidesteps it.
-
 ---
 
 ## 7. Quick reference

--- a/docs/PRODUCER_SWITCHING_API_GUIDE.md
+++ b/docs/PRODUCER_SWITCHING_API_GUIDE.md
@@ -10,10 +10,6 @@ page. Companion to the [Vision Mixer Operator Guide](VISION_MIXER_OPERATOR_GUIDE
 which covers the same mixer from the GUI. Read that one first for the concepts; this one
 is the call-by-call recipe, the on-air behaviour of each move, and what breaks.
 
-Everything below was exercised against a live five-seat meeting flow and checked against
-captured program frames, not against HTTP status codes. Where a claim is about what the
-audience sees, it was read off a frame.
-
 ---
 
 ## 1. The model in one minute
@@ -29,7 +25,7 @@ The mixer has two buses, **PGM** (on air) and **PVW** (preview). Each bus holds 
 So "all five up" and "one participant full frame" are not different features. They are
 two sources you can put on either bus. Cutting between them is an ordinary take.
 
-Three endpoints do all the work:
+Four calls do all the work:
 
 | Call | What it does |
 |---|---|
@@ -159,9 +155,8 @@ curl -X PUT -H 'content-type: application/json' -d '{
 **It is safe, and it is not a cut.** Changing zones on the PiP currently on PGM produces an
 animated re-tile: every source that stays in the composition slides and scales from its old
 box to its new one over about 250 ms, sources that are leaving fade out, sources that are
-arriving fade in. No black frame, no flash, no dropped frame. Frame-by-frame inspection of
-a full mirror-image layout change (big box moved from left to right, three small boxes moved
-from right to left) showed a smooth eight-frame move with every source visible throughout.
+arriving fade in. No black frame, no flash, no dropped frame. A full mirror-image layout
+change animates over about eight frames with every source visible throughout.
 
 So the choice between editing on air and preview-then-take is editorial, not technical:
 
@@ -170,11 +165,8 @@ So the choice between editing on air and preview-then-take is editorial, not tec
   rearrangement, which is what a viewer expects from a video call layout.
 - **Preview then take** when you want the change to be invisible until you commit, or when
   you are building something complex and do not want half-finished states on air. Editing
-  the PiP that is on PVW provably does not touch PGM: a full re-layout of the preview PiP
-  left every program frame unchanged.
-
-Preview-then-take is therefore **not mandatory**. It is the right habit for anything you
-are still composing, and unnecessary for a single deliberate move.
+  the PiP that is on PVW does not touch PGM: a full re-layout of the preview PiP left
+  every program frame unchanged.
 
 ---
 
@@ -191,13 +183,10 @@ are still composing, and unnecessary for a single deliberate move.
 | PiP → anything, **sharing a source** | `fade` | **Not a dissolve.** The shared source animates from its old box to its new one — going from a four-up to that participant full frame reads as a zoom-in, with the other tiles covered as the box grows. |
 | either bus is a PiP | `slide_*` | Silently downgraded to `fade`. The server logs the downgrade; the HTTP response reports the transition that actually ran in `actual_transition_type`. |
 
-The shared-source case is the one that surprises people. The engine animates pads, not
-pictures: a source present in both the outgoing and incoming composition is treated as
+The engine animates pads, not pictures: a source present in both the outgoing and incoming composition is treated as
 *moving*, and only sources exclusive to one side cross-fade. If you want a genuine dissolve
 out of a multi-box layout, take to a composition that shares no inputs with it, or use a
 cut.
-
-Check `actual_transition_type` in the response if you care which one ran.
 
 ---
 
@@ -283,11 +272,10 @@ Expect the recording to sit a couple of seconds behind your API calls — the mi
 queue plus the encoder. Wait 6–10 s after a move before closing the segment, or the moment
 you care about lands in the next file.
 
-One environment caveat worth knowing: on the macOS development rig, pulling the program
-with a GStreamer WHEP client failed ICE negotiation every time, roughly two seconds into
-the session, after the first connectivity check had already succeeded. The same client
-against a plain standalone WHEP sink on the same machine worked. This was not chased down;
-it is a capture-path problem, not a mixer problem, and the file tap sidesteps it entirely.
+Capturing the program with a GStreamer WHEP client failed ICE negotiation on the macOS
+rig, about two seconds in, while the same client against a plain standalone WHEP sink on
+the same machine worked. That is a capture-path problem, not a mixer one, and the file tap
+sidesteps it.
 
 ---
 

--- a/docs/PRODUCER_SWITCHING_API_GUIDE.md
+++ b/docs/PRODUCER_SWITCHING_API_GUIDE.md
@@ -4,9 +4,9 @@
 > implementation.** This guide describes behaviour observed on a running rig at one point
 > in time. When in doubt, read the code and check the in-app UI.
 
-How a producer changes what the audience sees — all participants, one participant, or
-anything in between — by driving the vision mixer block over HTTP instead of the operator
-page. Companion to the [Vision Mixer Operator Guide](VISION_MIXER_OPERATOR_GUIDE.md),
+How a producer changes what the audience sees — one camera full frame, several sources at
+once, or anything in between — by driving the vision mixer block over HTTP instead of the
+operator page. Companion to the [Vision Mixer Operator Guide](VISION_MIXER_OPERATOR_GUIDE.md),
 which covers the same mixer from the GUI. Read that one first for the concepts; this one
 is the call-by-call recipe, the on-air behaviour of each move, and what breaks.
 
@@ -22,7 +22,7 @@ The mixer has two buses, **PGM** (on air) and **PVW** (preview). Each bus holds 
   full-region background input plus a list of **zones**. Each zone is a rectangle holding
   one or more inputs that auto-tile inside it.
 
-So "all five up" and "one participant full frame" are not different features. They are
+So "a five-box" and "one camera full frame" are not different features. They are
 two sources you can put on either bus. Cutting between them is an ordinary take.
 
 Four calls do all the work:
@@ -60,12 +60,14 @@ air.
 
 ---
 
-## 2. The four layouts, verified
+## 2. The layouts, verified
 
-All examples assume a five-input mixer with two PiPs, inputs `0..4` fed by participants
-P1..P5. Every layout below was taken to air and read off a captured program frame.
+All examples assume a five-input mixer with two PiPs, inputs `0..4` fed by five sources —
+CAM 1..5 below, though nothing here cares whether a given input is a camera, a remote
+contributor or a graphics feed. Every layout was taken to air and read off a captured
+program frame.
 
-### All five up
+### All five sources up
 
 One zone, no rect (fills the PiP region), all five inputs. The zone auto-tiles them.
 
@@ -84,10 +86,10 @@ Result: three tiles across the top, two on the second row. The tiling is a
 `cols = ceil(sqrt(N))` by `rows = ceil(N/cols)` grid, so five sources give a 3×2 grid with
 one empty cell. The grid **as a block** is centred in the region, but cells fill row-major
 left to right, so the short last row sits to the **left**, not centred under the row above.
-If you want the odd participant centred, do not use a single auto-tiling zone — give each
+If you want the odd source centred, do not use a single auto-tiling zone — give each
 row its own zone, or each source its own zone.
 
-### One participant full frame
+### One source full frame
 
 No PiP involved. Preview the input and take.
 
@@ -99,7 +101,7 @@ curl -X POST -H 'content-type: application/json' \
 
 ### Two up
 
-Same as five up with two sources. Two sources tile side by side, each cell aspect-fitted,
+Same as the five-box with two sources. Two sources tile side by side, each cell aspect-fitted,
 the pair vertically centred with black above and below when the region is wider than two
 16:9 cells.
 
@@ -160,7 +162,7 @@ So the choice between editing on air and preview-then-take is editorial, not tec
 
 - **Edit on air** when you want the audience to see the move — opening a box for a guest who
   just joined, dropping a box when someone leaves. It reads as a deliberate animated
-  rearrangement, which is what a viewer expects from a video call layout.
+  rearrangement rather than a fault.
 - **Preview then take** when you want the change to be invisible until you commit, or when
   you are building something complex and do not want half-finished states on air. Editing
   the PiP that is on PVW does not touch PGM: a full re-layout of the preview PiP left
@@ -181,45 +183,50 @@ So the choice between editing on air and preview-then-take is editorial, not tec
 | anything → anything | `cut` (or `duration_ms: 0`) | One-frame switch. Verified: last frame of the old look, next frame the new look, nothing between. |
 | input → input | `fade` | A true dissolve. Frames mid-transition show both pictures blended. |
 | PiP → PiP, **no shared sources** | `fade` | A true dissolve between the two compositions. |
-| PiP → anything, **sharing a source** | `fade` | **Not a dissolve.** The shared source animates from its old box to its new one — going from a four-up to that participant full frame reads as a zoom-in, with the other tiles covered as the box grows. |
+| PiP → anything, **sharing a source** | `fade` | **Not a dissolve.** The shared source animates from its old box to its new one — going from a four-box to that source full frame reads as a zoom-in, with the other tiles covered as the box grows. |
 | either bus is a PiP | `slide_*` | Silently downgraded to `fade`. The server logs the downgrade; the HTTP response reports the transition that actually ran in `actual_transition_type`. |
 
-The engine animates pads, not pictures: a source present in both the outgoing and incoming composition is treated as
-*moving*, and only sources exclusive to one side cross-fade. If you want a genuine dissolve
-out of a multi-box layout, take to a composition that shares no inputs with it, or use a
-cut.
+The engine animates pads, not pictures: a source present in both the outgoing and
+incoming composition is treated as *moving*, and only sources exclusive to one side
+cross-fade. If you want a genuine dissolve out of a multi-box layout, take to a
+composition that shares no inputs with it, or use a cut.
 
 ---
 
 ## 5. Failure modes
 
-### A zone names a seat that is not publishing
+### A zone names a source that is not delivering frames
 
 **Nothing warns you, and the layout does not re-flow.** The call succeeds, the layout keeps
-a cell for that participant, and the cell is simply empty. A five-up including one absent
-seat renders as a 3×2 grid with a black hole where they would be — not as a tidy four-up.
+a cell for that source, and the cell is simply empty. A five-box including one silent input
+renders as a 3×2 grid with a black hole where it would be — not as a tidy four-box.
 
-The fix is to rebuild the zone without that source, which re-tiles the remaining
-participants into a full 2×2. There is no automatic compaction.
+The fix is to rebuild the zone without that source, which re-tiles the rest into a full
+2×2. There is no automatic compaction. This bites hardest with remote contributors, who
+come and go on their own schedule; a wired camera is either there for the whole show or
+obviously absent before you start.
 
-### A seat drops while it is on air
+### A source stops while it is on air
 
 **The tile freezes on its last frame and stays there indefinitely.** It does not go black,
-it is not removed, and the composition does not re-flow. On the rig the freeze followed the
-publisher's death within about two seconds — the measurement cannot separate the jitter
-buffer from the mixer's own output latency, so treat it as immediate. The frozen frame was
-still on air minutes later, long after the ingest session had been reaped for inactivity.
+it is not removed, and the composition does not re-flow. A compositor pad repeats its last
+buffer for as long as the mixer runs, so this is the general behaviour for any input that
+stops, not a property of one ingest type. Measured on a WHIP contributor, the freeze
+followed the publisher's death within about two seconds — the measurement cannot separate
+the jitter buffer from the mixer's own output latency, so treat it as immediate. The frozen
+frame was still on air minutes later, long after the ingest session had been reaped for
+inactivity.
 
-This is the most dangerous failure in the set, because a frozen participant looks exactly
-like a still one. Two consequences for a live show:
+This is the most dangerous failure in the set, because a frozen tile looks exactly like a
+static one. Two consequences for a live show:
 
-- Do not trust the program picture to tell you a seat is gone. Watch the ingest session
-  state or the per-seat block health instead.
-- The recovery is automatic: when the participant rejoins, their tile resumes in place with
-  no operator action and no layout change.
+- Do not trust the program picture to tell you a source is gone. Watch the ingest session
+  state or the per-input block health instead.
+- The recovery is automatic: when the source resumes, its tile picks up in place with no
+  operator action and no layout change.
 
-If you need the seat gone from the picture, you must remove it from the zone yourself —
-which is a live edit and animates as described in §3.
+If you need it gone from the picture, you must remove it from the zone yourself — which is
+a live edit and animates as described in §3.
 
 ### A zone holds more sources than its capacity
 
@@ -254,16 +261,15 @@ but that ceiling is unreachable on a mixer with fewer than 16 inputs.
 ## 6. Verifying what is actually on air
 
 **A 200 is not evidence.** Every claim in this guide was checked against program frames,
-and two of the findings (the shared-source "fade", the frozen dropped seat) look completely
-correct from the API side.
+and two of the findings (the shared-source "fade", the frozen stopped input) look
+completely correct from the API side.
 
 Two things make verification reliable:
 
 1. **Give every source a visible clock.** A frozen tile is indistinguishable from a live
-   one unless the picture itself is moving. Burning a running timecode into each
-   participant feed turns "is this seat alive?" into something you can read off a single
-   frame. Two seats reading the same time and one reading an older time is the whole
-   diagnosis.
+   one unless the picture itself is moving. Burning a running timecode into each feed turns
+   "is this input alive?" into something you can read off a single frame. Two tiles reading
+   the same time and one reading an older time is the whole diagnosis.
 2. **Tap the program output to a file** rather than capturing it over the network. Adding a
    video encoder plus a recorder block fed from the mixer's PGM output gives frame-accurate
    material with no transport in the way, and the recorder's split endpoint closes a

--- a/docs/PRODUCER_SWITCHING_API_GUIDE.md
+++ b/docs/PRODUCER_SWITCHING_API_GUIDE.md
@@ -34,10 +34,6 @@ Four calls do all the work:
 | `POST /api/flows/{flow_id}/blocks/{block_id}/transition` | Take: swap PGM and PVW. |
 | `GET  /api/flows/{flow_id}/blocks/{block_id}/state` | Read back both buses and every PiP. |
 
-The broadcast pattern is: build the next look on a PiP that is **not** on air, preview it,
-take it. A mixer with `num_pips: 2` supports this indefinitely, because the take swaps the
-buses and hands the previous PGM composition back to you on preview to rebuild.
-
 ### On a vision mixer, the take is a swap
 
 `POST .../transition` takes `from_input` and `to_input`, but a vision mixer ignores them
@@ -168,7 +164,10 @@ So the choice between editing on air and preview-then-take is editorial, not tec
 - **Preview then take** when you want the change to be invisible until you commit, or when
   you are building something complex and do not want half-finished states on air. Editing
   the PiP that is on PVW does not touch PGM: a full re-layout of the preview PiP left
-  every program frame unchanged.
+  every program frame unchanged. Note what actually protects you. A bus points at a PiP
+  slot rather than holding a copy of it, so what makes the edit safe is the slot being off
+  air, not the fact that you previewed it. `num_pips: 2` keeps a spare slot available
+  permanently, because the take hands the outgoing composition back on preview.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ Common questions are answered in the [FAQ](FAQ.md).
 ## Using Strom
 
 - [VISION_MIXER_OPERATOR_GUIDE.md](VISION_MIXER_OPERATOR_GUIDE.md) — broadcast PVW/PGM switcher: transitions, DSK, PiP, multiview.
+- [PRODUCER_SWITCHING_API_GUIDE.md](PRODUCER_SWITCHING_API_GUIDE.md) — driving the vision mixer over HTTP: PiP layout recipes, on-air edits, failure modes.
 - [AUDIO_MIXER_OPERATOR_GUIDE.md](AUDIO_MIXER_OPERATOR_GUIDE.md) — audio mixing console signal flow and operation.
 - [HTML_RENDER.md](HTML_RENDER.md) — render web pages as video sources (CEF / `strom-full`).
 - [STREAM_SYNCHRONIZATION.md](STREAM_SYNCHRONIZATION.md) — aligning multiple inputs with PTP/NTP clocks.

--- a/docs/VISION_MIXER_OPERATOR_GUIDE.md
+++ b/docs/VISION_MIXER_OPERATOR_GUIDE.md
@@ -263,6 +263,10 @@ just like a regular input.
 
 ### 4.3 How the operator configures a PiP
 
+> Driving the same compositions from a control surface or script instead of the page?
+> See the [Producer Switching over the API guide](PRODUCER_SWITCHING_API_GUIDE.md) for
+> the call-by-call recipes, what an on-air layout edit looks like, and the failure modes.
+
 A PiP is configured at runtime from the **operator control page** served
 by the backend. Press **Edit** on a PiP row to open the layout editor —
 two side-by-side panels:


### PR DESCRIPTION
## What

Adds `docs/PRODUCER_SWITCHING_API_GUIDE.md`, an operator guide for driving the vision
mixer's PGM/PVW buses and PiP compositions over HTTP rather than from the operator page.
Indexed in `docs/README.md` and cross-linked from the vision mixer guide.

## Why

The PiP endpoints support the full producer workflow — build a composition on an off-air
PiP, preview it, take it — but nothing described the call sequence, and several of the
behaviours are not guessable from the API surface.

## How it was checked

Exercised against a running five-seat WHIP flow. Program was tapped to file through a
videoenc + recorder chain on the mixer's `pgm_out`, each participant carried a burned-in
timecode, and every claim was read off extracted frames rather than an HTTP status.

Three behaviours that return 200 and look correct from the API:

- A `fade` take between compositions **sharing a source** does not dissolve. The engine
  animates pads, so the shared source moves and scales from its old box to its new one —
  a four-up taken to that participant full frame reads as a zoom. Disjoint compositions
  and plain input-to-input fades do dissolve.
- A zone naming a source that is not delivering frames **keeps its cell and leaves it
  empty**. The layout does not compact.
- A source that stops while on air **freezes on its last frame indefinitely**, surviving
  the ingest session being reaped, and is indistinguishable from a static picture. The
  compositor pad repeats its last buffer, so this holds for any input that stops.

## Tests

No tests added or changed — documentation only. Verification was the manual rig exercise
described above; nothing else was run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
