### PR TITLE
fix(build): accept git provenance as Docker build args

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -190,6 +190,16 @@ COPY --from=frontend-builder /app/backend/dist backend/dist
 # Build the backend (headless - no native GUI needed in Docker) and MCP server
 ENV RUST_BACKTRACE=1
 
+# Git provenance for /api/version and --version-info. The build context has no .git/
+# (see .dockerignore), so build.rs cannot shell out to git here and takes these instead.
+# Declared immediately before the build so an earlier layer is not invalidated per commit.
+ARG GIT_HASH
+ARG GIT_TAG
+ARG GIT_BRANCH
+ENV GIT_HASH=${GIT_HASH} \
+    GIT_TAG=${GIT_TAG} \
+    GIT_BRANCH=${GIT_BRANCH}
+
 # Cross-compilation: Use cargo-zigbuild with glibc 2.36 targeting (Raspberry Pi compatible)
 # Native compilation: Use regular cargo build
 # sccache: see the frontend stage — probe the backend and only wrap rustc when

--- a/backend/build.rs
+++ b/backend/build.rs
@@ -5,6 +5,8 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use uuid::Uuid;
 
+include!("build_version.rs");
+
 fn main() {
     // Set version and build information
     set_version_info();
@@ -35,6 +37,12 @@ fn main() {
     // Rerun if .git/HEAD changes (new commits)
     println!("cargo:rerun-if-changed=../.git/HEAD");
     println!("cargo:rerun-if-changed=../.git/refs");
+    // Rerun if the included version-field helper changes
+    println!("cargo:rerun-if-changed=build_version.rs");
+    // Rerun if the Docker build args carrying git provenance change
+    println!("cargo:rerun-if-env-changed=GIT_HASH");
+    println!("cargo:rerun-if-env-changed=GIT_TAG");
+    println!("cargo:rerun-if-env-changed=GIT_BRANCH");
     // Rerun if Windows icon changes
     println!("cargo:rerun-if-changed=strom.ico");
 
@@ -60,53 +68,23 @@ fn main() {
 
 /// Set version and build information as environment variables
 fn set_version_info() {
-    // Get git commit hash (short)
-    let git_hash = Command::new("git")
-        .args(["rev-parse", "--short=8", "HEAD"])
-        .output()
-        .ok()
-        .and_then(|output| {
-            if output.status.success() {
-                String::from_utf8(output.stdout).ok()
-            } else {
-                None
-            }
-        })
-        .map(|s| s.trim().to_string())
+    // Docker builds carry no repository: `.dockerignore` excludes `.git/` so the layer cache
+    // is not invalidated on every commit. The publish workflow passes these in as build args
+    // instead, and they take precedence over the shell-out that cannot succeed there.
+    let git_hash = version_field_from_env("GIT_HASH")
+        .or_else(|| git_value(&["rev-parse", "--short=8", "HEAD"]))
         .unwrap_or_else(|| "unknown".to_string());
 
-    // Get git tag (if on a tagged commit)
-    let git_tag = Command::new("git")
-        .args(["describe", "--tags", "--exact-match"])
-        .output()
-        .ok()
-        .and_then(|output| {
-            if output.status.success() {
-                String::from_utf8(output.stdout).ok()
-            } else {
-                None
-            }
-        })
-        .map(|s| s.trim().to_string())
+    let git_tag = version_field_from_env("GIT_TAG")
+        .or_else(|| git_value(&["describe", "--tags", "--exact-match"]))
         .unwrap_or_default();
+
+    let git_branch = version_field_from_env("GIT_BRANCH")
+        .or_else(|| git_value(&["rev-parse", "--abbrev-ref", "HEAD"]))
+        .unwrap_or_else(|| "unknown".to_string());
 
     // Get build timestamp (ISO 8601 format)
     let build_timestamp = chrono::Utc::now().to_rfc3339();
-
-    // Get git branch
-    let git_branch = Command::new("git")
-        .args(["rev-parse", "--abbrev-ref", "HEAD"])
-        .output()
-        .ok()
-        .and_then(|output| {
-            if output.status.success() {
-                String::from_utf8(output.stdout).ok()
-            } else {
-                None
-            }
-        })
-        .map(|s| s.trim().to_string())
-        .unwrap_or_else(|| "unknown".to_string());
 
     // Check if working directory is dirty
     let git_dirty = Command::new("git")
@@ -139,6 +117,23 @@ fn set_version_info() {
         },
         git_hash
     );
+}
+
+/// Run `git` with `args` and return its trimmed output, or `None` if it did not succeed.
+fn git_value(args: &[&str]) -> Option<String> {
+    Command::new("git")
+        .args(args)
+        .output()
+        .ok()
+        .and_then(|output| {
+            if output.status.success() {
+                String::from_utf8(output.stdout).ok()
+            } else {
+                None
+            }
+        })
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
 }
 
 /// Compute a hash of all frontend source files

--- a/backend/build_version.rs
+++ b/backend/build_version.rs
@@ -1,0 +1,13 @@
+// Included by `build.rs` and by `tests/build_version_test.rs`. Build scripts are not test
+// targets, so anything about them that needs a guard has to live in a file a test can include.
+
+/// Read a version field supplied at build time, e.g. by a Docker build arg.
+///
+/// A declared `ARG` the caller never passed arrives as an empty string rather than staying
+/// unset, so blank is treated as absent and the caller falls back to `git`.
+fn version_field_from_env(key: &str) -> Option<String> {
+    std::env::var(key)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}

--- a/backend/tests/build_version_test.rs
+++ b/backend/tests/build_version_test.rs
@@ -1,0 +1,46 @@
+//! Guards the build-arg fallback that gives published Docker images their git provenance.
+//!
+//! `build.rs` is a build script and so is not a test target. The part of it that chooses
+//! between a build arg and the `git` shell-out therefore lives in `backend/build_version.rs`,
+//! which both the build script and this test include — the test exercises that file itself,
+//! not a copy of its logic.
+
+include!("../build_version.rs");
+
+const SET: &str = "STROM_TEST_PROVENANCE_SET";
+const PADDED: &str = "STROM_TEST_PROVENANCE_PADDED";
+const BLANK: &str = "STROM_TEST_PROVENANCE_BLANK";
+const WHITESPACE: &str = "STROM_TEST_PROVENANCE_WHITESPACE";
+const UNSET: &str = "STROM_TEST_PROVENANCE_UNSET";
+
+#[test]
+fn a_set_build_arg_is_preferred() {
+    std::env::set_var(SET, "13722d5a");
+    assert_eq!(version_field_from_env(SET), Some("13722d5a".to_string()));
+}
+
+#[test]
+fn a_build_arg_is_trimmed() {
+    std::env::set_var(PADDED, " 13722d5a\n");
+    assert_eq!(version_field_from_env(PADDED), Some("13722d5a".to_string()));
+}
+
+#[test]
+fn a_blank_build_arg_counts_as_absent() {
+    // An ARG the caller never passed still reaches the builder stage, as an empty string.
+    // Treating "set" as "usable" would embed "" and lose the git fallback entirely.
+    std::env::set_var(BLANK, "");
+    assert_eq!(version_field_from_env(BLANK), None);
+}
+
+#[test]
+fn a_whitespace_only_build_arg_counts_as_absent() {
+    std::env::set_var(WHITESPACE, "  \n");
+    assert_eq!(version_field_from_env(WHITESPACE), None);
+}
+
+#[test]
+fn an_unset_build_arg_is_absent() {
+    std::env::remove_var(UNSET);
+    assert_eq!(version_field_from_env(UNSET), None);
+}


### PR DESCRIPTION
Class C — blocked on a dispatch: `gh workflow run docker-publish.yml --ref agent/fix-741-docker-git-provenance`.

Refs #741

**This diff is half the fix and is inert on its own.** The `docker-publish.yml` half that supplies the build args could not be pushed — this token has no `workflow` scope. The patch is in a comment below; until it lands, published images still report `"unknown"`.

Implements **Option A** (`/agent-fix A`, 2026-09-09); the triage marker's `work=bug radius=LOCAL excluded=none` describes that option, which I built unchanged.

## Problem

`.dockerignore:21` keeps the repository out of the build context, rightly: it is large and changes every commit. `build.rs` got all four values by shelling out to `git`, so inside the image build every call fails into its default. `backend/src/version.rs:50` — `        git_hash: env!("GIT_HASH").to_string(),` — embeds the result, so `/api/version` and `--version-info` report `"unknown"` for every published image.

## Change

`build.rs` prefers values from the environment — `backend/build.rs:74` — `    let git_hash = version_field_from_env("GIT_HASH")` — falling back to `git` when blank, because an `ARG` the caller never passed arrives as an empty string rather than unset: the trap PR #738 hit. The `backend-builder` stage declares them — `Dockerfile:196` — `ARG GIT_HASH` — immediately before the build, so no earlier layer is invalidated per commit.

The three near-identical `git` chains collapse into one `git_value()` helper.

Option B — OCI labels only — was rejected in triage: the binary, and therefore `/api/version`, would still say `"unknown"`.

## Evidence

**No Rust test can guard the wiring, and I did not write one that pretends to.** Build scripts are not test targets; `backend/tests/build_version_test.rs` includes `backend/build_version.rs` — the real file `build.rs` includes, not a copy — covering blank, whitespace, unset and trimmed values. It does not prove `build.rs` consults the environment: deleting the `.or_else` wiring leaves it green. The wiring's only guard is the `Verify git provenance` step in the patch below: it runs the pushed image and asserts `/api/version` reports its commit. `docker-publish.yml` runs only on a tag or a dispatch, so it can never run on a PR — hence class C.

Commit 1 **fails to compile**: `build_version.rs` does not exist yet. That is the intended red, not a broken PR.

- `c1b5ce2` https://github.com/Eyevinn/strom/actions/runs/34587991127 — test alone, red on `Check (Linux)`: `couldn't read backend/tests/../build_version.rs`
- `457f754` https://github.com/Eyevinn/strom/actions/runs/34588068641 — with the fix, green

With no `cargo` or Docker here, the one thing I ran is the patch's new `Extract version` shell against this repository: a tag push yields `git_tag=v0.6.8`, `git_branch=main`, `git_hash=c1b5ce2d`; a dispatch on a branch yields an empty tag and the branch name  — as the issue asks.

## Not verified

Untested here: the end-to-end round trip, the ARM64 cross-compile path, cold-container start-up timing, and `git_dirty`.

## Blast radius

LOCAL. Both new helpers are called only from `set_version_info`, which `main()` calls once — `backend/build.rs:12` — `    set_version_info();`. Local and CI builds set no `GIT_*` variable, so the `git` fallback runs exactly as before. `/api/version` changes values, never its shape.

<!-- strom-agent protocol=v3 kind=fix issue=741 pr=800 class=C -->
