### PR TITLE
feat(vision mixer): report take morphs and per-input media age

### DIFF
--- a/backend/src/api/flows.rs
+++ b/backend/src/api/flows.rs
@@ -2153,6 +2153,10 @@ pub async fn get_vision_mixer_state(
         .map(|e| e.clone())
         .unwrap_or_default();
 
+    let input_media_age_ms: Vec<Option<u64>> = (0..overlay.num_inputs)
+        .map(|i| overlay.input_media_age_ms(i))
+        .collect();
+
     Ok(Json(strom_types::api::VisionMixerState {
         program_input: overlay.pgm_input(),
         preview_input: overlay.pvw_input(),
@@ -2168,6 +2172,7 @@ pub async fn get_vision_mixer_state(
         fx_available,
         input_effects,
         master_effect,
+        input_media_age_ms,
     }))
 }
 

--- a/backend/src/blocks/builtin/vision_mixer/activity.rs
+++ b/backend/src/blocks/builtin/vision_mixer/activity.rs
@@ -1,0 +1,50 @@
+//! Per-input media activity for the vision mixer.
+//!
+//! The compositor repeats an input's last frame forever once that input stops
+//! delivering, so a participant who drops looks identical on air to one who is
+//! sitting still. These probes stamp the arrival of every input buffer, which
+//! is what lets `input_media_age_ms` tell those two apart.
+//!
+//! These ARE per-buffer probes — the hottest path in the pipeline. The
+//! callback reads the monotonic clock and stores one relaxed atomic: no locks,
+//! no allocation, no formatting, no state lookup. The overlay state is
+//! captured as an `Arc`, not looked up per buffer, and it is not a GStreamer
+//! object, so it forms no reference cycle with the pipeline.
+
+use gstreamer as gst;
+use gstreamer::prelude::*;
+use std::sync::Arc;
+use tracing::debug;
+
+use super::overlay::VisionMixerOverlayState;
+use crate::gst::pipeline::effects::find_pad;
+
+/// Install a buffer probe on each of the dist compositor's input sink pads so
+/// the overlay state knows when each input last delivered a frame.
+///
+/// Must run after linking, when the request pads exist. `sink_i` on the dist
+/// compositor carries input `i` regardless of what is on air — visibility is
+/// an alpha property, so a hidden input still stamps activity.
+pub fn install_input_activity_probes(
+    block_id: &str,
+    mixer: &gst::Element,
+    state: &Arc<VisionMixerOverlayState>,
+    num_inputs: usize,
+) {
+    let mut installed = 0;
+    for i in 0..num_inputs {
+        let Some(pad) = find_pad(mixer, &format!("sink_{}", i)) else {
+            continue;
+        };
+        let state = Arc::clone(state);
+        pad.add_probe(gst::PadProbeType::BUFFER, move |_pad, _info| {
+            state.note_input_buffer(i);
+            gst::PadProbeReturn::Ok
+        });
+        installed += 1;
+    }
+    debug!(
+        "Vision mixer {}: installed {} input activity probes",
+        block_id, installed
+    );
+}

--- a/backend/src/blocks/builtin/vision_mixer/builder/pipeline_cpu.rs
+++ b/backend/src/blocks/builtin/vision_mixer/builder/pipeline_cpu.rs
@@ -548,12 +548,19 @@ pub(super) fn build_cpu_pipeline(
         let block_id = p.instance_id.to_string();
         let num_inputs = p.num_inputs;
         let num_pips = p.num_pips;
+        let activity_state = std::sync::Arc::clone(&overlay_state);
         ctx.register_element_setup(Box::new(move |_flow_id, _events| {
             let (Some(mixer), Some(mv_comp)) = (dist_weak.upgrade(), mv_weak.upgrade()) else {
                 return;
             };
             super::super::geometry::install_caps_probes(
                 &block_id, &mixer, &mv_comp, num_inputs, num_pips,
+            );
+            super::super::activity::install_input_activity_probes(
+                &block_id,
+                &mixer,
+                &activity_state,
+                num_inputs,
             );
         }));
     }

--- a/backend/src/blocks/builtin/vision_mixer/builder/pipeline_gpu.rs
+++ b/backend/src/blocks/builtin/vision_mixer/builder/pipeline_gpu.rs
@@ -563,12 +563,19 @@ pub(super) fn build_gpu_pipeline(
         let block_id = p.instance_id.to_string();
         let num_inputs = p.num_inputs;
         let num_pips = p.num_pips;
+        let activity_state = std::sync::Arc::clone(&overlay_state);
         ctx.register_element_setup(Box::new(move |_flow_id, _events| {
             let (Some(mixer), Some(mv_comp)) = (dist_weak.upgrade(), mv_weak.upgrade()) else {
                 return;
             };
             super::super::geometry::install_caps_probes(
                 &block_id, &mixer, &mv_comp, num_inputs, num_pips,
+            );
+            super::super::activity::install_input_activity_probes(
+                &block_id,
+                &mixer,
+                &activity_state,
+                num_inputs,
             );
         }));
     }

--- a/backend/src/blocks/builtin/vision_mixer/mod.rs
+++ b/backend/src/blocks/builtin/vision_mixer/mod.rs
@@ -20,6 +20,7 @@
 //! Distribution output: `dist_comp → capsfilter_dist → [pgm_out]`
 //! Multiview output: `mv_comp → gldownload_mv → videoconvert_pre_cairo → cairooverlay → capsfilter_mv → [multiview_out]`
 
+pub(crate) mod activity;
 mod builder;
 mod definition;
 mod elements;

--- a/backend/src/blocks/builtin/vision_mixer/overlay.rs
+++ b/backend/src/blocks/builtin/vision_mixer/overlay.rs
@@ -123,6 +123,10 @@ pub struct VisionMixerOverlayState {
     pub pgm_peak: AtomicU8,
     /// Quantized decay (0..255) for the PGM audio input; max of L/R.
     pub pgm_decay: AtomicU8,
+    /// Milliseconds after `instant_base` at which each input last delivered a
+    /// buffer to the dist compositor, or [`NO_MEDIA`] when it never has.
+    /// Written from a BUFFER pad probe, so it stays one relaxed store.
+    input_last_buffer_ms: Vec<AtomicU64>,
 }
 
 /// Initial PiP runtime state passed to [`VisionMixerOverlayState::new`].
@@ -146,6 +150,10 @@ pub const NO_PIP: u64 = u64::MAX;
 /// Sentinel for "no input source on this bus" in [`VisionMixerOverlayState::pgm_input`]
 /// / `pvw_input` (e.g. when the bus shows a PiP composition instead).
 pub const NO_SOURCE: u64 = u64::MAX;
+
+/// Sentinel for "this input has never delivered a buffer" in
+/// [`VisionMixerOverlayState::input_media_age_ms`].
+const NO_MEDIA: u64 = u64::MAX;
 
 impl VisionMixerOverlayState {
     #[allow(clippy::too_many_arguments)]
@@ -223,7 +231,32 @@ impl VisionMixerOverlayState {
             input_decay: (0..num_inputs).map(|_| AtomicU8::new(0)).collect(),
             pgm_peak: AtomicU8::new(0),
             pgm_decay: AtomicU8::new(0),
+            input_last_buffer_ms: (0..num_inputs).map(|_| AtomicU64::new(NO_MEDIA)).collect(),
         }
+    }
+
+    /// Stamp input `i` as having just delivered a buffer.
+    ///
+    /// Called from a BUFFER pad probe — the hottest path in the pipeline — so
+    /// it does no more than read the monotonic clock and store one atomic.
+    pub fn note_input_buffer(&self, i: usize) {
+        if let Some(slot) = self.input_last_buffer_ms.get(i) {
+            let ms = self.instant_base.elapsed().as_millis() as u64;
+            slot.store(ms, Ordering::Relaxed);
+        }
+    }
+
+    /// Milliseconds since input `i` last delivered a buffer to the mixer.
+    ///
+    /// `None` means it has never delivered one. A value that keeps growing is
+    /// a frozen input: the compositor repeats its last frame indefinitely, so
+    /// the picture alone cannot distinguish that from a motionless source.
+    pub fn input_media_age_ms(&self, i: usize) -> Option<u64> {
+        let last = self.input_last_buffer_ms.get(i)?.load(Ordering::Relaxed);
+        if last == NO_MEDIA {
+            return None;
+        }
+        Some((self.instant_base.elapsed().as_millis() as u64).saturating_sub(last))
     }
 
     /// Returns the PiP index currently displayed on PGM, or `None` if PGM

--- a/backend/src/blocks/builtin/vision_mixer/tests.rs
+++ b/backend/src/blocks/builtin/vision_mixer/tests.rs
@@ -638,3 +638,71 @@ fn input_media_age_tracks_buffer_arrival() {
     assert_eq!(state.input_media_age_ms(9), None);
     state.note_input_buffer(9);
 }
+
+/// The activity probes must land on the dist compositor's input sink pads and
+/// stamp real buffers. Exercised against a running compositor, because the
+/// accessor test alone would still pass if the probes were never installed or
+/// were attached to the wrong pad names.
+#[test]
+fn activity_probes_stamp_buffers_from_a_running_compositor() {
+    use super::layout;
+    use super::overlay::VisionMixerOverlayState;
+    use gstreamer as gst;
+    use gstreamer::prelude::*;
+    use std::sync::Arc;
+
+    gst::init().unwrap();
+
+    let lo = layout::compute_layout(1280, 720, 2, 0, ASPECT_16_9, false);
+    let state = Arc::new(VisionMixerOverlayState::new(
+        2,
+        0,
+        0,
+        1,
+        vec!["A".into(), "B".into()],
+        lo,
+        1280,
+        720,
+        false,
+        super::overlay::PipInitialState::default(),
+    ));
+
+    let pipeline = gst::Pipeline::new();
+    let src = gst::ElementFactory::make("videotestsrc")
+        .property("num-buffers", 5i32)
+        .build()
+        .expect("videotestsrc is in gst-plugins-base");
+    let comp = gst::ElementFactory::make("compositor")
+        .build()
+        .expect("compositor is in gst-plugins-base");
+    let sink = gst::ElementFactory::make("fakesink")
+        .property("sync", false)
+        .build()
+        .unwrap();
+    pipeline.add_many([&src, &comp, &sink]).unwrap();
+    gst::Element::link_many([&comp, &sink]).unwrap();
+
+    // sink_0 carries input 0, and must exist before the probe is installed.
+    let sink_pad = comp.request_pad_simple("sink_0").expect("sink_0");
+    src.static_pad("src").unwrap().link(&sink_pad).unwrap();
+
+    super::activity::install_input_activity_probes("test-vm-activity", &comp, &state, 2);
+
+    // Input 0 has not delivered anything until the pipeline runs.
+    assert_eq!(state.input_media_age_ms(0), None);
+
+    pipeline.set_state(gst::State::Playing).unwrap();
+    let bus = pipeline.bus().unwrap();
+    let _ = bus.timed_pop_filtered(
+        gst::ClockTime::from_seconds(10),
+        &[gst::MessageType::Eos, gst::MessageType::Error],
+    );
+    pipeline.set_state(gst::State::Null).unwrap();
+
+    assert!(
+        state.input_media_age_ms(0).is_some(),
+        "input 0 delivered buffers, so its age must be stamped"
+    );
+    // Input 1 was never linked, so it stays unstamped.
+    assert_eq!(state.input_media_age_ms(1), None);
+}

--- a/backend/src/blocks/builtin/vision_mixer/tests.rs
+++ b/backend/src/blocks/builtin/vision_mixer/tests.rs
@@ -579,3 +579,62 @@ fn overlay_timer_exits_when_its_appsrc_is_orphaned() {
     let _ = appsrc.set_state(gst::State::Null);
     unregister_flow(&flow_id);
 }
+
+/// An input that has never delivered a buffer reads as `None`; once it has,
+/// the age is measured from that buffer and keeps growing while the input
+/// stays silent. This is what separates a frozen participant from a
+/// motionless one, which the picture alone cannot do.
+#[test]
+fn input_media_age_tracks_buffer_arrival() {
+    use super::layout;
+    use super::overlay::VisionMixerOverlayState;
+
+    let lo = layout::compute_layout(1280, 720, 3, 0, ASPECT_16_9, false);
+    let state = VisionMixerOverlayState::new(
+        3,
+        0,
+        0,
+        1,
+        vec!["A".into(), "B".into(), "C".into()],
+        lo,
+        1920,
+        1080,
+        false,
+        super::overlay::PipInitialState::default(),
+    );
+
+    // Nothing has arrived yet on any input.
+    for i in 0..3 {
+        assert_eq!(state.input_media_age_ms(i), None, "input {}", i);
+    }
+
+    state.note_input_buffer(1);
+    let age = state
+        .input_media_age_ms(1)
+        .expect("input 1 has delivered a buffer");
+    assert!(age < 1000, "fresh buffer should read as young, got {}", age);
+
+    // Its silent neighbours are still untouched.
+    assert_eq!(state.input_media_age_ms(0), None);
+    assert_eq!(state.input_media_age_ms(2), None);
+
+    // The age grows while the input stays silent.
+    std::thread::sleep(std::time::Duration::from_millis(30));
+    let later = state
+        .input_media_age_ms(1)
+        .expect("input 1 has delivered a buffer");
+    assert!(
+        later >= age + 20,
+        "age should grow while silent: {} -> {}",
+        age,
+        later
+    );
+
+    // A fresh buffer resets it.
+    state.note_input_buffer(1);
+    assert!(state.input_media_age_ms(1).unwrap() < later);
+
+    // Out-of-range inputs have no slot rather than panicking.
+    assert_eq!(state.input_media_age_ms(9), None);
+    state.note_input_buffer(9);
+}

--- a/backend/src/gst/pipeline/effects/take.rs
+++ b/backend/src/gst/pipeline/effects/take.rs
@@ -12,6 +12,26 @@ use super::mixer_layout::{
     pads_for_source,
 };
 
+/// Name the animated PiP-aware take `outgoing` → `incoming` produces.
+///
+/// The animated path is not always a dissolve: a source present in both
+/// compositions animates position+size instead of cross-fading, so a four-up
+/// taken to that participant full frame reads as a zoom, and reports "morph".
+fn animated_kind(
+    outgoing: &[crate::gst::transitions::PadTarget],
+    incoming: &[crate::gst::transitions::PadTarget],
+) -> &'static str {
+    use crate::gst::transitions::{plan_transition, PadAction};
+    let moves = plan_transition(outgoing, incoming)
+        .iter()
+        .any(|(_, action)| matches!(action, PadAction::Morph { .. }));
+    if moves {
+        "morph"
+    } else {
+        "fade"
+    }
+}
+
 impl PipelineManager {
     /// Trigger a transition on a compositor/mixer block.
     ///
@@ -23,8 +43,9 @@ impl PipelineManager {
     /// Returns `(was_ftb_cancelled, old_pgm, new_pgm, actual_kind)`. The two
     /// middle elements are `None` when the corresponding bus is a PiP source.
     /// `actual_kind` is the transition that actually ran — differs from
-    /// `transition_type` when the engine downgraded the request (e.g. Slide
-    /// across heterogeneous PiP/input sources downgrades to "fade").
+    /// `transition_type` when the engine downgraded the request (Slide across
+    /// heterogeneous PiP/input sources downgrades to "fade") and when an
+    /// animated take moved a shared source instead of dissolving ("morph").
     pub fn trigger_transition(
         &self,
         block_instance_id: &str,
@@ -368,9 +389,11 @@ impl PipelineManager {
                     new_pvw_pip,
                     new_pvw_swap,
                 );
-                // After the downgrade guard above, the PiP-aware branch only
-                // ever runs a Cut or a Fade.
-                let actual_kind = if is_cut { "cut" } else { "fade" }.to_string();
+                let actual_kind = if is_cut {
+                    "cut".to_string()
+                } else {
+                    animated_kind(&old_dist_targets, &new_dist_targets).to_string()
+                };
                 return Ok((was_ftb, old_pgm, new_pgm_swap, actual_kind));
             }
         }
@@ -494,5 +517,50 @@ impl PipelineManager {
             trans_type.to_string()
         };
         Ok((was_ftb, old_pgm, new_pgm, actual_kind))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::animated_kind;
+    use crate::gst::transitions::PadTarget;
+
+    fn pad(idx: usize, x: i32, y: i32, w: i32, h: i32) -> PadTarget {
+        PadTarget {
+            pad_idx: idx,
+            x,
+            y,
+            w,
+            h,
+            zorder: 10,
+            underlay: None,
+        }
+    }
+
+    #[test]
+    fn disjoint_compositions_report_fade() {
+        // Nothing is shared between the two looks, so every pad cross-fades.
+        let old = vec![pad(0, 0, 0, 640, 720), pad(1, 640, 0, 640, 720)];
+        let new = vec![pad(2, 0, 0, 640, 720), pad(3, 640, 0, 640, 720)];
+        assert_eq!(animated_kind(&old, &new), "fade");
+    }
+
+    #[test]
+    fn shared_source_that_moves_reports_morph() {
+        // Input 1 is a quadrant in the outgoing look and full frame in the
+        // incoming one: it animates, and the audience sees a zoom, not a
+        // dissolve.
+        let old = vec![pad(0, 0, 0, 640, 360), pad(1, 640, 0, 640, 360)];
+        let new = vec![pad(1, 0, 0, 1280, 720)];
+        assert_eq!(animated_kind(&old, &new), "morph");
+    }
+
+    #[test]
+    fn shared_source_that_stays_put_reports_fade() {
+        // Input 0 keeps its exact box, so it is affirmed rather than morphed;
+        // the visible change is input 1 fading out and input 2 fading in.
+        let old = vec![pad(0, 0, 0, 640, 360), pad(1, 640, 0, 640, 360)];
+        let new = vec![pad(0, 0, 0, 640, 360), pad(2, 640, 0, 640, 360)];
+        assert_eq!(animated_kind(&old, &new), "fade");
     }
 }

--- a/docs/PRODUCER_SWITCHING_API_GUIDE.md
+++ b/docs/PRODUCER_SWITCHING_API_GUIDE.md
@@ -1,0 +1,318 @@
+# Producer Switching over the API — Operator Guide
+
+> **Code is the source of truth — this may have drifted; read the code for the current
+> implementation.** This guide describes behaviour observed on a running rig at one point
+> in time. When in doubt, read the code and check the in-app UI.
+
+How a producer changes what the audience sees — all participants, one participant, or
+anything in between — by driving the vision mixer block over HTTP instead of the operator
+page. Companion to the [Vision Mixer Operator Guide](VISION_MIXER_OPERATOR_GUIDE.md),
+which covers the same mixer from the GUI. Read that one first for the concepts; this one
+is the call-by-call recipe, the on-air behaviour of each move, and what breaks.
+
+Everything below was exercised against a live five-seat meeting flow and checked against
+captured program frames, not against HTTP status codes. Where a claim is about what the
+audience sees, it was read off a frame.
+
+---
+
+## 1. The model in one minute
+
+The mixer has two buses, **PGM** (on air) and **PVW** (preview). Each bus holds one
+**source**, and a source is one of two things:
+
+- `{"input": N}` — a single input, full frame.
+- `{"pip": K}` — a **PiP**, which despite the name is a whole composition: an optional
+  full-region background input plus a list of **zones**. Each zone is a rectangle holding
+  one or more inputs that auto-tile inside it.
+
+So "all five up" and "one participant full frame" are not different features. They are
+two sources you can put on either bus. Cutting between them is an ordinary take.
+
+Three endpoints do all the work:
+
+| Call | What it does |
+|---|---|
+| `PUT /api/flows/{flow_id}/blocks/{block_id}/pip/{pip_idx}` | Replace a PiP's composition. Applies live. |
+| `PUT /api/flows/{flow_id}/blocks/{block_id}/preview` | Put a source on PVW. |
+| `POST /api/flows/{flow_id}/blocks/{block_id}/transition` | Take: swap PGM and PVW. |
+| `GET  /api/flows/{flow_id}/blocks/{block_id}/state` | Read back both buses and every PiP. |
+
+The broadcast pattern is: build the next look on a PiP that is **not** on air, preview it,
+take it. A mixer with `num_pips: 2` supports this indefinitely, because the take swaps the
+buses and hands the previous PGM composition back to you on preview to rebuild.
+
+### The take is a swap, and it ignores half its own request body
+
+`POST .../transition` takes `from_input` and `to_input`, but whenever the block has live
+state the engine ignores them and swaps whatever is currently on PGM and PVW. Send `0` for
+both. What matters is `transition_type` and `duration_ms`.
+
+```bash
+FLOW=945fa329-...   BLOCK=vmix
+API=http://127.0.0.1:8123/api/flows/$FLOW/blocks/$BLOCK
+
+curl -X POST -H 'content-type: application/json' \
+  -d '{"from_input":0,"to_input":0,"transition_type":"cut","duration_ms":0}' \
+  $API/transition
+```
+
+After a take, `GET .../state` reports the swap: the composition that was on air is now on
+`preview_pip` (or `preview_input`), ready to be rebuilt for the next move.
+
+One reporting quirk: when a PiP with a background is on air, `program_input` reports that
+background's index rather than `null`. Read `program_pip` to know which composition is on
+air.
+
+---
+
+## 2. The four layouts, verified
+
+All examples assume a five-input mixer with two PiPs, inputs `0..4` fed by participants
+P1..P5. Every layout below was taken to air and read off a captured program frame.
+
+### All five up
+
+One zone, no rect (fills the PiP region), all five inputs. The zone auto-tiles them.
+
+```bash
+curl -X PUT -H 'content-type: application/json' -d '{
+  "bg": null, "transforms": {},
+  "zones": [ { "rect": null, "sources": [0,1,2,3,4] } ]
+}' $API/pip/0
+
+curl -X PUT -H 'content-type: application/json' -d '{"source":{"pip":0}}' $API/preview
+curl -X POST -H 'content-type: application/json' \
+  -d '{"from_input":0,"to_input":0,"transition_type":"cut","duration_ms":0}' $API/transition
+```
+
+Result: three tiles across the top, two on the second row. The tiling is a
+`cols = ceil(sqrt(N))` by `rows = ceil(N/cols)` grid, so five sources give a 3×2 grid with
+one empty cell. The grid **as a block** is centred in the region, but cells fill row-major
+left to right, so the short last row sits to the **left**, not centred under the row above.
+If you want the odd participant centred, do not use a single auto-tiling zone — give each
+row its own zone, or each source its own zone.
+
+### One participant full frame
+
+No PiP involved. Preview the input and take.
+
+```bash
+curl -X PUT -H 'content-type: application/json' -d '{"source":{"input":2}}' $API/preview
+curl -X POST -H 'content-type: application/json' \
+  -d '{"from_input":0,"to_input":0,"transition_type":"cut","duration_ms":0}' $API/transition
+```
+
+### Two up
+
+Same as five up with two sources. Two sources tile side by side, each cell aspect-fitted,
+the pair vertically centred with black above and below when the region is wider than two
+16:9 cells.
+
+```bash
+curl -X PUT -H 'content-type: application/json' -d '{
+  "bg": null, "transforms": {},
+  "zones": [ { "rect": null, "sources": [0,1] } ]
+}' $API/pip/1
+```
+
+### One plus three
+
+Do **not** express this as one big zone plus one auto-tiling zone of three. Three sources
+in a zone tile as a 2×2 grid with a hole, not as a vertical stack. Give each small box its
+own zone. Rects are normalised to the PiP region, `x`/`y` is the top-left corner.
+
+```bash
+curl -X PUT -H 'content-type: application/json' -d '{
+  "bg": null, "transforms": {},
+  "zones": [
+    {"rect": {"x":0.02,"y":0.14,"w":0.64,"h":0.72}, "sources":[0]},
+    {"rect": {"x":0.68,"y":0.06,"w":0.30,"h":0.28}, "sources":[1]},
+    {"rect": {"x":0.68,"y":0.36,"w":0.30,"h":0.28}, "sources":[2]},
+    {"rect": {"x":0.68,"y":0.66,"w":0.30,"h":0.28}, "sources":[3]}
+  ]
+}' $API/pip/0
+```
+
+### Background plus boxes
+
+Set `bg` to fill the whole region behind the zones. Useful for a full-frame speaker with
+two guests boxed over the corner. Zones can carry a border, which draws outside the picture
+edge so it never covers content.
+
+```bash
+curl -X PUT -H 'content-type: application/json' -d '{
+  "bg": 0, "transforms": {},
+  "zones": [
+    {"rect": {"x":0.62,"y":0.06,"w":0.34,"h":0.26}, "sources":[1],
+     "border": {"color":"#FFCC00","width":4}},
+    {"rect": {"x":0.62,"y":0.36,"w":0.34,"h":0.26}, "sources":[2],
+     "border": {"color":"#FFCC00","width":4}}
+  ]
+}' $API/pip/1
+```
+
+---
+
+## 3. Editing the PiP that is on air
+
+**It is safe, and it is not a cut.** Changing zones on the PiP currently on PGM produces an
+animated re-tile: every source that stays in the composition slides and scales from its old
+box to its new one over about 250 ms, sources that are leaving fade out, sources that are
+arriving fade in. No black frame, no flash, no dropped frame. Frame-by-frame inspection of
+a full mirror-image layout change (big box moved from left to right, three small boxes moved
+from right to left) showed a smooth eight-frame move with every source visible throughout.
+
+So the choice between editing on air and preview-then-take is editorial, not technical:
+
+- **Edit on air** when you want the audience to see the move — opening a box for a guest who
+  just joined, dropping a box when someone leaves. It reads as a deliberate animated
+  rearrangement, which is what a viewer expects from a video call layout.
+- **Preview then take** when you want the change to be invisible until you commit, or when
+  you are building something complex and do not want half-finished states on air. Editing
+  the PiP that is on PVW provably does not touch PGM: a full re-layout of the preview PiP
+  left every program frame unchanged.
+
+Preview-then-take is therefore **not mandatory**. It is the right habit for anything you
+are still composing, and unnecessary for a single deliberate move.
+
+---
+
+## 4. What each take actually looks like
+
+`transition_type` accepts `cut`, `fade`, `slide_left`, `slide_right`, `slide_up`,
+`slide_down`. What you get depends on whether a PiP is involved.
+
+| From → To | `transition_type` | What the audience sees |
+|---|---|---|
+| anything → anything | `cut` (or `duration_ms: 0`) | One-frame switch. Verified: last frame of the old look, next frame the new look, nothing between. |
+| input → input | `fade` | A true dissolve. Frames mid-transition show both pictures blended. |
+| PiP → PiP, **no shared sources** | `fade` | A true dissolve between the two compositions. |
+| PiP → anything, **sharing a source** | `fade` | **Not a dissolve.** The shared source animates from its old box to its new one — going from a four-up to that participant full frame reads as a zoom-in, with the other tiles covered as the box grows. |
+| either bus is a PiP | `slide_*` | Silently downgraded to `fade`. The server logs the downgrade; the HTTP response reports the transition that actually ran in `actual_transition_type`. |
+
+The shared-source case is the one that surprises people. The engine animates pads, not
+pictures: a source present in both the outgoing and incoming composition is treated as
+*moving*, and only sources exclusive to one side cross-fade. If you want a genuine dissolve
+out of a multi-box layout, take to a composition that shares no inputs with it, or use a
+cut.
+
+Check `actual_transition_type` in the response if you care which one ran.
+
+---
+
+## 5. Failure modes
+
+### A zone names a seat that is not publishing
+
+**Nothing warns you, and the layout does not re-flow.** The call succeeds, the layout keeps
+a cell for that participant, and the cell is simply empty. A five-up including one absent
+seat renders as a 3×2 grid with a black hole where they would be — not as a tidy four-up.
+
+The fix is to rebuild the zone without that source, which re-tiles the remaining
+participants into a full 2×2. There is no automatic compaction.
+
+### A seat drops while it is on air
+
+**The tile freezes on its last frame and stays there indefinitely.** It does not go black,
+it is not removed, and the composition does not re-flow. On the rig the freeze followed the
+publisher's death within about two seconds — the measurement cannot separate the jitter
+buffer from the mixer's own output latency, so treat it as immediate. The frozen frame was
+still on air minutes later, long after the ingest session had been reaped for inactivity.
+
+This is the most dangerous failure in the set, because a frozen participant looks exactly
+like a still one. Two consequences for a live show:
+
+- Do not trust the program picture to tell you a seat is gone. Watch the ingest session
+  state or the per-seat block health instead.
+- The recovery is automatic: when the participant rejoins, their tile resumes in place with
+  no operator action and no layout change.
+
+If you need the seat gone from the picture, you must remove it from the zone yourself —
+which is a live edit and animates as described in §3.
+
+### A zone holds more sources than its capacity
+
+**Silently truncated, oldest first, and the API lies to you about it.** A zone with
+`"capacity": 2` and `"sources": [0,1,2]` renders inputs 1 and 2 only — input 0 is dropped
+because it is the oldest entry. No error, no warning. `GET .../pip/{idx}` reads back all
+three sources, so state and picture disagree: the state is the intent, the picture is the
+newest `capacity` entries.
+
+Capacity is a feature, not a guard — capacity 1 is "swap mode", where pushing a new source
+cross-fades it over the old one. If you do not want eviction, leave `capacity` unset.
+
+### Things that *are* rejected
+
+These all return HTTP 400 with a readable reason, before anything reaches the picture:
+
+| Request | Response |
+|---|---|
+| Zone source index ≥ number of inputs | `Zone source 5 out of range (num_inputs=5)` |
+| A zone source that is also the background | `Zone source 1 duplicates bg` |
+| The same source in two zones of one PiP | `Zone source 1 appears in more than one zone` |
+| Border colour that is not `#RRGGBB`/`#RRGGBBAA` | `Invalid border color "red"` |
+| PiP index ≥ `num_pips` | `PiP index 7 out of range (configured: 2)` |
+| Preview to an input or PiP that does not exist | `Input 9 out of range (max 4)` |
+
+Rects are **clamped**, not rejected — a rect running past the region edge is silently
+pulled back inside. More than 15 overlay sources across all zones of one PiP is rejected,
+but that ceiling is unreachable on a mixer with fewer than 16 inputs.
+
+---
+
+## 6. Verifying what is actually on air
+
+**A 200 is not evidence.** Every claim in this guide was checked against program frames,
+and two of the findings (the shared-source "fade", the frozen dropped seat) look completely
+correct from the API side.
+
+Two things make verification reliable:
+
+1. **Give every source a visible clock.** A frozen tile is indistinguishable from a live
+   one unless the picture itself is moving. Burning a running timecode into each
+   participant feed turns "is this seat alive?" into something you can read off a single
+   frame. Two seats reading the same time and one reading an older time is the whole
+   diagnosis.
+2. **Tap the program output to a file** rather than capturing it over the network. Adding a
+   video encoder plus a recorder block fed from the mixer's PGM output gives frame-accurate
+   material with no transport in the way, and the recorder's split endpoint closes a
+   segment on demand so you can read it while the show continues.
+
+Expect the recording to sit a couple of seconds behind your API calls — the mixer's output
+queue plus the encoder. Wait 6–10 s after a move before closing the segment, or the moment
+you care about lands in the next file.
+
+One environment caveat worth knowing: on the macOS development rig, pulling the program
+with a GStreamer WHEP client failed ICE negotiation every time, roughly two seconds into
+the session, after the first connectivity check had already succeeded. The same client
+against a plain standalone WHEP sink on the same machine worked. This was not chased down;
+it is a capture-path problem, not a mixer problem, and the file tap sidesteps it entirely.
+
+---
+
+## 7. Quick reference
+
+```bash
+API=http://127.0.0.1:8123/api/flows/$FLOW/blocks/$BLOCK
+
+# Read everything: both buses, every PiP composition
+curl -s $API/state
+
+# Read one PiP (useful for saving a look you want to restore later)
+curl -s $API/pip/0
+
+# Build a look on an off-air PiP
+curl -X PUT -H 'content-type: application/json' -d '{"bg":null,"transforms":{},"zones":[...]}' $API/pip/0
+
+# Preview it
+curl -X PUT -H 'content-type: application/json' -d '{"source":{"pip":0}}' $API/preview
+
+# Take it
+curl -X POST -H 'content-type: application/json' \
+  -d '{"from_input":0,"to_input":0,"transition_type":"cut","duration_ms":0}' $API/transition
+```
+
+`GET .../pip/{idx}` and `PUT .../pip/{idx}` use the same shape, so a GET is how you snapshot
+a look and a PUT is how you restore it. Saving the four or five looks a show needs as JSON
+files, and replaying them by PUT, is the whole of a producer's cue stack.

--- a/docs/PRODUCER_SWITCHING_API_GUIDE.md
+++ b/docs/PRODUCER_SWITCHING_API_GUIDE.md
@@ -188,7 +188,7 @@ are still composing, and unnecessary for a single deliberate move.
 | anything → anything | `cut` (or `duration_ms: 0`) | One-frame switch. Verified: last frame of the old look, next frame the new look, nothing between. |
 | input → input | `fade` | A true dissolve. Frames mid-transition show both pictures blended. |
 | PiP → PiP, **no shared sources** | `fade` | A true dissolve between the two compositions. |
-| PiP → anything, **sharing a source** | `fade` | **Not a dissolve.** The shared source animates from its old box to its new one — going from a four-up to that participant full frame reads as a zoom-in, with the other tiles covered as the box grows. |
+| PiP → anything, **sharing a source** | `fade` | **Not a dissolve.** The shared source animates from its old box to its new one — going from a four-up to that participant full frame reads as a zoom-in, with the other tiles covered as the box grows. Reported back as `actual_transition_type: "morph"`. |
 | either bus is a PiP | `slide_*` | Silently downgraded to `fade`. The server logs the downgrade; the HTTP response reports the transition that actually ran in `actual_transition_type`. |
 
 The shared-source case is the one that surprises people. The engine animates pads, not
@@ -197,7 +197,8 @@ pictures: a source present in both the outgoing and incoming composition is trea
 out of a multi-box layout, take to a composition that shares no inputs with it, or use a
 cut.
 
-Check `actual_transition_type` in the response if you care which one ran.
+`actual_transition_type` in the take response always names what ran — `cut`, `fade`,
+or `morph` — so a control surface can label the move without replaying this table.
 
 ---
 
@@ -215,18 +216,28 @@ participants into a full 2×2. There is no automatic compaction.
 ### A seat drops while it is on air
 
 **The tile freezes on its last frame and stays there indefinitely.** It does not go black,
-it is not removed, and the composition does not re-flow. On the rig the freeze followed the
-publisher's death within about two seconds — the measurement cannot separate the jitter
-buffer from the mixer's own output latency, so treat it as immediate. The frozen frame was
-still on air minutes later, long after the ingest session had been reaped for inactivity.
+it is not removed, and the composition does not re-flow. The last frame arrives about a
+quarter of a second after the publisher dies, which is the jitter buffer draining, and then
+the picture stops. The frozen frame was still on air minutes later, long after the ingest
+session had been reaped for inactivity.
 
 This is the most dangerous failure in the set, because a frozen participant looks exactly
-like a still one. Two consequences for a live show:
+like a still one. **Do not use the program picture to decide whether a seat is alive.** Use
+`input_media_age_ms` from `GET .../state`, which reports milliseconds since each input last
+delivered a frame to the mixer:
 
-- Do not trust the program picture to tell you a seat is gone. Watch the ingest session
-  state or the per-seat block health instead.
-- The recovery is automatic: when the participant rejoins, their tile resumes in place with
-  no operator action and no layout change.
+```jsonc
+"input_media_age_ms": [ 24, 24, 7727, 24, null ]
+//                       ^live ^live  ^^^^ frozen 7.7s   ^never published
+```
+
+A live 30 fps source sits in the tens of milliseconds. Anything past a second or so is a
+seat that has stopped, and `null` is a seat that has never published at all. The counter is
+stamped from the mixer's own input pads, so it covers every kind of input, not just WHIP
+seats, and it measures what actually determines the picture.
+
+Recovery is automatic: when the participant rejoins, their tile resumes in place with no
+operator action and no layout change, and the age drops back to single-frame values.
 
 If you need the seat gone from the picture, you must remove it from the zone yourself —
 which is a live edit and animates as described in §3.
@@ -273,7 +284,8 @@ Two things make verification reliable:
    one unless the picture itself is moving. Burning a running timecode into each
    participant feed turns "is this seat alive?" into something you can read off a single
    frame. Two seats reading the same time and one reading an older time is the whole
-   diagnosis.
+   diagnosis. `input_media_age_ms` answers the same question without a capture, and the
+   two agree; the burned clock is what proves the field is telling the truth.
 2. **Tap the program output to a file** rather than capturing it over the network. Adding a
    video encoder plus a recorder block fed from the mixer's PGM output gives frame-accurate
    material with no transport in the way, and the recorder's split endpoint closes a
@@ -283,11 +295,21 @@ Expect the recording to sit a couple of seconds behind your API calls — the mi
 queue plus the encoder. Wait 6–10 s after a move before closing the segment, or the moment
 you care about lands in the next file.
 
-One environment caveat worth knowing: on the macOS development rig, pulling the program
-with a GStreamer WHEP client failed ICE negotiation every time, roughly two seconds into
-the session, after the first connectivity check had already succeeded. The same client
-against a plain standalone WHEP sink on the same machine worked. This was not chased down;
-it is a capture-path problem, not a mixer problem, and the file tap sidesteps it entirely.
+If you would rather pull the program over WHEP than tap it to a file, **use `whepsrc`, not
+`whepclientsrc`**:
+
+```bash
+gst-launch-1.0 -e whepsrc whep-endpoint="http://127.0.0.1:8123/whep/program-video" \
+  ! queue ! decodebin ! videoconvert ! videorate ! video/x-raw,framerate=1/1 \
+  ! pngenc ! multifilesink location="frames/f_%03d.png"
+```
+
+`whepclientsrc`, the newer `webrtcsrc`-based client, could not complete ICE against
+Strom's WHEP output on the macOS rig — it reached one successful connectivity check, then
+the server side stopped answering and it gave up about eight seconds in. `whepsrc` pulls
+the identical endpoint without trouble, which is also why Strom's own WHEP *input* block
+defaults to the `whepsrc` implementation. Treat this as a client-element choice, not a
+server problem.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ Common questions are answered in the [FAQ](FAQ.md).
 ## Using Strom
 
 - [VISION_MIXER_OPERATOR_GUIDE.md](VISION_MIXER_OPERATOR_GUIDE.md) — broadcast PVW/PGM switcher: transitions, DSK, PiP, multiview.
+- [PRODUCER_SWITCHING_API_GUIDE.md](PRODUCER_SWITCHING_API_GUIDE.md) — driving the vision mixer over HTTP: PiP layout recipes, on-air edits, failure modes.
 - [AUDIO_MIXER_OPERATOR_GUIDE.md](AUDIO_MIXER_OPERATOR_GUIDE.md) — audio mixing console signal flow and operation.
 - [HTML_RENDER.md](HTML_RENDER.md) — render web pages as video sources (CEF / `strom-full`).
 - [STREAM_SYNCHRONIZATION.md](STREAM_SYNCHRONIZATION.md) — aligning multiple inputs with PTP/NTP clocks.

--- a/docs/VISION_MIXER_OPERATOR_GUIDE.md
+++ b/docs/VISION_MIXER_OPERATOR_GUIDE.md
@@ -263,6 +263,10 @@ just like a regular input.
 
 ### 4.3 How the operator configures a PiP
 
+> Driving the same compositions from a control surface or script instead of the page?
+> See the [Producer Switching over the API guide](PRODUCER_SWITCHING_API_GUIDE.md) for
+> the call-by-call recipes, what an on-air layout edit looks like, and the failure modes.
+
 A PiP is configured at runtime from the **operator control page** served
 by the backend. Press **Edit** on a PiP row to open the layout editor —
 two side-by-side panels:

--- a/openapi.json
+++ b/openapi.json
@@ -11526,6 +11526,18 @@
             },
             "description": "Current per-input video effects (length = configured `num_inputs`).\nEmpty when the FX engine is unavailable."
           },
+          "input_media_age_ms": {
+            "type": "array",
+            "items": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int64",
+              "minimum": 0
+            },
+            "description": "Milliseconds since each input last delivered a frame to the mixer\n(length = configured `num_inputs`). `None` for an input that has never\ndelivered one. A value that keeps growing marks a frozen input: the\ncompositor repeats its last frame, so a source that stopped looks the\nsame on air as one that is motionless."
+          },
           "input_resolutions": {
             "type": "array",
             "items": {

--- a/types/src/api.rs
+++ b/types/src/api.rs
@@ -1297,6 +1297,13 @@ pub struct VisionMixerState {
     /// Current master (PGM) video effect.
     #[serde(default)]
     pub master_effect: crate::effects::VideoEffect,
+    /// Milliseconds since each input last delivered a frame to the mixer
+    /// (length = configured `num_inputs`). `None` for an input that has never
+    /// delivered one. A value that keeps growing marks a frozen input: the
+    /// compositor repeats its last frame, so a source that stopped looks the
+    /// same on air as one that is motionless.
+    #[serde(default)]
+    pub input_media_age_ms: Vec<Option<u64>>,
 }
 
 /// Request to set the multiview overlay alpha on a vision mixer block.


### PR DESCRIPTION
## What

Two vision mixer changes from exercising the producer switching workflow on a five-seat
meeting rig:

1. `actual_transition_type` reports `morph` when a take animated a shared source instead
   of dissolving.
2. Vision mixer state carries `input_media_age_ms`, so a frozen input can be told apart
   from a motionless one.

**Stacked on #798**, which adds the guide this amends. A cross-fork PR cannot base on a
fork-only branch, so #798's commit shows here too and the diff narrows once it merges.
Review the last four commits.

## Why

**The take reported a move as a dissolve.** The PiP-aware path animates pads, not
pictures: a source in both compositions moves into its new box, and only sources
exclusive to one side cross-fade. Taking a four-up to that participant full frame reads
as a zoom. That is deliberate, but the path reported `fade` for every non-cut take, so a
caller asking for a dissolve was told it got one. Behaviour is unchanged; only the report
is accurate. On the rig: four-up to a member of it now reports `morph`; disjoint PiPs and
input-to-input still report `fade`; the existing `slide_*` downgrade still reports `fade`.

**A dropped participant stays on air as a still frame.** The compositor repeats an
input's last frame indefinitely, so a lost connection looks exactly like someone sitting
motionless and persists after the ingest session is reaped. `input_media_age_ms` gives
milliseconds since each input last delivered a frame:

```jsonc
"input_media_age_ms": [ 24, 24, 7727, 24, null ]
//                       ^live ^live  ^^^^ frozen 7.7s   ^never published
```

Stamping at the mixer's own sink pads covers every input type, not only WHIP seats, and
measures what actually decides the picture. Killing one publisher produced 1.8s → 29.9s
on that input while three live neighbours stayed under 30 ms, and the age returned to
25 ms on rejoin.

## Risk the reviewer should weigh

These are BUFFER probes, the hottest path in the pipeline. The callback reads the
monotonic clock and stores one relaxed atomic: no lock, no allocation, no formatting, no
state lookup. The overlay state is captured as an `Arc`, not looked up per buffer, and is
not a GStreamer object, so the closure forms no reference cycle with the pipeline. Five
inputs at 30 fps is 150 stores per second. I did not A/B measure the cost.

## Tests

Added: three covering the morph classification, one covering the age accessors, and
`activity_probes_stamp_buffers_from_a_running_compositor`, which runs a real `compositor`
and asserts the age is stamped from its buffers. I confirmed that last one is a real
guard by pointing the probes at a nonexistent pad name and watching it fail; the accessor
test alone passes either way. `compositor` is in gst-plugins-base, which CI installs.

Run: `cargo test --lib` (581 passing), `pipeline_lifecycle_test` (the leak guard),
`openapi_test`, `cargo fmt --check`, `cargo clippy --all-targets`. The OpenAPI snapshot
was updated intentionally for one additive optional field.

Not run: the rest of the integration suite, and CI on Linux. All of the above was macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
