### PR TITLE
fix(whip): stop asking a reconnecting publisher for needless keyframes

### DIFF
--- a/backend/src/api/whip_ingest.rs
+++ b/backend/src/api/whip_ingest.rs
@@ -7,7 +7,7 @@
 use crate::api::sdp_transform::{
     add_goog_remb, fix_video_bitrate_hints, strip_cvo_extension, strip_redundancy_codecs,
 };
-use crate::blocks::builtin::whip::create_whipserversrc_for_session;
+use crate::blocks::builtin::whip::{create_whipserversrc_for_session, CreatedSession};
 use crate::json_rejection::JsonBody;
 use crate::state::AppState;
 use crate::whip_session_manager::{NewWhipSession, WhipSessionManager};
@@ -132,11 +132,15 @@ pub async fn whip_post(
     // Allocate a slot for this session (pre-allocate with a temporary resource_id,
     // will be updated when we learn the real resource_id from the Location header)
     let temp_resource_id = uuid::Uuid::new_v4().to_string();
-    let slot = match config.allocate_slot(&temp_resource_id) {
+    let slot = match state
+        .whip_session_manager()
+        .allocate_slot_or_take_over(&config, &temp_resource_id)
+        .await
+    {
         Some(s) => s,
         None => {
             warn!(
-                "WHIP endpoint '{}': all {} slots occupied, rejecting client",
+                "WHIP endpoint '{}': all {} slots occupied by live sessions, rejecting client",
                 endpoint_id, config.max_sessions
             );
             return (
@@ -155,7 +159,12 @@ pub async fn whip_post(
     let cleanup_tx = state.whip_session_manager().cleanup_sender();
     let cleanup_sent = Arc::new(AtomicBool::new(false));
     let cleanup_sent_for_session = cleanup_sent.clone();
-    let (element, session_pipeline, port) = match tokio::task::spawn_blocking(move || {
+    let CreatedSession {
+        element,
+        session_pipeline,
+        port,
+        activity,
+    } = match tokio::task::spawn_blocking(move || {
         create_whipserversrc_for_session(
             &config_for_session,
             slot,
@@ -369,6 +378,7 @@ pub async fn whip_post(
                         endpoint_id: endpoint_id.clone(),
                         slot,
                         cleanup_sent,
+                        activity,
                     });
                 if !registered {
                     warn!(

--- a/backend/src/blocks/builder.rs
+++ b/backend/src/blocks/builder.rs
@@ -63,6 +63,23 @@ pub type BusWatchSetupFn = BusMessageConnectFn;
 /// The GStreamer element(s) to connect signals on are captured in the closure during build time.
 pub type ElementSetupFn = Box<dyn FnOnce(FlowId, EventBroadcaster) + Send + Sync>;
 
+/// A block that knows something about its own liveness that the flow's
+/// stalled-pad-task scan cannot see.
+///
+/// That scan finds a branch whose pad task was paused, which is how a *blocked*
+/// chain shows up. A chain that is simply never pushed to stalls nothing: every
+/// element in it sits idle and `PLAYING`, and there is no paused task to find.
+/// A block that can tell the difference reports it here.
+///
+/// Polled from the block health task; keep it cheap and free of GStreamer
+/// object references, which would keep the pipeline alive past drop.
+pub trait BlockLiveness: Send + Sync {
+    /// `Some(detail)` when the block is running but not delivering what it was
+    /// built to deliver. Becomes `BlockHealth::detail`, so phrase it for an
+    /// operator reading a log line.
+    fn failure(&self) -> Option<String>;
+}
+
 /// WHIP endpoint registration info (for WHIP Input blocks).
 #[derive(Debug, Clone)]
 pub struct WhipEndpointInfo {
@@ -104,6 +121,8 @@ pub struct BlockBuildContext {
     whip_endpoints: RefCell<Vec<WhipEndpointInfo>>,
     /// WHIP endpoint configs queued for session manager registration
     whip_endpoint_configs: RefCell<Vec<(String, WhipEndpointConfig)>>,
+    /// Per-block liveness reporters queued for the block health scan
+    block_liveness: RefCell<Vec<(String, Arc<dyn BlockLiveness>)>>,
     /// ICE servers for WebRTC NAT traversal (STUN/TURN URLs)
     ice_servers: Vec<String>,
     /// ICE transport policy ("all" or "relay")
@@ -131,6 +150,7 @@ impl BlockBuildContext {
             whep_endpoints: RefCell::new(Vec::new()),
             whip_endpoints: RefCell::new(Vec::new()),
             whip_endpoint_configs: RefCell::new(Vec::new()),
+            block_liveness: RefCell::new(Vec::new()),
             ice_servers,
             ice_transport_policy,
             dynamic_webrtcbins: Arc::new(Mutex::new(HashMap::new())),
@@ -154,6 +174,7 @@ impl BlockBuildContext {
             whep_endpoints: RefCell::new(Vec::new()),
             whip_endpoints: RefCell::new(Vec::new()),
             whip_endpoint_configs: RefCell::new(Vec::new()),
+            block_liveness: RefCell::new(Vec::new()),
             ice_servers,
             ice_transport_policy,
             dynamic_webrtcbins,
@@ -320,6 +341,21 @@ impl BlockBuildContext {
     /// Called after block expansion to register configs with the session manager.
     pub fn take_whip_endpoint_configs(&self) -> Vec<(String, WhipEndpointConfig)> {
         self.whip_endpoint_configs.borrow_mut().drain(..).collect()
+    }
+
+    /// Register a liveness reporter for a block instance.
+    ///
+    /// Called during build by blocks whose failure modes the stalled-pad-task
+    /// scan cannot see; see `BlockLiveness`.
+    pub fn register_block_liveness(&self, block_id: &str, reporter: Arc<dyn BlockLiveness>) {
+        self.block_liveness
+            .borrow_mut()
+            .push((block_id.to_string(), reporter));
+    }
+
+    /// Take all queued block liveness reporters.
+    pub fn take_block_liveness(&self) -> Vec<(String, Arc<dyn BlockLiveness>)> {
+        self.block_liveness.borrow_mut().drain(..).collect()
     }
 
     /// Register an element signal setup function to be called at pipeline start.

--- a/backend/src/blocks/builtin/whip.rs
+++ b/backend/src/blocks/builtin/whip.rs
@@ -1030,13 +1030,15 @@ pub fn create_whipserversrc_for_session(
                 let main_pipeline_for_ts = main_pipeline_weak.clone();
                 let media_for_log = media_type.to_string();
                 let activity_cb = activity_for_pads.clone();
+                // Resolved here, not per buffer: the pad's media type is fixed.
+                let pad_is_audio = media_type == "audio";
 
                 appsink.set_callbacks(
                     gst_app::AppSinkCallbacks::builder()
                         .new_sample(move |sink| {
                             // Mark the session live: read by its inactivity
                             // watchdog and by slot takeover
-                            activity_cb.touch();
+                            activity_cb.touch(pad_is_audio);
 
                             let sample = sink.pull_sample().map_err(|_| gst::FlowError::Eos)?;
                             let buffer = sample.buffer().ok_or(gst::FlowError::Error)?;

--- a/backend/src/blocks/builtin/whip.rs
+++ b/backend/src/blocks/builtin/whip.rs
@@ -318,11 +318,6 @@ fn build_whipserversrc(
     // the pipeline owns them.
     let mut slot_decodebins: Vec<Vec<gst::glib::WeakRef<gst::Element>>> = Vec::new();
 
-    // One flag per slot, set when decodebin exposes that slot's video pad.
-    // A session stops asking the publisher for keyframes once its flag flips.
-    let video_decoding: Arc<Vec<AtomicBool>> =
-        Arc::new((0..max_sessions).map(|_| AtomicBool::new(false)).collect());
-
     // One record per slot, one stamp per medium inside it, written by a probe on
     // that slot's output tees below. This is where a session's media becomes
     // usable to the flow, so this is where its liveness is measured; see
@@ -497,15 +492,9 @@ fn build_whipserversrc(
 
                 // decodebin has dynamic pads — connect pad-added to link to videoconvert
                 let videoconvert_weak = videoconvert.downgrade();
-                let video_decoding_for_pad = video_decoding.clone();
                 decodebin.connect_pad_added(move |_dec, src_pad| {
                     if src_pad.direction() != gst::PadDirection::Src {
                         return;
-                    }
-                    // Video is decoding: whoever is asking for keyframes on
-                    // this slot can stop.
-                    if let Some(flag) = video_decoding_for_pad.get(slot) {
-                        flag.store(true, Ordering::Relaxed);
                     }
                     if let Some(vc) = videoconvert_weak.upgrade() {
                         let sink = vc.static_pad("sink").unwrap();
@@ -586,7 +575,6 @@ fn build_whipserversrc(
             ice_transport_policy: ctx.ice_transport_policy().to_string(),
             pipeline_weak: gst::glib::WeakRef::new(),
             decode,
-            video_decoding,
             jitterbuffer_latency_ms,
             do_retransmission,
             dynamic_webrtcbin_store: ctx.dynamic_webrtcbin_store(),
@@ -883,13 +871,6 @@ pub fn create_whipserversrc_for_session(
     let slot_audio_appsrc: Option<gst_app::AppSrc> = config.slot_audio_appsrcs.get(slot).cloned();
     let slot_video_appsrc: Option<gst_app::AppSrc> = config.slot_video_appsrcs.get(slot).cloned();
 
-    // Re-arm the slot: this session has to prove for itself that video decodes.
-    // A previous session on the same slot left the flag set.
-    let video_decoding = config.video_decoding.clone();
-    if let Some(flag) = video_decoding.get(slot) {
-        flag.store(false, Ordering::Relaxed);
-    }
-
     // Shared timestamp offset for A/V sync across audio and video appsrcs.
     // Computed from the first buffer on either stream:
     //   offset = main_pipeline_running_time - buffer_pts
@@ -913,7 +894,7 @@ pub fn create_whipserversrc_for_session(
             Arc::new(SlotOutput::new(Instant::now()))
         }
     };
-    let activity = Arc::new(SessionActivity::new(Instant::now(), slot_output));
+    let activity = Arc::new(SessionActivity::new(Instant::now(), slot_output.clone()));
 
     // Inactivity watchdog. A background thread triggers cleanup once the session
     // has gone INACTIVITY_TIMEOUT without producing usable media — which covers
@@ -965,6 +946,7 @@ pub fn create_whipserversrc_for_session(
         let audio_connected = Arc::new(AtomicBool::new(false));
         let video_connected = Arc::new(AtomicBool::new(false));
         let activity_for_pads = activity.clone();
+        let slot_output_for_pads = slot_output.clone();
 
         whipserversrc.connect_pad_added(move |_src, pad| {
             let pad_name = pad.name();
@@ -1063,21 +1045,26 @@ pub fn create_whipserversrc_for_session(
                     // Ask for one. The event has to be sent here, on the WebRTC
                     // source's pad, because this is the only side of the
                     // appsink/appsrc boundary from which it reaches the
-                    // publisher. It stops as soon as video decodes, so a
-                    // healthy session is normally never asked at all.
+                    // publisher. It stops as soon as video decodes, so a healthy
+                    // session is asked once at most, before its first frame has
+                    // finished crossing the slot's decode chain.
                     let request_pad = pad.clone();
-                    let request_flag = video_decoding.clone();
+                    // Stop asking when *this session's* video comes out of the
+                    // slot's chain. `decodebin` exposing a pad is the wrong
+                    // signal: it happens once per flow, so on a reused slot the
+                    // pad is already there and no later session could ever be
+                    // seen to start. The slot's video stamp is reset when a
+                    // session claims the slot, so a reading of it is about this
+                    // session and no other.
+                    let request_output = slot_output_for_pads.clone();
                     let request_slot = slot;
                     if let Err(e) = std::thread::Builder::new()
                         .name(format!("whip-keyframe-{}", request_slot))
                         .spawn(move || {
                             let policy = keyframe_request::KeyframeRequestPolicy::default();
-                            let Some(flag) = request_flag.get(request_slot) else {
-                                return;
-                            };
                             let sent = keyframe_request::request_until_decoding(
                                 policy,
-                                flag,
+                                || request_output.stamp(Medium::Video).last() != 0,
                                 std::thread::sleep,
                                 |attempt| {
                                     debug!(
@@ -2209,6 +2196,107 @@ mod tests {
             std::thread::sleep(std::time::Duration::from_millis(20));
         }
         panic!("timed out waiting for {}", what);
+    }
+
+    /// A publisher that reconnects to a slot must not be asked for keyframes it
+    /// does not need.
+    ///
+    /// Every request forces a keyframe on the publisher's uplink, so a session
+    /// whose video is already decoding has to be left alone. The signal that says
+    /// so cannot be `decodebin` exposing a pad: that happens once per flow, so on
+    /// a slot that has carried a session before, the pad is already there and no
+    /// later session can ever be seen to start. The slot's video stamp can,
+    /// because claiming a slot clears it.
+    ///
+    /// This pins the stop condition, not the wiring that consults it.
+    #[test]
+    fn a_reconnecting_publisher_is_not_asked_for_keyframes() {
+        let _ = gst::init();
+
+        let ctx = BlockBuildContext::new(Vec::new(), "all".to_string());
+        let result = build_whipserversrc(
+            "whip-rearm-test",
+            &props(&[
+                ("mode", PropertyValue::String("video".to_string())),
+                ("decode", PropertyValue::Bool(true)),
+                ("max_sessions", PropertyValue::Int(1)),
+            ]),
+            &ctx,
+        )
+        .expect("build_whipserversrc failed");
+
+        let configs = ctx.take_whip_endpoint_configs();
+        let config = &configs[0].1;
+        let output = config.slot_output[0].clone();
+        let appsrc = config.slot_video_appsrcs[0].clone();
+
+        let pipeline = assemble(&result);
+        let sink = gst::ElementFactory::make("fakesink")
+            .property("async", false)
+            .property("sync", false)
+            .build()
+            .expect("fakesink is part of gstreamer core");
+        pipeline.add(&sink).expect("add fakesink");
+        let tee = result
+            .elements
+            .iter()
+            .find(|(id, _)| id.ends_with(":video_out_tee_0"))
+            .map(|(_, element)| element.clone())
+            .expect("the block builds an output tee per slot");
+        let tee_src = tee.request_pad_simple("src_%u").expect("tee src pad");
+        tee_src
+            .link(&sink.static_pad("sink").unwrap())
+            .expect("link tee to fakesink");
+
+        appsrc.set_caps(Some(
+            &gst::Caps::builder("video/x-raw")
+                .field("format", "I420")
+                .field("width", 64i32)
+                .field("height", 64i32)
+                .field("framerate", gst::Fraction::new(30, 1))
+                .build(),
+        ));
+        pipeline
+            .set_state(gst::State::Playing)
+            .expect("pipeline to PLAYING");
+
+        // First session on the slot.
+        assert_eq!(config.allocate_slot("first"), Some(0));
+        for index in 0..30 {
+            appsrc.push_buffer(i420_frame(index)).expect("push frame");
+        }
+        wait_for("the first session's video to reach the slot's tee", || {
+            output.stamp(Medium::Video).last() != 0
+        });
+        config.release_slot(0);
+
+        // The slot is reused. `SessionActivity::new` is what clears the stamps a
+        // session inherits, so go through it rather than resetting by hand.
+        assert_eq!(config.allocate_slot("second"), Some(0));
+        let _activity = SessionActivity::new(Instant::now(), output.clone());
+        assert_eq!(
+            output.stamp(Medium::Video).last(),
+            0,
+            "claiming the slot has to clear what the last session left behind"
+        );
+
+        for index in 30..60 {
+            appsrc.push_buffer(i420_frame(index)).expect("push frame");
+        }
+        wait_for("the second session's video to reach the slot's tee", || {
+            output.stamp(Medium::Video).last() != 0
+        });
+
+        // What the keyframe requester runs, with the real policy.
+        let sent = keyframe_request::request_until_decoding(
+            keyframe_request::KeyframeRequestPolicy::default(),
+            || output.stamp(Medium::Video).last() != 0,
+            |_| {},
+            |_| panic!("a session whose video is decoding was asked for a keyframe"),
+        );
+        assert_eq!(sent, 0);
+
+        let _ = pipeline.set_state(gst::State::Null);
     }
 
     /// The signal a WHIP slot is judged by has to mean "this session is producing

--- a/backend/src/blocks/builtin/whip.rs
+++ b/backend/src/blocks/builtin/whip.rs
@@ -16,7 +16,7 @@ use crate::blocks::{
 };
 use crate::gst::ice_preflight;
 use crate::gst::keyframe_request;
-use crate::whip_session_manager::{SessionCleanupRequest, WhipEndpointConfig};
+use crate::whip_session_manager::{SessionActivity, SessionCleanupRequest, WhipEndpointConfig};
 use gstreamer as gst;
 use gstreamer::prelude::*;
 use gstreamer_app as gst_app;
@@ -599,6 +599,17 @@ fn wait_for_inactivity(
     }
 }
 
+/// A whipserversrc session that has been created and is playing, handed back to
+/// the HTTP handler so it can register the session with the manager.
+pub struct CreatedSession {
+    pub element: gst::Element,
+    pub session_pipeline: gst::Pipeline,
+    /// Internal port the session's whipserversrc is listening on.
+    pub port: u16,
+    /// Liveness handle, shared with the appsink callbacks that feed the slot.
+    pub activity: Arc<SessionActivity>,
+}
+
 /// Create a new whipserversrc element for a single WHIP client session.
 ///
 /// Each session runs in its own isolated GStreamer pipeline to avoid
@@ -608,7 +619,6 @@ fn wait_for_inactivity(
 /// Media is bridged to the main pipeline via appsink→appsrc, where the
 /// appsrc targets are the pre-built slot elements.
 ///
-/// Returns (element, session_pipeline, port) on success.
 /// `cleanup_sent` is owned by the caller so it can be handed to the session
 /// manager alongside the session: every teardown path sets it, which both
 /// suppresses duplicate cleanup requests and stops this session's inactivity
@@ -618,7 +628,7 @@ pub fn create_whipserversrc_for_session(
     slot: usize,
     cleanup_tx: tokio::sync::mpsc::UnboundedSender<SessionCleanupRequest>,
     cleanup_sent: Arc<AtomicBool>,
-) -> Result<(gst::Element, gst::Pipeline, u16), String> {
+) -> Result<CreatedSession, String> {
     // Allocate a free port
     let listener =
         TcpListener::bind("127.0.0.1:0").map_err(|e| format!("Failed to find free port: {}", e))?;
@@ -828,6 +838,13 @@ pub fn create_whipserversrc_for_session(
     // that (recycled) port pending cleanup for nothing.
     let last_buffer_epoch = Instant::now();
     let last_buffer_ms = Arc::new(AtomicU64::new(0));
+    // Same two values, in the shape the session manager reads them: it has to be
+    // able to tell a slot with a live publisher behind it from one whose
+    // publisher went away without a WHIP DELETE.
+    let activity = Arc::new(SessionActivity::new(
+        last_buffer_epoch,
+        last_buffer_ms.clone(),
+    ));
     {
         let last_buffer_ms_watchdog = last_buffer_ms.clone();
         let cleanup_sent_watchdog = cleanup_sent.clone();
@@ -867,6 +884,7 @@ pub fn create_whipserversrc_for_session(
         let stream_counter = Arc::new(AtomicUsize::new(0));
         let audio_connected = Arc::new(AtomicBool::new(false));
         let video_connected = Arc::new(AtomicBool::new(false));
+        let activity_for_pads = activity.clone();
 
         whipserversrc.connect_pad_added(move |_src, pad| {
             let pad_name = pad.name();
@@ -1011,17 +1029,14 @@ pub fn create_whipserversrc_for_session(
                 let ts_offset = shared_ts_offset.clone();
                 let main_pipeline_for_ts = main_pipeline_weak.clone();
                 let media_for_log = media_type.to_string();
-                let last_buffer_ms_cb = last_buffer_ms.clone();
-                let last_buffer_epoch_cb = last_buffer_epoch;
+                let activity_cb = activity_for_pads.clone();
 
                 appsink.set_callbacks(
                     gst_app::AppSinkCallbacks::builder()
                         .new_sample(move |sink| {
-                            // Update inactivity watchdog
-                            last_buffer_ms_cb.store(
-                                last_buffer_epoch_cb.elapsed().as_millis() as u64,
-                                Ordering::Relaxed,
-                            );
+                            // Mark the session live: read by its inactivity
+                            // watchdog and by slot takeover
+                            activity_cb.touch();
 
                             let sample = sink.pull_sample().map_err(|_| gst::FlowError::Eos)?;
                             let buffer = sample.buffer().ok_or(gst::FlowError::Error)?;
@@ -1116,7 +1131,12 @@ pub fn create_whipserversrc_for_session(
         slot
     );
 
-    Ok((whipserversrc, session_pipeline, port))
+    Ok(CreatedSession {
+        element: whipserversrc,
+        session_pipeline,
+        port,
+        activity,
+    })
 }
 
 // ============================================================================

--- a/backend/src/blocks/builtin/whip.rs
+++ b/backend/src/blocks/builtin/whip.rs
@@ -17,7 +17,8 @@ use crate::blocks::{
 use crate::gst::ice_preflight;
 use crate::gst::keyframe_request;
 use crate::whip_session_manager::{
-    ActivityStamp, SessionActivity, SessionCleanupRequest, WhipEndpointConfig,
+    Medium, SessionActivity, SessionCleanupRequest, SlotOutput, WhipEndpointConfig,
+    WhipSlotLiveness,
 };
 use gstreamer as gst;
 use gstreamer::prelude::*;
@@ -185,7 +186,7 @@ fn prepare_idle_decodebin(decodebin: &gst::Element) {
     decodebin.set_locked_state(true);
 }
 
-/// Stamp a slot's output activity for every buffer that reaches its tee.
+/// Stamp one medium of a slot's output for every buffer that reaches its tee.
 ///
 /// The tee's sink pad is the far end of the slot's chain: with `decode=true`
 /// everything upstream of it — `decodebin`, the converter — has already run, and
@@ -200,7 +201,7 @@ fn prepare_idle_decodebin(decodebin: &gst::Element) {
 /// BUFFER probes fire per buffer, so the callback is one clock read (`Instant`
 /// takes the vDSO fast path) and a couple of relaxed atomic ops — no lock, no
 /// allocation, no formatting. See `ActivityStamp::touch`.
-fn stamp_slot_output(tee: &gst::Element, stamp: Arc<ActivityStamp>, slot: usize, media: &str) {
+fn stamp_slot_output(tee: &gst::Element, output: Arc<SlotOutput>, slot: usize, medium: Medium) {
     let Some(sink_pad) = tee.static_pad("sink") else {
         // Unreachable: a tee has a static sink pad. If it ever were not, nothing
         // would stamp this slot and every session on it would be reaped once its
@@ -208,7 +209,8 @@ fn stamp_slot_output(tee: &gst::Element, stamp: Arc<ActivityStamp>, slot: usize,
         // and this line is what makes it diagnosable.
         warn!(
             "WHIP Input: slot {} {} output tee has no sink pad, cannot track its liveness",
-            slot, media
+            slot,
+            medium.as_str()
         );
         return;
     };
@@ -217,7 +219,7 @@ fn stamp_slot_output(tee: &gst::Element, stamp: Arc<ActivityStamp>, slot: usize,
         // element that started to would silently stop the stamp otherwise.
         gst::PadProbeType::BUFFER | gst::PadProbeType::BUFFER_LIST,
         move |_pad, _info| {
-            stamp.touch();
+            output.touch(medium);
             gst::PadProbeReturn::Ok
         },
     );
@@ -321,13 +323,14 @@ fn build_whipserversrc(
     let video_decoding: Arc<Vec<AtomicBool>> =
         Arc::new((0..max_sessions).map(|_| AtomicBool::new(false)).collect());
 
-    // One stamp per slot, written by a probe on that slot's output tees below.
-    // This is where a session's media becomes usable to the flow, so this is
-    // where its liveness is measured; see `SessionActivity`. All slots share an
-    // epoch — the stamps are only ever compared against their own readings.
+    // One record per slot, one stamp per medium inside it, written by a probe on
+    // that slot's output tees below. This is where a session's media becomes
+    // usable to the flow, so this is where its liveness is measured; see
+    // `SessionActivity` and `WhipSlotLiveness`. All slots share an epoch — the
+    // stamps are only ever compared against their own readings.
     let output_epoch = Instant::now();
-    let slot_output: Vec<Arc<ActivityStamp>> = (0..max_sessions)
-        .map(|_| Arc::new(ActivityStamp::new(output_epoch)))
+    let slot_output: Vec<Arc<SlotOutput>> = (0..max_sessions)
+        .map(|_| Arc::new(SlotOutput::new(output_epoch)))
         .collect();
 
     for (slot, output_stamp) in slot_output.iter().enumerate() {
@@ -434,7 +437,7 @@ fn build_whipserversrc(
                 ));
             }
 
-            stamp_slot_output(&audio_out_tee, output_stamp.clone(), slot, "audio");
+            stamp_slot_output(&audio_out_tee, output_stamp.clone(), slot, Medium::Audio);
 
             slot_audio_appsrcs.push(appsrc.clone());
             elements.push((appsrc_id, appsrc.upcast()));
@@ -535,7 +538,7 @@ fn build_whipserversrc(
                 ));
             }
 
-            stamp_slot_output(&video_out_tee, output_stamp.clone(), slot, "video");
+            stamp_slot_output(&video_out_tee, output_stamp.clone(), slot, Medium::Video);
 
             slot_video_appsrcs.push(appsrc.clone());
             elements.push((appsrc_id, appsrc.upcast()));
@@ -557,6 +560,19 @@ fn build_whipserversrc(
     ctx.register_whip_endpoint(instance_id, &endpoint_id, 0, mode);
 
     let slot_assignments = Arc::new(RwLock::new(vec![None; max_sessions]));
+
+    // A slot medium that stops producing stalls nothing — its appsrc is simply
+    // never pushed to — so the flow's stalled-pad-task scan cannot see it. Hand
+    // the scan the stamps instead; see `WhipSlotLiveness`.
+    ctx.register_block_liveness(
+        instance_id,
+        Arc::new(WhipSlotLiveness::new(
+            endpoint_id.clone(),
+            mode,
+            slot_output.clone(),
+            slot_assignments.clone(),
+        )),
+    );
 
     // Store endpoint config for the session manager (will be wired up in start_flow)
     ctx.register_whip_endpoint_config(
@@ -885,16 +901,16 @@ pub fn create_whipserversrc_for_session(
     // from one whose publisher went away without a WHIP DELETE, or whose media
     // arrives but never comes out of the slot's chain.
     let slot_output = match config.slot_output.get(slot) {
-        Some(stamp) => stamp.clone(),
+        Some(output) => output.clone(),
         None => {
-            // Unreachable: one stamp is built per slot. The orphan below is
+            // Unreachable: one record is built per slot. The orphan below is
             // never written, so this session would be reaped once its decode
             // grace ran out; this line is what makes that diagnosable.
             warn!(
-                "WHIP Input: no output stamp for slot {}, its liveness cannot be tracked",
+                "WHIP Input: no output stamps for slot {}, its liveness cannot be tracked",
                 slot
             );
-            Arc::new(ActivityStamp::new(Instant::now()))
+            Arc::new(SlotOutput::new(Instant::now()))
         }
     };
     let activity = Arc::new(SessionActivity::new(Instant::now(), slot_output));
@@ -1921,6 +1937,7 @@ fn setup_incoming_rtp_handler(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::whip_session_manager::{ActivityStamp, SlotMediumStall, StallThresholds};
 
     fn props(entries: &[(&str, PropertyValue)]) -> HashMap<String, PropertyValue> {
         entries
@@ -2034,7 +2051,7 @@ mod tests {
     fn watchdog_detects_inactivity_within_one_poll_of_the_timeout() {
         let timeout = std::time::Duration::from_millis(1000);
         let stop = Arc::new(AtomicBool::new(false));
-        let output = Arc::new(ActivityStamp::new(Instant::now()));
+        let output = Arc::new(SlotOutput::new(Instant::now()));
         let activity = Arc::new(SessionActivity::new(Instant::now(), output.clone()));
 
         // One buffer that both arrives and comes out of the slot, then nothing.
@@ -2042,7 +2059,7 @@ mod tests {
         std::thread::spawn(move || {
             std::thread::sleep(std::time::Duration::from_millis(150));
             publisher.touch_ingress(true);
-            output.touch();
+            output.touch(Medium::Audio);
         });
 
         let started = Instant::now();
@@ -2076,7 +2093,7 @@ mod tests {
         // and only the stop flag can end the wait.
         let activity = Arc::new(SessionActivity::new(
             Instant::now(),
-            Arc::new(ActivityStamp::new(Instant::now())),
+            Arc::new(SlotOutput::new(Instant::now())),
         ));
 
         let setter = stop.clone();
@@ -2112,7 +2129,8 @@ mod tests {
                 std::time::Duration::from_secs(60),
                 std::time::Duration::ZERO,
             ),
-            Arc::new(ActivityStamp::new(Instant::now())),
+            ActivityStamp::new(Instant::now()),
+            Arc::new(SlotOutput::new(Instant::now())),
         ));
 
         let publisher_stop = Arc::new(AtomicBool::new(false));
@@ -2221,13 +2239,10 @@ mod tests {
 
         let configs = ctx.take_whip_endpoint_configs();
         let config = &configs[0].1;
-        let stamp = config.slot_output[0].clone();
+        let output = config.slot_output[0].clone();
+        let stamp = || output.stamp(Medium::Video).last();
         let appsrc = config.slot_video_appsrcs[0].clone();
-        assert_eq!(
-            stamp.last(),
-            0,
-            "nothing has gone through the slot's chain yet"
-        );
+        assert_eq!(stamp(), 0, "nothing has gone through the slot's chain yet");
 
         let pipeline = assemble(&result);
 
@@ -2275,7 +2290,7 @@ mod tests {
             appsrc.push_buffer(i420_frame(index)).expect("push frame");
         }
         wait_for("the slot's stamp to follow the first frames", || {
-            stamp.last() != 0
+            stamp() != 0
         });
 
         // Now stall the slot's consumer, the way a stuck recorder branch does:
@@ -2298,7 +2313,7 @@ mod tests {
             appsrc.push_buffer(i420_frame(index)).expect("push frame");
         }
         std::thread::sleep(std::time::Duration::from_millis(300));
-        let stalled_at = stamp.last();
+        let stalled_at = stamp();
 
         for index in 60..150 {
             appsrc.push_buffer(i420_frame(index)).expect("push frame");
@@ -2306,7 +2321,7 @@ mod tests {
         std::thread::sleep(std::time::Duration::from_millis(500));
 
         assert_eq!(
-            stamp.last(),
+            stamp(),
             stalled_at,
             "media kept arriving at the slot's appsrc while its chain was blocked; \
              the stamp must not move for media that never gets through"
@@ -2319,6 +2334,244 @@ mod tests {
         pipeline
             .set_state(gst::State::Null)
             .expect("pipeline to NULL");
+    }
+
+    fn s16_audio_chunk(index: u64) -> gst::Buffer {
+        // 10 ms of stereo 48 kHz S16LE, the shape an Opus decoder produces.
+        let mut buffer = gst::Buffer::with_size(480 * 2 * 2).expect("allocate audio chunk");
+        {
+            let buffer = buffer.get_mut().unwrap();
+            buffer.set_pts(gst::ClockTime::from_mseconds(index * 10));
+            buffer.set_duration(gst::ClockTime::from_mseconds(10));
+        }
+        buffer
+    }
+
+    /// A seat whose audio is dead while its video still flows must be reported as
+    /// exactly that.
+    ///
+    /// This is the failure a single per-slot stamp cannot express: either medium
+    /// stamping it keeps the whole seat looking alive, so a commentator whose
+    /// microphone has stopped reaching the mix holds its slot to the end of the
+    /// session with every liveness signal green. Nothing else catches it either —
+    /// an unfed chain stalls no pad task, so the flow's health scan has nothing
+    /// to find, and the publisher is still connected so the watchdog has no
+    /// reason to act.
+    ///
+    /// Drives the real probes on the real block's output tees and reads the real
+    /// reporter the health scan polls. Thresholds are the only thing the test
+    /// supplies, so it does not have to wait out the production budgets.
+    #[test]
+    fn a_slot_reports_the_medium_that_died_while_the_other_kept_flowing() {
+        let _ = gst::init();
+
+        let ctx = BlockBuildContext::new(Vec::new(), "all".to_string());
+        let result = build_whipserversrc(
+            "whip-half-dead-test",
+            &props(&[
+                ("mode", PropertyValue::String("audio_video".to_string())),
+                // RTP passthrough: appsrc straight to the slot's output tee, so
+                // the test drives the tee probes without standing up a decoder.
+                ("decode", PropertyValue::Bool(false)),
+                ("max_sessions", PropertyValue::Int(1)),
+            ]),
+            &ctx,
+        )
+        .expect("build_whipserversrc failed");
+
+        // The block has to hand the health scan a reporter, or none of this is
+        // visible to an operator however well the stamps work.
+        let reporters = ctx.take_block_liveness();
+        assert_eq!(
+            reporters
+                .iter()
+                .map(|(block_id, _)| block_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["whip-half-dead-test"],
+            "the block must register itself with the block health scan"
+        );
+        assert!(
+            reporters[0].1.failure().is_none(),
+            "an endpoint with no session yet has nothing to report"
+        );
+
+        let configs = ctx.take_whip_endpoint_configs();
+        let config = &configs[0].1;
+        // The same shared state the block just registered, read with thresholds
+        // short enough for a test.
+        let liveness = WhipSlotLiveness::new(
+            "half-dead-test".to_string(),
+            StreamMode::AudioVideo,
+            config.slot_output.clone(),
+            config.slot_assignments.clone(),
+        );
+        let thresholds = StallThresholds {
+            audio: std::time::Duration::from_millis(200),
+            video: std::time::Duration::from_millis(500),
+            absent: std::time::Duration::from_millis(200),
+        };
+
+        let audio_src = config.slot_audio_appsrcs[0].clone();
+        let video_src = config.slot_video_appsrcs[0].clone();
+        audio_src.set_caps(Some(
+            &gst::Caps::builder("audio/x-raw")
+                .field("format", "S16LE")
+                .field("rate", 48000i32)
+                .field("channels", 2i32)
+                .field("layout", "interleaved")
+                .build(),
+        ));
+        video_src.set_caps(Some(
+            &gst::Caps::builder("video/x-raw")
+                .field("format", "I420")
+                .field("width", 64i32)
+                .field("height", 64i32)
+                .field("framerate", gst::Fraction::new(30, 1))
+                .build(),
+        ));
+
+        let pipeline = assemble(&result);
+        pipeline
+            .set_state(gst::State::Playing)
+            .expect("pipeline to PLAYING");
+        assert_eq!(
+            config.allocate_slot("half-dead-test"),
+            Some(0),
+            "the endpoint has one free slot"
+        );
+
+        // A publisher whose video arrives and whose audio never does.
+        let video_index = std::sync::atomic::AtomicU64::new(0);
+        let push_video = |count: u64| {
+            for _ in 0..count {
+                video_src
+                    .push_buffer(i420_frame(video_index.fetch_add(1, Ordering::Relaxed)))
+                    .expect("push frame");
+            }
+        };
+        push_video(30);
+        wait_for("the slot's video stamp to move", || {
+            liveness
+                .stalls(thresholds)
+                .iter()
+                .any(|stall| stall.medium == Medium::Audio && stall.silent_for.is_none())
+        });
+        assert_eq!(
+            liveness.stalls(thresholds),
+            vec![SlotMediumStall {
+                slot: 0,
+                medium: Medium::Audio,
+                silent_for: None,
+            }],
+            "video is flowing and audio has never arrived; only the audio is dead"
+        );
+
+        // Audio starts: the seat is whole again and must report nothing.
+        for index in 0..30 {
+            audio_src
+                .push_buffer(s16_audio_chunk(index))
+                .expect("push audio chunk");
+        }
+        push_video(15);
+        wait_for("both media to be flowing", || {
+            liveness.stalls(thresholds).is_empty()
+        });
+
+        // Audio stops for good while video carries on: the failure this exists
+        // for, and the one the session's own watchdog will never see.
+        wait_for("the audio to fall past its threshold", || {
+            push_video(5);
+            liveness
+                .stalls(thresholds)
+                .iter()
+                .any(|stall| stall.medium == Medium::Audio && stall.silent_for.is_some())
+        });
+        let stalls = liveness.stalls(thresholds);
+        assert_eq!(stalls.len(), 1, "video is healthy: {:?}", stalls);
+        assert_eq!(stalls[0].slot, 0);
+        assert_eq!(stalls[0].medium, Medium::Audio);
+        assert!(
+            stalls[0].to_string().contains("no audio"),
+            "an operator has to be able to grep the medium out of the detail: {}",
+            stalls[0]
+        );
+
+        pipeline
+            .set_state(gst::State::Null)
+            .expect("pipeline to NULL");
+    }
+
+    /// An unoccupied slot produces nothing by definition, and a whole seat going
+    /// quiet is the inactivity watchdog's business. Neither may be reported as a
+    /// half-dead slot, or every idle endpoint in a flow paints the flow red.
+    #[test]
+    fn an_empty_or_wholly_idle_slot_is_not_reported() {
+        let _ = gst::init();
+
+        let assignments = Arc::new(RwLock::new(vec![None]));
+        let output = Arc::new(SlotOutput::new(Instant::now()));
+        let liveness = WhipSlotLiveness::new(
+            "quiet-test".to_string(),
+            StreamMode::AudioVideo,
+            vec![output.clone()],
+            assignments.clone(),
+        );
+        let thresholds = StallThresholds {
+            audio: std::time::Duration::from_millis(50),
+            video: std::time::Duration::from_millis(50),
+            absent: std::time::Duration::from_millis(50),
+        };
+
+        output.touch(Medium::Video);
+        std::thread::sleep(std::time::Duration::from_millis(120));
+        assert!(
+            liveness.stalls(thresholds).is_empty(),
+            "nobody is in the slot"
+        );
+
+        assignments.write().unwrap()[0] = Some("someone".to_string());
+        assert!(
+            liveness.stalls(thresholds).is_empty(),
+            "both media are silent, so this is a seat that left, not a half-dead one"
+        );
+    }
+
+    /// A seat that loses its transport stops both media at once, and their
+    /// budgets differ: audio is past its own seconds before video is anywhere
+    /// near its own. That window must not read as a dead microphone — the seat
+    /// is simply gone, and the inactivity watchdog owns it.
+    #[test]
+    fn a_seat_that_stopped_altogether_is_not_reported_as_half_dead() {
+        let _ = gst::init();
+
+        let assignments = Arc::new(RwLock::new(vec![Some("gone".to_string())]));
+        let output = Arc::new(SlotOutput::new(Instant::now()));
+        let liveness = WhipSlotLiveness::new(
+            "dropped-test".to_string(),
+            StreamMode::AudioVideo,
+            vec![output.clone()],
+            assignments,
+        );
+        // The shape of a real drop: audio's cadence is tight and video's is not,
+        // so audio's budget is much the shorter of the two.
+        let thresholds = StallThresholds {
+            audio: std::time::Duration::from_millis(100),
+            video: std::time::Duration::from_millis(2000),
+            absent: std::time::Duration::from_millis(100),
+        };
+
+        // Both stamps stop within a frame interval of each other, as they do
+        // when the transport goes away.
+        output.touch(Medium::Audio);
+        std::thread::sleep(std::time::Duration::from_millis(30));
+        output.touch(Medium::Video);
+        std::thread::sleep(std::time::Duration::from_millis(400));
+
+        assert!(
+            liveness.stalls(thresholds).is_empty(),
+            "audio is well past its budget, but video outlived it by 30 ms, not by a              failure: {:?}",
+            liveness.stalls(thresholds)
+        );
     }
 
     /// The block property must reach the `WhipEndpointConfig` handed to the

--- a/backend/src/blocks/builtin/whip.rs
+++ b/backend/src/blocks/builtin/whip.rs
@@ -16,14 +16,16 @@ use crate::blocks::{
 };
 use crate::gst::ice_preflight;
 use crate::gst::keyframe_request;
-use crate::whip_session_manager::{SessionActivity, SessionCleanupRequest, WhipEndpointConfig};
+use crate::whip_session_manager::{
+    ActivityStamp, SessionActivity, SessionCleanupRequest, WhipEndpointConfig,
+};
 use gstreamer as gst;
 use gstreamer::prelude::*;
 use gstreamer_app as gst_app;
 use gstreamer_video as gst_video;
 use std::collections::HashMap;
 use std::net::TcpListener;
-use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI64, AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::Instant;
 use strom_types::block::StreamMode;
@@ -183,6 +185,44 @@ fn prepare_idle_decodebin(decodebin: &gst::Element) {
     decodebin.set_locked_state(true);
 }
 
+/// Stamp a slot's output activity for every buffer that reaches its tee.
+///
+/// The tee's sink pad is the far end of the slot's chain: with `decode=true`
+/// everything upstream of it — `decodebin`, the converter — has already run, and
+/// everything downstream is a flow consumer. A buffer here is media the flow can
+/// actually use, which is the thing the session's appsink cannot see. The appsink
+/// sits in the isolated session pipeline, upstream of all of this, so it stamps
+/// bytes arriving over the network and nothing more.
+///
+/// It is also where a stall shows up: a blocked consumer backs pressure up
+/// through the tee, and the probe simply stops firing while RTP keeps arriving.
+///
+/// BUFFER probes fire per buffer, so the callback is one clock read (`Instant`
+/// takes the vDSO fast path) and a couple of relaxed atomic ops — no lock, no
+/// allocation, no formatting. See `ActivityStamp::touch`.
+fn stamp_slot_output(tee: &gst::Element, stamp: Arc<ActivityStamp>, slot: usize, media: &str) {
+    let Some(sink_pad) = tee.static_pad("sink") else {
+        // Unreachable: a tee has a static sink pad. If it ever were not, nothing
+        // would stamp this slot and every session on it would be reaped once its
+        // decode grace ran out — recoverable, unlike a panic in a block build,
+        // and this line is what makes it diagnosable.
+        warn!(
+            "WHIP Input: slot {} {} output tee has no sink pad, cannot track its liveness",
+            slot, media
+        );
+        return;
+    };
+    sink_pad.add_probe(
+        // BUFFER_LIST as well: nothing on this chain batches today, but an
+        // element that started to would silently stop the stamp otherwise.
+        gst::PadProbeType::BUFFER | gst::PadProbeType::BUFFER_LIST,
+        move |_pad, _info| {
+            stamp.touch();
+            gst::PadProbeReturn::Ok
+        },
+    );
+}
+
 /// Build WHIP Input per-slot output chains.
 ///
 /// At build time, per-slot chains are created in the main pipeline:
@@ -281,7 +321,16 @@ fn build_whipserversrc(
     let video_decoding: Arc<Vec<AtomicBool>> =
         Arc::new((0..max_sessions).map(|_| AtomicBool::new(false)).collect());
 
-    for slot in 0..max_sessions {
+    // One stamp per slot, written by a probe on that slot's output tees below.
+    // This is where a session's media becomes usable to the flow, so this is
+    // where its liveness is measured; see `SessionActivity`. All slots share an
+    // epoch — the stamps are only ever compared against their own readings.
+    let output_epoch = Instant::now();
+    let slot_output: Vec<Arc<ActivityStamp>> = (0..max_sessions)
+        .map(|_| Arc::new(ActivityStamp::new(output_epoch)))
+        .collect();
+
+    for (slot, output_stamp) in slot_output.iter().enumerate() {
         let mut decodebins_for_slot: Vec<gst::glib::WeakRef<gst::Element>> = Vec::new();
 
         // Audio chain for this slot
@@ -385,6 +434,8 @@ fn build_whipserversrc(
                 ));
             }
 
+            stamp_slot_output(&audio_out_tee, output_stamp.clone(), slot, "audio");
+
             slot_audio_appsrcs.push(appsrc.clone());
             elements.push((appsrc_id, appsrc.upcast()));
             elements.push((audio_out_tee_id, audio_out_tee));
@@ -484,6 +535,8 @@ fn build_whipserversrc(
                 ));
             }
 
+            stamp_slot_output(&video_out_tee, output_stamp.clone(), slot, "video");
+
             slot_video_appsrcs.push(appsrc.clone());
             elements.push((appsrc_id, appsrc.upcast()));
             elements.push((video_out_tee_id, video_out_tee));
@@ -526,6 +579,7 @@ fn build_whipserversrc(
             slot_audio_appsrcs,
             slot_video_appsrcs,
             slot_decodebins,
+            slot_output,
             slot_assignments,
         },
     );
@@ -538,7 +592,8 @@ fn build_whipserversrc(
     })
 }
 
-/// How long a session may go without a buffer before the watchdog tears it down.
+/// How long a session may go without producing usable media before the watchdog
+/// tears it down; see `SessionActivity::idle`.
 const INACTIVITY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
 /// How often the watchdog re-checks its stop flag while waiting.
@@ -564,14 +619,17 @@ fn wait_until_deadline_or_stop(stop: &AtomicBool, deadline: Instant) -> bool {
     }
 }
 
-/// Block until the session has been idle for `timeout`, or until `stop` is set.
+/// Block until the session has gone `timeout` without producing usable media, or
+/// until `stop` is set.
 ///
 /// Returns `Some(idle_ms)` once the idle time crosses `timeout`, or `None` if a
 /// teardown path set `stop` first.
 ///
-/// `last_buffer_ms` is the arrival time of the most recent buffer on any stream,
-/// as milliseconds since `epoch`; 0 means no buffer has arrived yet, in which case
-/// the session is still negotiating and the clock has not started.
+/// Idle comes from `SessionActivity::idle`, so this reaps both a publisher that
+/// went away and a seat that keeps receiving RTP while nothing comes out of its
+/// slot's chain. `None` from it means the session must not be judged yet — still
+/// negotiating, or inside the grace a decoder gets before its first frame — and
+/// the clock has not started.
 ///
 /// Idle is re-evaluated on every `WATCHDOG_POLL` tick. The poll must stay finer than
 /// `timeout`: evaluating once per `timeout` puts detection anywhere between one and
@@ -579,22 +637,18 @@ fn wait_until_deadline_or_stop(stop: &AtomicBool, deadline: Instant) -> bool {
 /// the next one.
 fn wait_for_inactivity(
     stop: &AtomicBool,
-    last_buffer_ms: &AtomicU64,
-    epoch: Instant,
+    activity: &SessionActivity,
     timeout: std::time::Duration,
 ) -> Option<u64> {
-    let timeout_ms = timeout.as_millis() as u64;
     loop {
         if wait_until_deadline_or_stop(stop, Instant::now() + WATCHDOG_POLL) {
             return None;
         }
-        let last = last_buffer_ms.load(Ordering::Relaxed);
-        if last == 0 {
+        let Some(idle) = activity.idle() else {
             continue;
-        }
-        let idle_ms = (epoch.elapsed().as_millis() as u64).saturating_sub(last);
-        if idle_ms >= timeout_ms {
-            return Some(idle_ms);
+        };
+        if idle >= timeout {
+            return Some(idle.as_millis() as u64);
         }
     }
 }
@@ -826,27 +880,38 @@ pub fn create_whipserversrc_for_session(
     // i64::MIN means "not yet computed".
     let shared_ts_offset = Arc::new(AtomicI64::new(i64::MIN));
 
-    // Inactivity watchdog: tracks when the last buffer arrived on any stream.
-    // A background thread checks this and triggers cleanup if no data arrives
-    // for INACTIVITY_TIMEOUT (covers the case where ICE disconnect
-    // notification doesn't fire from the isolated session pipeline).
+    // Liveness for this session, in the shape the session manager reads it: it
+    // has to tell a slot that still has a publisher producing media behind it
+    // from one whose publisher went away without a WHIP DELETE, or whose media
+    // arrives but never comes out of the slot's chain.
+    let slot_output = match config.slot_output.get(slot) {
+        Some(stamp) => stamp.clone(),
+        None => {
+            // Unreachable: one stamp is built per slot. The orphan below is
+            // never written, so this session would be reaped once its decode
+            // grace ran out; this line is what makes that diagnosable.
+            warn!(
+                "WHIP Input: no output stamp for slot {}, its liveness cannot be tracked",
+                slot
+            );
+            Arc::new(ActivityStamp::new(Instant::now()))
+        }
+    };
+    let activity = Arc::new(SessionActivity::new(Instant::now(), slot_output));
+
+    // Inactivity watchdog. A background thread triggers cleanup once the session
+    // has gone INACTIVITY_TIMEOUT without producing usable media — which covers
+    // both a transport that went away without the ICE disconnect notification
+    // reaching this isolated session pipeline, and a seat that keeps receiving
+    // RTP while nothing decodes out the other end. Neither is worth a slot.
     //
     // The wait is sliced rather than one long sleep so that `cleanup_sent` — set by
     // the ICE callback and by every teardown path in the session manager — ends the
     // thread promptly. A watchdog that outlived its session would send a cleanup
     // request for a port the manager no longer knows, and the manager would then mark
     // that (recycled) port pending cleanup for nothing.
-    let last_buffer_epoch = Instant::now();
-    let last_buffer_ms = Arc::new(AtomicU64::new(0));
-    // Same two values, in the shape the session manager reads them: it has to be
-    // able to tell a slot with a live publisher behind it from one whose
-    // publisher went away without a WHIP DELETE.
-    let activity = Arc::new(SessionActivity::new(
-        last_buffer_epoch,
-        last_buffer_ms.clone(),
-    ));
     {
-        let last_buffer_ms_watchdog = last_buffer_ms.clone();
+        let activity_watchdog = activity.clone();
         let cleanup_sent_watchdog = cleanup_sent.clone();
         let cleanup_tx_watchdog = cleanup_tx.clone();
         std::thread::Builder::new()
@@ -856,20 +921,19 @@ pub fn create_whipserversrc_for_session(
                 // finished with this session first.
                 let Some(idle_ms) = wait_for_inactivity(
                     &cleanup_sent_watchdog,
-                    &last_buffer_ms_watchdog,
-                    last_buffer_epoch,
+                    &activity_watchdog,
                     INACTIVITY_TIMEOUT,
                 ) else {
                     return;
                 };
                 if !cleanup_sent_watchdog.swap(true, Ordering::SeqCst) {
                     info!(
-                        "WHIP Input: Inactivity timeout ({}ms idle) on port {}, triggering cleanup",
+                        "WHIP Input: Inactivity timeout ({}ms without usable media) on port {}, triggering cleanup",
                         idle_ms, port
                     );
                     let _ = cleanup_tx_watchdog.send(SessionCleanupRequest {
                         port,
-                        reason: format!("inactivity ({}ms idle)", idle_ms),
+                        reason: format!("inactivity ({}ms without usable media)", idle_ms),
                     });
                 }
             })
@@ -1036,9 +1100,10 @@ pub fn create_whipserversrc_for_session(
                 appsink.set_callbacks(
                     gst_app::AppSinkCallbacks::builder()
                         .new_sample(move |sink| {
-                            // Mark the session live: read by its inactivity
-                            // watchdog and by slot takeover
-                            activity_cb.touch(pad_is_audio);
+                            // Media arriving from the publisher. Half of this
+                            // session's liveness; the other half is stamped on
+                            // the slot's output tee in the main pipeline.
+                            activity_cb.touch_ingress(pad_is_audio);
 
                             let sample = sink.pull_sample().map_err(|_| gst::FlowError::Eos)?;
                             let buffer = sample.buffer().ok_or(gst::FlowError::Error)?;
@@ -1960,8 +2025,8 @@ mod tests {
     /// A dead session must be detected one poll interval after the inactivity
     /// threshold, not one whole extra timeout later.
     ///
-    /// The last buffer here lands 150 ms after the epoch, so the threshold is crossed
-    /// at ~1150 ms — just *after* a once-per-timeout check at 1000 ms would have run,
+    /// The session's only buffer lands 150 ms in, so the threshold is crossed at
+    /// ~1150 ms — just *after* a once-per-timeout check at 1000 ms would have run,
     /// and far enough past it that scheduler slop cannot blur the two. Evaluating once
     /// per `timeout` instead of once per poll fails this test: it detects at ~2000 ms,
     /// where polling detects at ~1250 ms.
@@ -1969,11 +2034,19 @@ mod tests {
     fn watchdog_detects_inactivity_within_one_poll_of_the_timeout() {
         let timeout = std::time::Duration::from_millis(1000);
         let stop = Arc::new(AtomicBool::new(false));
-        let epoch = Instant::now();
-        let last_buffer_ms = Arc::new(AtomicU64::new(150));
+        let output = Arc::new(ActivityStamp::new(Instant::now()));
+        let activity = Arc::new(SessionActivity::new(Instant::now(), output.clone()));
+
+        // One buffer that both arrives and comes out of the slot, then nothing.
+        let publisher = activity.clone();
+        std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(150));
+            publisher.touch_ingress(true);
+            output.touch();
+        });
 
         let started = Instant::now();
-        let idle_ms = wait_for_inactivity(&stop, &last_buffer_ms, epoch, timeout)
+        let idle_ms = wait_for_inactivity(&stop, &activity, timeout)
             .expect("watchdog must report inactivity, not a stop");
         let detection = started.elapsed();
 
@@ -1999,10 +2072,12 @@ mod tests {
     #[test]
     fn watchdog_inactivity_wait_gives_up_when_stopped() {
         let stop = Arc::new(AtomicBool::new(false));
-        let epoch = Instant::now();
-        // Still negotiating: no buffer has arrived, so the idle clock never starts
+        // Still negotiating: nothing has arrived, so the idle clock never starts
         // and only the stop flag can end the wait.
-        let last_buffer_ms = Arc::new(AtomicU64::new(0));
+        let activity = Arc::new(SessionActivity::new(
+            Instant::now(),
+            Arc::new(ActivityStamp::new(Instant::now())),
+        ));
 
         let setter = stop.clone();
         std::thread::spawn(move || {
@@ -2011,12 +2086,7 @@ mod tests {
         });
 
         let started = Instant::now();
-        let result = wait_for_inactivity(
-            &stop,
-            &last_buffer_ms,
-            epoch,
-            std::time::Duration::from_secs(30),
-        );
+        let result = wait_for_inactivity(&stop, &activity, std::time::Duration::from_secs(30));
 
         assert!(
             result.is_none(),
@@ -2027,6 +2097,228 @@ mod tests {
             "wait took {:?} — it is not polling the stop flag",
             started.elapsed()
         );
+    }
+
+    /// The watchdog reads the same signal slot takeover does, so it reaps a seat
+    /// that keeps receiving RTP while nothing comes out of its slot's chain.
+    /// Measured on arriving bytes alone such a seat never goes idle, and holds
+    /// its slot for as long as its publisher keeps sending.
+    #[test]
+    fn watchdog_reaps_a_session_that_receives_media_it_never_decodes() {
+        let stop = Arc::new(AtomicBool::new(false));
+        // Receiving for a minute already, so the decoder's grace is long spent.
+        let activity = Arc::new(SessionActivity::from_stamps(
+            ActivityStamp::backdated(
+                std::time::Duration::from_secs(60),
+                std::time::Duration::ZERO,
+            ),
+            Arc::new(ActivityStamp::new(Instant::now())),
+        ));
+
+        let publisher_stop = Arc::new(AtomicBool::new(false));
+        let receiving = activity.clone();
+        let stop_receiving = publisher_stop.clone();
+        std::thread::spawn(move || {
+            while !stop_receiving.load(Ordering::SeqCst) {
+                receiving.touch_ingress(true);
+                std::thread::sleep(std::time::Duration::from_millis(20));
+            }
+        });
+
+        // The wait never returns while the seat counts as live, so it runs on its
+        // own thread: a regression has to fail this test, not hang it.
+        let (tx, rx) = std::sync::mpsc::channel();
+        let watched = activity.clone();
+        std::thread::spawn(move || {
+            let _ = tx.send(wait_for_inactivity(&stop, &watched, INACTIVITY_TIMEOUT));
+        });
+        let reaped = rx.recv_timeout(std::time::Duration::from_secs(5));
+        publisher_stop.store(true, Ordering::SeqCst);
+
+        assert!(
+            matches!(reaped, Ok(Some(ms)) if ms >= INACTIVITY_TIMEOUT.as_millis() as u64),
+            "a seat receiving RTP it never decodes must be reaped, not held \
+             alive by its arriving-bytes counter: {:?}",
+            reaped
+        );
+    }
+
+    /// Assemble a built block's elements into a pipeline the way the flow
+    /// builder does: add them all, then make the links the block asked for.
+    /// `decodebin`'s src pad is dynamic and is linked by the block's own
+    /// `pad-added` handler, so it is deliberately absent from `internal_links`.
+    fn assemble(result: &BlockBuildResult) -> gst::Pipeline {
+        let pipeline = gst::Pipeline::new();
+        for (_, element) in &result.elements {
+            pipeline.add(element).expect("add element");
+        }
+        let by_id: HashMap<&str, &gst::Element> = result
+            .elements
+            .iter()
+            .map(|(id, element)| (id.as_str(), element))
+            .collect();
+        for (from, to) in &result.internal_links {
+            let src = by_id[from.element_id.as_str()]
+                .static_pad(from.pad_name.as_deref().unwrap_or("src"))
+                .expect("source pad");
+            let sink = by_id[to.element_id.as_str()]
+                .static_pad(to.pad_name.as_deref().unwrap_or("sink"))
+                .expect("sink pad");
+            src.link(&sink).expect("internal link");
+        }
+        pipeline
+    }
+
+    fn i420_frame(index: u64) -> gst::Buffer {
+        let mut buffer = gst::Buffer::with_size(64 * 64 * 3 / 2).expect("allocate frame");
+        {
+            let buffer = buffer.get_mut().unwrap();
+            buffer.set_pts(gst::ClockTime::from_mseconds(index * 33));
+            buffer.set_duration(gst::ClockTime::from_mseconds(33));
+        }
+        buffer
+    }
+
+    /// Poll until `check` holds, up to five seconds. Buffers cross a pipeline on
+    /// its own streaming threads, so a test cannot read the result straight after
+    /// pushing.
+    fn wait_for(what: &str, check: impl Fn() -> bool) {
+        let deadline = Instant::now() + std::time::Duration::from_secs(5);
+        while Instant::now() < deadline {
+            if check() {
+                return;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        }
+        panic!("timed out waiting for {}", what);
+    }
+
+    /// The signal a WHIP slot is judged by has to mean "this session is producing
+    /// media the flow can use", so it is stamped at the end of the slot's chain,
+    /// past `decodebin` and the converter. The session's own appsink is upstream
+    /// of all of that, in a separate pipeline, and only ever sees bytes arrive.
+    ///
+    /// Both halves matter, so this checks both: media that gets through stamps
+    /// the slot, and media that arrives but cannot get through does not. The
+    /// second half is the seat that holds a slot for 45 minutes while receiving
+    /// RTP the whole time — here its tee is blocked by a stuck consumer, which is
+    /// what a stalled recorder branch does to it in a real flow.
+    #[test]
+    fn the_slot_stamp_follows_media_out_of_the_decode_chain_not_into_it() {
+        let _ = gst::init();
+
+        let ctx = BlockBuildContext::new(Vec::new(), "all".to_string());
+        let result = build_whipserversrc(
+            "whip-liveness-test",
+            &props(&[
+                ("mode", PropertyValue::String("video".to_string())),
+                ("decode", PropertyValue::Bool(true)),
+                ("max_sessions", PropertyValue::Int(1)),
+            ]),
+            &ctx,
+        )
+        .expect("build_whipserversrc failed");
+
+        let configs = ctx.take_whip_endpoint_configs();
+        let config = &configs[0].1;
+        let stamp = config.slot_output[0].clone();
+        let appsrc = config.slot_video_appsrcs[0].clone();
+        assert_eq!(
+            stamp.last(),
+            0,
+            "nothing has gone through the slot's chain yet"
+        );
+
+        let pipeline = assemble(&result);
+
+        // The slot's `decodebin` is built with its state locked so an unclaimed
+        // slot cannot hold the pipeline short of PLAYING. Claiming the slot is
+        // what unlocks it, exactly as a WHIP POST does.
+        assert_eq!(
+            config.allocate_slot("test-session"),
+            Some(0),
+            "the endpoint starts with its only slot free"
+        );
+
+        // Somewhere for the slot's tee to push, and a pad this test can block to
+        // stall the chain.
+        let sink = gst::ElementFactory::make("fakesink")
+            .property("async", false)
+            .property("sync", false)
+            .build()
+            .expect("fakesink is part of gstreamer core");
+        pipeline.add(&sink).expect("add fakesink");
+        let tee = result
+            .elements
+            .iter()
+            .find(|(id, _)| id.ends_with(":video_out_tee_0"))
+            .map(|(_, element)| element.clone())
+            .expect("the block builds an output tee per slot");
+        let tee_src = tee.request_pad_simple("src_%u").expect("tee src pad");
+        tee_src
+            .link(&sink.static_pad("sink").unwrap())
+            .expect("link tee to fakesink");
+
+        appsrc.set_caps(Some(
+            &gst::Caps::builder("video/x-raw")
+                .field("format", "I420")
+                .field("width", 64i32)
+                .field("height", 64i32)
+                .field("framerate", gst::Fraction::new(30, 1))
+                .build(),
+        ));
+        pipeline
+            .set_state(gst::State::Playing)
+            .expect("pipeline to PLAYING");
+
+        for index in 0..30 {
+            appsrc.push_buffer(i420_frame(index)).expect("push frame");
+        }
+        wait_for("the slot's stamp to follow the first frames", || {
+            stamp.last() != 0
+        });
+
+        // Now stall the slot's consumer, the way a stuck recorder branch does:
+        // hold the streaming thread inside a probe until the test releases it.
+        // Returning from the callback would let the buffer straight through.
+        let release = Arc::new(AtomicBool::new(false));
+        let gate = release.clone();
+        let block = tee_src
+            .add_probe(gst::PadProbeType::BLOCK_DOWNSTREAM, move |_, _| {
+                while !gate.load(Ordering::Relaxed) {
+                    std::thread::sleep(std::time::Duration::from_millis(5));
+                }
+                gst::PadProbeReturn::Ok
+            })
+            .expect("block probe");
+        // One buffer still reaches the tee's sink pad — it is the one that runs
+        // into the block — and stamps the slot on its way. Let it, and read the
+        // stamp afterwards: everything behind it is stuck upstream.
+        for index in 30..60 {
+            appsrc.push_buffer(i420_frame(index)).expect("push frame");
+        }
+        std::thread::sleep(std::time::Duration::from_millis(300));
+        let stalled_at = stamp.last();
+
+        for index in 60..150 {
+            appsrc.push_buffer(i420_frame(index)).expect("push frame");
+        }
+        std::thread::sleep(std::time::Duration::from_millis(500));
+
+        assert_eq!(
+            stamp.last(),
+            stalled_at,
+            "media kept arriving at the slot's appsrc while its chain was blocked; \
+             the stamp must not move for media that never gets through"
+        );
+
+        // Let the held streaming thread go before removing the probe: removing it
+        // waits for the callback to return.
+        release.store(true, Ordering::Relaxed);
+        tee_src.remove_probe(block);
+        pipeline
+            .set_state(gst::State::Null)
+            .expect("pipeline to NULL");
     }
 
     /// The block property must reach the `WhipEndpointConfig` handed to the

--- a/backend/src/blocks/mod.rs
+++ b/backend/src/blocks/mod.rs
@@ -8,8 +8,8 @@ pub mod storage;
 pub mod transforms;
 
 pub use builder::{
-    BlockBuildContext, BlockBuildError, BlockBuildResult, BlockBuilder, BusMessageConnectFn,
-    DynamicWebrtcbinStore, ElementSetupFn, WhepEndpointInfo, WhipEndpointInfo,
+    BlockBuildContext, BlockBuildError, BlockBuildResult, BlockBuilder, BlockLiveness,
+    BusMessageConnectFn, DynamicWebrtcbinStore, ElementSetupFn, WhepEndpointInfo, WhipEndpointInfo,
 };
 pub use registry::BlockRegistry;
 

--- a/backend/src/gst/block_expansion.rs
+++ b/backend/src/gst/block_expansion.rs
@@ -35,6 +35,8 @@ pub struct ExpandedPipeline {
     pub whip_endpoints: Vec<WhipEndpointInfo>,
     /// WHIP endpoint configs for session manager registration
     pub whip_endpoint_configs: Vec<(String, WhipEndpointConfig)>,
+    /// Per-block liveness reporters for the block health scan
+    pub block_liveness: Vec<(String, std::sync::Arc<dyn crate::blocks::BlockLiveness>)>,
 }
 
 /// Expand block instances into GStreamer elements using BlockBuilder trait.
@@ -211,6 +213,8 @@ pub async fn expand_blocks(
         );
     }
 
+    let block_liveness = ctx.take_block_liveness();
+
     debug!(
         "Block expansion complete: {} GStreamer elements, {} links, {} bus message handlers, {} element setups, {} elements with pad properties, {} WHEP endpoints, {} WHIP endpoints",
         gst_elements.len(),
@@ -231,6 +235,7 @@ pub async fn expand_blocks(
         whep_endpoints,
         whip_endpoints,
         whip_endpoint_configs,
+        block_liveness,
     })
 }
 

--- a/backend/src/gst/keyframe_request.rs
+++ b/backend/src/gst/keyframe_request.rs
@@ -20,10 +20,10 @@
 //!
 //! This module is the part worth testing: *when* to ask, and when to stop.
 //! Asking is cheap but not free — a forced keyframe is a bitrate spike — so a
-//! healthy session should never be asked at all, and a stalled one should be
-//! asked a bounded number of times and then left alone.
+//! healthy session should be asked at most once, while its first frames are still
+//! crossing the decode chain, and a stalled one should be asked a bounded number
+//! of times and then left alone.
 
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 /// How persistently to ask for a keyframe before giving up.
@@ -57,14 +57,14 @@ impl Default for KeyframeRequestPolicy {
 /// and without a pipeline. Returns the number of requests actually sent.
 pub fn request_until_decoding(
     policy: KeyframeRequestPolicy,
-    decoding: &AtomicBool,
+    decoding: impl Fn() -> bool,
     mut wait: impl FnMut(Duration),
     mut send: impl FnMut(u32),
 ) -> u32 {
     let mut sent = 0;
     for attempt in 1..=policy.attempts {
         wait(policy.interval);
-        if decoding.load(Ordering::Relaxed) {
+        if decoding() {
             break;
         }
         send(attempt);
@@ -76,6 +76,7 @@ pub fn request_until_decoding(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
 
     fn policy(attempts: u32) -> KeyframeRequestPolicy {
         KeyframeRequestPolicy {
@@ -90,7 +91,12 @@ mod tests {
     #[test]
     fn a_healthy_session_is_never_asked() {
         let decoding = AtomicBool::new(true);
-        let sent = request_until_decoding(policy(5), &decoding, |_| {}, |_| panic!("asked anyway"));
+        let sent = request_until_decoding(
+            policy(5),
+            || decoding.load(Ordering::Relaxed),
+            |_| {},
+            |_| panic!("asked anyway"),
+        );
         assert_eq!(sent, 0);
     }
 
@@ -100,7 +106,7 @@ mod tests {
         let decoding = AtomicBool::new(false);
         let sent = request_until_decoding(
             policy(5),
-            &decoding,
+            || decoding.load(Ordering::Relaxed),
             |_| decoding.store(true, Ordering::Relaxed),
             |_| panic!("asked after video started"),
         );
@@ -114,7 +120,7 @@ mod tests {
         let mut waits = 0;
         let sent = request_until_decoding(
             policy(5),
-            &decoding,
+            || decoding.load(Ordering::Relaxed),
             |_| waits += 1,
             |_| decoding.store(true, Ordering::Relaxed),
         );
@@ -132,7 +138,7 @@ mod tests {
         let mut attempts_seen = Vec::new();
         let sent = request_until_decoding(
             policy(5),
-            &decoding,
+            || decoding.load(Ordering::Relaxed),
             |_| {},
             |attempt| attempts_seen.push(attempt),
         );
@@ -146,7 +152,12 @@ mod tests {
     fn it_waits_once_per_attempt_and_not_after_the_last() {
         let decoding = AtomicBool::new(false);
         let mut waits = 0;
-        request_until_decoding(policy(3), &decoding, |_| waits += 1, |_| {});
+        request_until_decoding(
+            policy(3),
+            || decoding.load(Ordering::Relaxed),
+            |_| waits += 1,
+            |_| {},
+        );
         assert_eq!(waits, 3);
     }
 

--- a/backend/src/gst/pipeline/construction.rs
+++ b/backend/src/gst/pipeline/construction.rs
@@ -90,6 +90,8 @@ impl PipelineManager {
             cached_state: std::sync::Arc::new(std::sync::RwLock::new(PipelineState::Null)),
             qos_aggregator: QoSAggregator::new(),
             qos_broadcast_task: None,
+            block_health: std::sync::Arc::new(std::sync::RwLock::new(Vec::new())),
+            block_health_task: None,
             ptp_clock: None,
             ptp_stats: std::sync::Arc::new(std::sync::RwLock::new(None)),
             ntp_clock: None,

--- a/backend/src/gst/pipeline/construction.rs
+++ b/backend/src/gst/pipeline/construction.rs
@@ -100,6 +100,7 @@ impl PipelineManager {
             whep_endpoints: Vec::new(),
             whip_endpoints: Vec::new(),
             whip_endpoint_configs: Vec::new(),
+            block_liveness: Vec::new(),
             dynamic_webrtcbins: Arc::clone(&dynamic_webrtcbins),
             thumbnail_taps: crate::gst::new_tap_store(),
             thumbnail_deactivation_task: None,
@@ -235,6 +236,7 @@ impl PipelineManager {
         }
         manager.whip_endpoints = expanded.whip_endpoints;
         manager.whip_endpoint_configs = expanded.whip_endpoint_configs;
+        manager.block_liveness = expanded.block_liveness;
 
         // Analyze links and auto-insert tee elements where needed
         let all_links = expanded.links;

--- a/backend/src/gst/pipeline/health.rs
+++ b/backend/src/gst/pipeline/health.rs
@@ -49,14 +49,21 @@ fn first_stalled_pad(element: &gst::Element) -> Option<StalledPad> {
 
 /// Find the first paused pad task on `element` itself.
 ///
-/// Two kinds of legitimately paused task are excluded. An element held below
-/// `PLAYING` - a webrtcbin added for a newly connected WHEP consumer, say -
-/// pauses its tasks as part of that transition. And a pad that has seen EOS is
-/// finished by definition:
-/// `gst_base_src_loop` pauses its task on the way out for *every* reason
-/// including end of stream, and the element stays `PLAYING` afterwards, so a
-/// finite source that has played out would otherwise be reported as failed
-/// forever. The stall this looks for pushes no EOS.
+/// Three kinds of legitimately paused task are excluded.
+///
+/// An element held below `PLAYING` - a webrtcbin added for a newly connected
+/// WHEP consumer, say - pauses its tasks as part of that transition.
+///
+/// A pad that has seen EOS is finished by definition: `gst_base_src_loop` pauses
+/// its task on the way out for *every* reason including end of stream, and the
+/// element stays `PLAYING` afterwards, so a finite source that has played out
+/// would otherwise be reported as failed forever. The stall this looks for
+/// pushes no EOS.
+///
+/// An unlinked pad has no branch to report on. A `queue` feeding a block output
+/// that the flow leaves unconnected gets `not-linked` from its loop and parks
+/// the task there permanently - the vision mixer's `multiview_out` does exactly
+/// this whenever a flow uses only the program output.
 fn stalled_pad_on(element: &gst::Element) -> Option<StalledPad> {
     if element.current_state() != gst::State::Playing {
         return None;
@@ -67,6 +74,7 @@ fn stalled_pad_on(element: &gst::Element) -> Option<StalledPad> {
         .find(|pad| {
             pad.task_state() == gst::TaskState::Paused
                 && !pad.pad_flags().contains(gst::PadFlags::EOS)
+                && pad.peer().is_some()
         })
         .map(|pad| StalledPad {
             element: element.name().to_string(),
@@ -309,6 +317,46 @@ mod tests {
         flow
     }
 
+    /// videotestsrc -> tee, with one tee branch queued and left unconnected.
+    ///
+    /// Mirrors a block output the flow does not wire up - the vision mixer's
+    /// `multiview_out` is exactly this - where the queue's loop takes
+    /// `not-linked` and parks its task for good.
+    fn unwired_output_flow() -> Flow {
+        let mut flow = Flow::new("unwired output health test");
+        flow.elements = vec![
+            element(
+                "src",
+                "videotestsrc",
+                &[("is-live", PropertyValue::Bool(true))],
+            ),
+            element("split", "tee", &[]),
+            element("q_used", "queue", &[]),
+            element("sink", "fakesink", &[("sync", PropertyValue::Bool(false))]),
+            // Fed by the tee, going nowhere.
+            element("q_dangling", "queue", &[]),
+        ];
+        flow.links = vec![
+            Link {
+                from: "src".to_string(),
+                to: "split".to_string(),
+            },
+            Link {
+                from: "split".to_string(),
+                to: "q_used".to_string(),
+            },
+            Link {
+                from: "q_used".to_string(),
+                to: "sink".to_string(),
+            },
+            Link {
+                from: "split".to_string(),
+                to: "q_dangling".to_string(),
+            },
+        ];
+        flow
+    }
+
     /// videotestsrc with a fixed buffer count -> fakesink. Runs to EOS.
     fn finite_source_flow() -> Flow {
         let mut flow = Flow::new("eos health test");
@@ -336,6 +384,53 @@ mod tests {
             std::thread::sleep(Duration::from_millis(100));
         }
         condition()
+    }
+
+    /// A `queue` whose source pad is left unconnected takes `not-linked` from its
+    /// loop and parks the task while the element stays `PLAYING`. Blocks expose
+    /// optional outputs built this way, so reporting it would mark most flows
+    /// using them permanently failed.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn an_unwired_output_branch_is_not_reported_as_failed() {
+        gst::init().unwrap();
+
+        let mut manager = PipelineManager::new(
+            &unwired_output_flow(),
+            EventBroadcaster::default(),
+            &BlockRegistry::new("test_blocks.json"),
+            vec!["stun:stun.l.google.com:19302".to_string()],
+            "all".to_string(),
+            None,
+            std::path::PathBuf::from("./media"),
+            std::sync::Arc::new(std::sync::Mutex::new(HashMap::new())),
+        )
+        .expect("pipeline should build");
+
+        manager.start().expect("pipeline should start");
+        assert!(
+            wait_for(
+                || manager.get_state() == strom_types::PipelineState::Playing,
+                Duration::from_secs(10)
+            ),
+            "pipeline never reached Playing"
+        );
+
+        let went_failed = wait_for(
+            || {
+                manager
+                    .get_block_health()
+                    .iter()
+                    .any(|h| h.status == BlockHealthStatus::Failed)
+            },
+            HEALTH_POLL_INTERVAL * (CONFIRMATIONS_BEFORE_FAILED + 3),
+        );
+        assert!(
+            !went_failed,
+            "an unwired output branch must not read as failed: {:?}",
+            manager.get_block_health()
+        );
+
+        manager.stop().expect("pipeline should stop");
     }
 
     /// `gst_base_src_loop` pauses its pad task on the way out for every reason,

--- a/backend/src/gst/pipeline/health.rs
+++ b/backend/src/gst/pipeline/health.rs
@@ -41,9 +41,13 @@ fn first_stalled_pad(element: &gst::Element) -> Option<StalledPad> {
 
 /// Find the first paused pad task on `element` itself.
 ///
-/// Only elements that are themselves playing are considered. A sub-bin held in
-/// `PAUSED` inside a playing pipeline - a WebRTC session bin mid-setup, say -
-/// has paused pad tasks legitimately.
+/// Two kinds of legitimately paused task are excluded. An element held below
+/// `PLAYING` - a WebRTC session bin mid-setup, say - pauses its tasks as part of
+/// that transition. And a pad that has seen EOS is finished by definition:
+/// `gst_base_src_loop` pauses its task on the way out for *every* reason
+/// including end of stream, and the element stays `PLAYING` afterwards, so a
+/// finite source that has played out would otherwise be reported as failed
+/// forever. The stall this looks for pushes no EOS.
 fn stalled_pad_on(element: &gst::Element) -> Option<StalledPad> {
     if element.current_state() != gst::State::Playing {
         return None;
@@ -51,7 +55,10 @@ fn stalled_pad_on(element: &gst::Element) -> Option<StalledPad> {
     element
         .pads()
         .into_iter()
-        .find(|pad| pad.task_state() == gst::TaskState::Paused)
+        .find(|pad| {
+            pad.task_state() == gst::TaskState::Paused
+                && !pad.pad_flags().contains(gst::PadFlags::EOS)
+        })
         .map(|pad| StalledPad {
             element: element.name().to_string(),
             pad: pad.name().to_string(),
@@ -90,7 +97,7 @@ pub(crate) fn scan_block_health(elements: &HashMap<String, gst::Element>) -> Vec
         if let Some(stalled) = first_stalled_pad(element) {
             entry.status = BlockHealthStatus::Failed;
             entry.detail = Some(format!(
-                "pad task stopped on {}:{} - this branch is not passing data",
+                "pad task paused on {}:{} - this branch is not passing data",
                 stalled.element, stalled.pad
             ));
         }
@@ -101,6 +108,13 @@ pub(crate) fn scan_block_health(elements: &HashMap<String, gst::Element>) -> Vec
 
 /// How often the running pipeline is scanned for stalled pad tasks.
 const HEALTH_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// Consecutive scans a block must look stalled before it is reported.
+///
+/// Pad tasks are briefly paused for legitimate reasons - a flushing seek, a
+/// dynamic bin being linked in - so a single sample is not enough to call a
+/// block failed. Costs one extra poll interval of detection latency.
+const CONFIRMATIONS_BEFORE_FAILED: u32 = 2;
 
 impl super::PipelineManager {
     /// Current per-block health. Empty until the health task has run once.
@@ -129,6 +143,7 @@ impl super::PipelineManager {
         let task = tokio::spawn(async move {
             let mut interval = tokio::time::interval(HEALTH_POLL_INTERVAL);
             let mut failed: std::collections::HashSet<String> = std::collections::HashSet::new();
+            let mut strikes: HashMap<String, u32> = HashMap::new();
 
             loop {
                 interval.tick().await;
@@ -136,9 +151,8 @@ impl super::PipelineManager {
                 // Only meaningful while playing - a paused task is expected in
                 // every other state, including during startup and shutdown.
                 if *cached_state.read().unwrap() != strom_types::PipelineState::Playing {
-                    if !failed.is_empty() {
-                        failed.clear();
-                    }
+                    failed.clear();
+                    strikes.clear();
                     block_health.write().unwrap().clear();
                     continue;
                 }
@@ -151,7 +165,29 @@ impl super::PipelineManager {
                     continue;
                 }
 
-                let snapshot = scan_block_health(&elements);
+                let mut snapshot = scan_block_health(&elements);
+
+                // A block is only reported once it has looked stalled on
+                // CONFIRMATIONS_BEFORE_FAILED scans in a row. Downgrade the
+                // unconfirmed ones before anything observes the snapshot.
+                for health in &mut snapshot {
+                    if health.status.is_failed() {
+                        let count = strikes.entry(health.block_id.clone()).or_insert(0);
+                        *count += 1;
+                        if *count < CONFIRMATIONS_BEFORE_FAILED {
+                            health.status = BlockHealthStatus::Ok;
+                            health.detail = None;
+                        }
+                    } else {
+                        strikes.remove(&health.block_id);
+                    }
+                }
+
+                // Blocks whose elements have gone away drop out of the scan
+                // entirely; forget them rather than leaving a stale entry that
+                // no later iteration can clear.
+                failed.retain(|block_id| snapshot.iter().any(|h| &h.block_id == block_id));
+                strikes.retain(|block_id, _| snapshot.iter().any(|h| &h.block_id == block_id));
 
                 for health in &snapshot {
                     let was_failed = failed.contains(&health.block_id);
@@ -264,6 +300,24 @@ mod tests {
         flow
     }
 
+    /// videotestsrc with a fixed buffer count -> fakesink. Runs to EOS.
+    fn finite_source_flow() -> Flow {
+        let mut flow = Flow::new("eos health test");
+        flow.elements = vec![
+            element(
+                "src",
+                "videotestsrc",
+                &[("num-buffers", PropertyValue::Int(5))],
+            ),
+            element("sink", "fakesink", &[("sync", PropertyValue::Bool(false))]),
+        ];
+        flow.links = vec![Link {
+            from: "src".to_string(),
+            to: "sink".to_string(),
+        }];
+        flow
+    }
+
     fn wait_for(condition: impl Fn() -> bool, timeout: Duration) -> bool {
         let start = Instant::now();
         while start.elapsed() < timeout {
@@ -273,6 +327,64 @@ mod tests {
             std::thread::sleep(Duration::from_millis(100));
         }
         condition()
+    }
+
+    /// `gst_base_src_loop` pauses its pad task on the way out for every reason,
+    /// end of stream included, and leaves the element in `PLAYING`. Playing a
+    /// finite source to completion must not read as a failure.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_source_that_reaches_eos_is_not_reported_as_failed() {
+        gst::init().unwrap();
+
+        let mut manager = PipelineManager::new(
+            &finite_source_flow(),
+            EventBroadcaster::default(),
+            &BlockRegistry::new("test_blocks.json"),
+            vec!["stun:stun.l.google.com:19302".to_string()],
+            "all".to_string(),
+            None,
+            std::path::PathBuf::from("./media"),
+            std::sync::Arc::new(std::sync::Mutex::new(HashMap::new())),
+        )
+        .expect("pipeline should build");
+
+        manager.start().expect("pipeline should start");
+
+        // Let the source play out and the scan run several times over the
+        // drained pipeline.
+        assert!(
+            wait_for(
+                || manager
+                    .elements
+                    .get("src")
+                    .map(|e| e.static_pad("src").unwrap().pad_flags())
+                    .is_some_and(|f| f.contains(gst::PadFlags::EOS)),
+                Duration::from_secs(15)
+            ),
+            "source never reached EOS"
+        );
+        // Watch across several scans - long enough that a block would clear the
+        // confirmation threshold - and assert it never flips to failed.
+        let went_failed = wait_for(
+            || {
+                manager
+                    .get_block_health()
+                    .iter()
+                    .any(|h| h.status == BlockHealthStatus::Failed)
+            },
+            HEALTH_POLL_INTERVAL * (CONFIRMATIONS_BEFORE_FAILED + 3),
+        );
+        assert!(
+            !went_failed,
+            "a drained finite source must not read as failed: {:?}",
+            manager.get_block_health()
+        );
+        assert!(
+            !manager.get_block_health().is_empty(),
+            "health scan never produced a snapshot"
+        );
+
+        manager.stop().expect("pipeline should stop");
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/backend/src/gst/pipeline/health.rs
+++ b/backend/src/gst/pipeline/health.rs
@@ -29,10 +29,17 @@
 //! with `allow-not-linked=true` - what every block output bus ends in - absorbs
 //! the `not-linked` that would otherwise surface upstream. The flow reaches
 //! `PLAYING` carrying nothing on that branch.
+//!
+//! Neither scan can see a chain that is linked and simply never pushed to: its
+//! elements sit idle and `PLAYING` with no task to pause. Only the block that
+//! owns it knows, so a block may report on itself through `BlockLiveness`, and
+//! the scan folds that verdict in.
 
+use crate::blocks::BlockLiveness;
 use gstreamer as gst;
 use gstreamer::prelude::*;
 use std::collections::{BTreeMap, HashMap};
+use std::sync::Arc;
 use strom_types::flow::{BlockHealth, BlockHealthStatus};
 use strom_types::Link;
 
@@ -135,11 +142,16 @@ fn unformed_link(elements: &HashMap<String, gst::Element>, link: &Link) -> bool 
 /// `pending_links` are the links construction could not make, carried from the
 /// `PipelineManager` unchanged.
 ///
+/// `reporters` are blocks that judge their own liveness; see `BlockLiveness`.
+/// A reporter for a block with no element left in the pipeline is skipped, so
+/// its verdict cannot outlive the elements it describes.
+///
 /// Call only while the pipeline is playing; a paused task is expected in any
 /// other pipeline state.
 pub(crate) fn scan_block_health(
     elements: &HashMap<String, gst::Element>,
     pending_links: &[Link],
+    reporters: &[(String, Arc<dyn BlockLiveness>)],
 ) -> Vec<BlockHealth> {
     let mut by_block: BTreeMap<&str, BlockHealth> = BTreeMap::new();
 
@@ -189,6 +201,21 @@ pub(crate) fn scan_block_health(
         ));
     }
 
+    // A block that reports on itself. Checked last, after both scans above,
+    // which name the more specific failure when more than one fires.
+    for (block_id, reporter) in reporters {
+        let Some(entry) = by_block.get_mut(block_id.as_str()) else {
+            continue;
+        };
+        if entry.status.is_failed() {
+            continue;
+        }
+        if let Some(detail) = reporter.failure() {
+            entry.status = BlockHealthStatus::Failed;
+            entry.detail = Some(detail);
+        }
+    }
+
     by_block.into_values().collect()
 }
 
@@ -223,6 +250,7 @@ impl super::PipelineManager {
         // Construction is the only writer of pending_links, and it has finished
         // by the time this task starts.
         let pending_links = self.pending_links.clone();
+        let reporters = self.block_liveness.clone();
         let cached_state = self.cached_state.clone();
         let block_health = self.block_health.clone();
         let events = self.events.clone();
@@ -254,7 +282,7 @@ impl super::PipelineManager {
                     continue;
                 }
 
-                let mut snapshot = scan_block_health(&elements, &pending_links);
+                let mut snapshot = scan_block_health(&elements, &pending_links, &reporters);
 
                 // A block is only reported once it has looked stalled on
                 // CONFIRMATIONS_BEFORE_FAILED scans in a row. Downgrade the
@@ -378,13 +406,13 @@ mod tests {
         let (elements, link) = unlinkable_pair();
 
         assert!(
-            scan_block_health(&elements, &[])
+            scan_block_health(&elements, &[], &[])
                 .iter()
                 .all(|h| h.status == BlockHealthStatus::Ok),
             "nothing is stalled, so the pad-task scan must find nothing"
         );
 
-        let detail = failure_detail(&scan_block_health(&elements, &[link]), "vconv")
+        let detail = failure_detail(&scan_block_health(&elements, &[link], &[]), "vconv")
             .expect("the unformed link must fail the block owning its source");
         assert!(
             detail.contains("vconv:src -> aconv:sink"),
@@ -413,7 +441,7 @@ mod tests {
         }];
 
         assert!(
-            scan_block_health(&elements, &pending)
+            scan_block_health(&elements, &pending, &[])
                 .iter()
                 .all(|h| h.status == BlockHealthStatus::Ok),
             "a source pad that has not appeared yet is not a failure"
@@ -434,10 +462,60 @@ mod tests {
             .expect("videoconvert should link to fakesink");
 
         assert!(
-            scan_block_health(&elements, &[link])
+            scan_block_health(&elements, &[link], &[])
                 .iter()
                 .all(|h| h.status == BlockHealthStatus::Ok),
             "a linked source pad means the deferred link resolved"
+        );
+    }
+
+    /// A block that judges its own liveness has to reach the snapshot. Nothing
+    /// else can report it: a chain that is never pushed to stalls no pad task,
+    /// so the scan itself has nothing to find, and the pipeline stays `Playing`
+    /// throughout.
+    #[test]
+    fn a_blocks_own_failure_report_reaches_its_health() {
+        let _ = gst::init();
+
+        struct HalfDead;
+        impl BlockLiveness for HalfDead {
+            fn failure(&self) -> Option<String> {
+                Some("slot 0 has produced no audio for 12.0 s".to_string())
+            }
+        }
+
+        let sink = gst::ElementFactory::make("fakesink")
+            .build()
+            .expect("fakesink is part of gstreamer core");
+        let elements: HashMap<String, gst::Element> =
+            HashMap::from([("whip:sink".to_string(), sink)]);
+
+        let healthy = scan_block_health(&elements, &[], &[]);
+        assert_eq!(healthy.len(), 1);
+        assert_eq!(healthy[0].status, BlockHealthStatus::Ok);
+
+        let reporters: Vec<(String, Arc<dyn BlockLiveness>)> =
+            vec![("whip".to_string(), Arc::new(HalfDead))];
+        let reported = scan_block_health(&elements, &[], &reporters);
+        assert_eq!(reported.len(), 1);
+        assert_eq!(reported[0].block_id, "whip");
+        assert_eq!(reported[0].status, BlockHealthStatus::Failed);
+        assert_eq!(
+            reported[0].detail.as_deref(),
+            Some("slot 0 has produced no audio for 12.0 s")
+        );
+
+        // A verdict about a block with nothing left in the pipeline must not
+        // conjure an entry for it.
+        let orphan: Vec<(String, Arc<dyn BlockLiveness>)> =
+            vec![("gone".to_string(), Arc::new(HalfDead))];
+        let scanned = scan_block_health(&elements, &[], &orphan);
+        assert_eq!(
+            scanned
+                .iter()
+                .map(|h| h.block_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["whip"]
         );
     }
 

--- a/backend/src/gst/pipeline/health.rs
+++ b/backend/src/gst/pipeline/health.rs
@@ -11,6 +11,14 @@
 //! `GstBaseSrc` is the exception: it posts a flow error before pausing, so
 //! source-side failures already reach the bus handler.
 //!
+//! Scope: the scan reaches the flow pipeline's own elements and the bins beneath
+//! them, and nothing else. Blocks that run an isolated `gst::Pipeline` of their
+//! own - WHIP ingest sessions, a Media Player's decode chain - are siblings of
+//! that pipeline rather than children of it, so `iterate_recurse` never enters
+//! them. An `Ok` here therefore means "no stalled pad task among this flow
+//! pipeline's elements", not "this flow is passing data". Sinks that live in the
+//! flow pipeline, `whepserversink` included, are covered.
+//!
 //! A paused task on an element that is itself `PLAYING` is always wrong, so
 //! that is the signal used here. `gst_pad_get_task_state()` returns `Stopped`
 //! both for a pad whose task was stopped and for a pad that never had one, so
@@ -42,8 +50,9 @@ fn first_stalled_pad(element: &gst::Element) -> Option<StalledPad> {
 /// Find the first paused pad task on `element` itself.
 ///
 /// Two kinds of legitimately paused task are excluded. An element held below
-/// `PLAYING` - a WebRTC session bin mid-setup, say - pauses its tasks as part of
-/// that transition. And a pad that has seen EOS is finished by definition:
+/// `PLAYING` - a webrtcbin added for a newly connected WHEP consumer, say -
+/// pauses its tasks as part of that transition. And a pad that has seen EOS is
+/// finished by definition:
 /// `gst_base_src_loop` pauses its task on the way out for *every* reason
 /// including end of stream, and the element stays `PLAYING` afterwards, so a
 /// finite source that has played out would otherwise be reported as failed

--- a/backend/src/gst/pipeline/health.rs
+++ b/backend/src/gst/pipeline/health.rs
@@ -168,12 +168,18 @@ pub(crate) fn scan_block_health(
     // Reported against the block owning the source element, which is where the
     // branch dies, and allowed to overwrite a stall found above: a task parked
     // behind a link that never formed is the symptom, and the link is the cause.
+    // Where a block has several, the first names it, as in the scan above.
+    let mut named_by_link: std::collections::HashSet<String> = std::collections::HashSet::new();
     for link in pending_links {
         if !unformed_link(elements, link) {
             continue;
         }
         let (from_ref, _) = link.to_pad_refs();
-        let Some(entry) = by_block.get_mut(owning_block(&from_ref.element_id)) else {
+        let block_id = owning_block(&from_ref.element_id);
+        if !named_by_link.insert(block_id.to_string()) {
+            continue;
+        }
+        let Some(entry) = by_block.get_mut(block_id) else {
             continue;
         };
         entry.status = BlockHealthStatus::Failed;

--- a/backend/src/gst/pipeline/health.rs
+++ b/backend/src/gst/pipeline/health.rs
@@ -23,11 +23,18 @@
 //! that is the signal used here. `gst_pad_get_task_state()` returns `Stopped`
 //! both for a pad whose task was stopped and for a pad that never had one, so
 //! `Stopped` cannot be told apart from the common case and is not reported.
+//!
+//! A branch that never started is the other thing reported here, and the scan
+//! above cannot see it: with no link there is no pad task to pause, and a tee
+//! with `allow-not-linked=true` - what every block output bus ends in - absorbs
+//! the `not-linked` that would otherwise surface upstream. The flow reaches
+//! `PLAYING` carrying nothing on that branch.
 
 use gstreamer as gst;
 use gstreamer::prelude::*;
 use std::collections::{BTreeMap, HashMap};
 use strom_types::flow::{BlockHealth, BlockHealthStatus};
+use strom_types::Link;
 
 /// A pad whose task has been paused while the pipeline is playing.
 struct StalledPad {
@@ -91,11 +98,49 @@ fn owning_block(element_id: &str) -> &str {
     element_id.split(':').next().unwrap_or(element_id)
 }
 
+/// Whether a deferred link has missed its only chance to form.
+///
+/// `pending_links` holds every link `try_link_elements` refused, and the only
+/// thing that retries one is the `pad-added` handler on its source element. A
+/// pad that is already there will not be added again, so a deferred link whose
+/// named source pad exists and has no peer is unformed for the life of the
+/// pipeline, not merely slow.
+///
+/// The converse is deliberately not reported. A source pad that does not exist
+/// yet - `decodebin` before it has typefound, a `whipserversrc` before a
+/// publisher arrives - is the case the deferral was built for, and the handler
+/// will link it when it appears.
+///
+/// Two links are outside what this can judge, and both read as formed. One
+/// whose source pad appeared under a different name than the link asked for
+/// (`src` matching `src_0`) is linked through the handler's pattern match, and
+/// one whose unlinked dynamic pad picked up an auto-tee has a peer that is not
+/// the declared destination.
+fn unformed_link(elements: &HashMap<String, gst::Element>, link: &Link) -> bool {
+    let (from_ref, _) = link.to_pad_refs();
+    let Some(element) = elements.get(&from_ref.element_id) else {
+        return false;
+    };
+    // An element-level link names no pad; GStreamer would have used the
+    // element's own `src` pad, so that is what is checked.
+    let pad_name = from_ref.pad_name.as_deref().unwrap_or("src");
+    let Some(pad) = element.static_pad(pad_name) else {
+        return false;
+    };
+    pad.direction() == gst::PadDirection::Src && pad.peer().is_none()
+}
+
 /// Report health for every block with at least one element in `elements`.
+///
+/// `pending_links` are the links construction could not make, carried from the
+/// `PipelineManager` unchanged.
 ///
 /// Call only while the pipeline is playing; a paused task is expected in any
 /// other pipeline state.
-pub(crate) fn scan_block_health(elements: &HashMap<String, gst::Element>) -> Vec<BlockHealth> {
+pub(crate) fn scan_block_health(
+    elements: &HashMap<String, gst::Element>,
+    pending_links: &[Link],
+) -> Vec<BlockHealth> {
     let mut by_block: BTreeMap<&str, BlockHealth> = BTreeMap::new();
 
     for (element_id, element) in elements {
@@ -118,6 +163,24 @@ pub(crate) fn scan_block_health(elements: &HashMap<String, gst::Element>) -> Vec
                 stalled.element, stalled.pad
             ));
         }
+    }
+
+    // Reported against the block owning the source element, which is where the
+    // branch dies, and allowed to overwrite a stall found above: a task parked
+    // behind a link that never formed is the symptom, and the link is the cause.
+    for link in pending_links {
+        if !unformed_link(elements, link) {
+            continue;
+        }
+        let (from_ref, _) = link.to_pad_refs();
+        let Some(entry) = by_block.get_mut(owning_block(&from_ref.element_id)) else {
+            continue;
+        };
+        entry.status = BlockHealthStatus::Failed;
+        entry.detail = Some(format!(
+            "link {} -> {} never formed - this branch has carried no data since the flow started",
+            link.from, link.to
+        ));
     }
 
     by_block.into_values().collect()
@@ -151,6 +214,9 @@ impl super::PipelineManager {
             .map(|(id, element)| (id.clone(), element.downgrade()))
             .collect();
 
+        // Construction is the only writer of pending_links, and it has finished
+        // by the time this task starts.
+        let pending_links = self.pending_links.clone();
         let cached_state = self.cached_state.clone();
         let block_health = self.block_health.clone();
         let events = self.events.clone();
@@ -182,7 +248,7 @@ impl super::PipelineManager {
                     continue;
                 }
 
-                let mut snapshot = scan_block_health(&elements);
+                let mut snapshot = scan_block_health(&elements, &pending_links);
 
                 // A block is only reported once it has looked stalled on
                 // CONFIRMATIONS_BEFORE_FAILED scans in a row. Downgrade the
@@ -212,7 +278,7 @@ impl super::PipelineManager {
                         (true, false) => {
                             failed.insert(health.block_id.clone());
                             tracing::error!(
-                                "Block '{}' in flow '{}' has stopped: {}. The pipeline still reports Playing",
+                                "Block '{}' in flow '{}' is not passing data: {}. The pipeline still reports Playing",
                                 health.block_id,
                                 flow_name,
                                 health.detail.as_deref().unwrap_or("no detail")
@@ -266,6 +332,108 @@ mod tests {
     use crate::gst::pipeline::PipelineManager;
     use std::time::{Duration, Instant};
     use strom_types::{Element, Flow, Link, PropertyValue};
+
+    /// `videoconvert:src` and `audioconvert:sink` have no format in common, so
+    /// a link between them is refused, now and on every retry.
+    fn unlinkable_pair() -> (HashMap<String, gst::Element>, Link) {
+        gst::init().unwrap();
+        let elements: HashMap<String, gst::Element> = [
+            ("vconv", "videoconvert"),
+            ("aconv", "audioconvert"),
+            ("holder", "fakesink"),
+        ]
+        .into_iter()
+        .map(|(id, factory)| {
+            (
+                id.to_string(),
+                gst::ElementFactory::make(factory)
+                    .name(id)
+                    .build()
+                    .expect("element should build"),
+            )
+        })
+        .collect();
+        let link = Link {
+            from: "vconv:src".to_string(),
+            to: "aconv:sink".to_string(),
+        };
+        (elements, link)
+    }
+
+    fn failure_detail(health: &[BlockHealth], block_id: &str) -> Option<String> {
+        health
+            .iter()
+            .find(|h| h.block_id == block_id && h.status == BlockHealthStatus::Failed)
+            .and_then(|h| h.detail.clone())
+    }
+
+    #[test]
+    fn a_deferred_link_that_never_formed_fails_its_block() {
+        let (elements, link) = unlinkable_pair();
+
+        assert!(
+            scan_block_health(&elements, &[])
+                .iter()
+                .all(|h| h.status == BlockHealthStatus::Ok),
+            "nothing is stalled, so the pad-task scan must find nothing"
+        );
+
+        let detail = failure_detail(&scan_block_health(&elements, &[link]), "vconv")
+            .expect("the unformed link must fail the block owning its source");
+        assert!(
+            detail.contains("vconv:src -> aconv:sink"),
+            "the detail must name the link: {}",
+            detail
+        );
+    }
+
+    /// The deferral exists for a source pad that is not there yet. Reporting one
+    /// would mark every `decodebin` failed for as long as it takes to typefind.
+    #[test]
+    fn a_deferred_link_waiting_on_a_dynamic_pad_is_not_reported() {
+        gst::init().unwrap();
+        let elements: HashMap<String, gst::Element> = [(
+            "dec".to_string(),
+            gst::ElementFactory::make("decodebin")
+                .name("dec")
+                .build()
+                .expect("decodebin should build"),
+        )]
+        .into_iter()
+        .collect();
+        let pending = [Link {
+            from: "dec:src_0".to_string(),
+            to: "sink:sink".to_string(),
+        }];
+
+        assert!(
+            scan_block_health(&elements, &pending)
+                .iter()
+                .all(|h| h.status == BlockHealthStatus::Ok),
+            "a source pad that has not appeared yet is not a failure"
+        );
+    }
+
+    /// A link the `pad-added` handler resolved is still in `pending_links`, so a
+    /// linked source pad has to read as healthy.
+    #[test]
+    fn a_deferred_link_that_did_form_is_not_reported() {
+        let (elements, link) = unlinkable_pair();
+        let vconv = elements.get("vconv").unwrap();
+        let holder = elements.get("holder").unwrap();
+        vconv
+            .static_pad("src")
+            .unwrap()
+            .link(&holder.static_pad("sink").unwrap())
+            .expect("videoconvert should link to fakesink");
+
+        assert!(
+            scan_block_health(&elements, &[link])
+                .iter()
+                .all(|h| h.status == BlockHealthStatus::Ok),
+            "a linked source pad means the deferred link resolved"
+        );
+    }
 
     #[test]
     fn block_elements_are_attributed_to_their_block() {
@@ -352,6 +520,38 @@ mod tests {
             Link {
                 from: "split".to_string(),
                 to: "q_dangling".to_string(),
+            },
+        ];
+        flow
+    }
+
+    /// A live chain that keeps the pipeline running, plus a declared link between
+    /// two elements with no format in common.
+    ///
+    /// Nothing feeds the unlinkable pair, so no pad task parks and the pad-task
+    /// scan has nothing to find - the same blind spot a real flow presents when
+    /// a block's `allow-not-linked` output tee absorbs the `not-linked` from
+    /// below an unformed link.
+    fn unformed_link_flow() -> Flow {
+        let mut flow = Flow::new("unformed link health test");
+        flow.elements = vec![
+            element(
+                "src",
+                "videotestsrc",
+                &[("is-live", PropertyValue::Bool(true))],
+            ),
+            element("sink", "fakesink", &[("sync", PropertyValue::Bool(false))]),
+            element("vconv", "videoconvert", &[]),
+            element("aconv", "audioconvert", &[]),
+        ];
+        flow.links = vec![
+            Link {
+                from: "src".to_string(),
+                to: "sink".to_string(),
+            },
+            Link {
+                from: "vconv:src".to_string(),
+                to: "aconv:sink".to_string(),
             },
         ];
         flow
@@ -487,6 +687,65 @@ mod tests {
             !manager.get_block_health().is_empty(),
             "health scan never produced a snapshot"
         );
+
+        manager.stop().expect("pipeline should stop");
+    }
+
+    /// A link that construction could not make and nothing retried. The branch
+    /// below it carries no data, and with no pad task to pause there is nothing
+    /// for the stalled-pad scan to find.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_link_that_never_formed_is_reported_on_a_playing_pipeline() {
+        gst::init().unwrap();
+
+        let mut manager = PipelineManager::new(
+            &unformed_link_flow(),
+            EventBroadcaster::default(),
+            &BlockRegistry::new("test_blocks.json"),
+            vec!["stun:stun.l.google.com:19302".to_string()],
+            "all".to_string(),
+            None,
+            std::path::PathBuf::from("./media"),
+            std::sync::Arc::new(std::sync::Mutex::new(HashMap::new())),
+        )
+        .expect("pipeline should build");
+
+        manager.start().expect("pipeline should start");
+        assert!(
+            wait_for(
+                || manager.get_state() == strom_types::PipelineState::Playing,
+                Duration::from_secs(10)
+            ),
+            "pipeline never reached Playing"
+        );
+
+        assert!(
+            wait_for(
+                || failure_detail(&manager.get_block_health(), "vconv").is_some(),
+                HEALTH_POLL_INTERVAL * (CONFIRMATIONS_BEFORE_FAILED + 4),
+            ),
+            "the unformed link was not reported: {:?}",
+            manager.get_block_health()
+        );
+
+        let health = manager.get_block_health();
+        let detail = failure_detail(&health, "vconv").unwrap();
+        assert!(
+            detail.contains("vconv:src -> aconv:sink"),
+            "the detail must name the link: {}",
+            detail
+        );
+        // Nothing is stalled: the pad-task scan contributes no failure here, so
+        // removing the unformed-link check leaves this flow reading healthy.
+        assert!(
+            health
+                .iter()
+                .filter(|h| h.status == BlockHealthStatus::Failed)
+                .all(|h| h.block_id == "vconv"),
+            "only the block owning the unformed link should fail: {:?}",
+            health
+        );
+        assert_eq!(manager.get_state(), strom_types::PipelineState::Playing);
 
         manager.stop().expect("pipeline should stop");
     }

--- a/backend/src/gst/pipeline/health.rs
+++ b/backend/src/gst/pipeline/health.rs
@@ -1,0 +1,368 @@
+//! Detection of stalled pad tasks in a running pipeline.
+//!
+//! A pad task is the thread that drives data out of a pad. Elements pause their
+//! own task when a downstream push fails with a non-fatal flow return such as
+//! `not-negotiated` - video encoders do this, and so does `GstAggregator`,
+//! which additionally marks all its sink pads flushing, stalling everything
+//! upstream of it. Neither posts to the bus, and pausing a task is not a state
+//! change, so the pipeline and every element in it stay `PLAYING` while that
+//! branch carries nothing.
+//!
+//! `GstBaseSrc` is the exception: it posts a flow error before pausing, so
+//! source-side failures already reach the bus handler.
+//!
+//! A paused task on an element that is itself `PLAYING` is always wrong, so
+//! that is the signal used here. `gst_pad_get_task_state()` returns `Stopped`
+//! both for a pad whose task was stopped and for a pad that never had one, so
+//! `Stopped` cannot be told apart from the common case and is not reported.
+
+use gstreamer as gst;
+use gstreamer::prelude::*;
+use std::collections::{BTreeMap, HashMap};
+use strom_types::flow::{BlockHealth, BlockHealthStatus};
+
+/// A pad whose task has been paused while the pipeline is playing.
+struct StalledPad {
+    element: String,
+    pad: String,
+}
+
+/// Find the first paused pad task on `element`, and on its children if it is a bin.
+fn first_stalled_pad(element: &gst::Element) -> Option<StalledPad> {
+    if let Some(stalled) = stalled_pad_on(element) {
+        return Some(stalled);
+    }
+    let bin = element.downcast_ref::<gst::Bin>()?;
+    bin.iterate_recurse()
+        .into_iter()
+        .flatten()
+        .find_map(|child| stalled_pad_on(&child))
+}
+
+/// Find the first paused pad task on `element` itself.
+///
+/// Only elements that are themselves playing are considered. A sub-bin held in
+/// `PAUSED` inside a playing pipeline - a WebRTC session bin mid-setup, say -
+/// has paused pad tasks legitimately.
+fn stalled_pad_on(element: &gst::Element) -> Option<StalledPad> {
+    if element.current_state() != gst::State::Playing {
+        return None;
+    }
+    element
+        .pads()
+        .into_iter()
+        .find(|pad| pad.task_state() == gst::TaskState::Paused)
+        .map(|pad| StalledPad {
+            element: element.name().to_string(),
+            pad: pad.name().to_string(),
+        })
+}
+
+/// Block instance ID owning `element_id`.
+///
+/// Block elements are namespaced `block_id:internal_id` by `BlockBuildResult`.
+/// A standalone element has no prefix and is reported under its own ID so that
+/// a stall outside a block is not silently dropped.
+fn owning_block(element_id: &str) -> &str {
+    element_id.split(':').next().unwrap_or(element_id)
+}
+
+/// Report health for every block with at least one element in `elements`.
+///
+/// Call only while the pipeline is playing; a paused task is expected in any
+/// other pipeline state.
+pub(crate) fn scan_block_health(elements: &HashMap<String, gst::Element>) -> Vec<BlockHealth> {
+    let mut by_block: BTreeMap<&str, BlockHealth> = BTreeMap::new();
+
+    for (element_id, element) in elements {
+        let block_id = owning_block(element_id);
+        let entry = by_block.entry(block_id).or_insert_with(|| BlockHealth {
+            block_id: block_id.to_string(),
+            status: BlockHealthStatus::Ok,
+            detail: None,
+        });
+
+        // A block is failed if any of its elements has a stalled pad; the first
+        // one found names the failure.
+        if entry.status.is_failed() {
+            continue;
+        }
+        if let Some(stalled) = first_stalled_pad(element) {
+            entry.status = BlockHealthStatus::Failed;
+            entry.detail = Some(format!(
+                "pad task stopped on {}:{} - this branch is not passing data",
+                stalled.element, stalled.pad
+            ));
+        }
+    }
+
+    by_block.into_values().collect()
+}
+
+/// How often the running pipeline is scanned for stalled pad tasks.
+const HEALTH_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);
+
+impl super::PipelineManager {
+    /// Current per-block health. Empty until the health task has run once.
+    pub fn get_block_health(&self) -> Vec<BlockHealth> {
+        self.block_health.read().unwrap().clone()
+    }
+
+    /// Start the periodic scan for stalled pad tasks.
+    pub(super) fn start_block_health_task(&mut self) {
+        self.stop_block_health_task();
+
+        // WeakRef, not a clone: a task holding strong element references would
+        // keep the pipeline alive past drop.
+        let weak_elements: Vec<(String, gst::glib::WeakRef<gst::Element>)> = self
+            .elements
+            .iter()
+            .map(|(id, element)| (id.clone(), element.downgrade()))
+            .collect();
+
+        let cached_state = self.cached_state.clone();
+        let block_health = self.block_health.clone();
+        let events = self.events.clone();
+        let flow_id = self.flow_id;
+        let flow_name = self.flow_name.clone();
+
+        let task = tokio::spawn(async move {
+            let mut interval = tokio::time::interval(HEALTH_POLL_INTERVAL);
+            let mut failed: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+            loop {
+                interval.tick().await;
+
+                // Only meaningful while playing - a paused task is expected in
+                // every other state, including during startup and shutdown.
+                if *cached_state.read().unwrap() != strom_types::PipelineState::Playing {
+                    if !failed.is_empty() {
+                        failed.clear();
+                    }
+                    block_health.write().unwrap().clear();
+                    continue;
+                }
+
+                let elements: HashMap<String, gst::Element> = weak_elements
+                    .iter()
+                    .filter_map(|(id, weak)| weak.upgrade().map(|el| (id.clone(), el)))
+                    .collect();
+                if elements.is_empty() {
+                    continue;
+                }
+
+                let snapshot = scan_block_health(&elements);
+
+                for health in &snapshot {
+                    let was_failed = failed.contains(&health.block_id);
+                    match (health.status.is_failed(), was_failed) {
+                        (true, false) => {
+                            failed.insert(health.block_id.clone());
+                            tracing::error!(
+                                "Block '{}' in flow '{}' has stopped: {}. The pipeline still reports Playing",
+                                health.block_id,
+                                flow_name,
+                                health.detail.as_deref().unwrap_or("no detail")
+                            );
+                            events.broadcast(strom_types::StromEvent::BlockHealthChanged {
+                                flow_id,
+                                block_id: health.block_id.clone(),
+                                status: health.status,
+                                detail: health.detail.clone(),
+                            });
+                        }
+                        (false, true) => {
+                            failed.remove(&health.block_id);
+                            tracing::info!(
+                                "Block '{}' in flow '{}' resumed passing data",
+                                health.block_id,
+                                flow_name
+                            );
+                            events.broadcast(strom_types::StromEvent::BlockHealthChanged {
+                                flow_id,
+                                block_id: health.block_id.clone(),
+                                status: health.status,
+                                detail: None,
+                            });
+                        }
+                        _ => {}
+                    }
+                }
+
+                *block_health.write().unwrap() = snapshot;
+            }
+        });
+
+        self.block_health_task = Some(task);
+    }
+
+    /// Stop the periodic health scan and drop the last snapshot.
+    pub(super) fn stop_block_health_task(&mut self) {
+        if let Some(task) = self.block_health_task.take() {
+            task.abort();
+        }
+        self.block_health.write().unwrap().clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::blocks::BlockRegistry;
+    use crate::events::EventBroadcaster;
+    use crate::gst::pipeline::PipelineManager;
+    use std::time::{Duration, Instant};
+    use strom_types::{Element, Flow, Link, PropertyValue};
+
+    #[test]
+    fn block_elements_are_attributed_to_their_block() {
+        assert_eq!(owning_block("whep:videoenc"), "whep");
+        assert_eq!(owning_block("whep:sink:inner"), "whep");
+        assert_eq!(owning_block("standalone_element"), "standalone_element");
+    }
+
+    fn element(id: &str, element_type: &str, props: &[(&str, PropertyValue)]) -> Element {
+        Element {
+            id: id.to_string(),
+            element_type: element_type.to_string(),
+            properties: props
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.clone()))
+                .collect(),
+            pad_properties: HashMap::new(),
+            position: (0.0, 0.0),
+        }
+    }
+
+    /// videotestsrc -> compositor -> capsfilter -> fakesink, as a real flow.
+    fn stall_flow() -> Flow {
+        let mut flow = Flow::new("block health test");
+        flow.elements = vec![
+            element(
+                "src",
+                "videotestsrc",
+                &[("is-live", PropertyValue::Bool(true))],
+            ),
+            element("comp", "compositor", &[]),
+            element("filter", "capsfilter", &[]),
+            element("sink", "fakesink", &[("sync", PropertyValue::Bool(false))]),
+        ];
+        flow.links = vec![
+            Link {
+                from: "src".to_string(),
+                to: "comp".to_string(),
+            },
+            Link {
+                from: "comp".to_string(),
+                to: "filter".to_string(),
+            },
+            Link {
+                from: "filter".to_string(),
+                to: "sink".to_string(),
+            },
+        ];
+        flow
+    }
+
+    fn wait_for(condition: impl Fn() -> bool, timeout: Duration) -> bool {
+        let start = Instant::now();
+        while start.elapsed() < timeout {
+            if condition() {
+                return true;
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+        condition()
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stalled_branch_is_reported_while_the_pipeline_still_says_playing() {
+        gst::init().unwrap();
+
+        let mut manager = PipelineManager::new(
+            &stall_flow(),
+            EventBroadcaster::default(),
+            &BlockRegistry::new("test_blocks.json"),
+            vec!["stun:stun.l.google.com:19302".to_string()],
+            "all".to_string(),
+            None,
+            std::path::PathBuf::from("./media"),
+            std::sync::Arc::new(std::sync::Mutex::new(HashMap::new())),
+        )
+        .expect("pipeline should build");
+
+        manager.start().expect("pipeline should start");
+        assert!(
+            wait_for(
+                || manager.get_state() == strom_types::PipelineState::Playing,
+                Duration::from_secs(10)
+            ),
+            "pipeline never reached Playing"
+        );
+        assert!(
+            wait_for(
+                || !manager.get_block_health().is_empty(),
+                Duration::from_secs(10)
+            ),
+            "health scan never produced a snapshot"
+        );
+        assert!(
+            manager
+                .get_block_health()
+                .iter()
+                .all(|h| h.status == BlockHealthStatus::Ok),
+            "a healthy pipeline should report no failures: {:?}",
+            manager.get_block_health()
+        );
+
+        // Retighten the capsfilter to a format the compositor cannot produce.
+        // The next push fails negotiation and the compositor pauses its source
+        // pad task without posting anything to the bus.
+        manager
+            .elements
+            .get("filter")
+            .expect("capsfilter should exist")
+            .set_property(
+                "caps",
+                gst::Caps::builder("video/x-bayer")
+                    .field("format", "bggr")
+                    .build(),
+            );
+
+        assert!(
+            wait_for(
+                || manager
+                    .get_block_health()
+                    .iter()
+                    .any(|h| h.block_id == "comp" && h.status == BlockHealthStatus::Failed),
+                Duration::from_secs(15)
+            ),
+            "stalled compositor was not reported: {:?}",
+            manager.get_block_health()
+        );
+
+        // The failure has to be visible without the pipeline state changing,
+        // which is the case the scan exists for.
+        assert_eq!(manager.get_state(), strom_types::PipelineState::Playing);
+
+        // An element deliberately held below Playing has paused pad tasks for a
+        // legitimate reason and must not be reported. Upstream elements that
+        // are still Playing and now blocked behind it are a real stall and stay
+        // reported, so only the paused element itself is checked here.
+        let compositor = manager.elements.get("comp").unwrap().clone();
+        compositor.set_state(gst::State::Paused).unwrap();
+        assert!(
+            wait_for(
+                || manager
+                    .get_block_health()
+                    .iter()
+                    .any(|h| h.block_id == "comp" && h.status == BlockHealthStatus::Ok),
+                Duration::from_secs(15)
+            ),
+            "a paused element should not be reported as failed: {:?}",
+            manager.get_block_health()
+        );
+
+        manager.stop().expect("pipeline should stop");
+    }
+}

--- a/backend/src/gst/pipeline/lifecycle.rs
+++ b/backend/src/gst/pipeline/lifecycle.rs
@@ -47,6 +47,9 @@ impl PipelineManager {
         self.start_qos_broadcast_task();
         info!("QoS stats task started");
 
+        // Start the scan for stalled pad tasks
+        self.start_block_health_task();
+
         // Configure clock before starting
         info!(
             "Configuring clock (type: {:?})...",
@@ -202,6 +205,7 @@ impl PipelineManager {
 
         // Stop QoS broadcast task
         self.stop_qos_broadcast_task();
+        self.stop_block_health_task();
 
         // Stop thumbnail deactivation task
         if let Some(task) = self.thumbnail_deactivation_task.take() {

--- a/backend/src/gst/pipeline/mod.rs
+++ b/backend/src/gst/pipeline/mod.rs
@@ -219,6 +219,8 @@ pub struct PipelineManager {
     whip_endpoints: Vec<crate::blocks::WhipEndpointInfo>,
     /// WHIP endpoint configs for session manager (collected from block expansion)
     whip_endpoint_configs: Vec<(String, crate::whip_session_manager::WhipEndpointConfig)>,
+    /// Per-block liveness reporters, polled alongside the stalled-pad-task scan
+    block_liveness: Vec<(String, std::sync::Arc<dyn crate::blocks::BlockLiveness>)>,
     /// Dynamically created webrtcbins (from webrtcsink/whepserversink consumer-added callbacks).
     /// Maps block_id to list of (consumer_id, webrtcbin) pairs.
     dynamic_webrtcbins: crate::blocks::DynamicWebrtcbinStore,

--- a/backend/src/gst/pipeline/mod.rs
+++ b/backend/src/gst/pipeline/mod.rs
@@ -3,6 +3,7 @@
 mod bus;
 mod construction;
 pub(crate) mod effects;
+mod health;
 mod lifecycle;
 mod linking;
 mod properties;
@@ -195,6 +196,10 @@ pub struct PipelineManager {
     qos_aggregator: QoSAggregator,
     /// Handle for the periodic QoS stats broadcast task
     qos_broadcast_task: Option<tokio::task::JoinHandle<()>>,
+    /// Latest per-block health snapshot from the stalled-pad-task scan
+    block_health: std::sync::Arc<std::sync::RwLock<Vec<strom_types::flow::BlockHealth>>>,
+    /// Handle for the periodic block health scan task
+    block_health_task: Option<tokio::task::JoinHandle<()>>,
     /// PTP clock reference (stored for querying grandmaster/master info)
     ptp_clock: Option<gst_net::PtpClock>,
     /// PTP statistics (updated by statistics callback)
@@ -244,6 +249,7 @@ impl Drop for PipelineManager {
         self.probe_manager.stop_broadcast_task();
         self.probe_manager.deactivate_all();
         self.stop_qos_broadcast_task();
+        self.stop_block_health_task();
 
         // Ensure pipeline is in Null state before releasing references.
         // If stop() was already called this is a no-op.

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -609,9 +609,11 @@ impl AppState {
                     }
                     flow.properties.ntp_info = pipeline.get_ntp_info();
                     flow.properties.thread_priority_status = pipeline.get_thread_priority_status();
+                    flow.block_health = pipeline.get_block_health();
                 } else {
                     // Clear runtime-only status when no pipeline is running
                     flow.set_gst_state(None);
+                    flow.block_health.clear();
                     flow.properties.thread_priority_status = None;
                     flow.properties.clock_sync_status = None;
                     flow.properties.ptp_info = None;
@@ -643,9 +645,11 @@ impl AppState {
                 }
                 flow.properties.ntp_info = pipeline.get_ntp_info();
                 flow.properties.thread_priority_status = pipeline.get_thread_priority_status();
+                flow.block_health = pipeline.get_block_health();
             } else {
                 // Clear runtime-only status when no pipeline is running
                 flow.set_gst_state(None);
+                flow.block_health.clear();
                 flow.properties.thread_priority_status = None;
                 flow.properties.clock_sync_status = None;
                 flow.properties.ptp_info = None;

--- a/backend/src/whip_session_manager.rs
+++ b/backend/src/whip_session_manager.rs
@@ -62,6 +62,10 @@ pub struct WhipEndpointConfig {
     /// cannot hold the pipeline short of PLAYING; `allocate_slot` unlocks them.
     /// Empty when the endpoint runs with `decode=false`.
     pub slot_decodebins: Vec<Vec<gst::glib::WeakRef<gst::Element>>>,
+    /// Per-slot stamp of the media coming out of that slot's chain, written by
+    /// a pad probe on its output tee. The session sitting in a slot borrows its
+    /// stamp; see `SessionActivity`.
+    pub slot_output: Vec<Arc<ActivityStamp>>,
     /// Slot assignments: slot index → Option<resource_id>
     /// Protected by RwLock for concurrent access from HTTP handlers.
     pub slot_assignments: Arc<RwLock<Vec<Option<String>>>>,
@@ -154,64 +158,188 @@ pub struct SessionCleanupRequest {
     pub reason: String,
 }
 
-/// Liveness of one WHIP session: when its last media buffer crossed the
-/// appsink→appsrc bridge into the main pipeline.
+/// One stream of buffers, reduced to when its first and most recent buffer went
+/// past, as milliseconds from a fixed epoch.
 ///
-/// The counters are written from the appsink's `new_sample` callback, i.e. once
-/// per buffer, so a stamp is a single relaxed store against an epoch taken at
-/// session start. They are read by the session's own inactivity watchdog and by
-/// `allocate_slot_or_take_over`, which needs to know whether an occupied slot
-/// still has a publisher behind it. `last_buffer_ms` is an `Arc` of its own
-/// because the session's watchdog thread reads it directly.
-pub struct SessionActivity {
-    /// Session start. All timestamps are milliseconds from here.
+/// Written from GStreamer's data path — an appsink callback, a pad probe — so
+/// `touch` is one clock read (`Instant` takes the vDSO fast path) plus relaxed
+/// atomics: no lock, no allocation, no formatting. 0 means "nothing yet", so a
+/// buffer landing inside the first millisecond counts as 1.
+pub struct ActivityStamp {
     epoch: Instant,
-    /// Milliseconds from `epoch` at which the last buffer arrived on any
-    /// stream; 0 = none yet.
-    last_buffer_ms: Arc<AtomicU64>,
-    /// The same, counting audio buffers only. Non-zero means this session
-    /// negotiated an audio stream and it produced something, which is what
-    /// makes `TAKEOVER_IDLE_THRESHOLD` a sound bound; see `has_delivered_audio`.
-    last_audio_ms: AtomicU64,
+    first_ms: AtomicU64,
+    last_ms: AtomicU64,
+}
+
+impl ActivityStamp {
+    pub fn new(epoch: Instant) -> Self {
+        Self {
+            epoch,
+            first_ms: AtomicU64::new(0),
+            last_ms: AtomicU64::new(0),
+        }
+    }
+
+    /// Stamp a buffer. Per-buffer hot path; see the type comment.
+    pub fn touch(&self) {
+        let ms = (self.epoch.elapsed().as_millis() as u64).max(1);
+        self.last_ms.store(ms, Ordering::Relaxed);
+        // Only the very first buffer writes `first_ms`; every later one pays a
+        // relaxed load and a branch that predicts perfectly.
+        if self.first_ms.load(Ordering::Relaxed) == 0 {
+            let _ = self
+                .first_ms
+                .compare_exchange(0, ms, Ordering::Relaxed, Ordering::Relaxed);
+        }
+    }
+
+    /// Forget everything seen so far. Used when a new session claims a slot
+    /// whose output chain outlives individual sessions.
+    pub fn reset(&self) {
+        self.first_ms.store(0, Ordering::Relaxed);
+        self.last_ms.store(0, Ordering::Relaxed);
+    }
+
+    /// Milliseconds from `epoch` at which the most recent buffer went past,
+    /// 0 if none has. Only meaningful compared against another reading of the
+    /// same stamp — a value that changed between two of them is a stream that
+    /// is still moving.
+    pub fn last(&self) -> u64 {
+        self.last_ms.load(Ordering::Relaxed)
+    }
+
+    /// Time since the most recent buffer, `None` if none has gone past.
+    pub fn since_last(&self) -> Option<Duration> {
+        self.since(self.last_ms.load(Ordering::Relaxed))
+    }
+
+    /// Time since the first buffer, `None` if none has gone past.
+    pub fn since_first(&self) -> Option<Duration> {
+        self.since(self.first_ms.load(Ordering::Relaxed))
+    }
+
+    /// A stamp that already looks as if its first buffer went past
+    /// `since_first` ago and its most recent one `since_last` ago, so a test can
+    /// stand a session up mid-life without waiting out real seconds.
+    #[cfg(test)]
+    pub fn backdated(since_first: Duration, since_last: Duration) -> Self {
+        assert!(
+            since_last <= since_first,
+            "the first buffer cannot be newer than the last"
+        );
+        // 1 ms of headroom keeps `first_ms` clear of the 0 that means "nothing
+        // yet", exactly as `touch` does.
+        let stamp = Self::new(Instant::now() - since_first - Duration::from_millis(1));
+        stamp.first_ms.store(1, Ordering::Relaxed);
+        stamp.last_ms.store(
+            (since_first - since_last).as_millis() as u64 + 1,
+            Ordering::Relaxed,
+        );
+        stamp
+    }
+
+    fn since(&self, ms: u64) -> Option<Duration> {
+        if ms == 0 {
+            return None;
+        }
+        Some(
+            self.epoch
+                .elapsed()
+                .saturating_sub(Duration::from_millis(ms)),
+        )
+    }
+}
+
+/// Liveness of one WHIP session, in the only terms that matter to the slot it
+/// occupies: is it still producing media the flow can use?
+///
+/// Two stamps decide it, because arriving bytes are not the same thing as usable
+/// media:
+///
+/// - `ingress` is stamped by the session pipeline's appsink, once per buffer
+///   that crosses the appsink→appsrc bridge. It says the publisher is still
+///   sending, and nothing more.
+/// - `output` is stamped by a pad probe on the slot's output tee, in the *main*
+///   pipeline, downstream of the slot's `decodebin`. It says frames are coming
+///   out the far end and reaching the flow's consumers.
+///
+/// A third, `ingress_audio`, does not measure liveness at all — it only records
+/// whether this session ever carried audio, which is what decides how short a
+/// silence may be held against it; see `has_delivered_audio`.
+///
+/// A seat can sit at the first without the second indefinitely — a decoder that
+/// never gets the keyframe it needs, or a downstream consumer that blocks and
+/// backs pressure up through the slot's tee — and by `ingress` alone it looks
+/// perfectly healthy while producing nothing.
+///
+/// Read by the session's inactivity watchdog and by
+/// `allocate_slot_or_take_over`.
+pub struct SessionActivity {
+    ingress: ActivityStamp,
+    /// The same arrivals, counting audio buffers only. Shares `ingress`'s epoch.
+    /// Non-zero means this session negotiated an audio stream and it produced
+    /// something, which is what makes `TAKEOVER_IDLE_THRESHOLD` a sound bound;
+    /// see `has_delivered_audio`.
+    ingress_audio: ActivityStamp,
+    /// Shared with the slot, not owned by the session: the slot's output chain
+    /// is built once, at flow build time, and outlives the sessions that pass
+    /// through it. `SessionActivity::new` resets it so one session never
+    /// inherits its predecessor's liveness.
+    output: Arc<ActivityStamp>,
 }
 
 impl SessionActivity {
-    pub fn new(epoch: Instant, last_buffer_ms: Arc<AtomicU64>) -> Self {
+    /// `epoch` is session start; `output` is the stamp belonging to the slot
+    /// this session was assigned.
+    pub fn new(epoch: Instant, output: Arc<ActivityStamp>) -> Self {
+        // This session has to prove for itself that its media comes out of the
+        // slot's chain. Buffers left in flight from the previous occupant can
+        // still stamp it for a moment afterwards, which only ever makes the new
+        // session look healthier than it is — the safe direction, and it
+        // corrects itself as soon as the chain drains.
+        output.reset();
         Self {
-            epoch,
-            last_buffer_ms,
-            last_audio_ms: AtomicU64::new(0),
+            ingress: ActivityStamp::new(epoch),
+            ingress_audio: ActivityStamp::new(epoch),
+            output,
         }
     }
 
-    /// Stamp the arrival of a buffer. Called from the appsink callback, so this
-    /// is the per-buffer hot path: one `Instant::now()` and one or two relaxed
-    /// stores, no lock and no allocation.
-    pub fn touch(&self, is_audio: bool) {
-        // 0 is reserved for "no buffer yet", so a buffer that lands inside the
-        // first millisecond of the session counts as 1.
-        let now_ms = (self.epoch.elapsed().as_millis() as u64).max(1);
-        self.last_buffer_ms.store(now_ms, Ordering::Relaxed);
-        if is_audio {
-            self.last_audio_ms.store(now_ms, Ordering::Relaxed);
-        }
-    }
-
-    /// Assemble a session whose counters a test has already positioned in time.
+    /// Assemble a session from stamps a test has already positioned in time.
+    /// Skips the reset `new` does, which would wipe them.
     #[cfg(test)]
-    pub fn from_counters(
-        epoch: Instant,
-        last_buffer_ms: Arc<AtomicU64>,
-        last_audio_ms: u64,
-    ) -> Self {
+    pub fn from_stamps(ingress: ActivityStamp, output: Arc<ActivityStamp>) -> Self {
+        // Carries audio, so it is in displacement range at all.
+        let ingress_audio = ActivityStamp::new(Instant::now());
+        ingress_audio.touch();
         Self {
-            epoch,
-            last_buffer_ms,
-            last_audio_ms: AtomicU64::new(last_audio_ms),
+            ingress,
+            ingress_audio,
+            output,
         }
     }
 
-    /// Whether this session has ever delivered an audio buffer.
+    /// Assemble a session that has never carried audio, so nothing about it can
+    /// be judged on a short silence; see `has_delivered_audio`.
+    #[cfg(test)]
+    pub fn video_only_from_stamps(ingress: ActivityStamp, output: Arc<ActivityStamp>) -> Self {
+        Self {
+            ingress,
+            ingress_audio: ActivityStamp::new(Instant::now()),
+            output,
+        }
+    }
+
+    /// Stamp the arrival of a buffer from the publisher. Called from the
+    /// appsink callback, so this is the per-buffer hot path.
+    pub fn touch_ingress(&self, is_audio: bool) {
+        self.ingress.touch();
+        if is_audio {
+            self.ingress_audio.touch();
+        }
+    }
+
+    /// Whether this session has ever carried an audio buffer.
     ///
     /// Only an audio-bearing session can be judged dead on a couple of seconds
     /// of silence, because only audio has a cadence tight enough for a gap that
@@ -222,29 +350,46 @@ impl SessionActivity {
     /// perfectly healthy transport, and is indistinguishable from a dead one by
     /// any media-based signal. Such a session is left to the inactivity
     /// watchdog; see `allocate_slot_or_take_over`.
+    ///
+    /// Read on the arriving side, not the slot's output: the output stamp is
+    /// shared by the slot's audio and video tees and cannot tell them apart,
+    /// and the question is what the publisher negotiated.
     pub fn has_delivered_audio(&self) -> bool {
-        self.last_audio_ms.load(Ordering::Relaxed) != 0
+        self.ingress_audio.last() != 0
     }
 
-    /// The raw counter: milliseconds from `epoch` at which the last buffer
-    /// arrived, 0 if none has. Only useful for comparing two readings — a value
-    /// that changes between them is a publisher that is still sending.
-    pub fn last_buffer(&self) -> u64 {
-        self.last_buffer_ms.load(Ordering::Relaxed)
+    /// The slot's output counter, for comparing two readings a poll apart. A
+    /// value that changed is a session that is genuinely still producing.
+    pub fn last_usable(&self) -> u64 {
+        self.output.last()
     }
 
-    /// Time since the last media buffer, or `None` if no buffer has arrived at
-    /// all — the session is still negotiating, or never produced media.
+    /// Time since this session last produced usable media, or `None` if it must
+    /// not be judged yet.
+    ///
+    /// `None` means one of two states that must both be left alone: nothing has
+    /// arrived at all (still negotiating — ICE through a TURN relay is slow, and
+    /// evicting it lets two clients take turns throwing each other off before
+    /// either sends media), or the first buffers arrived less than
+    /// `DECODE_GRACE` ago and the decoder may still be waiting for the keyframe
+    /// that carries H.264's parameter sets.
+    ///
+    /// Otherwise it is the staler of the two stamps: a session is usable only
+    /// while both move, and a publisher going away freezes `ingress` first while
+    /// a stall below the decoder freezes `output` first.
     pub fn idle(&self) -> Option<Duration> {
-        let last = self.last_buffer_ms.load(Ordering::Relaxed);
-        if last == 0 {
-            return None;
-        }
-        Some(
-            self.epoch
-                .elapsed()
-                .saturating_sub(Duration::from_millis(last)),
-        )
+        let ingress_idle = self.ingress.since_last()?;
+
+        let output_idle = match self.output.since_last() {
+            Some(idle) => idle,
+            // Media is arriving but nothing has come out of the decode chain.
+            // Inside the grace that is just preroll; past it, this is the
+            // failure the output stamp exists to catch, and the session has
+            // been useless since the grace ran out.
+            None => self.ingress.since_first()?.checked_sub(DECODE_GRACE)?,
+        };
+
+        Some(ingress_idle.max(output_idle))
     }
 }
 
@@ -317,6 +462,17 @@ pub struct WhipSessionManager {
 /// sub-second in practice.
 const PENDING_CLEANUP_TTL: Duration = Duration::from_secs(30);
 
+/// How long a session may receive media without any of it coming out of its
+/// slot's chain before it counts as producing nothing.
+///
+/// Some delay is normal: H.264 cannot be decoded until a keyframe brings its
+/// parameter sets, and `decodebin` has to autoplug a decoder first. Measured
+/// from the session's *first* buffer, so a session that spent a minute
+/// negotiating still gets the full grace once media starts. It has to stay under
+/// the watchdog's `INACTIVITY_TIMEOUT` for the watchdog to reap a session that
+/// never decodes at all.
+const DECODE_GRACE: Duration = Duration::from_secs(5);
+
 /// How long a session must have gone without media before a new client is
 /// allowed to take its slot.
 ///
@@ -342,10 +498,11 @@ const TAKEOVER_POLL: Duration = Duration::from_millis(100);
 struct IdlestSession {
     resource_id: String,
     port: u16,
-    /// Time since its last media buffer, `None` if it has never delivered one.
+    /// Time since it last produced usable media, `None` if it must not be
+    /// judged yet; see `SessionActivity::idle`.
     idle: Option<Duration>,
-    /// Its raw buffer counter, for comparison against the previous poll.
-    last_buffer: u64,
+    /// Its slot's output counter, for comparison against the previous poll.
+    last_usable: u64,
     /// Another path is already tearing it down, so its slot is about to free.
     dying: bool,
     /// Whether it has ever delivered audio; see `SessionActivity::has_delivered_audio`.
@@ -529,22 +686,24 @@ impl WhipSessionManager {
         true
     }
 
-    /// Allocate a slot for a new client, displacing a demonstrably dead session
-    /// if the endpoint is full.
+    /// Allocate a slot for a new client, displacing a session that is no longer
+    /// producing usable media if the endpoint is full.
     ///
-    /// A publisher that dies without sending a WHIP DELETE — network loss, the
-    /// common case for a real participant — leaves its slot occupied until the
-    /// session's inactivity watchdog notices, and every reconnect in between is
-    /// refused with 503.
+    /// Two ways a seat stops being worth its slot: the publisher dies without
+    /// sending a WHIP DELETE (network loss, the common case for a real
+    /// participant), or its media keeps arriving while nothing usable comes out
+    /// the far end — a decoder that never gets its keyframe, or a consumer
+    /// downstream of the slot's tee that blocks and backs pressure up the chain.
+    /// `SessionActivity` covers both.
     ///
     /// When all slots are taken, this watches the sitting session for up to
-    /// `TAKEOVER_WAIT` instead of refusing outright. A session whose buffer
-    /// counter is still moving has a publisher behind it and is never touched:
-    /// the new client gets its 503 as soon as the counter is seen to move, which
-    /// is a poll interval, not a wait. A counter that stays frozen past
-    /// `TAKEOVER_IDLE_THRESHOLD` is a dead transport, and the session is handed
-    /// to the ordinary cleanup path so the new client can take the slot it
-    /// releases.
+    /// `TAKEOVER_WAIT` instead of refusing outright. A session whose output
+    /// counter is still moving is producing for real and is never touched: the
+    /// new client gets its 503 as soon as the counter is seen to move, which is
+    /// a poll interval, not a wait. A counter frozen past
+    /// `TAKEOVER_IDLE_THRESHOLD` means the seat is dead, and the session is
+    /// handed to the ordinary cleanup path so the new client can take the slot
+    /// it releases.
     ///
     /// Both cases start out looking identical — a reconnect that lands 300 ms
     /// after the drop sees the same near-zero idle time as a healthy stream —
@@ -564,7 +723,7 @@ impl WhipSessionManager {
         resource_id: &str,
     ) -> Option<usize> {
         let deadline = Instant::now() + TAKEOVER_WAIT;
-        // The candidate's buffer counter as of the previous poll, so this poll
+        // The candidate's output counter as of the previous poll, so this poll
         // can tell whether it moved.
         let mut previous: Option<(String, u64)> = None;
 
@@ -591,41 +750,39 @@ impl WhipSessionManager {
                 if !candidate.cleanup_sent.swap(true, Ordering::SeqCst) {
                     let idle_ms = candidate.idle.unwrap_or_default().as_millis();
                     warn!(
-                        "WhipSessionManager: Displacing session '{}' on port {} ({} ms without media) so a new client can take its slot on endpoint '{}'",
+                        "WhipSessionManager: Displacing session '{}' on port {} ({} ms without usable media) so a new client can take its slot on endpoint '{}'",
                         candidate.resource_id, candidate.port, idle_ms, config.endpoint_id
                     );
                     let _ = self.cleanup_tx.send(SessionCleanupRequest {
                         port: candidate.port,
                         reason: format!(
-                            "displaced by a new client after {} ms without media",
+                            "displaced by a new client after {} ms without usable media",
                             idle_ms
                         ),
                     });
                 }
             } else if previous.as_ref().is_some_and(|(id, last)| {
-                *id == candidate.resource_id && *last != candidate.last_buffer
+                *id == candidate.resource_id && *last != candidate.last_usable
             }) {
-                // Its counter moved while we watched: the publisher is still
-                // sending and the endpoint is genuinely full.
+                // Its counter moved while we watched: media is still coming out
+                // of that slot and the endpoint is genuinely full.
                 return None;
             }
 
             if Instant::now() + TAKEOVER_POLL >= deadline {
                 return None;
             }
-            previous = Some((candidate.resource_id, candidate.last_buffer));
+            previous = Some((candidate.resource_id, candidate.last_usable));
             tokio::time::sleep(TAKEOVER_POLL).await;
         }
     }
 
-    /// The session on an endpoint that has gone longest without media — the one
-    /// a new client would displace. `None` if the endpoint has no registered
-    /// session at all.
+    /// The session on an endpoint that has gone longest without producing usable
+    /// media — the one a new client would displace. `None` if the endpoint has
+    /// no registered session at all.
     ///
-    /// A session that has never delivered a buffer sorts last and is never
-    /// displaced: it may simply be slow to negotiate (ICE through a TURN relay),
-    /// and evicting it would let two clients take turns throwing each other off
-    /// before either ever sends media.
+    /// A session `SessionActivity::idle` refuses to judge sorts last and is
+    /// never displaced: it is still negotiating, or still inside `DECODE_GRACE`.
     fn idlest_session(&self, endpoint_id: &str) -> Option<IdlestSession> {
         let sessions = self.sessions.read().unwrap();
         sessions
@@ -635,7 +792,7 @@ impl WhipSessionManager {
                 resource_id: resource_id.clone(),
                 port: s.port,
                 idle: s.activity.idle(),
-                last_buffer: s.activity.last_buffer(),
+                last_usable: s.activity.last_usable(),
                 dying: s.cleanup_sent.load(Ordering::SeqCst),
                 has_audio: s.activity.has_delivered_audio(),
                 cleanup_sent: s.cleanup_sent.clone(),
@@ -799,54 +956,104 @@ mod tests {
         (element, pipeline, Arc::new(AtomicBool::new(false)))
     }
 
-    /// A publisher whose transport is gone: its last buffer arrived `idle` ago
-    /// and the counter has not moved since. `idle` of zero is the case that
-    /// matters — a client reconnecting the instant its publisher died looks, at
-    /// that moment, exactly like a healthy one.
-    ///
-    /// It carries audio, so it is in displacement range at all.
-    fn dead_publisher(idle: Duration) -> Arc<SessionActivity> {
-        // The buffer landed 1 ms into the session, so the counter is non-zero
-        // (0 is reserved for "no buffer yet") and nothing has stamped it since.
-        let epoch = Instant::now() - idle - Duration::from_millis(1);
-        Arc::new(SessionActivity::from_counters(
-            epoch,
-            Arc::new(AtomicU64::new(1)),
-            1,
-        ))
-    }
+    /// How long a fixture session has been running before the test looks at it.
+    /// Comfortably past `DECODE_GRACE`, so a session that has produced nothing
+    /// usable in that time is genuinely broken rather than still starting up.
+    const RUNNING_FOR: Duration = Duration::from_secs(60);
 
-    /// A healthy video-only publisher of static content, mid-gap: its last frame
-    /// arrived `gap` ago and the next one is not due yet. Never delivered audio,
-    /// so nothing about it can be judged on a two-second silence.
-    fn sparse_video_publisher(gap: Duration) -> Arc<SessionActivity> {
-        let epoch = Instant::now() - gap - Duration::from_millis(1);
-        Arc::new(SessionActivity::new(epoch, Arc::new(AtomicU64::new(1))))
-    }
-
-    /// A publisher that is still sending: a thread stamps the counter every
-    /// 20 ms, the way the appsink callback does for every buffer that crosses
-    /// the bridge. The caller sets `stop` to end it.
-    fn live_publisher(stop: Arc<AtomicBool>) -> Arc<SessionActivity> {
-        let activity = Arc::new(SessionActivity::new(
-            Instant::now(),
-            Arc::new(AtomicU64::new(0)),
-        ));
-        let ticking = activity.clone();
+    /// Tick `stamp` every 20 ms until `stop` is set — the rate the session
+    /// appsink and the slot's output probe stamp a running publisher at.
+    fn tick_until_stopped(stop: Arc<AtomicBool>, stamp: impl Fn() + Send + 'static) {
         std::thread::spawn(move || {
             while !stop.load(Ordering::SeqCst) {
-                ticking.touch(true);
+                stamp();
                 std::thread::sleep(Duration::from_millis(20));
             }
         });
+    }
+
+    /// A publisher whose transport is gone: nothing has arrived and nothing has
+    /// come out of its slot for `idle`. `idle` of zero is the case that matters
+    /// — a client reconnecting the instant its publisher died looks, at that
+    /// moment, exactly like a healthy one.
+    fn dead_publisher(idle: Duration) -> Arc<SessionActivity> {
+        let ran_for = RUNNING_FOR + idle;
+        Arc::new(SessionActivity::from_stamps(
+            ActivityStamp::backdated(ran_for, idle),
+            Arc::new(ActivityStamp::backdated(ran_for, idle)),
+        ))
+    }
+
+    /// A publisher that is still sending and whose media still comes out of its
+    /// slot: both stamps tick, the way the appsink callback and the tee probe do
+    /// for a running session. The caller sets `stop` to end it.
+    fn live_publisher(stop: Arc<AtomicBool>) -> Arc<SessionActivity> {
+        let output = Arc::new(ActivityStamp::backdated(RUNNING_FOR, Duration::ZERO));
+        let activity = Arc::new(SessionActivity::from_stamps(
+            ActivityStamp::backdated(RUNNING_FOR, Duration::ZERO),
+            output.clone(),
+        ));
+        let ingress = activity.clone();
+        tick_until_stopped(stop.clone(), move || ingress.touch_ingress(true));
+        tick_until_stopped(stop, move || output.touch());
         activity
     }
 
-    /// A session that is still negotiating: connected, but no media yet.
+    /// A healthy video-only publisher of static content, mid-gap: its last frame
+    /// arrived `gap` ago, came out of its slot, and the next one is not due yet.
+    /// Never carried audio, so nothing about it can be judged on a two-second
+    /// silence.
+    fn sparse_video_publisher(gap: Duration) -> Arc<SessionActivity> {
+        let ran_for = RUNNING_FOR + gap;
+        Arc::new(SessionActivity::video_only_from_stamps(
+            ActivityStamp::backdated(ran_for, gap),
+            Arc::new(ActivityStamp::backdated(ran_for, gap)),
+        ))
+    }
+
+    /// The bug: RTP keeps arriving and has done for a minute, but nothing has
+    /// ever come out of the slot's chain — the decoder never got a usable
+    /// keyframe, or a consumer below the slot's tee is blocking it. Judged on
+    /// arriving bytes alone this seat looks perfectly healthy.
+    fn receiving_but_never_usable(stop: Arc<AtomicBool>) -> Arc<SessionActivity> {
+        let activity = Arc::new(SessionActivity::from_stamps(
+            ActivityStamp::backdated(RUNNING_FOR, Duration::ZERO),
+            Arc::new(ActivityStamp::new(Instant::now())),
+        ));
+        let ingress = activity.clone();
+        tick_until_stopped(stop, move || ingress.touch_ingress(true));
+        activity
+    }
+
+    /// The other half of the bug: the seat decoded fine and then froze
+    /// `stalled_for` ago, while RTP keeps arriving.
+    fn receiving_but_stalled(stop: Arc<AtomicBool>, stalled_for: Duration) -> Arc<SessionActivity> {
+        let activity = Arc::new(SessionActivity::from_stamps(
+            ActivityStamp::backdated(RUNNING_FOR, Duration::ZERO),
+            Arc::new(ActivityStamp::backdated(RUNNING_FOR, stalled_for)),
+        ));
+        let ingress = activity.clone();
+        tick_until_stopped(stop, move || ingress.touch_ingress(true));
+        activity
+    }
+
+    /// Media has only just started arriving and nothing has decoded yet. Normal:
+    /// H.264 cannot be decoded until a keyframe brings its parameter sets.
+    fn still_prerolling(stop: Arc<AtomicBool>) -> Arc<SessionActivity> {
+        let activity = Arc::new(SessionActivity::from_stamps(
+            ActivityStamp::backdated(Duration::from_millis(200), Duration::ZERO),
+            Arc::new(ActivityStamp::new(Instant::now())),
+        ));
+        let ingress = activity.clone();
+        tick_until_stopped(stop, move || ingress.touch_ingress(true));
+        activity
+    }
+
+    /// A session that is still negotiating: connected, but nothing has arrived.
     fn no_media_yet() -> Arc<SessionActivity> {
         Arc::new(SessionActivity::new(
             Instant::now(),
-            Arc::new(AtomicU64::new(0)),
+            Arc::new(ActivityStamp::new(Instant::now())),
         ))
     }
 
@@ -869,6 +1076,9 @@ mod tests {
             slot_audio_appsrcs: Vec::new(),
             slot_video_appsrcs: Vec::new(),
             slot_decodebins: vec![Vec::new(); max_sessions],
+            slot_output: (0..max_sessions)
+                .map(|_| Arc::new(ActivityStamp::new(Instant::now())))
+                .collect(),
             slot_assignments: Arc::new(RwLock::new(vec![None; max_sessions])),
         }
     }
@@ -1127,6 +1337,110 @@ mod tests {
             "a live publisher must be recognised from its moving counter, not \
              waited out: took {:?}",
             started.elapsed()
+        );
+    }
+
+    /// THE BUG. A seat keeps receiving RTP while nothing usable ever comes out
+    /// of its slot — the decoder never got a keyframe it could use, or a
+    /// consumer below the slot's tee is blocking the chain. Its arriving-bytes
+    /// counter moves the whole time, so liveness measured there says "healthy"
+    /// and every rejoining client is refused for as long as the seat sits there.
+    #[tokio::test]
+    async fn a_session_receiving_media_it_never_decodes_is_displaced() {
+        let stop = Arc::new(AtomicBool::new(false));
+        let (manager, config, cleanup_sent) = full_endpoint(
+            "receiving-nothing-usable",
+            40014,
+            receiving_but_never_usable(stop.clone()),
+        );
+
+        let slot = manager
+            .allocate_slot_or_take_over(&config, "rejoining-client")
+            .await;
+        stop.store(true, Ordering::SeqCst);
+
+        assert_eq!(
+            slot,
+            Some(0),
+            "a seat producing nothing usable must give its slot up, however much RTP it receives"
+        );
+        assert!(cleanup_sent.load(Ordering::SeqCst));
+        assert!(
+            manager
+                .get_session_port("receiving-nothing-usable")
+                .is_none(),
+            "the displaced session must be torn down by the ordinary cleanup path"
+        );
+    }
+
+    /// The same seat by the other route: it decoded fine and then froze, which is
+    /// what tee backpressure from a stuck consumer does to it. RTP keeps
+    /// arriving either way.
+    #[tokio::test]
+    async fn a_session_whose_output_has_stalled_is_displaced() {
+        let stop = Arc::new(AtomicBool::new(false));
+        let (manager, config, cleanup_sent) = full_endpoint(
+            "stalled-output",
+            40015,
+            receiving_but_stalled(stop.clone(), TAKEOVER_IDLE_THRESHOLD * 2),
+        );
+
+        let slot = manager
+            .allocate_slot_or_take_over(&config, "rejoining-client")
+            .await;
+        stop.store(true, Ordering::SeqCst);
+
+        assert_eq!(slot, Some(0), "a stalled seat must give its slot up");
+        assert!(cleanup_sent.load(Ordering::SeqCst));
+    }
+
+    /// The risk in judging a seat by its decoded output: media arrives before it
+    /// can be decoded, because H.264 carries its parameter sets with a keyframe
+    /// and `decodebin` has a decoder to autoplug first. A session inside that
+    /// window has produced nothing usable yet and must still be left alone.
+    #[tokio::test]
+    async fn a_session_still_waiting_for_its_first_decoded_frame_is_not_displaced() {
+        let stop = Arc::new(AtomicBool::new(false));
+        let (manager, config, cleanup_sent) =
+            full_endpoint("prerolling", 40016, still_prerolling(stop.clone()));
+
+        let slot = manager
+            .allocate_slot_or_take_over(&config, "second-client")
+            .await;
+        stop.store(true, Ordering::SeqCst);
+
+        assert_eq!(slot, None, "a prerolling session must keep its slot");
+        assert!(!cleanup_sent.load(Ordering::SeqCst));
+        assert!(
+            manager.get_session_port("prerolling").is_some(),
+            "the prerolling session must still be registered"
+        );
+    }
+
+    /// The output stamp belongs to the slot, which outlives the sessions passing
+    /// through it. A new session must not be judged on frames its predecessor
+    /// produced: inheriting a stale one makes the newcomer look stalled the
+    /// moment its own media starts arriving, and the next client evicts it.
+    #[test]
+    fn a_new_session_does_not_inherit_the_slots_previous_liveness() {
+        let slot_output = Arc::new(ActivityStamp::backdated(RUNNING_FOR, Duration::ZERO));
+        assert!(
+            slot_output.last() != 0,
+            "the previous occupant left the slot's stamp set"
+        );
+
+        let session = SessionActivity::new(Instant::now(), slot_output.clone());
+        session.touch_ingress(true);
+
+        assert_eq!(
+            slot_output.last(),
+            0,
+            "claiming a slot must clear what the previous session left on it"
+        );
+        assert_eq!(
+            session.idle(),
+            None,
+            "a session whose own media has only just started must not be judged yet"
         );
     }
 

--- a/backend/src/whip_session_manager.rs
+++ b/backend/src/whip_session_manager.rs
@@ -12,7 +12,7 @@ use gstreamer as gst;
 use gstreamer::prelude::*;
 use gstreamer_app as gst_app;
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, Instant};
 use strom_types::block::StreamMode;
@@ -154,6 +154,64 @@ pub struct SessionCleanupRequest {
     pub reason: String,
 }
 
+/// Liveness of one WHIP session: when its last media buffer crossed the
+/// appsink→appsrc bridge into the main pipeline.
+///
+/// The counter is written from the appsink's `new_sample` callback, i.e. once
+/// per buffer, so it is a single relaxed store against an epoch taken at session
+/// start. It is read by the session's own inactivity watchdog and by
+/// `allocate_slot_or_take_over`, which needs to know whether an occupied slot
+/// still has a publisher behind it. The counter is an `Arc` of its own because
+/// the session's watchdog thread reads it directly.
+pub struct SessionActivity {
+    /// Session start. All timestamps are milliseconds from here.
+    epoch: Instant,
+    /// Milliseconds from `epoch` at which the last buffer arrived; 0 = none yet.
+    last_buffer_ms: Arc<AtomicU64>,
+}
+
+impl SessionActivity {
+    pub fn new(epoch: Instant, last_buffer_ms: Arc<AtomicU64>) -> Self {
+        Self {
+            epoch,
+            last_buffer_ms,
+        }
+    }
+
+    /// Stamp the arrival of a buffer. Called from the appsink callback, so this
+    /// is the per-buffer hot path: one `Instant::now()` and one relaxed store,
+    /// no lock and no allocation.
+    pub fn touch(&self) {
+        // 0 is reserved for "no buffer yet", so a buffer that lands inside the
+        // first millisecond of the session counts as 1.
+        self.last_buffer_ms.store(
+            (self.epoch.elapsed().as_millis() as u64).max(1),
+            Ordering::Relaxed,
+        );
+    }
+
+    /// The raw counter: milliseconds from `epoch` at which the last buffer
+    /// arrived, 0 if none has. Only useful for comparing two readings — a value
+    /// that changes between them is a publisher that is still sending.
+    pub fn last_buffer(&self) -> u64 {
+        self.last_buffer_ms.load(Ordering::Relaxed)
+    }
+
+    /// Time since the last media buffer, or `None` if no buffer has arrived at
+    /// all — the session is still negotiating, or never produced media.
+    pub fn idle(&self) -> Option<Duration> {
+        let last = self.last_buffer_ms.load(Ordering::Relaxed);
+        if last == 0 {
+            return None;
+        }
+        Some(
+            self.epoch
+                .elapsed()
+                .saturating_sub(Duration::from_millis(last)),
+        )
+    }
+}
+
 /// An active WHIP session (one whipserversrc element per client).
 /// Each session runs in its own GStreamer pipeline to isolate NiceAgent instances.
 struct WhipSession {
@@ -171,6 +229,9 @@ struct WhipSession {
     /// Stops the session's inactivity watchdog thread and suppresses duplicate
     /// cleanup requests. Shared with the callbacks in `whip.rs`.
     cleanup_sent: Arc<AtomicBool>,
+    /// When this session last delivered media. Shared with the session's appsink
+    /// callbacks; see `SessionActivity`.
+    activity: Arc<SessionActivity>,
 }
 
 /// A freshly created WHIP session, handed to `register_session`.
@@ -189,6 +250,8 @@ pub struct NewWhipSession {
     pub slot: usize,
     /// Shared with the session's own callbacks; see `WhipSession::cleanup_sent`.
     pub cleanup_sent: Arc<AtomicBool>,
+    /// Shared with the session's appsink callbacks; see `SessionActivity`.
+    pub activity: Arc<SessionActivity>,
 }
 
 /// Manages WHIP sessions across all endpoints.
@@ -217,6 +280,40 @@ pub struct WhipSessionManager {
 /// gap between a session dying and `register_session` running for it, which is
 /// sub-second in practice.
 const PENDING_CLEANUP_TTL: Duration = Duration::from_secs(30);
+
+/// How long a session must have gone without media before a new client is
+/// allowed to take its slot.
+///
+/// A connected WebRTC publisher delivers audio every ~20 ms and video every
+/// ~33 ms, so two seconds of nothing means the transport is gone, not that the
+/// network had a bad moment. The threshold has to stay well under the session
+/// watchdog's own inactivity timeout, otherwise the watchdog frees the slot
+/// first and takeover buys nothing.
+const TAKEOVER_IDLE_THRESHOLD: Duration = Duration::from_secs(2);
+
+/// How long a POST may be held while the sitting session is judged. Long enough
+/// for a dead session to cross `TAKEOVER_IDLE_THRESHOLD` with polls to spare; the
+/// reasoning is on `allocate_slot_or_take_over`.
+const TAKEOVER_WAIT: Duration = Duration::from_secs(3);
+
+/// How often the takeover wait re-reads the slots and the sitting session's
+/// buffer counter. A live publisher stamps that counter every audio packet
+/// (~20 ms) and every video frame (~33 ms), so one poll is plenty to catch it
+/// moving.
+const TAKEOVER_POLL: Duration = Duration::from_millis(100);
+
+/// The least-live session on an endpoint: the one a new client would displace.
+struct IdlestSession {
+    resource_id: String,
+    port: u16,
+    /// Time since its last media buffer, `None` if it has never delivered one.
+    idle: Option<Duration>,
+    /// Its raw buffer counter, for comparison against the previous poll.
+    last_buffer: u64,
+    /// Another path is already tearing it down, so its slot is about to free.
+    dying: bool,
+    cleanup_sent: Arc<AtomicBool>,
+}
 
 impl WhipSessionManager {
     pub fn new() -> Self {
@@ -347,6 +444,7 @@ impl WhipSessionManager {
             endpoint_id,
             slot,
             cleanup_sent,
+            activity,
         } = session;
 
         // Check if this port was marked for cleanup before we could register it
@@ -387,9 +485,114 @@ impl WhipSessionManager {
                 endpoint_id,
                 slot,
                 cleanup_sent,
+                activity,
             },
         );
         true
+    }
+
+    /// Allocate a slot for a new client, displacing a demonstrably dead session
+    /// if the endpoint is full.
+    ///
+    /// A publisher that dies without sending a WHIP DELETE — network loss, the
+    /// common case for a real participant — leaves its slot occupied until the
+    /// session's inactivity watchdog notices, and every reconnect in between is
+    /// refused with 503.
+    ///
+    /// When all slots are taken, this watches the sitting session for up to
+    /// `TAKEOVER_WAIT` instead of refusing outright. A session whose buffer
+    /// counter is still moving has a publisher behind it and is never touched:
+    /// the new client gets its 503 as soon as the counter is seen to move, which
+    /// is a poll interval, not a wait. A counter that stays frozen past
+    /// `TAKEOVER_IDLE_THRESHOLD` is a dead transport, and the session is handed
+    /// to the ordinary cleanup path so the new client can take the slot it
+    /// releases.
+    ///
+    /// Both cases start out looking identical — a reconnect that lands 300 ms
+    /// after the drop sees the same near-zero idle time as a healthy stream —
+    /// which is why the decision is made on the counter moving rather than on a
+    /// single reading of it.
+    pub async fn allocate_slot_or_take_over(
+        &self,
+        config: &WhipEndpointConfig,
+        resource_id: &str,
+    ) -> Option<usize> {
+        let deadline = Instant::now() + TAKEOVER_WAIT;
+        // The candidate's buffer counter as of the previous poll, so this poll
+        // can tell whether it moved.
+        let mut previous: Option<(String, u64)> = None;
+
+        loop {
+            if let Some(slot) = config.allocate_slot(resource_id) {
+                return Some(slot);
+            }
+
+            // Full. Nothing registered on this endpoint means the slots are held
+            // by sessions still being set up: there is nothing to displace.
+            let candidate = self.idlest_session(&config.endpoint_id)?;
+
+            if candidate.dying {
+                // Another path is already tearing it down. Wait for the slot it
+                // is about to release rather than asking for cleanup twice.
+            } else if candidate
+                .idle
+                .is_some_and(|idle| idle >= TAKEOVER_IDLE_THRESHOLD)
+            {
+                // Win the flag every other teardown path uses, so the session is
+                // cleaned up exactly once and its watchdog thread stops. The
+                // cleanup task is what releases the slot; the next poll takes it.
+                if !candidate.cleanup_sent.swap(true, Ordering::SeqCst) {
+                    let idle_ms = candidate.idle.unwrap_or_default().as_millis();
+                    warn!(
+                        "WhipSessionManager: Displacing session '{}' on port {} ({} ms without media) so a new client can take its slot on endpoint '{}'",
+                        candidate.resource_id, candidate.port, idle_ms, config.endpoint_id
+                    );
+                    let _ = self.cleanup_tx.send(SessionCleanupRequest {
+                        port: candidate.port,
+                        reason: format!(
+                            "displaced by a new client after {} ms without media",
+                            idle_ms
+                        ),
+                    });
+                }
+            } else if previous.as_ref().is_some_and(|(id, last)| {
+                *id == candidate.resource_id && *last != candidate.last_buffer
+            }) {
+                // Its counter moved while we watched: the publisher is still
+                // sending and the endpoint is genuinely full.
+                return None;
+            }
+
+            if Instant::now() + TAKEOVER_POLL >= deadline {
+                return None;
+            }
+            previous = Some((candidate.resource_id, candidate.last_buffer));
+            tokio::time::sleep(TAKEOVER_POLL).await;
+        }
+    }
+
+    /// The session on an endpoint that has gone longest without media — the one
+    /// a new client would displace. `None` if the endpoint has no registered
+    /// session at all.
+    ///
+    /// A session that has never delivered a buffer sorts last and is never
+    /// displaced: it may simply be slow to negotiate (ICE through a TURN relay),
+    /// and evicting it would let two clients take turns throwing each other off
+    /// before either ever sends media.
+    fn idlest_session(&self, endpoint_id: &str) -> Option<IdlestSession> {
+        let sessions = self.sessions.read().unwrap();
+        sessions
+            .iter()
+            .filter(|(_, s)| s.endpoint_id == endpoint_id)
+            .map(|(resource_id, s)| IdlestSession {
+                resource_id: resource_id.clone(),
+                port: s.port,
+                idle: s.activity.idle(),
+                last_buffer: s.activity.last_buffer(),
+                dying: s.cleanup_sent.load(Ordering::SeqCst),
+                cleanup_sent: s.cleanup_sent.clone(),
+            })
+            .max_by_key(|c| (c.dying, c.idle))
     }
 
     /// Look up the port for a session by resource_id.
@@ -548,10 +751,111 @@ mod tests {
         (element, pipeline, Arc::new(AtomicBool::new(false)))
     }
 
+    /// A publisher whose transport is gone: its last buffer arrived `idle` ago
+    /// and the counter has not moved since. `idle` of zero is the case that
+    /// matters — a client reconnecting the instant its publisher died looks, at
+    /// that moment, exactly like a healthy one.
+    fn dead_publisher(idle: Duration) -> Arc<SessionActivity> {
+        // The buffer landed 1 ms into the session, so the counter is non-zero
+        // (0 is reserved for "no buffer yet") and nothing has stamped it since.
+        let epoch = Instant::now() - idle - Duration::from_millis(1);
+        Arc::new(SessionActivity::new(epoch, Arc::new(AtomicU64::new(1))))
+    }
+
+    /// A publisher that is still sending: a thread stamps the counter every
+    /// 20 ms, the way the appsink callback does for every buffer that crosses
+    /// the bridge. The caller sets `stop` to end it.
+    fn live_publisher(stop: Arc<AtomicBool>) -> Arc<SessionActivity> {
+        let activity = Arc::new(SessionActivity::new(
+            Instant::now(),
+            Arc::new(AtomicU64::new(0)),
+        ));
+        let ticking = activity.clone();
+        std::thread::spawn(move || {
+            while !stop.load(Ordering::SeqCst) {
+                ticking.touch();
+                std::thread::sleep(Duration::from_millis(20));
+            }
+        });
+        activity
+    }
+
+    /// A session that is still negotiating: connected, but no media yet.
+    fn no_media_yet() -> Arc<SessionActivity> {
+        Arc::new(SessionActivity::new(
+            Instant::now(),
+            Arc::new(AtomicU64::new(0)),
+        ))
+    }
+
+    fn endpoint_config(max_sessions: usize) -> WhipEndpointConfig {
+        WhipEndpointConfig {
+            instance_id: "whip-input".to_string(),
+            endpoint_id: "endpoint".to_string(),
+            mode: StreamMode::AudioVideo,
+            stun_server: None,
+            turn_server: None,
+            ice_transport_policy: "all".to_string(),
+            pipeline_weak: Default::default(),
+            decode: true,
+            video_decoding: Arc::new((0..max_sessions).map(|_| AtomicBool::new(false)).collect()),
+            jitterbuffer_latency_ms: 200,
+            do_retransmission: true,
+            dynamic_webrtcbin_store: Arc::new(Mutex::new(HashMap::new())),
+            max_video_bitrate_kbps: 4000,
+            max_sessions,
+            slot_audio_appsrcs: Vec::new(),
+            slot_video_appsrcs: Vec::new(),
+            slot_decodebins: vec![Vec::new(); max_sessions],
+            slot_assignments: Arc::new(RwLock::new(vec![None; max_sessions])),
+        }
+    }
+
+    /// A manager with one single-slot endpoint whose only slot is held by a
+    /// registered session with the given liveness — i.e. a full endpoint.
+    fn full_endpoint(
+        resource_id: &str,
+        port: u16,
+        activity: Arc<SessionActivity>,
+    ) -> (
+        Arc<WhipSessionManager>,
+        Arc<WhipEndpointConfig>,
+        Arc<AtomicBool>,
+    ) {
+        let manager = Arc::new(WhipSessionManager::new());
+        manager.start_cleanup_task();
+        manager.register_endpoint("endpoint".to_string(), endpoint_config(1));
+        let config = manager
+            .get_endpoint_config("endpoint")
+            .expect("endpoint was just registered");
+
+        assert_eq!(
+            config.allocate_slot(resource_id),
+            Some(0),
+            "the endpoint starts with its only slot free"
+        );
+        let cleanup_sent = register_with_activity(&manager, resource_id, port, activity);
+        assert_eq!(
+            config.allocate_slot("someone-else"),
+            None,
+            "the endpoint is now full"
+        );
+        (manager, config, cleanup_sent)
+    }
+
     /// A session's `cleanup_sent` flag is the only way to stop its inactivity
     /// watchdog thread. Every path that removes a session must set it, or the
     /// watchdog outlives the session and asks for cleanup of a port that is gone.
     fn register(manager: &WhipSessionManager, resource_id: &str, port: u16) -> Arc<AtomicBool> {
+        register_with_activity(manager, resource_id, port, dead_publisher(Duration::ZERO))
+    }
+
+    fn register_with_activity(
+        manager: &WhipSessionManager,
+        resource_id: &str,
+        port: u16,
+        activity: Arc<SessionActivity>,
+    ) -> Arc<AtomicBool> {
         let (element, pipeline, cleanup_sent) = dummy_session();
         let registered = manager.register_session(NewWhipSession {
             resource_id: resource_id.to_string(),
@@ -561,6 +865,7 @@ mod tests {
             endpoint_id: "endpoint".to_string(),
             slot: 0,
             cleanup_sent: cleanup_sent.clone(),
+            activity,
         });
         assert!(registered, "session should register");
         assert!(
@@ -629,6 +934,7 @@ mod tests {
             endpoint_id: "endpoint".to_string(),
             slot: 0,
             cleanup_sent: cleanup_sent.clone(),
+            activity: dead_publisher(Duration::ZERO),
         });
 
         assert!(
@@ -657,12 +963,127 @@ mod tests {
             endpoint_id: "endpoint".to_string(),
             slot: 0,
             cleanup_sent: cleanup_sent.clone(),
+            activity: dead_publisher(Duration::ZERO),
         });
 
         assert!(!registered, "a fresh mark must still reject the session");
         assert!(
             cleanup_sent.load(Ordering::SeqCst),
             "a rejected session's watchdog must be stopped too"
+        );
+    }
+
+    /// The bug this guards: a publisher that dies without sending a WHIP DELETE
+    /// (network loss) leaves its slot occupied, and the rejoining client is
+    /// refused with 503 until the inactivity watchdog reclaims the slot seconds
+    /// later. A session whose media has stopped must give its slot up instead.
+    #[tokio::test]
+    async fn a_dead_session_gives_its_slot_to_a_new_client() {
+        let (manager, config, cleanup_sent) = full_endpoint(
+            "dead-session",
+            40010,
+            dead_publisher(TAKEOVER_IDLE_THRESHOLD * 2),
+        );
+
+        let slot = manager
+            .allocate_slot_or_take_over(&config, "rejoining-client")
+            .await;
+
+        assert_eq!(
+            slot,
+            Some(0),
+            "the rejoining client must get the dead session's slot"
+        );
+        assert!(
+            cleanup_sent.load(Ordering::SeqCst),
+            "the displaced session's watchdog must be stopped"
+        );
+        assert!(
+            manager.get_session_port("dead-session").is_none(),
+            "the displaced session must be torn down by the ordinary cleanup path"
+        );
+        assert_eq!(
+            config.slot_assignments.read().unwrap()[0].as_deref(),
+            Some("rejoining-client"),
+            "the slot must be assigned to the new client, not left free"
+        );
+    }
+
+    /// The measured case, and the one a single reading of the idle time gets
+    /// wrong: the publisher is SIGKILLed and its client reconnects a few hundred
+    /// milliseconds later, while the dead session still looks freshly fed. It is
+    /// the counter staying frozen, not its value, that gives the session away.
+    #[tokio::test]
+    async fn a_session_that_died_moments_before_the_post_is_still_displaced() {
+        let (manager, config, cleanup_sent) =
+            full_endpoint("just-died", 40013, dead_publisher(Duration::ZERO));
+
+        let started = Instant::now();
+        let slot = manager
+            .allocate_slot_or_take_over(&config, "rejoining-client")
+            .await;
+
+        assert_eq!(
+            slot,
+            Some(0),
+            "a client reconnecting straight after the drop must still get the slot"
+        );
+        assert!(cleanup_sent.load(Ordering::SeqCst));
+        assert!(
+            started.elapsed() >= TAKEOVER_IDLE_THRESHOLD,
+            "the session must not be displaced before it has been quiet long enough"
+        );
+    }
+
+    /// The risk in takeover: a second participant must not be able to evict a
+    /// publisher that is streaming fine. Its buffer counter is moving, so that
+    /// client still gets 503, and gets it in a poll interval rather than after
+    /// the full takeover wait.
+    #[tokio::test]
+    async fn a_live_session_is_never_displaced() {
+        let stop = Arc::new(AtomicBool::new(false));
+        let (manager, config, cleanup_sent) =
+            full_endpoint("live-session", 40011, live_publisher(stop.clone()));
+
+        let started = Instant::now();
+        let slot = manager
+            .allocate_slot_or_take_over(&config, "second-client")
+            .await;
+        stop.store(true, Ordering::SeqCst);
+
+        assert_eq!(slot, None, "a second client must still be refused");
+        assert!(
+            !cleanup_sent.load(Ordering::SeqCst),
+            "a session that is delivering media must not be torn down"
+        );
+        assert!(
+            manager.get_session_port("live-session").is_some(),
+            "the live session must still be registered"
+        );
+        assert!(
+            started.elapsed() < TAKEOVER_IDLE_THRESHOLD,
+            "a live publisher must be recognised from its moving counter, not \
+             waited out: took {:?}",
+            started.elapsed()
+        );
+    }
+
+    /// A session that has not produced a buffer yet may just be slow to
+    /// negotiate (ICE through a TURN relay). Displacing it would let two clients
+    /// take turns evicting each other before either ever sends media.
+    #[tokio::test]
+    async fn a_session_that_has_not_delivered_media_yet_is_not_displaced() {
+        let (manager, config, cleanup_sent) = full_endpoint("negotiating", 40012, no_media_yet());
+
+        let slot = manager
+            .allocate_slot_or_take_over(&config, "second-client")
+            .await;
+
+        assert_eq!(slot, None, "a negotiating session must keep its slot");
+        assert!(!cleanup_sent.load(Ordering::SeqCst));
+        assert!(
+            manager.get_session_port("negotiating").is_some(),
+            "the negotiating session must still be registered"
         );
     }
 }

--- a/backend/src/whip_session_manager.rs
+++ b/backend/src/whip_session_manager.rs
@@ -157,17 +157,22 @@ pub struct SessionCleanupRequest {
 /// Liveness of one WHIP session: when its last media buffer crossed the
 /// appsink→appsrc bridge into the main pipeline.
 ///
-/// The counter is written from the appsink's `new_sample` callback, i.e. once
-/// per buffer, so it is a single relaxed store against an epoch taken at session
-/// start. It is read by the session's own inactivity watchdog and by
+/// The counters are written from the appsink's `new_sample` callback, i.e. once
+/// per buffer, so a stamp is a single relaxed store against an epoch taken at
+/// session start. They are read by the session's own inactivity watchdog and by
 /// `allocate_slot_or_take_over`, which needs to know whether an occupied slot
-/// still has a publisher behind it. The counter is an `Arc` of its own because
-/// the session's watchdog thread reads it directly.
+/// still has a publisher behind it. `last_buffer_ms` is an `Arc` of its own
+/// because the session's watchdog thread reads it directly.
 pub struct SessionActivity {
     /// Session start. All timestamps are milliseconds from here.
     epoch: Instant,
-    /// Milliseconds from `epoch` at which the last buffer arrived; 0 = none yet.
+    /// Milliseconds from `epoch` at which the last buffer arrived on any
+    /// stream; 0 = none yet.
     last_buffer_ms: Arc<AtomicU64>,
+    /// The same, counting audio buffers only. Non-zero means this session
+    /// negotiated an audio stream and it produced something, which is what
+    /// makes `TAKEOVER_IDLE_THRESHOLD` a sound bound; see `has_delivered_audio`.
+    last_audio_ms: AtomicU64,
 }
 
 impl SessionActivity {
@@ -175,19 +180,50 @@ impl SessionActivity {
         Self {
             epoch,
             last_buffer_ms,
+            last_audio_ms: AtomicU64::new(0),
         }
     }
 
     /// Stamp the arrival of a buffer. Called from the appsink callback, so this
-    /// is the per-buffer hot path: one `Instant::now()` and one relaxed store,
-    /// no lock and no allocation.
-    pub fn touch(&self) {
+    /// is the per-buffer hot path: one `Instant::now()` and one or two relaxed
+    /// stores, no lock and no allocation.
+    pub fn touch(&self, is_audio: bool) {
         // 0 is reserved for "no buffer yet", so a buffer that lands inside the
         // first millisecond of the session counts as 1.
-        self.last_buffer_ms.store(
-            (self.epoch.elapsed().as_millis() as u64).max(1),
-            Ordering::Relaxed,
-        );
+        let now_ms = (self.epoch.elapsed().as_millis() as u64).max(1);
+        self.last_buffer_ms.store(now_ms, Ordering::Relaxed);
+        if is_audio {
+            self.last_audio_ms.store(now_ms, Ordering::Relaxed);
+        }
+    }
+
+    /// Assemble a session whose counters a test has already positioned in time.
+    #[cfg(test)]
+    pub fn from_counters(
+        epoch: Instant,
+        last_buffer_ms: Arc<AtomicU64>,
+        last_audio_ms: u64,
+    ) -> Self {
+        Self {
+            epoch,
+            last_buffer_ms,
+            last_audio_ms: AtomicU64::new(last_audio_ms),
+        }
+    }
+
+    /// Whether this session has ever delivered an audio buffer.
+    ///
+    /// Only an audio-bearing session can be judged dead on a couple of seconds
+    /// of silence, because only audio has a cadence tight enough for a gap that
+    /// short to mean anything: ~20 ms per packet, against a video stream whose
+    /// interval is whatever the publisher's encoder decided to emit. A
+    /// video-only publisher of static content — a screen share of a window
+    /// nobody is touching — legitimately goes seconds between frames on a
+    /// perfectly healthy transport, and is indistinguishable from a dead one by
+    /// any media-based signal. Such a session is left to the inactivity
+    /// watchdog; see `allocate_slot_or_take_over`.
+    pub fn has_delivered_audio(&self) -> bool {
+        self.last_audio_ms.load(Ordering::Relaxed) != 0
     }
 
     /// The raw counter: milliseconds from `epoch` at which the last buffer
@@ -312,6 +348,8 @@ struct IdlestSession {
     last_buffer: u64,
     /// Another path is already tearing it down, so its slot is about to free.
     dying: bool,
+    /// Whether it has ever delivered audio; see `SessionActivity::has_delivered_audio`.
+    has_audio: bool,
     cleanup_sent: Arc<AtomicBool>,
 }
 
@@ -512,6 +550,14 @@ impl WhipSessionManager {
     /// after the drop sees the same near-zero idle time as a healthy stream —
     /// which is why the decision is made on the counter moving rather than on a
     /// single reading of it.
+    ///
+    /// Only a session that has delivered audio is ever displaced. Audio is what
+    /// makes `TAKEOVER_IDLE_THRESHOLD` mean anything; a video-only session can
+    /// sit that long between frames while its publisher is healthy, so it is
+    /// left to the inactivity watchdog and the new client gets a 503. The
+    /// residual case is a session whose audio stopped for good — a muted or
+    /// failed microphone — while its video continues at gaps wider than the
+    /// threshold: that one can still be displaced.
     pub async fn allocate_slot_or_take_over(
         &self,
         config: &WhipEndpointConfig,
@@ -534,9 +580,10 @@ impl WhipSessionManager {
             if candidate.dying {
                 // Another path is already tearing it down. Wait for the slot it
                 // is about to release rather than asking for cleanup twice.
-            } else if candidate
-                .idle
-                .is_some_and(|idle| idle >= TAKEOVER_IDLE_THRESHOLD)
+            } else if candidate.has_audio
+                && candidate
+                    .idle
+                    .is_some_and(|idle| idle >= TAKEOVER_IDLE_THRESHOLD)
             {
                 // Win the flag every other teardown path uses, so the session is
                 // cleaned up exactly once and its watchdog thread stops. The
@@ -590,6 +637,7 @@ impl WhipSessionManager {
                 idle: s.activity.idle(),
                 last_buffer: s.activity.last_buffer(),
                 dying: s.cleanup_sent.load(Ordering::SeqCst),
+                has_audio: s.activity.has_delivered_audio(),
                 cleanup_sent: s.cleanup_sent.clone(),
             })
             .max_by_key(|c| (c.dying, c.idle))
@@ -755,10 +803,24 @@ mod tests {
     /// and the counter has not moved since. `idle` of zero is the case that
     /// matters — a client reconnecting the instant its publisher died looks, at
     /// that moment, exactly like a healthy one.
+    ///
+    /// It carries audio, so it is in displacement range at all.
     fn dead_publisher(idle: Duration) -> Arc<SessionActivity> {
         // The buffer landed 1 ms into the session, so the counter is non-zero
         // (0 is reserved for "no buffer yet") and nothing has stamped it since.
         let epoch = Instant::now() - idle - Duration::from_millis(1);
+        Arc::new(SessionActivity::from_counters(
+            epoch,
+            Arc::new(AtomicU64::new(1)),
+            1,
+        ))
+    }
+
+    /// A healthy video-only publisher of static content, mid-gap: its last frame
+    /// arrived `gap` ago and the next one is not due yet. Never delivered audio,
+    /// so nothing about it can be judged on a two-second silence.
+    fn sparse_video_publisher(gap: Duration) -> Arc<SessionActivity> {
+        let epoch = Instant::now() - gap - Duration::from_millis(1);
         Arc::new(SessionActivity::new(epoch, Arc::new(AtomicU64::new(1))))
     }
 
@@ -773,7 +835,7 @@ mod tests {
         let ticking = activity.clone();
         std::thread::spawn(move || {
             while !stop.load(Ordering::SeqCst) {
-                ticking.touch();
+                ticking.touch(true);
                 std::thread::sleep(Duration::from_millis(20));
             }
         });
@@ -1084,6 +1146,36 @@ mod tests {
         assert!(
             manager.get_session_port("negotiating").is_some(),
             "the negotiating session must still be registered"
+        );
+    }
+
+    /// A video-only publisher of static content goes seconds between frames on a
+    /// healthy transport, so its frozen counter says nothing about whether it is
+    /// still there. Measured on the rig: a 0.2 fps video-only seat was displaced
+    /// at 3100 ms without media while its publisher was still sending.
+    #[tokio::test]
+    async fn a_sparse_video_only_session_is_not_displaced() {
+        let (manager, config, cleanup_sent) = full_endpoint(
+            "screenshare",
+            40013,
+            sparse_video_publisher(TAKEOVER_IDLE_THRESHOLD * 2),
+        );
+
+        let slot = manager
+            .allocate_slot_or_take_over(&config, "second-client")
+            .await;
+
+        assert_eq!(
+            slot, None,
+            "a video-only session must keep its slot however wide its frame gap"
+        );
+        assert!(
+            !cleanup_sent.load(Ordering::SeqCst),
+            "a healthy publisher must not be torn down"
+        );
+        assert!(
+            manager.get_session_port("screenshare").is_some(),
+            "the video-only session must still be registered"
         );
     }
 }

--- a/backend/src/whip_session_manager.rs
+++ b/backend/src/whip_session_manager.rs
@@ -62,10 +62,10 @@ pub struct WhipEndpointConfig {
     /// cannot hold the pipeline short of PLAYING; `allocate_slot` unlocks them.
     /// Empty when the endpoint runs with `decode=false`.
     pub slot_decodebins: Vec<Vec<gst::glib::WeakRef<gst::Element>>>,
-    /// Per-slot stamp of the media coming out of that slot's chain, written by
-    /// a pad probe on its output tee. The session sitting in a slot borrows its
-    /// stamp; see `SessionActivity`.
-    pub slot_output: Vec<Arc<ActivityStamp>>,
+    /// Per-slot record of the media coming out of that slot's chain, one stamp
+    /// per medium, written by a pad probe on each output tee. The session
+    /// sitting in a slot borrows it; see `SessionActivity`.
+    pub slot_output: Vec<Arc<SlotOutput>>,
     /// Slot assignments: slot index → Option<resource_id>
     /// Protected by RwLock for concurrent access from HTTP handlers.
     pub slot_assignments: Arc<RwLock<Vec<Option<String>>>>,
@@ -250,10 +250,118 @@ impl ActivityStamp {
     }
 }
 
+/// One of the two kinds of media a WHIP slot carries.
+///
+/// A slot in `StreamMode::AudioVideo` has an independent chain per medium —
+/// its own appsrc, its own `decodebin`, its own output tee — so the two fail
+/// independently and have to be tracked independently.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Medium {
+    Audio,
+    Video,
+}
+
+impl Medium {
+    fn other(self) -> Self {
+        match self {
+            Medium::Audio => Medium::Video,
+            Medium::Video => Medium::Audio,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Medium::Audio => "audio",
+            Medium::Video => "video",
+        }
+    }
+}
+
+/// What has actually come out of one slot's chain, one stamp per medium.
+///
+/// Built once per slot at flow build time and shared with the session sitting
+/// in that slot; the stamps are written by a `BUFFER` probe on each medium's
+/// output tee (see `stamp_slot_output` in the WHIP block).
+///
+/// Per medium, because a slot's audio and video are separate chains all the way
+/// from the publisher's RTP session to the flow's consumers. One stamp for both
+/// cannot express a seat whose audio has stopped while its video keeps moving.
+pub struct SlotOutput {
+    audio: ActivityStamp,
+    video: ActivityStamp,
+}
+
+impl SlotOutput {
+    /// Both media share `epoch`, so their raw `last()` readings are comparable.
+    pub fn new(epoch: Instant) -> Self {
+        Self {
+            audio: ActivityStamp::new(epoch),
+            video: ActivityStamp::new(epoch),
+        }
+    }
+
+    /// Assemble from stamps a test has already positioned in time.
+    #[cfg(test)]
+    pub fn from_stamps(audio: ActivityStamp, video: ActivityStamp) -> Self {
+        Self { audio, video }
+    }
+
+    pub fn stamp(&self, medium: Medium) -> &ActivityStamp {
+        match medium {
+            Medium::Audio => &self.audio,
+            Medium::Video => &self.video,
+        }
+    }
+
+    /// Stamp a buffer leaving the slot. Per-buffer hot path; see
+    /// `ActivityStamp::touch`.
+    pub fn touch(&self, medium: Medium) {
+        self.stamp(medium).touch();
+    }
+
+    /// Forget everything seen so far, both media. Used when a new session claims
+    /// a slot whose output chain outlives individual sessions.
+    pub fn reset(&self) {
+        self.audio.reset();
+        self.video.reset();
+    }
+
+    /// Time since either medium last produced, `None` if neither ever has. This
+    /// is the slot-level reading: the slot is producing something as long as one
+    /// of its chains moves.
+    fn since_last(&self) -> Option<Duration> {
+        newest(self.audio.since_last(), self.video.since_last())
+    }
+
+    /// A counter that changes whenever either medium produces a buffer, for
+    /// comparing two readings a poll apart. Both stamps only ever increase, so
+    /// their sum changes if and only if one of them did; it is not a time and
+    /// means nothing on its own.
+    fn counter(&self) -> u64 {
+        self.audio.last().wrapping_add(self.video.last())
+    }
+}
+
+/// The more recent of two idle times, ignoring a medium that never produced.
+fn newest(a: Option<Duration>, b: Option<Duration>) -> Option<Duration> {
+    match (a, b) {
+        (Some(a), Some(b)) => Some(a.min(b)),
+        (some, None) | (None, some) => some,
+    }
+}
+
+/// The older of two idle times, ignoring a medium that never produced.
+fn oldest(a: Option<Duration>, b: Option<Duration>) -> Option<Duration> {
+    match (a, b) {
+        (Some(a), Some(b)) => Some(a.max(b)),
+        (some, None) | (None, some) => some,
+    }
+}
+
 /// Liveness of one WHIP session, in the only terms that matter to the slot it
 /// occupies: is it still producing media the flow can use?
 ///
-/// Two stamps decide it, because arriving bytes are not the same thing as usable
+/// Two legs decide it, because arriving bytes are not the same thing as usable
 /// media:
 ///
 /// - `ingress` is stamped by the session pipeline's appsink, once per buffer
@@ -263,35 +371,36 @@ impl ActivityStamp {
 ///   pipeline, downstream of the slot's `decodebin`. It says frames are coming
 ///   out the far end and reaching the flow's consumers.
 ///
-/// A third, `ingress_audio`, does not measure liveness at all — it only records
-/// whether this session ever carried audio, which is what decides how short a
-/// silence may be held against it; see `has_delivered_audio`.
-///
 /// A seat can sit at the first without the second indefinitely — a decoder that
 /// never gets the keyframe it needs, or a downstream consumer that blocks and
 /// backs pressure up through the slot's tee — and by `ingress` alone it looks
 /// perfectly healthy while producing nothing.
 ///
+/// Both legs are per medium. The session-level readings below deliberately fold
+/// them back together — a session is alive while *any* of its media moves, and
+/// reaping one whose audio stopped would take its working video with it. The
+/// per-medium failure is reported instead, by `WhipSlotLiveness`.
+///
 /// Read by the session's inactivity watchdog and by
 /// `allocate_slot_or_take_over`.
 pub struct SessionActivity {
-    ingress: ActivityStamp,
-    /// The same arrivals, counting audio buffers only. Shares `ingress`'s epoch.
-    /// Non-zero means this session negotiated an audio stream and it produced
+    /// Ingress, split by the pad the appsink callback is installed on. A session
+    /// that has stamped `ingress_audio` has an audio stream that produced
     /// something, which is what makes `TAKEOVER_IDLE_THRESHOLD` a sound bound;
     /// see `has_delivered_audio`.
     ingress_audio: ActivityStamp,
+    ingress_video: ActivityStamp,
     /// Shared with the slot, not owned by the session: the slot's output chain
     /// is built once, at flow build time, and outlives the sessions that pass
     /// through it. `SessionActivity::new` resets it so one session never
     /// inherits its predecessor's liveness.
-    output: Arc<ActivityStamp>,
+    output: Arc<SlotOutput>,
 }
 
 impl SessionActivity {
     /// `epoch` is session start; `output` is the stamp belonging to the slot
     /// this session was assigned.
-    pub fn new(epoch: Instant, output: Arc<ActivityStamp>) -> Self {
+    pub fn new(epoch: Instant, output: Arc<SlotOutput>) -> Self {
         // This session has to prove for itself that its media comes out of the
         // slot's chain. Buffers left in flight from the previous occupant can
         // still stamp it for a moment afterwards, which only ever makes the new
@@ -299,33 +408,24 @@ impl SessionActivity {
         // corrects itself as soon as the chain drains.
         output.reset();
         Self {
-            ingress: ActivityStamp::new(epoch),
             ingress_audio: ActivityStamp::new(epoch),
+            ingress_video: ActivityStamp::new(epoch),
             output,
         }
     }
 
     /// Assemble a session from stamps a test has already positioned in time.
-    /// Skips the reset `new` does, which would wipe them.
+    /// Skips the reset `new` does, which would wipe them. An untouched
+    /// `ingress_audio` makes it a video-only session.
     #[cfg(test)]
-    pub fn from_stamps(ingress: ActivityStamp, output: Arc<ActivityStamp>) -> Self {
-        // Carries audio, so it is in displacement range at all.
-        let ingress_audio = ActivityStamp::new(Instant::now());
-        ingress_audio.touch();
+    pub fn from_stamps(
+        ingress_audio: ActivityStamp,
+        ingress_video: ActivityStamp,
+        output: Arc<SlotOutput>,
+    ) -> Self {
         Self {
-            ingress,
             ingress_audio,
-            output,
-        }
-    }
-
-    /// Assemble a session that has never carried audio, so nothing about it can
-    /// be judged on a short silence; see `has_delivered_audio`.
-    #[cfg(test)]
-    pub fn video_only_from_stamps(ingress: ActivityStamp, output: Arc<ActivityStamp>) -> Self {
-        Self {
-            ingress,
-            ingress_audio: ActivityStamp::new(Instant::now()),
+            ingress_video,
             output,
         }
     }
@@ -333,9 +433,10 @@ impl SessionActivity {
     /// Stamp the arrival of a buffer from the publisher. Called from the
     /// appsink callback, so this is the per-buffer hot path.
     pub fn touch_ingress(&self, is_audio: bool) {
-        self.ingress.touch();
         if is_audio {
             self.ingress_audio.touch();
+        } else {
+            self.ingress_video.touch();
         }
     }
 
@@ -351,9 +452,9 @@ impl SessionActivity {
     /// any media-based signal. Such a session is left to the inactivity
     /// watchdog; see `allocate_slot_or_take_over`.
     ///
-    /// Read on the arriving side, not the slot's output: the output stamp is
-    /// shared by the slot's audio and video tees and cannot tell them apart,
-    /// and the question is what the publisher negotiated.
+    /// Read on the arriving side, not the slot's output: the question is what
+    /// the publisher negotiated, and a slot's audio chain can be silent for
+    /// reasons that have nothing to do with whether the session offered audio.
     pub fn has_delivered_audio(&self) -> bool {
         self.ingress_audio.last() != 0
     }
@@ -361,7 +462,7 @@ impl SessionActivity {
     /// The slot's output counter, for comparing two readings a poll apart. A
     /// value that changed is a session that is genuinely still producing.
     pub fn last_usable(&self) -> u64 {
-        self.output.last()
+        self.output.counter()
     }
 
     /// Time since this session last produced usable media, or `None` if it must
@@ -374,11 +475,15 @@ impl SessionActivity {
     /// `DECODE_GRACE` ago and the decoder may still be waiting for the keyframe
     /// that carries H.264's parameter sets.
     ///
-    /// Otherwise it is the staler of the two stamps: a session is usable only
+    /// Otherwise it is the staler of the two legs: a session is usable only
     /// while both move, and a publisher going away freezes `ingress` first while
     /// a stall below the decoder freezes `output` first.
+    ///
+    /// Within a leg the media are folded together on the *newest* of them, so
+    /// this stays a whole-session reading: one dead medium does not cost a
+    /// session its slot. `WhipSlotLiveness` reports that case instead.
     pub fn idle(&self) -> Option<Duration> {
-        let ingress_idle = self.ingress.since_last()?;
+        let ingress_idle = self.ingress_since_last()?;
 
         let output_idle = match self.output.since_last() {
             Some(idle) => idle,
@@ -386,10 +491,227 @@ impl SessionActivity {
             // Inside the grace that is just preroll; past it, this is the
             // failure the output stamp exists to catch, and the session has
             // been useless since the grace ran out.
-            None => self.ingress.since_first()?.checked_sub(DECODE_GRACE)?,
+            None => self.ingress_since_first()?.checked_sub(DECODE_GRACE)?,
         };
 
         Some(ingress_idle.max(output_idle))
+    }
+
+    /// Time since either medium last arrived from the publisher.
+    fn ingress_since_last(&self) -> Option<Duration> {
+        newest(
+            self.ingress_audio.since_last(),
+            self.ingress_video.since_last(),
+        )
+    }
+
+    /// Time since the first buffer of either medium arrived.
+    fn ingress_since_first(&self) -> Option<Duration> {
+        oldest(
+            self.ingress_audio.since_first(),
+            self.ingress_video.since_first(),
+        )
+    }
+}
+
+/// How long a medium may be silent before its slot is reported as half dead.
+///
+/// The two media get different budgets because their cadences are not
+/// comparable. A connected publisher sends audio every ~20 ms even while its
+/// microphone is muted — WebRTC keeps the RTP stream running and fills it with
+/// silence — so a couple of seconds of nothing is already a broken chain. Video
+/// has no such floor: a screen share of a window nobody is touching
+/// legitimately goes many seconds between frames, so judging it that fast would
+/// report a healthy seat.
+#[derive(Debug, Clone, Copy)]
+pub struct StallThresholds {
+    /// Audio that produced and then stopped.
+    pub audio: Duration,
+    /// Video that produced and then stopped.
+    pub video: Duration,
+    /// A medium that has never produced at all, measured from the other
+    /// medium's first buffer. Generous, because the two chains do not start
+    /// together: `decodebin` autoplugs each of them separately, and video waits
+    /// for a keyframe that audio has no equivalent of.
+    pub absent: Duration,
+}
+
+impl Default for StallThresholds {
+    fn default() -> Self {
+        Self {
+            audio: Duration::from_secs(2),
+            video: Duration::from_secs(10),
+            absent: Duration::from_secs(10),
+        }
+    }
+}
+
+impl StallThresholds {
+    fn stopped(&self, medium: Medium) -> Duration {
+        match medium {
+            Medium::Audio => self.audio,
+            Medium::Video => self.video,
+        }
+    }
+}
+
+/// One medium of one occupied slot that is producing nothing while the slot's
+/// other medium keeps going.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SlotMediumStall {
+    pub slot: usize,
+    /// The medium that has stopped.
+    pub medium: Medium,
+    /// Time since it last produced, `None` if it never has.
+    pub silent_for: Option<Duration>,
+}
+
+impl std::fmt::Display for SlotMediumStall {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.silent_for {
+            Some(silent) => write!(
+                f,
+                "slot {} has produced no {} for {:.1} s while its {} is still flowing",
+                self.slot,
+                self.medium.as_str(),
+                silent.as_secs_f32(),
+                self.medium.other().as_str()
+            ),
+            None => write!(
+                f,
+                "slot {} has produced no {} at all while its {} is flowing",
+                self.slot,
+                self.medium.as_str(),
+                self.medium.other().as_str()
+            ),
+        }
+    }
+}
+
+/// Per-medium liveness of one WHIP Input block's slots, for the flow's block
+/// health scan.
+///
+/// The scan itself looks for paused pad tasks, which is how a *stalled* branch
+/// shows up. A slot medium that carries nothing does not stall anything: its
+/// appsrc is simply never pushed to, every element downstream sits idle and
+/// `PLAYING`, and the pad-task scan has nothing to find. The only evidence is
+/// that buffers stopped arriving at the slot's output tee, which is what
+/// `SlotOutput` records.
+///
+/// Reports a medium only while the slot's *other* medium is producing. A slot
+/// that has gone quiet altogether is a publisher that left, which is the
+/// inactivity watchdog's job and would otherwise be reported twice.
+pub struct WhipSlotLiveness {
+    endpoint_id: String,
+    mode: StreamMode,
+    slots: Vec<Arc<SlotOutput>>,
+    /// Shared with `WhipEndpointConfig`: an unoccupied slot produces nothing by
+    /// definition and is never reported.
+    assignments: Arc<RwLock<Vec<Option<String>>>>,
+}
+
+impl WhipSlotLiveness {
+    pub fn new(
+        endpoint_id: String,
+        mode: StreamMode,
+        slots: Vec<Arc<SlotOutput>>,
+        assignments: Arc<RwLock<Vec<Option<String>>>>,
+    ) -> Self {
+        Self {
+            endpoint_id,
+            mode,
+            slots,
+            assignments,
+        }
+    }
+
+    /// Every occupied slot medium that has stopped producing while its
+    /// counterpart has not.
+    ///
+    /// Thresholds are a parameter so a test can drive the real decision without
+    /// waiting out the production budgets; `BlockLiveness::failure` uses
+    /// `StallThresholds::default`.
+    pub fn stalls(&self, thresholds: StallThresholds) -> Vec<SlotMediumStall> {
+        // Only `StreamMode::AudioVideo` can be half dead: with one medium there
+        // is no counterpart to compare against, and a slot that stops entirely
+        // belongs to the watchdog.
+        if !self.mode.has_audio() || !self.mode.has_video() {
+            return Vec::new();
+        }
+
+        let occupied = self.assignments.read().unwrap();
+        let mut stalls = Vec::new();
+
+        for (slot, output) in self.slots.iter().enumerate() {
+            if !occupied.get(slot).is_some_and(|s| s.is_some()) {
+                continue;
+            }
+            for medium in [Medium::Audio, Medium::Video] {
+                let counterpart = output.stamp(medium.other());
+                // The counterpart has to be producing right now for this to be
+                // a half-dead seat rather than a dead one.
+                let Some(counterpart_idle) = counterpart.since_last() else {
+                    continue;
+                };
+                if counterpart_idle >= thresholds.stopped(medium.other()) {
+                    continue;
+                }
+
+                let stamp = output.stamp(medium);
+                match stamp.since_last() {
+                    // Silent for its own budget, and silent for that budget
+                    // *longer* than the counterpart. Without the second half, a
+                    // seat whose two media stop together reads as half dead for
+                    // the difference between their budgets: audio crosses two
+                    // seconds while video is still nine from crossing ten. On
+                    // the rig that mislabelled a seat whose transport had gone
+                    // for the 5.6 s before the watchdog reaped it.
+                    Some(silent) if silent >= counterpart_idle + thresholds.stopped(medium) => {
+                        stalls.push(SlotMediumStall {
+                            slot,
+                            medium,
+                            silent_for: Some(silent),
+                        });
+                    }
+                    Some(_) => {}
+                    // Never produced. Judged from how long the counterpart has
+                    // been running, so a slot whose media start a moment apart
+                    // is not reported for the gap between them.
+                    None => {
+                        if counterpart
+                            .since_first()
+                            .is_some_and(|running| running >= thresholds.absent)
+                        {
+                            stalls.push(SlotMediumStall {
+                                slot,
+                                medium,
+                                silent_for: None,
+                            });
+                        }
+                    }
+                }
+            }
+        }
+
+        stalls
+    }
+}
+
+impl crate::blocks::BlockLiveness for WhipSlotLiveness {
+    fn failure(&self) -> Option<String> {
+        let stalls = self.stalls(StallThresholds::default());
+        if stalls.is_empty() {
+            return None;
+        }
+        Some(format!(
+            "WHIP endpoint '{}': {}",
+            self.endpoint_id,
+            stalls
+                .iter()
+                .map(|stall| stall.to_string())
+                .collect::<Vec<_>>()
+                .join("; ")
+        ))
     }
 }
 
@@ -961,6 +1283,14 @@ mod tests {
     /// usable in that time is genuinely broken rather than still starting up.
     const RUNNING_FOR: Duration = Duration::from_secs(60);
 
+    /// A slot whose two media have both been producing for `RUNNING_FOR`.
+    fn running_output() -> SlotOutput {
+        SlotOutput::from_stamps(
+            ActivityStamp::backdated(RUNNING_FOR, Duration::ZERO),
+            ActivityStamp::backdated(RUNNING_FOR, Duration::ZERO),
+        )
+    }
+
     /// Tick `stamp` every 20 ms until `stop` is set — the rate the session
     /// appsink and the slot's output probe stamp a running publisher at.
     fn tick_until_stopped(stop: Arc<AtomicBool>, stamp: impl Fn() + Send + 'static) {
@@ -979,8 +1309,29 @@ mod tests {
     fn dead_publisher(idle: Duration) -> Arc<SessionActivity> {
         let ran_for = RUNNING_FOR + idle;
         Arc::new(SessionActivity::from_stamps(
+            // It carried audio while it lived, so it is in displacement range
+            // at all.
             ActivityStamp::backdated(ran_for, idle),
-            Arc::new(ActivityStamp::backdated(ran_for, idle)),
+            ActivityStamp::backdated(ran_for, idle),
+            Arc::new(SlotOutput::from_stamps(
+                ActivityStamp::backdated(ran_for, idle),
+                ActivityStamp::backdated(ran_for, idle),
+            )),
+        ))
+    }
+
+    /// A healthy video-only publisher of static content, mid-gap: its last frame
+    /// arrived `gap` ago and the next one is not due yet. Never delivered audio,
+    /// so nothing about it can be judged on a two-second silence.
+    fn sparse_video_publisher(gap: Duration) -> Arc<SessionActivity> {
+        let ran_for = RUNNING_FOR + gap;
+        Arc::new(SessionActivity::from_stamps(
+            ActivityStamp::new(Instant::now()),
+            ActivityStamp::backdated(ran_for, gap),
+            Arc::new(SlotOutput::from_stamps(
+                ActivityStamp::new(Instant::now()),
+                ActivityStamp::backdated(ran_for, gap),
+            )),
         ))
     }
 
@@ -988,27 +1339,16 @@ mod tests {
     /// slot: both stamps tick, the way the appsink callback and the tee probe do
     /// for a running session. The caller sets `stop` to end it.
     fn live_publisher(stop: Arc<AtomicBool>) -> Arc<SessionActivity> {
-        let output = Arc::new(ActivityStamp::backdated(RUNNING_FOR, Duration::ZERO));
+        let output = Arc::new(running_output());
         let activity = Arc::new(SessionActivity::from_stamps(
+            ActivityStamp::backdated(RUNNING_FOR, Duration::ZERO),
             ActivityStamp::backdated(RUNNING_FOR, Duration::ZERO),
             output.clone(),
         ));
         let ingress = activity.clone();
         tick_until_stopped(stop.clone(), move || ingress.touch_ingress(true));
-        tick_until_stopped(stop, move || output.touch());
+        tick_until_stopped(stop, move || output.touch(Medium::Audio));
         activity
-    }
-
-    /// A healthy video-only publisher of static content, mid-gap: its last frame
-    /// arrived `gap` ago, came out of its slot, and the next one is not due yet.
-    /// Never carried audio, so nothing about it can be judged on a two-second
-    /// silence.
-    fn sparse_video_publisher(gap: Duration) -> Arc<SessionActivity> {
-        let ran_for = RUNNING_FOR + gap;
-        Arc::new(SessionActivity::video_only_from_stamps(
-            ActivityStamp::backdated(ran_for, gap),
-            Arc::new(ActivityStamp::backdated(ran_for, gap)),
-        ))
     }
 
     /// The bug: RTP keeps arriving and has done for a minute, but nothing has
@@ -1018,7 +1358,8 @@ mod tests {
     fn receiving_but_never_usable(stop: Arc<AtomicBool>) -> Arc<SessionActivity> {
         let activity = Arc::new(SessionActivity::from_stamps(
             ActivityStamp::backdated(RUNNING_FOR, Duration::ZERO),
-            Arc::new(ActivityStamp::new(Instant::now())),
+            ActivityStamp::backdated(RUNNING_FOR, Duration::ZERO),
+            Arc::new(SlotOutput::new(Instant::now())),
         ));
         let ingress = activity.clone();
         tick_until_stopped(stop, move || ingress.touch_ingress(true));
@@ -1030,7 +1371,11 @@ mod tests {
     fn receiving_but_stalled(stop: Arc<AtomicBool>, stalled_for: Duration) -> Arc<SessionActivity> {
         let activity = Arc::new(SessionActivity::from_stamps(
             ActivityStamp::backdated(RUNNING_FOR, Duration::ZERO),
-            Arc::new(ActivityStamp::backdated(RUNNING_FOR, stalled_for)),
+            ActivityStamp::backdated(RUNNING_FOR, Duration::ZERO),
+            Arc::new(SlotOutput::from_stamps(
+                ActivityStamp::backdated(RUNNING_FOR, stalled_for),
+                ActivityStamp::backdated(RUNNING_FOR, stalled_for),
+            )),
         ));
         let ingress = activity.clone();
         tick_until_stopped(stop, move || ingress.touch_ingress(true));
@@ -1042,7 +1387,8 @@ mod tests {
     fn still_prerolling(stop: Arc<AtomicBool>) -> Arc<SessionActivity> {
         let activity = Arc::new(SessionActivity::from_stamps(
             ActivityStamp::backdated(Duration::from_millis(200), Duration::ZERO),
-            Arc::new(ActivityStamp::new(Instant::now())),
+            ActivityStamp::backdated(Duration::from_millis(200), Duration::ZERO),
+            Arc::new(SlotOutput::new(Instant::now())),
         ));
         let ingress = activity.clone();
         tick_until_stopped(stop, move || ingress.touch_ingress(true));
@@ -1053,7 +1399,7 @@ mod tests {
     fn no_media_yet() -> Arc<SessionActivity> {
         Arc::new(SessionActivity::new(
             Instant::now(),
-            Arc::new(ActivityStamp::new(Instant::now())),
+            Arc::new(SlotOutput::new(Instant::now())),
         ))
     }
 
@@ -1077,7 +1423,7 @@ mod tests {
             slot_video_appsrcs: Vec::new(),
             slot_decodebins: vec![Vec::new(); max_sessions],
             slot_output: (0..max_sessions)
-                .map(|_| Arc::new(ActivityStamp::new(Instant::now())))
+                .map(|_| Arc::new(SlotOutput::new(Instant::now())))
                 .collect(),
             slot_assignments: Arc::new(RwLock::new(vec![None; max_sessions])),
         }
@@ -1423,17 +1769,17 @@ mod tests {
     /// moment its own media starts arriving, and the next client evicts it.
     #[test]
     fn a_new_session_does_not_inherit_the_slots_previous_liveness() {
-        let slot_output = Arc::new(ActivityStamp::backdated(RUNNING_FOR, Duration::ZERO));
+        let slot_output = Arc::new(running_output());
         assert!(
-            slot_output.last() != 0,
-            "the previous occupant left the slot's stamp set"
+            slot_output.counter() != 0,
+            "the previous occupant left the slot's stamps set"
         );
 
         let session = SessionActivity::new(Instant::now(), slot_output.clone());
         session.touch_ingress(true);
 
         assert_eq!(
-            slot_output.last(),
+            slot_output.counter(),
             0,
             "claiming a slot must clear what the previous session left on it"
         );
@@ -1490,6 +1836,67 @@ mod tests {
         assert!(
             manager.get_session_port("screenshare").is_some(),
             "the video-only session must still be registered"
+        );
+    }
+
+    /// A commentator whose microphone stopped `silent_for` ago while their
+    /// camera keeps sending: half dead, and reported as such by
+    /// `WhipSlotLiveness`. The video half ticks like any live publisher.
+    fn dead_audio_publisher(stop: Arc<AtomicBool>, silent_for: Duration) -> Arc<SessionActivity> {
+        let ran_for = RUNNING_FOR + silent_for;
+        let output = Arc::new(SlotOutput::from_stamps(
+            ActivityStamp::backdated(ran_for, silent_for),
+            ActivityStamp::backdated(ran_for, Duration::ZERO),
+        ));
+        let activity = Arc::new(SessionActivity::from_stamps(
+            ActivityStamp::backdated(ran_for, silent_for),
+            ActivityStamp::backdated(ran_for, Duration::ZERO),
+            output.clone(),
+        ));
+        let ingress = activity.clone();
+        tick_until_stopped(stop.clone(), move || ingress.touch_ingress(false));
+        tick_until_stopped(stop, move || output.touch(Medium::Video));
+        activity
+    }
+
+    /// One dead medium must not cost a session its slot.
+    ///
+    /// The reap paths judge a session on its *newest* medium on purpose. A
+    /// publisher that stops sending audio has not gone away: taking its slot
+    /// would drop the video it is still delivering, and a client that
+    /// renegotiates away its microphone would be thrown off and reconnect in a
+    /// loop. The half-dead state is reported instead, by `WhipSlotLiveness`;
+    /// what an operator does about it is their call, not the reaper's.
+    #[tokio::test]
+    async fn a_session_whose_audio_died_keeps_its_slot() {
+        let stop = Arc::new(AtomicBool::new(false));
+        let activity = dead_audio_publisher(stop.clone(), Duration::from_secs(600));
+
+        assert!(
+            activity
+                .idle()
+                .is_some_and(|idle| idle < TAKEOVER_IDLE_THRESHOLD),
+            "its video is current, so the session is not idle: {:?}",
+            activity.idle()
+        );
+
+        let (manager, config, cleanup_sent) = full_endpoint("commentator", 40014, activity);
+        let slot = manager
+            .allocate_slot_or_take_over(&config, "second-client")
+            .await;
+        stop.store(true, Ordering::SeqCst);
+
+        assert_eq!(
+            slot, None,
+            "a publisher still delivering video must keep its slot"
+        );
+        assert!(
+            !cleanup_sent.load(Ordering::SeqCst),
+            "a half-dead seat must not be torn down"
+        );
+        assert!(
+            manager.get_session_port("commentator").is_some(),
+            "the session must still be registered"
         );
     }
 }

--- a/backend/src/whip_session_manager.rs
+++ b/backend/src/whip_session_manager.rs
@@ -34,13 +34,6 @@ pub struct WhipEndpointConfig {
     pub pipeline_weak: gst::glib::WeakRef<gst::Pipeline>,
     /// Whether to decode RTP to raw media (true) or pass through RTP (false)
     pub decode: bool,
-    /// Per-slot flag, set once the main pipeline's `decodebin` has exposed a
-    /// video pad for that slot — i.e. video is genuinely being decoded.
-    ///
-    /// A session asks the publisher for a keyframe until this flips, because
-    /// without the parameter sets that travel with a keyframe the depayloader
-    /// can never produce an access unit. See `gst::keyframe_request`.
-    pub video_decoding: Arc<Vec<AtomicBool>>,
     /// Jitterbuffer latency in milliseconds for the per-session webrtcbin.
     pub jitterbuffer_latency_ms: u32,
     /// Whether whipserversrc should request retransmission (NACK) of lost
@@ -1413,7 +1406,6 @@ mod tests {
             ice_transport_policy: "all".to_string(),
             pipeline_weak: Default::default(),
             decode: true,
-            video_decoding: Arc::new((0..max_sessions).map(|_| AtomicBool::new(false)).collect()),
             jitterbuffer_latency_ms: 200,
             do_retransmission: true,
             dynamic_webrtcbin_store: Arc::new(Mutex::new(HashMap::new())),

--- a/backend/tests/block_health_test.rs
+++ b/backend/tests/block_health_test.rs
@@ -1,0 +1,146 @@
+//! A pipeline branch can stop dead while the pipeline still reports Playing.
+//!
+//! When a downstream push fails with `not-negotiated`, `GstAggregator` marks
+//! its sink pads flushing and pauses its source pad task. Nothing is posted to
+//! the bus and no element changes state, so the failure is invisible in
+//! `gst_state`. These tests pin both halves: that the stall is silent, and
+//! that the block health scan reports it.
+
+use gstreamer as gst;
+use gstreamer::prelude::*;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+fn init() {
+    gst::init().unwrap();
+}
+
+/// Poll `condition` until true or `timeout` elapses. Returns whether it held.
+fn wait_for(condition: impl Fn() -> bool, timeout: Duration) -> bool {
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        if condition() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    condition()
+}
+
+/// videotestsrc -> compositor -> capsfilter -> fakesink.
+///
+/// The capsfilter is the lever: retightening it to a caps the compositor
+/// cannot produce makes the next push fail negotiation.
+struct StallRig {
+    pipeline: gst::Pipeline,
+    compositor: gst::Element,
+    capsfilter: gst::Element,
+    bus_errors: Arc<Mutex<Vec<String>>>,
+}
+
+impl StallRig {
+    fn build() -> Self {
+        let pipeline = gst::Pipeline::new();
+        let src = gst::ElementFactory::make("videotestsrc")
+            .property("is-live", true)
+            .build()
+            .unwrap();
+        let compositor = gst::ElementFactory::make("compositor").build().unwrap();
+        let capsfilter = gst::ElementFactory::make("capsfilter")
+            .property(
+                "caps",
+                gst::Caps::builder("video/x-raw")
+                    .field("width", 320i32)
+                    .field("height", 240i32)
+                    .build(),
+            )
+            .build()
+            .unwrap();
+        let sink = gst::ElementFactory::make("fakesink")
+            .property("sync", false)
+            .build()
+            .unwrap();
+
+        pipeline
+            .add_many([&src, &compositor, &capsfilter, &sink])
+            .unwrap();
+        src.link(&compositor).unwrap();
+        gst::Element::link_many([&compositor, &capsfilter, &sink]).unwrap();
+
+        let bus_errors = Arc::new(Mutex::new(Vec::new()));
+        let collected = bus_errors.clone();
+        let bus = pipeline.bus().unwrap();
+        bus.add_signal_watch();
+        bus.connect_message(Some("error"), move |_, msg| {
+            if let gst::MessageView::Error(err) = msg.view() {
+                collected.lock().unwrap().push(err.error().to_string());
+            }
+        });
+
+        Self {
+            pipeline,
+            compositor,
+            capsfilter,
+            bus_errors,
+        }
+    }
+
+    fn compositor_task_state(&self) -> gst::TaskState {
+        self.compositor.static_pad("src").unwrap().task_state()
+    }
+
+    /// Force the next compositor push to fail negotiation.
+    fn break_negotiation(&self) {
+        self.capsfilter.set_property(
+            "caps",
+            gst::Caps::builder("video/x-bayer")
+                .field("format", "bggr")
+                .build(),
+        );
+    }
+}
+
+impl Drop for StallRig {
+    fn drop(&mut self) {
+        let _ = self.pipeline.set_state(gst::State::Null);
+    }
+}
+
+#[test]
+fn aggregator_stall_is_silent_and_leaves_pipeline_playing() {
+    init();
+    let rig = StallRig::build();
+    rig.pipeline.set_state(gst::State::Playing).unwrap();
+
+    // videotestsrc is live, so the transition is async. Block until it settles:
+    // the compositor task starts before the pipeline finishes reaching Playing,
+    // so waiting on the task state alone races the state change.
+    let (res, current, _) = rig.pipeline.state(gst::ClockTime::from_seconds(10));
+    assert_eq!(res, Ok(gst::StateChangeSuccess::Success));
+    assert_eq!(current, gst::State::Playing);
+    assert_eq!(rig.compositor_task_state(), gst::TaskState::Started);
+
+    rig.break_negotiation();
+
+    assert!(
+        wait_for(
+            || rig.compositor_task_state() == gst::TaskState::Paused,
+            Duration::from_secs(10)
+        ),
+        "compositor task never stalled after negotiation was broken"
+    );
+
+    // The whole point: the stall reports nothing where a caller would look.
+    let (_, current, _) = rig.pipeline.state(gst::ClockTime::from_seconds(1));
+    assert_eq!(
+        current,
+        gst::State::Playing,
+        "pipeline should still report Playing while the branch is dead"
+    );
+    let errors = rig.bus_errors.lock().unwrap();
+    assert!(
+        errors.is_empty(),
+        "expected no bus error, got: {:?}",
+        errors
+    );
+}

--- a/backend/tests/block_health_test.rs
+++ b/backend/tests/block_health_test.rs
@@ -1,10 +1,11 @@
-//! A pipeline branch can stop dead while the pipeline still reports Playing.
+//! A pipeline branch can carry nothing while the pipeline still reports Playing.
 //!
-//! When a downstream push fails with `not-negotiated`, `GstAggregator` marks
-//! its sink pads flushing and pauses its source pad task. Nothing is posted to
-//! the bus and no element changes state, so the failure is invisible in
-//! `gst_state`. These tests pin both halves: that the stall is silent, and
-//! that the block health scan reports it.
+//! Two ways in. When a downstream push fails with `not-negotiated`,
+//! `GstAggregator` marks its sink pads flushing and pauses its source pad task.
+//! When a link is refused for having no format in common, the branch below it
+//! never starts at all. Neither posts to the bus and neither changes any
+//! element's state, so both are invisible in `gst_state`. These tests pin that
+//! silence; `gst::pipeline::health` covers the detection.
 
 use gstreamer as gst;
 use gstreamer::prelude::*;
@@ -142,5 +143,135 @@ fn aggregator_stall_is_silent_and_leaves_pipeline_playing() {
         errors.is_empty(),
         "expected no bus error, got: {:?}",
         errors
+    );
+}
+
+/// videotestsrc -> tee -> videoconvert, with videoconvert's output meant to go
+/// to audioconvert - a pair with no format in common.
+///
+/// The shape a vision mixer takes when its output caps cannot be negotiated
+/// across `gldownload`: a tee with `allow-not-linked=true` above a branch whose
+/// link was refused.
+struct UnformedLinkRig {
+    pipeline: gst::Pipeline,
+    videoconvert: gst::Element,
+    audioconvert: gst::Element,
+    bus_errors: Arc<Mutex<Vec<String>>>,
+}
+
+impl UnformedLinkRig {
+    fn build() -> Self {
+        let pipeline = gst::Pipeline::new();
+        let src = gst::ElementFactory::make("videotestsrc")
+            .property("is-live", true)
+            .build()
+            .unwrap();
+        let tee = gst::ElementFactory::make("tee")
+            .property("allow-not-linked", true)
+            .build()
+            .unwrap();
+        let videoconvert = gst::ElementFactory::make("videoconvert").build().unwrap();
+        let audioconvert = gst::ElementFactory::make("audioconvert").build().unwrap();
+        let sink = gst::ElementFactory::make("fakesink")
+            .property("sync", false)
+            .build()
+            .unwrap();
+
+        pipeline
+            .add_many([&src, &tee, &videoconvert, &audioconvert, &sink])
+            .unwrap();
+        src.link(&tee).unwrap();
+        tee.link(&sink).unwrap();
+        tee.link(&videoconvert).unwrap();
+
+        let bus_errors = Arc::new(Mutex::new(Vec::new()));
+        let collected = bus_errors.clone();
+        let bus = pipeline.bus().unwrap();
+        bus.add_signal_watch();
+        bus.connect_message(Some("error"), move |_, msg| {
+            if let gst::MessageView::Error(err) = msg.view() {
+                collected.lock().unwrap().push(err.error().to_string());
+            }
+        });
+
+        Self {
+            pipeline,
+            videoconvert,
+            audioconvert,
+            bus_errors,
+        }
+    }
+
+    /// Pads parked in the state the stalled-pad-task scan looks for, across the
+    /// whole pipeline.
+    fn paused_pads(&self) -> Vec<String> {
+        self.pipeline
+            .iterate_recurse()
+            .into_iter()
+            .flatten()
+            .flat_map(|element| {
+                element
+                    .pads()
+                    .into_iter()
+                    .filter(|pad| pad.task_state() == gst::TaskState::Paused)
+                    .map(|pad| format!("{}:{}", element.name(), pad.name()))
+                    .collect::<Vec<_>>()
+            })
+            .collect()
+    }
+}
+
+impl Drop for UnformedLinkRig {
+    fn drop(&mut self) {
+        let _ = self.pipeline.set_state(gst::State::Null);
+    }
+}
+
+#[test]
+fn an_unformed_link_is_silent_and_leaves_no_paused_task() {
+    init();
+    let rig = UnformedLinkRig::build();
+
+    let refused = rig
+        .videoconvert
+        .static_pad("src")
+        .unwrap()
+        .link(&rig.audioconvert.static_pad("sink").unwrap());
+    assert_eq!(
+        refused,
+        Err(gst::PadLinkError::Noformat),
+        "the pair must be unlinkable for the rest of this test to mean anything"
+    );
+
+    rig.pipeline.set_state(gst::State::Playing).unwrap();
+    let (res, current, _) = rig.pipeline.state(gst::ClockTime::from_seconds(10));
+    assert_eq!(res, Ok(gst::StateChangeSuccess::Success));
+    assert_eq!(current, gst::State::Playing);
+
+    // Let the source push into the dead branch for a while.
+    std::thread::sleep(Duration::from_millis(500));
+
+    let (_, current, _) = rig.pipeline.state(gst::ClockTime::from_seconds(1));
+    assert_eq!(
+        current,
+        gst::State::Playing,
+        "pipeline should still report Playing while the branch carries nothing"
+    );
+    let errors = rig.bus_errors.lock().unwrap();
+    assert!(
+        errors.is_empty(),
+        "expected no bus error, got: {:?}",
+        errors
+    );
+    assert!(
+        rig.videoconvert.static_pad("src").unwrap().peer().is_none(),
+        "videoconvert should still be unlinked"
+    );
+    // The reason the stalled-pad-task scan cannot find this: the tee absorbs
+    // the not-linked return, so no task anywhere is paused.
+    assert!(
+        rig.paused_pads().is_empty(),
+        "expected no paused pad task, got: {:?}",
+        rig.paused_pads()
     );
 }

--- a/frontend/src/app/rendering.rs
+++ b/frontend/src/app/rendering.rs
@@ -8,6 +8,9 @@ use strom_types::Flow;
 
 use super::*;
 use super::{FocusTarget, ThemePreference};
+
+/// Colour for a block that has stopped passing data.
+const FAILED_BLOCK_COLOR: Color32 = Color32::from_rgb(220, 60, 60);
 impl StromApp {
     /// Render the top toolbar.
     pub(super) fn render_toolbar(&mut self, ui: &mut egui::Ui) {
@@ -762,14 +765,42 @@ impl StromApp {
                                 );
                                 child_ui.add_space(4.0);
 
-                                // Show running state icon
+                                // Show running state icon. A flow with a failed
+                                // block is not running even though GStreamer
+                                // still reports Playing, so it must not read as
+                                // healthy here.
+                                let failed_blocks: Vec<_> = flow.failed_blocks().collect();
                                 let state_icon = if flow.running { "▶" } else { "■" };
-                                let state_color = if flow.running {
+                                let state_color = if !failed_blocks.is_empty() {
+                                    FAILED_BLOCK_COLOR
+                                } else if flow.running {
                                     Color32::from_rgb(0, 200, 0)
                                 } else {
                                     Color32::GRAY
                                 };
                                 child_ui.colored_label(state_color, state_icon);
+
+                                if !failed_blocks.is_empty() {
+                                    child_ui
+                                        .colored_label(FAILED_BLOCK_COLOR, "⚠")
+                                        .on_hover_ui(|ui| {
+                                            ui.label(
+                                                egui::RichText::new("Stopped passing data")
+                                                    .strong(),
+                                            );
+                                            ui.separator();
+                                            for health in &failed_blocks {
+                                                ui.label(format!(
+                                                    "{}: {}",
+                                                    health.block_id,
+                                                    health
+                                                        .detail
+                                                        .as_deref()
+                                                        .unwrap_or("no detail")
+                                                ));
+                                            }
+                                        });
+                                }
 
                                 // Show QoS indicator if there are issues - make it clickable to open log
                                 if let Some(qos_health) = self.qos_stats.get_flow_health(&flow.id) {
@@ -898,12 +929,24 @@ impl StromApp {
                                     }
 
                                     ui.add_space(5.0);
-                                    let state_text = if flow.running {
+                                    let state_text = if flow.has_failed_block() {
+                                        "Failed"
+                                    } else if flow.running {
                                         "Running"
                                     } else {
                                         "Stopped"
                                     };
                                     ui.label(format!("State: {}", state_text));
+                                    for health in flow.failed_blocks() {
+                                        ui.colored_label(
+                                            FAILED_BLOCK_COLOR,
+                                            format!(
+                                                "{} stopped: {}",
+                                                health.block_id,
+                                                health.detail.as_deref().unwrap_or("no detail")
+                                            ),
+                                        );
+                                    }
 
                                     // Show timestamps
                                     if flow.properties.started_at.is_some()

--- a/frontend/src/app/update.rs
+++ b/frontend/src/app/update.rs
@@ -395,6 +395,46 @@ impl eframe::App for StromApp {
                                 }
                             });
                         }
+                        StromEvent::BlockHealthChanged {
+                            flow_id,
+                            block_id,
+                            status,
+                            detail,
+                        } => {
+                            // block_health rides on the Flow payload, so the
+                            // indicator only updates if the flow is refetched.
+                            match status {
+                                strom_types::BlockHealthStatus::Failed => tracing::error!(
+                                    "Block {} in flow {} stopped passing data: {}",
+                                    block_id,
+                                    flow_id,
+                                    detail.as_deref().unwrap_or("no detail")
+                                ),
+                                strom_types::BlockHealthStatus::Ok => {
+                                    tracing::info!("Block {} in flow {} resumed", block_id, flow_id)
+                                }
+                            }
+                            let api = self.api.clone();
+                            let tx = self.channels.sender();
+                            let ctx = ui.ctx().clone();
+
+                            spawn_task(async move {
+                                match api.get_flow(flow_id).await {
+                                    Ok(flow) => {
+                                        let _ = tx.send(AppMessage::FlowFetched(Box::new(flow)));
+                                        ctx.request_repaint();
+                                    }
+                                    Err(e) => {
+                                        tracing::error!(
+                                            "Failed to fetch flow after block health change: {}",
+                                            e
+                                        );
+                                        let _ = tx.send(AppMessage::RefreshNeeded);
+                                        ctx.request_repaint();
+                                    }
+                                }
+                            });
+                        }
                         StromEvent::FlowUpdated { flow_id } => {
                             // For updates, fetch the specific flow to update it in-place
                             tracing::info!("Flow {} updated, fetching updated flow", flow_id);

--- a/openapi.json
+++ b/openapi.json
@@ -4907,6 +4907,39 @@
           }
         }
       },
+      "BlockHealth": {
+        "type": "object",
+        "description": "Runtime health of one block in a running flow.",
+        "required": [
+          "block_id",
+          "status"
+        ],
+        "properties": {
+          "block_id": {
+            "type": "string",
+            "description": "Block instance ID this health report belongs to."
+          },
+          "detail": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Human-readable detail naming the element and pad whose task stopped.\n`None` when the block is healthy."
+          },
+          "status": {
+            "$ref": "#/components/schemas/BlockHealthStatus",
+            "description": "Whether the block's element chain is running or has stopped."
+          }
+        }
+      },
+      "BlockHealthStatus": {
+        "type": "string",
+        "description": "Health of a single block's element chain while the flow is running.\n\nPausing a pad task is not a state change: the pipeline and every element in\nit stay `PLAYING` while that branch stops passing data, so the failure does\nnot show up in the flow's `gst_state`.",
+        "enum": [
+          "ok",
+          "failed"
+        ]
+      },
       "BlockInstance": {
         "type": "object",
         "description": "Block instance in a flow",
@@ -5991,6 +6024,13 @@
           "name"
         ],
         "properties": {
+          "block_health": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BlockHealth"
+            },
+            "description": "Per-block runtime health. Populated only while a pipeline is running;\nempty otherwise. An entry with a failed status means that block has\nstopped passing data even though `gst_state` is still `Playing`."
+          },
           "blocks": {
             "type": "array",
             "items": {
@@ -9553,6 +9593,52 @@
                 "type": "string",
                 "enum": [
                   "SubscriptionStatusChanged"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "A block's element chain stopped passing data, or resumed.\n\nEmitted only on a change of status, not on every health poll.",
+            "required": [
+              "data",
+              "type"
+            ],
+            "properties": {
+              "data": {
+                "type": "object",
+                "description": "A block's element chain stopped passing data, or resumed.\n\nEmitted only on a change of status, not on every health poll.",
+                "required": [
+                  "flow_id",
+                  "block_id",
+                  "status"
+                ],
+                "properties": {
+                  "block_id": {
+                    "type": "string",
+                    "description": "Block instance ID, or element ID for a standalone element"
+                  },
+                  "detail": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Element and pad whose task stopped; None when the block recovered"
+                  },
+                  "flow_id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "status": {
+                    "$ref": "#/components/schemas/BlockHealthStatus",
+                    "description": "Whether the block is passing data or has stopped"
+                  }
+                }
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "BlockHealthChanged"
                 ]
               }
             }

--- a/types/src/events.rs
+++ b/types/src/events.rs
@@ -1,6 +1,7 @@
 //! Events for real-time updates across clients.
 
 use crate::element::PropertyValue;
+use crate::flow::BlockHealthStatus;
 use crate::system_monitor::SystemStats;
 use crate::thread_stats::ThreadStats;
 use crate::FlowId;
@@ -182,6 +183,19 @@ pub enum StromEvent {
         source_flow_id: FlowId,
         output_name: String,
         connected: bool,
+    },
+    /// A block's element chain stopped passing data, or resumed.
+    ///
+    /// Emitted only on a change of status, not on every health poll.
+    BlockHealthChanged {
+        #[cfg_attr(feature = "openapi", schema(value_type = String, format = Uuid))]
+        flow_id: FlowId,
+        /// Block instance ID, or element ID for a standalone element
+        block_id: String,
+        /// Whether the block is passing data or has stopped
+        status: BlockHealthStatus,
+        /// Element and pad whose task stopped; None when the block recovered
+        detail: Option<String>,
     },
     /// Quality of Service statistics (aggregated buffer drop info)
     QoSStats {
@@ -541,6 +555,22 @@ impl StromEvent {
             StromEvent::ThreadStats(stats) => {
                 format!("Thread stats: {} active threads", stats.threads.len())
             }
+            StromEvent::BlockHealthChanged {
+                flow_id,
+                block_id,
+                status,
+                detail,
+            } => match status {
+                BlockHealthStatus::Failed => format!(
+                    "Block {} in flow {} stopped passing data: {}",
+                    block_id,
+                    flow_id,
+                    detail.as_deref().unwrap_or("no detail")
+                ),
+                BlockHealthStatus::Ok => {
+                    format!("Block {} in flow {} resumed", block_id, flow_id)
+                }
+            },
             StromEvent::QoSStats {
                 flow_id,
                 block_id,

--- a/types/src/flow.rs
+++ b/types/src/flow.rs
@@ -419,6 +419,11 @@ pub struct Flow {
     /// Prefer [`running`](Self::running) for logic and display.
     #[serde(default)]
     pub gst_state: Option<PipelineState>,
+    /// Per-block runtime health. Populated only while a pipeline is running;
+    /// empty otherwise. An entry with a failed status means that block has
+    /// stopped passing data even though `gst_state` is still `Playing`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub block_health: Vec<BlockHealth>,
     /// Flow configuration properties
     #[serde(default)]
     pub properties: FlowProperties,
@@ -435,6 +440,7 @@ impl Flow {
             links: Vec::new(),
             running: false,
             gst_state: Some(PipelineState::Null),
+            block_health: Vec::new(),
             properties: FlowProperties::default(),
         }
     }
@@ -449,6 +455,7 @@ impl Flow {
             links: Vec::new(),
             running: false,
             gst_state: Some(PipelineState::Null),
+            block_health: Vec::new(),
             properties: FlowProperties::default(),
         }
     }
@@ -458,6 +465,57 @@ impl Flow {
         self.running = state.is_some_and(|s| s.is_active());
         self.gst_state = state;
     }
+
+    /// Blocks whose element chain has stopped passing data.
+    pub fn failed_blocks(&self) -> impl Iterator<Item = &BlockHealth> {
+        self.block_health.iter().filter(|h| h.status.is_failed())
+    }
+
+    /// Whether any block in this flow has failed.
+    ///
+    /// `running` only reports that the pipeline reached `Playing`; it stays
+    /// `true` when a block underneath has stopped. Callers deciding whether a
+    /// flow is actually working need both.
+    pub fn has_failed_block(&self) -> bool {
+        self.failed_blocks().next().is_some()
+    }
+}
+
+/// Health of a single block's element chain while the flow is running.
+///
+/// Pausing a pad task is not a state change: the pipeline and every element in
+/// it stay `PLAYING` while that branch stops passing data, so the failure does
+/// not show up in the flow's `gst_state`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[serde(rename_all = "lowercase")]
+pub enum BlockHealthStatus {
+    /// No stopped pad task was found in this block's element chain.
+    Ok,
+    /// A pad task in this block's element chain has stopped. The block is not
+    /// passing data, regardless of what the pipeline state says.
+    Failed,
+}
+
+impl BlockHealthStatus {
+    /// Whether this status means the block has failed.
+    pub fn is_failed(&self) -> bool {
+        matches!(self, BlockHealthStatus::Failed)
+    }
+}
+
+/// Runtime health of one block in a running flow.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct BlockHealth {
+    /// Block instance ID this health report belongs to.
+    pub block_id: String,
+    /// Whether the block's element chain is running or has stopped.
+    pub status: BlockHealthStatus,
+    /// Human-readable detail naming the element and pad whose task stopped.
+    /// `None` when the block is healthy.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
 }
 
 #[cfg(test)]

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -47,7 +47,9 @@ pub use block::{
 };
 pub use element::{Element, ElementId, Link, MediaType, PropertyValue};
 pub use events::StromEvent;
-pub use flow::{CpuAffinity, Flow, FlowId, ThreadPriority, ThreadPriorityStatus};
+pub use flow::{
+    BlockHealth, BlockHealthStatus, CpuAffinity, Flow, FlowId, ThreadPriority, ThreadPriorityStatus,
+};
 pub use network::{
     Ipv4AddressInfo, Ipv6AddressInfo, NetworkInterfaceInfo, NetworkInterfacesResponse,
 };


### PR DESCRIPTION
## Base

This does not sit on `main`. Reviewable content is the last commit only:

```
main
 └─ #753  wagenet/whip-slot-takeover
     └─ #756  wagenet/whip-liveness-decoded
         └─ merge of #796  wagenet/unlinked-branch-health-pr  (carries #786)
             └─ #792  feat(whip): track a slot's liveness per medium
                 └─ fix(whip): stop asking a reconnecting publisher ...   ← this PR
```

#792 is what this stops on: the per-medium slot output stamp. Merge after it.

## The bug

A WHIP session stops asking its publisher for keyframes once its video decodes, and the signal for that was `decodebin` exposing the slot's video pad. That fires **once per flow**. On a slot that has already carried a session the pad is there from the first one, so no later session could ever be seen to start.

Every reconnect therefore burned the full request budget and logged

```
WHIP Input: requested a keyframe 5 time(s) on slot 0 (video had not started decoding)
```

about video that was decoding perfectly well. Each request forces a keyframe on the publisher's uplink, so a meeting where participants reconnect paid a burst of bitrate spikes for nothing — and the log said the opposite of what was happening, which is its own cost when something else on that seat is being diagnosed.

## The fix

Stop on the slot's video output stamp instead. Claiming a slot clears it, so a reading is about the session that is asking and no other — which is exactly what a once-per-flow pad event cannot express.

That makes the per-slot `video_decoding` flag redundant, along with the re-arm it needed, so both go. `request_until_decoding` now takes a predicate rather than an `&AtomicBool`, which keeps the module free of any particular liveness type and leaves its policy tests unchanged in substance.

## Measured

Five-seat meeting rig, one seat reconnecting six times:

| | forced keyframes |
|---|---|
| before | 27 |
| after | 6 |

The seat stayed healthy throughout, checked by the tone in a second seat's return mix.

## A consequence worth knowing

The stamp is a **later** signal than a pad appearing, so a healthy session is now asked once at the 500 ms mark instead of not at all. Still well below the old cost, but the two comments claiming a healthy session is never asked were no longer true, so they are corrected rather than left lying.

I considered lengthening the first wait to reach zero requests and did not: that would bake a constant out of one machine's timing, and it would delay the first ask for a session that genuinely needs one.

## Tests

`a_reconnecting_publisher_is_not_asked_for_keyframes` drives the real slot chains through a session boundary and then runs the actual policy, asserting nothing is asked. Checked here by dropping the second session's video pushes, which makes it fail on the "asked for a keyframe" path.

It pins the stop condition, not the wiring that consults it — worth knowing if someone later rewires the requester.

Ran on this branch: `cargo test --workspace` (33 binaries, 769 tests, 0 failed, the 2 pre-existing ignored ones aside), `cargo clippy --workspace --all-targets` and `cargo fmt --check`, all green.

Not re-run after the re-cut: the rig measurement above. Those numbers are from the earlier build of this commit, before it was re-applied onto the current #756, #796 and #792. CI has not run either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
