### PR TITLE
fix(api): make transition indices optional and report the real take pair

### DIFF
--- a/backend/src/api/flows.rs
+++ b/backend/src/api/flows.rs
@@ -1779,6 +1779,10 @@ pub async fn get_flow_pad_caps(
 /// Trigger a scene transition on a compositor block.
 ///
 /// Animates the transition between two inputs on a compositor/mixer block.
+///
+/// A vision mixer takes between its own authoritative PGM/PVW bus state and
+/// ignores `from_input`/`to_input`. A block with no live state requires them.
+///
 /// Supported transition types:
 /// - `cut`: Instant switch (no animation)
 /// - `fade`: Cross-fade via alpha blending
@@ -1808,11 +1812,11 @@ pub async fn trigger_transition(
     ValidatedJson(req): ValidatedJson<TriggerTransitionRequest>,
 ) -> Result<Json<TransitionResponse>, (StatusCode, Json<ErrorResponse>)> {
     debug!(
-        "Triggering {} transition on block {} in flow {} ({} -> {}, {}ms)",
+        "Triggering {} transition on block {} in flow {} ({:?} -> {:?}, {}ms)",
         req.transition_type, block_id, flow_id, req.from_input, req.to_input, req.duration_ms
     );
 
-    let actual_transition_type = state
+    let (actual_transition_type, old_pgm, new_pgm) = state
         .trigger_transition(
             &flow_id,
             &block_id,
@@ -1833,11 +1837,18 @@ pub async fn trigger_transition(
             )
         })?;
 
-    Ok(Json(TransitionResponse {
-        message: format!(
+    // Report the sources the take actually ran between, not the request —
+    // on a vision mixer those differ. Neither is named when a bus is a PiP.
+    let message = match (old_pgm, new_pgm) {
+        (Some(from), Some(to)) => format!(
             "Transition {} started: input {} -> {}",
-            req.transition_type, req.from_input, req.to_input
+            req.transition_type, from, to
         ),
+        _ => format!("Transition {} started", req.transition_type),
+    };
+
+    Ok(Json(TransitionResponse {
+        message,
         transition_type: req.transition_type,
         actual_transition_type,
         duration_ms: req.duration_ms,

--- a/backend/src/gst/pipeline/effects/take.rs
+++ b/backend/src/gst/pipeline/effects/take.rs
@@ -20,6 +20,10 @@ impl PipelineManager {
     /// dist + multiview compositors; otherwise runs a standard single-pad
     /// transition on the mv mixer.
     ///
+    /// `from_input`/`to_input` are only consulted for a block that registered
+    /// no overlay state (a plain compositor). They are required in that case
+    /// and ignored otherwise.
+    ///
     /// Returns `(was_ftb_cancelled, old_pgm, new_pgm, actual_kind)`. The two
     /// middle elements are `None` when the corresponding bus is a PiP source.
     /// `actual_kind` is the transition that actually ran — differs from
@@ -28,15 +32,15 @@ impl PipelineManager {
     pub fn trigger_transition(
         &self,
         block_instance_id: &str,
-        from_input: usize,
-        to_input: usize,
+        from_input: Option<usize>,
+        to_input: Option<usize>,
         transition_type: &str,
         duration_ms: u64,
     ) -> Result<(bool, Option<usize>, Option<usize>, String), PipelineError> {
         use crate::gst::transitions::{TransitionController, TransitionType};
 
         debug!(
-            "Triggering {} transition on {} from input {} to {} ({}ms)",
+            "Triggering {} transition on {} from input {:?} to {:?} ({}ms)",
             transition_type, block_instance_id, from_input, to_input, duration_ms
         );
 
@@ -55,17 +59,41 @@ impl PipelineManager {
             .as_ref()
             .map(|s| s.num_inputs)
             .unwrap_or(usize::MAX);
+
+        // Without overlay state the request indices are the only thing naming
+        // the pads to animate, so an omitted one leaves the take
+        // underspecified rather than merely redundant.
+        if overlay_state.is_none() && (from_input.is_none() || to_input.is_none()) {
+            return Err(PipelineError::InvalidProperty {
+                element: block_instance_id.to_string(),
+                property: "from_input/to_input".to_string(),
+                reason: "block has no live PGM/PVW state: both indices are required".to_string(),
+            });
+        }
+
         // When overlay state is missing entirely, fall back to the request-
         // provided indices. When state exists but reports None (PiP on bus),
         // pass None through so the PiP-aware branch below handles it.
         let old_pgm: Option<usize> = match overlay_state.as_ref() {
             Some(s) => s.pgm_input(),
-            None => Some(from_input),
+            None => from_input,
         };
         let new_pgm: Option<usize> = match overlay_state.as_ref() {
             Some(s) => s.pvw_input(),
-            None => Some(to_input),
+            None => to_input,
         };
+
+        // The vision mixer page sends indices on every take, so a disagreement
+        // is routine rather than a fault — debug, not warn.
+        if overlay_state.is_some()
+            && (from_input.is_some_and(|i| Some(i) != old_pgm)
+                || to_input.is_some_and(|i| Some(i) != new_pgm))
+        {
+            debug!(
+                "Discarding client indices {:?} -> {:?} on {}: bus state says {:?} -> {:?}",
+                from_input, to_input, block_instance_id, old_pgm, new_pgm
+            );
+        }
 
         // Auto-cancel FTB if active. Zone-border underlays need no special
         // handling here: they are regular pads driven by the take paths
@@ -455,8 +483,8 @@ impl PipelineManager {
 
         // Single-input transition only. Multi-source compositions are now
         // expressed as PiPs which are handled by the PiP-aware branch above.
-        let from = old_pgm.unwrap_or(from_input);
-        let to = new_pgm.unwrap_or(to_input);
+        let from = old_pgm.or(from_input).unwrap_or(0);
+        let to = new_pgm.or(to_input).unwrap_or(0);
         let controller = TransitionController::new(mixer.clone(), canvas_width, canvas_height);
 
         // Shader transitions need the FX engine — downgrade to Fade when it

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -2101,17 +2101,25 @@ impl AppState {
     }
 
     /// Trigger a transition on a compositor/mixer block.
+    ///
+    /// `from_input`/`to_input` are honoured only for a block with no live
+    /// PGM/PVW state; see [`TriggerTransitionRequest`].
+    ///
+    /// Returns `(actual_kind, old_pgm, new_pgm)` — the latter two are the
+    /// sources the take actually ran between, `None` when that bus is a PiP.
+    ///
+    /// [`TriggerTransitionRequest`]: strom_types::api::TriggerTransitionRequest
     pub async fn trigger_transition(
         &self,
         flow_id: &FlowId,
         block_instance_id: &str,
-        from_input: usize,
-        to_input: usize,
+        from_input: Option<usize>,
+        to_input: Option<usize>,
         transition_type: &str,
         duration_ms: u64,
-    ) -> Result<String, PipelineError> {
+    ) -> Result<(String, Option<usize>, Option<usize>), PipelineError> {
         debug!(
-            "Triggering {} transition on block {} in flow {} ({} -> {}, {}ms)",
+            "Triggering {} transition on block {} in flow {} ({:?} -> {:?}, {}ms)",
             transition_type, block_instance_id, flow_id, from_input, to_input, duration_ms
         );
 
@@ -2221,19 +2229,21 @@ impl AppState {
             }
         }
 
-        // Broadcast transition event
+        // Report the sources the take actually ran between, falling back to
+        // the request. The variant's fields are `usize`, so a PiP bus still
+        // has to report something: 0 stands in.
         self.inner
             .events
             .broadcast(StromEvent::TransitionTriggered {
                 flow_id: *flow_id,
                 block_instance_id: block_instance_id.to_string(),
-                from_input,
-                to_input,
+                from_input: old_pgm.or(from_input).unwrap_or(0),
+                to_input: new_pgm.or(to_input).unwrap_or(0),
                 transition_type: transition_type.to_string(),
                 duration_ms,
             });
 
-        Ok(actual_kind)
+        Ok((actual_kind, old_pgm, new_pgm))
     }
 
     /// Select a preview input on a vision mixer block.

--- a/backend/tests/vision_mixer_fx_test.rs
+++ b/backend/tests/vision_mixer_fx_test.rs
@@ -201,12 +201,12 @@ async fn vision_mixer_fx_engine_end_to_end() {
 
     // Shader wipe take and master-FX take must run without error.
     manager
-        .trigger_transition(BLOCK_ID, 0, 1, "wipe_left", 200)
+        .trigger_transition(BLOCK_ID, None, None, "wipe_left", 200)
         .expect("wipe take failed");
     tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
 
     manager
-        .trigger_transition(BLOCK_ID, 1, 0, "glitch_cut", 200)
+        .trigger_transition(BLOCK_ID, None, None, "glitch_cut", 200)
         .expect("glitch take failed");
     tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
 
@@ -497,7 +497,7 @@ async fn wipe_between_letterboxed_sources_animates() {
 
     // --- classic orientation: 2.40:1 -> 2.34:1 (outgoing does not cover) ---
     manager
-        .trigger_transition(BLOCK_ID, 0, 1, "wipe_left", 2000)
+        .trigger_transition(BLOCK_ID, None, None, "wipe_left", 2000)
         .expect("wipe 0->1");
     // Mirror the API handler: persist the PGM/PVW swap after the take —
     // trigger_transition reads the authoritative bus state from overlay
@@ -523,7 +523,7 @@ async fn wipe_between_letterboxed_sources_animates() {
 
     // --- inverted orientation: 2.34:1 -> 2.40:1 (outgoing covers) ---
     manager
-        .trigger_transition(BLOCK_ID, 1, 0, "wipe_left", 2000)
+        .trigger_transition(BLOCK_ID, None, None, "wipe_left", 2000)
         .expect("wipe 1->0");
     manager
         .update_vision_mixer_after_take(BLOCK_ID, Some(0), Some(1), 2)

--- a/frontend/src/api/compositor.rs
+++ b/frontend/src/api/compositor.rs
@@ -110,8 +110,8 @@ impl ApiClient {
         );
 
         let request = TriggerTransitionRequest {
-            from_input,
-            to_input,
+            from_input: Some(from_input),
+            to_input: Some(to_input),
             transition_type: transition_type.to_string(),
             duration_ms,
         };

--- a/openapi.json
+++ b/openapi.json
@@ -1973,7 +1973,7 @@
           "flows"
         ],
         "summary": "Trigger a scene transition on a compositor block.",
-        "description": "Animates the transition between two inputs on a compositor/mixer block.\nSupported transition types:\n- `cut`: Instant switch (no animation)\n- `fade`: Cross-fade via alpha blending\n- `slide_left`: New input slides in from the right\n- `slide_right`: New input slides in from the left\n- `slide_up`: New input slides in from the bottom\n- `slide_down`: New input slides in from the top",
+        "description": "Animates the transition between two inputs on a compositor/mixer block.\n\nA vision mixer takes between its own authoritative PGM/PVW bus state and\nignores `from_input`/`to_input`. A block with no live state requires them.\n\nSupported transition types:\n- `cut`: Instant switch (no animation)\n- `fade`: Cross-fade via alpha blending\n- `slide_left`: New input slides in from the right\n- `slide_right`: New input slides in from the left\n- `slide_up`: New input slides in from the bottom\n- `slide_down`: New input slides in from the top",
         "operationId": "trigger_transition",
         "parameters": [
           {
@@ -10914,11 +10914,7 @@
       },
       "TriggerTransitionRequest": {
         "type": "object",
-        "description": "Request to trigger a transition on a compositor block.",
-        "required": [
-          "from_input",
-          "to_input"
-        ],
+        "description": "Request to trigger a transition on a compositor block.\n\nA vision mixer holds authoritative PGM/PVW bus state and takes between\nthose two sources, so `from_input` and `to_input` are accepted and\nignored. A plain compositor holds no such state, and there the two\nindices are the only thing naming which pads to animate.",
         "properties": {
           "duration_ms": {
             "type": "integer",
@@ -10927,13 +10923,19 @@
             "minimum": 0
           },
           "from_input": {
-            "type": "integer",
-            "description": "Index of the currently active input (0-based)",
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Index of the currently active input (0-based).\n\nIgnored by a vision mixer: an index the client computed can already\nbe stale when the request arrives, so honoring it would make every\ntake a lost-update race. Required when the block has no live\nPGM/PVW state.",
             "minimum": 0
           },
           "to_input": {
-            "type": "integer",
-            "description": "Index of the input to transition to (0-based)",
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Index of the input to transition to (0-based).\n\nSame rule as `from_input`.",
             "minimum": 0
           },
           "transition_type": {

--- a/types/src/api.rs
+++ b/types/src/api.rs
@@ -97,16 +97,30 @@ pub struct UpdatePropertyRequest {
 }
 
 /// Request to trigger a transition on a compositor block.
+///
+/// A vision mixer holds authoritative PGM/PVW bus state and takes between
+/// those two sources, so `from_input` and `to_input` are accepted and
+/// ignored. A plain compositor holds no such state, and there the two
+/// indices are the only thing naming which pads to animate.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 #[cfg_attr(feature = "validation", derive(garde::Validate))]
 pub struct TriggerTransitionRequest {
-    /// Index of the currently active input (0-based)
+    /// Index of the currently active input (0-based).
+    ///
+    /// Ignored by a vision mixer: an index the client computed can already
+    /// be stale when the request arrives, so honoring it would make every
+    /// take a lost-update race. Required when the block has no live
+    /// PGM/PVW state.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "validation", garde(skip))]
-    pub from_input: usize,
-    /// Index of the input to transition to (0-based)
+    pub from_input: Option<usize>,
+    /// Index of the input to transition to (0-based).
+    ///
+    /// Same rule as `from_input`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "validation", garde(skip))]
-    pub to_input: usize,
+    pub to_input: Option<usize>,
     /// Type of transition: "cut", "fade", "slide_left", "slide_right", "slide_up", "slide_down"
     #[serde(default = "default_transition_type")]
     #[cfg_attr(feature = "validation", garde(length(min = 1, max = 50)))]
@@ -1357,4 +1371,47 @@ pub struct FadeToBlackResponse {
 pub struct MultiviewEndpointResponse {
     /// WHEP endpoint path (e.g. "/whep/my-endpoint"), empty if not connected.
     pub endpoint: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Clients written against the old schema sent both indices as required
+    /// integers. They must keep deserializing unchanged.
+    #[test]
+    fn transition_request_accepts_legacy_body() {
+        let req: TriggerTransitionRequest = serde_json::from_str(
+            r#"{"from_input":0,"to_input":1,"transition_type":"fade","duration_ms":300}"#,
+        )
+        .expect("legacy body must still deserialize");
+        assert_eq!(req.from_input, Some(0));
+        assert_eq!(req.to_input, Some(1));
+    }
+
+    /// A vision mixer client has no useful index to send, so omitting both
+    /// must be accepted rather than rejected as a missing field.
+    #[test]
+    fn transition_request_accepts_omitted_indices() {
+        let req: TriggerTransitionRequest =
+            serde_json::from_str(r#"{"transition_type":"cut"}"#).expect("indices are optional");
+        assert_eq!(req.from_input, None);
+        assert_eq!(req.to_input, None);
+        assert_eq!(req.transition_type, "cut");
+    }
+
+    /// `skip_serializing_if` keeps the omitted case off the wire entirely
+    /// instead of sending explicit nulls.
+    #[test]
+    fn transition_request_omits_absent_indices() {
+        let json = serde_json::to_string(&TriggerTransitionRequest {
+            from_input: None,
+            to_input: None,
+            transition_type: "cut".to_string(),
+            duration_ms: 0,
+        })
+        .expect("serialize");
+        assert!(!json.contains("from_input"), "got {}", json);
+        assert!(!json.contains("to_input"), "got {}", json);
+    }
 }


### PR DESCRIPTION
## Problem

One handler serves two block kinds with different contracts. A vision mixer reads the authoritative PGM/PVW pair from overlay state and discards `from_input`/`to_input` — correct and unchanged, since a client-computed index can be stale by the time the request lands, which would make every take a lost-update race. A plain compositor (`builtin.compositor`, `builtin.glcompositor`) registers no overlay state, so there the indices are load-bearing.

`TriggerTransitionRequest` declared both required, documented as "Index of the currently active input (0-based)". That is false for a vision mixer, and the schema told every client to compute a value that is usually thrown away.

## Change

Both fields become `Option<usize>` with `#[serde(default)]`. utoipa emits them as `"type": ["integer", "null"]` and drops the `required` block, so clients that still send integers keep working.

**The judgment call worth reviewing:** supplied-but-unused indices are accepted and ignored, not rejected. A client cannot know whether a block has live state without a pre-flight GET, and that state can change before the POST lands — the same race the discard exists to prevent. A 400 would also break `vision-mixer.html`, which sends indices on every take. Disagreements log at debug, not warn, since that page makes them routine.

Omitting an index on a block with no live state is a different case and now returns 400: that take is underspecified rather than redundant.

The response `message` echoed the request indices, and the vision mixer page shows that string to the operator. `AppState::trigger_transition` now returns the real pair and the handler builds the message from it, naming no indices when a bus is a PiP. `StromEvent::TransitionTriggered` carries the authoritative pair too; its fields stay `usize` so the variant is unchanged, and a PiP bus reports 0. Nothing consumes it today.

## Frontend

`api_sync.rs` keeps its own `transition_from`/`transition_to`. That is not a mirror of server state: `CompositorEditor` opens only for the two compositor blocks, never for a vision mixer (whose UI is `vision-mixer.html`), and those blocks have no server-side pair to read — `GET /blocks/{block_id}/state` 404s for them. Left alone here.

Follow-up defect: the from/to swap happens before the POST, so a failed request leaves the pair backwards for the next take.

## Tests

Ran:

- `cargo test --package strom-types` — 73 passed, including 3 new wire-contract cases. The omitted-indices case fails with a missing-field error if `#[serde(default)]` is reverted.
- `cargo test --test openapi_test` — failed first as expected; `openapi.json` updated deliberately. Only delta is the two fields turning nullable, `required` disappearing, and the doc text. Re-ran green.
- `cargo test --test vision_mixer_fx_test` — 2 passed locally on macOS, GL pipeline running (4.86s, no `SKIP`). Both call sites pass `None, None`, so this covers a vision mixer take with no indices. **It skips on CI** (no GL environment; both cases finish in ~0.05s), so CI does not cover the vision mixer half. That skip predates this PR.
- `cargo test --test api_tests --test api_not_found_test` — 20 passed; neither covers this endpoint.
- `cargo fmt --all --check`, clippy on `strom` and on `strom-frontend` for `wasm32-unknown-unknown` — clean.

Not run: the rest of the backend suite. No test covers the new 400; that needs a running compositor block and no harness exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

