### PR TITLE
docs(agent): open fix-stage PRs ready for review, not as drafts

### DIFF
--- a/scripts/agent/FIX.md
+++ b/scripts/agent/FIX.md
@@ -1,4 +1,4 @@
-# Turning an approved design into a draft PR
+# Turning an approved design into a PR
 
 Read `PROTOCOL.md` first. This is the stage after a human answered a triage `Ask:`.
 
@@ -12,7 +12,7 @@ proposal** with the exact experiment that would falsify it.
 
 Do this first; it is cheap, and it is where most of the value of this stage accrues.
 
-For every open draft PR authored by you:
+For every open PR authored by you:
 
 1. Read its check runs (`gh pr checks <N>`). If both runs of the two-commit structure have
    concluded, edit the body to replace the pending evidence lines with the actual
@@ -116,7 +116,7 @@ exercises the new code rather than restating it — but say so explicitly in the
 an unexplained compile error reads as a broken PR and a reviewer who assumes that will close
 it.
 
-Everything else — the classes, the required sections, the draft rule, the excluded areas — is
+Everything else — the classes, the required sections, the excluded areas — is
 identical. Pick the row from `work=`, not from the issue's label.
 
 The test must exercise the code it guards — call the changed module, do not rebuild the
@@ -141,15 +141,18 @@ Expect a formatting round trip. Without `cargo` you cannot run `cargo fmt`, and 
 check is the only thing red, fix it and **force-push, keeping exactly the two commits**.
 Never add a third commit to repair a mechanical check.
 
-Push commit 1, open the draft PR, then push commit 2. CI has no concurrency group, so both
+Push commit 1, open the PR, then push commit 2. CI has no concurrency group, so both
 runs complete and both appear on the PR: the first is the deliberate failure, the second is
 the state you are proposing. Record both run URLs in the body; Phase 1 of a later run fills
 in their conclusions.
 
 ## The PR
 
-**Draft, always.** Title `fix(<scope>): <what it does>`, prefixed `[needs hardware]` when
-class B applies for want of a device rather than for want of time.
+**Ready for review, never a draft.** You stop when the work is finished, so the PR opens
+finished. The verdict line already carries whether the evidence has arrived; a draft flag
+would say it a second time, and less precisely. Title `fix(<scope>): <what it does>`,
+prefixed `[needs hardware]` when class B applies for want of a device rather than for want
+of time.
 
 - **Class A — verified.** You are holding execution evidence right now: test output you
   produced in this run, or two concluded CI runs showing commit 1 red and commit 2 green.
@@ -212,7 +215,7 @@ body** — link it. That comment is read alongside the PR, not instead of it.
 
 - `verify-citations.sh` exits zero on the body, if the body cites code.
 - The branch has exactly the two commits, in that order.
-- The PR is a draft.
+- The PR is ready for review, not a draft.
 - The class matches evidence you can point at. If you did not run the test yourself and CI
   has not concluded, it is B, and the body says `Refs`, not `Fixes`. The issue comment and
   the run summary repeat whatever class the body claims, so a premature A propagates to three

--- a/scripts/agent/PROTOCOL.md
+++ b/scripts/agent/PROTOCOL.md
@@ -125,7 +125,7 @@ exists; `feature` adds something new. **Most of the board is not `bug`.**
 
 `class=` appears **only** on a `kind=fix` marker — a PR the implementation stage authored,
 never a review of somebody else's PR. "Find the open class=C PRs" therefore means "the fix
-PRs you opened", which `gh pr list --author @me --draft` answers.
+PRs you opened", which `gh pr list --author @me` answers.
 
 `excluded=` lists the areas from `FIX.md`'s exclusion gate that the fix would **break or take
 a lifetime risk in**, comma-separated, or `none` — not the areas the diff merely touches.

--- a/scripts/agent/README.md
+++ b/scripts/agent/README.md
@@ -1,7 +1,7 @@
 # Agent review protocol
 
 Strom's open PRs and issues are worked by two scheduled agents: one reviews PRs and triages
-issues, the other turns an approved design into a draft PR. This directory is the protocol
+issues, the other turns an approved design into a PR. This directory is the protocol
 they follow, and their role, budget and priority order with it.
 
 **It lives in the repo on purpose.** All of this used to be embedded in the task definitions,
@@ -19,7 +19,7 @@ wiring, and a pointer to `ROLE_REVIEW.md` or `ROLE_FIX.md`.
 | `PROTOCOL.md` | Every run, first. Evidence rules, citation form, controlled vocabulary, markers. |
 | `REVIEW.md` | Reviewing a pull request. |
 | `TRIAGE.md` | Triaging an issue. |
-| `FIX.md` | Turning an approved design into a draft PR. |
+| `FIX.md` | Turning an approved design into a PR. |
 | `SUMMARY.md` | Writing the run summary. Every run, last. |
 | `board.sh` | Reporting the state of the open board before implementing anything. |
 | `verify-citations.sh` | Before posting anything that cites code, or that has a length ceiling. |
@@ -86,6 +86,16 @@ permission is a finding rather than an instruction.
   rubber stamp.
 - **`excluded=` means "would break", not "touches".** That distinction is what keeps gate 4 a
   real check.
+- **The implementation stage opens a PR ready for review, and holds other people's drafts.**
+  The two rules look contradictory and are not. A draft means "the author is not finished",
+  and the implementation stage stops only when it is finished — it opened drafts for a while,
+  which said the opposite and left a shelf of PRs nobody could tell apart from abandoned ones.
+  How far the *evidence* has got is a different axis, and the class line already carries it:
+  a class B PR is finished work whose proof has not arrived, not unfinished work. So the
+  draft flag is free to mean what it means everywhere else, and the hold below applies to
+  drafts from contributors, never to this stage's own PRs. The draft flag had been doing one
+  job nobody had noticed, though — keeping the review stage off these PRs — so `REVIEW.md`'s
+  skip list now says that outright, keyed on the `kind=fix` marker.
 - **A draft is held, not skipped, and the hold is said exactly once.** Those are two separate
   corrections to the same rule. Silently skipping a draft told its author nothing, so a
   contributor who had opened one had no way to know whether it was queued, ignored or waiting

--- a/scripts/agent/REVIEW.md
+++ b/scripts/agent/REVIEW.md
@@ -21,6 +21,9 @@ under review.
 - Dependency version bumps — but still dismiss any older-generation review of yours on them.
 - A PR whose current head SHA already carries your v3 review. Only a new head SHA or a new
   check conclusion is a re-review trigger.
+- A PR the implementation stage opened — the `kind=fix` marker in the body, never the author
+  name. These now open ready for review, so nothing else marks them off; `FIX.md` Phase 1
+  follows them, and a stage reviewing its own diff under its own protocol finds nothing.
 - Drafts are neither reviewed nor silently skipped — see "Drafts" below.
 
 A review is a verdict on a diff, not a turn in a conversation. The maintainer and the author
@@ -55,9 +58,10 @@ a comment asks you, or you are a requested reviewer. A new commit, a red check o
 thread is not being asked. Once asked, it is an ordinary review under this file with a
 `kind=review` marker.
 
-**Never post a draft-hold on a draft you opened.** Every implementation-stage PR is a draft;
-`FIX.md` Phase 1 owns those, and you know them by the `kind=fix` marker in the body — by the
-marker, never by the author.
+**Never post a draft-hold on a PR the implementation stage opened.** Those open ready for
+review, not as drafts, and `FIX.md` Phase 1 owns them; you know them by the `kind=fix` marker
+in the body — by the marker, never by the author. One that is somehow a draft is Phase 1's
+problem, not yours.
 
 A draft-hold is not a review: it never needs dismissal, and it does not stand in for the
 review the PR gets once it is marked ready.

--- a/scripts/agent/ROLE_FIX.md
+++ b/scripts/agent/ROLE_FIX.md
@@ -1,4 +1,4 @@
-# Role — turn an approved design into a draft PR
+# Role — turn an approved design into a PR
 
 A scheduled task points here. That task definition holds the **boundary** — what this stage
 may and may not do, its credentials, its schedule, where it reports. This file holds the
@@ -13,7 +13,7 @@ The implementation stage for this repository.
 
 A separate task verifies issues and writes a design proposal, then deliberately stops for a
 human decision. You are the stage after that decision: you turn an approved design into a
-draft PR the maintainer can read, run and finish. **You never decide the design yourself, and
+PR the maintainer can read, run and finish. **You never decide the design yourself, and
 you never merge.**
 
 A PR from you is only worth its review time if it is either mechanically checkable or

--- a/scripts/agent/SUMMARY.md
+++ b/scripts/agent/SUMMARY.md
@@ -83,7 +83,7 @@ Two things belong in `needs_human` **every run**, not just the run that discover
 otherwise they scroll away and the work stalls silently:
 
 - the dispatch command for every open `class=C` PR **that the implementation stage authored**
-  (`gh pr list --author @me --draft`), which cannot reach class A without it. A review you
+  (`gh pr list --author @me`), which cannot reach class A without it. A review you
   posted on someone else's PR carries no `class=` and never will — do not report its absence
   as a finding;
 - every issue `board.sh` lists under "replied, but not by someone who may decide", and every


### PR DESCRIPTION
The implementation stage opened every PR as a draft. A draft means "the author is not finished", and that stage stops only when it is finished — so the flag said the opposite of the truth, and left a shelf of PRs nobody could tell apart from abandoned ones.

How far the *evidence* has got is a different axis, and the verdict line already carries it: a class B PR is finished work whose proof has not arrived, not unfinished work.

## Change

`FIX.md` — "Draft, always" becomes "Ready for review, never a draft", with the reason. Phase 1's loop over open PRs and the pre-publish checklist follow.

`REVIEW.md` — the draft flag had been doing a second job nobody had written down: keeping the review stage off these PRs, since a stage never posts a draft-hold on its own draft. Without it the reviewer would start reviewing its own diffs, so the skip list now says so outright, keyed on the `kind=fix` marker rather than the author name.

`SUMMARY.md`, `PROTOCOL.md` — both found the open `class=C` PRs with `gh pr list --author @me --draft`, which now matches nothing; those PRs would have silently stopped appearing in `needs_human` every run.

`README.md`, `ROLE_FIX.md` — the reasoning, and the headings.

**The draft-hold machinery for contributors' drafts is unchanged.** Holding someone else's draft, the one-per-PR rule and the `kind=draft-hold` marker all still stand.

## Evidence

`scripts/agent/test-agent-scripts.sh` — 40 passed, 0 failed. It covers `board.sh` and `verify-citations.sh`; no test exercises the prose rules, because there is nothing mechanical to exercise. `grep -rn -i draft scripts/agent/` was read line by line to confirm every remaining mention is about a contributor's draft, the text sense of "first draft", or the historical note in `PROTOCOL.md:171`.

## Not verified

Whether the two scheduled tasks behave as intended under the new wording — that shows on their next runs. Per `README.md`'s "Changing the protocol", the task definitions need no update: no role file was renamed and no boundary or wiring changed.

## Blast radius

Documentation only; no code path reads these files at build or run time. The behaviour change lands on the next scheduled run of the implementation and review tasks.
